### PR TITLE
Specifying minimum version of cftime.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ certifi==2024.2.2
 certipy==0.1.3
 cf_xarray==0.9.5
 cffi==1.16.0
-cftime==1.5.1.1
+cftime>=1.5.2
 charset-normalizer==3.3.2
 click==8.1.7
 click-default-group==1.2.4


### PR DESCRIPTION
ARM support was only added in cftime==1.5.2. Thus, I'm updating the requirements.txt such that 1.5.2 is the minimum allowed version. This allows me to open Zarr datasets with Xarray on M1+ Macs.