### PR TITLE
Improving project test setup.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+# Run CPU-only tests for the project via pytest
+name: Test CPU
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: uv sync --dev --all-extras
+
+      - name: Run pytest
+        run: uv run pytest -m "not manual and not cuda"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing Guide
+
+TODO(#54): _Full contribution guide to come._
+
+## How to run tests
+
+<details>
+<summary><strong>TL;DR</strong></summary>
+
+```bash
+# local dev / CI
+pytest -m "not manual and not cuda"
+# all manual tests
+pytest -m manual
+# just the model weights test
+pytest -k "model and weights"
+```
+
+</details>
+
+We use `pytest` as a test runner. All tests in this project have several [_marks_](https://docs.pytest.org/en/stable/how-to/mark.html)
+that allow developers to control what tests are run locally. Two marks of particular interest are `cuda` and `manual`.
+
+"cuda" tests are tests that require an NVIDIA GPU to run. If tests use the `device` fixture, then they'll automatically
+be configured to run on both GPU and CPU simultaneously. Certain tests, however, can be marked with `@pytest.mark.cuda`
+if they need to run on that hardware. To run CUDA-only tests, call:
+
+```bash
+pytest -m cuda
+```
+And to exclude all cuda-marked tests, run:
+
+```bash
+pytest -m "not cuda"
+```
+
+"manual" tests are not run in continuous integration (CI), but are useful checks during the development process. For
+example, evaluating if two model weights are equal is marked `manual`. All manual tests can be run like so:
+
+```bash
+pytest -m manual
+```
+
+To exclude manual tests, run:
+
+```bash
+pytest -m "not manual"
+```
+
+Usually, if a test is marked `manual`, it means that it should be run alone. To run a specific subsets of tests —
+or even a single test — at a time, please do the following:
+```bash
+# single test
+pytest -k "models_have_same_weights"
+# test that match "model" and are manual
+pytest -k "models" -m manual
+# all model weights tests
+pytest -l "models and weights"
+```
+
+**To run the same tests that are run in CI, please run the following:**
+
+```bash
+pytest -m "not manual and not cuda"
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ pytest -m "not manual and not cuda"
 # all manual tests
 pytest -m manual
 # just the model weights test
-pytest -k "model and weights"
+pytest -k "model and weights" --model1 <path/to/model1.pt> --model2 <path/to/model2.pt>
 ```
 
 </details>
@@ -47,15 +47,16 @@ To exclude manual tests, run:
 pytest -m "not manual"
 ```
 
-Usually, if a test is marked `manual`, it means that it should be run alone. To run a specific subsets of tests —
-or even a single test — at a time, please do the following:
+Usually, if a test is marked `manual`, it means that it should be run alone. Further, manual tests often need to be run
+with specific arguments. To run a specific subsets of tests — or even a single test — at a time with arguments, please
+do the following:
 ```bash
 # single test
-pytest -k "models_have_same_weights"
+pytest -k "models_have_same_weights" --model1 <path/to/model1.pt> --model2 <path/to/model2.pt>
 # test that match "model" and are manual
-pytest -k "models" -m manual
+pytest -k "models" -m manual --model1 <path/to/model1.pt> --model2 <path/to/model2.pt>
 # all model weights tests
-pytest -l "models and weights"
+pytest -l "models and weights" --model1 <path/to/model1.pt> --model2 <path/to/model2.pt>
 ```
 
 **To run the same tests that are run in CI, please run the following:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ classifiers = [
 ]
 dynamic = [ "dependencies", "optional-dependencies", "version" ]
 
+[dependency-groups]
+dev = [
+  "pytest>=8.3.4",
+]
+
 [tool.setuptools.dynamic]
 dependencies = { file = "requirements.txt" }
 
@@ -37,6 +42,12 @@ lint.per-file-ignores."scripts/*" = [ "D" ]
 lint.per-file-ignores."test_*.py" = [ "D" ]
 lint.isort.split-on-trailing-comma = false
 lint.pydocstyle.convention = "google"
+
+[tool.pytest.ini_options]
+markers = [
+  "manual: marks tests as manually run (deselect with '-m \"not manual\"').",
+  "cuda: marks tests that need a CUDA-enabled device to run (deselect with '-m \"not cuda\"').",
+]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 
 
 def pytest_addoption(parser):
@@ -18,3 +19,9 @@ def model1_path(request):
 @pytest.fixture
 def model2_path(request):
     return request.config.getoption("--model2")
+
+
+# Used to automatically filter out CPU- or GPU- only tests.
+@pytest.fixture(params=["cpu", pytest.param("cuda", marks=pytest.mark.cuda)])
+def device(request):
+    return torch.device(request.param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def model2_path(request):
     return request.config.getoption("--model2")
 
 
-# Used to automatically filter out CPU- or GPU- only tests.
+# Run a test for both CPU and GPU, and allows selecting or skipping CUDA tests.
 @pytest.fixture(params=["cpu", pytest.param("cuda", marks=pytest.mark.cuda)])
 def device(request):
     return torch.device(request.param)

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -3,5 +3,5 @@ import torch
 
 
 def test_placeholder(device):
-    """A placeholder test that should fail when run on CPU."""
+    """A placeholder test that should fail when run on GPU."""
     assert device != torch.device("cuda:0")

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,7 @@
+# TODO(#21): Replace with real project tests.
+import torch
+
+
+def test_placeholder(device):
+    """A placeholder test that should fail when run on CPU."""
+    assert device != torch.device("cuda:0")

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -19,6 +19,8 @@ def compare_model_weights(model1_state_dict, model2_state_dict):
     return are_equal
 
 
+# How to pass options to this test:
+# https://docs.pytest.org/en/stable/example/simple.html#pass-different-values-to-a-test-function-depending-on-command-line-options
 @pytest.mark.manual
 def test_models_have_same_weights(model1_path, model2_path):
     torch.cuda.empty_cache()

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,5 +1,6 @@
 # https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html
 
+import pytest
 import torch
 
 
@@ -18,6 +19,7 @@ def compare_model_weights(model1_state_dict, model2_state_dict):
     return are_equal
 
 
+@pytest.mark.manual
 def test_models_have_same_weights(model1_path, model2_path):
     torch.cuda.empty_cache()
     model1_state_dict = load_model_weights(model1_path)


### PR DESCRIPTION
 This change runs tests inside CI via GitHub Actions. In addition, it introduces a test marking scheme to filter out what can run in CI and locally. Two pytest markers have been added: `cuda` and `manual`. Manual tests, like the model weights test, and GPU-powered tests have been excluded in the default test Action. Addresses https://github.com/suryadheeshjith/Ocean_Emulator/issues/21.

I've added the beginnings of a contributors guide to document how tests should be run.

In the (near) future, I plan to add significantly more tests.