### PR TITLE
Created test-bench for data loaders.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,7 @@ repos:
       args: ["--config", "pyproject.toml"]
       exclude: |
         (?x)^(
-        .+/conf.py |
-        .+/conftest.py
+        .+/conf.py
         )$
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: "v2.5.0"

--- a/configs/train_cm4.test.yaml
+++ b/configs/train_cm4.test.yaml
@@ -36,7 +36,7 @@ distributed:
 
 experiment:
   name: train
-  sub_name: local_cm4_samudra
+  sub_name: test_cm4_samudra
   rand_seed: 15
   base_output_dir: .LOCAL
   gantry: false
@@ -44,15 +44,15 @@ experiment:
   wandb:
     mode: disabled
     project: 3D_ocean_emu_CM4
-    entity: suryadheeshjith
+    entity: testrobot
   network: convnextunet
   exp_num_in: '3D_5'
   exp_num_extra: '3D_5'
   exp_num_out: '3D_5'
 data:
-  data_path: cm4_piControl_ocean_200yr_full.zarr
-  data_means_path: 2024-11-12-cm4-piControl-ocean-200yr-dataset-stats/centering.nc
-  data_stds_path: 2024-11-12-cm4-piControl-ocean-200yr-dataset-stats/scaling-full-field.nc
+  data_path: fake/data/path/cm4_piControl_ocean_200yr_full.zarr
+  data_means_path: fake/data/path/cm4-piControl-ocean-200yr-dataset-stats/centering.nc
+  data_stds_path: fake/data/path/piControl-ocean-200yr-dataset-stats/scaling-full-field.nc
   scaling_residuals_file: null
   depth_mode: all
   time_delta: 5
@@ -61,10 +61,10 @@ data:
 
 
 unet:
-  ch_width: [157, 200, 250, 300, 400]
-  n_out: 77
-  dilation: [1, 2, 4, 8]
-  n_layers: [1, 1, 1, 1]
+  ch_width: [2, 3]
+  n_out: 4
+  dilation: [1, 2]
+  n_layers: [1, 1]
   pred_residuals: false
   last_kernel_size: 3
   pad: "circular"
@@ -73,7 +73,7 @@ unet:
     block_type: "conv_next_block"
     kernel_size: 3
     activation: "capped_gelu"
-    upscale_factor: 4
+    upscale_factor: 2
     norm: "batch"
 
   corrector:

--- a/configs/train_cm4.test.yaml
+++ b/configs/train_cm4.test.yaml
@@ -15,13 +15,13 @@ inference_epochs: [-1]
 data_percent: 1.0
 train:
   start_time: '1969-08-15'
-  end_time: '1969-08-20'
+  end_time: '1969-10-20'
 val:
-  start_time: '1969-09-04'
-  end_time: '1969-09-09'
+  start_time: '1969-10-20'
+  end_time: '1969-11-20'
 inference:
-  - start_time: '1969-09-06'
-    end_time: '1969-09-14'
+  - start_time: '1969-11-20'
+    end_time: '1969-12-15'
 data_stride: [1]
 steps: [1]
 step_transition: []

--- a/configs/train_cm4.test.yaml
+++ b/configs/train_cm4.test.yaml
@@ -1,0 +1,84 @@
+# A config file to test training.
+# Used in automated tests.
+debug: true
+disk_mode: true
+pin_mem: false
+save_freq: 5
+epochs: 120
+batch_size: 2 # 4
+learning_rate: 0.0001
+scheduler: false
+loss: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: [-1]
+data_percent: 1.0
+train:
+  start_time: '1969-08-15'
+  end_time: '1969-08-30'
+val:
+  start_time: '1969-09-01'
+  end_time: '1969-09-05'
+inference:
+  - start_time: '1969-09-06'
+    end_time: '1969-09-12'
+data_stride: [1]
+steps: [4]
+step_transition: []
+
+distributed:
+  enabled: true
+  dist_url: null
+  world_size: null
+  rank: null
+  gpu: null
+  dist_backend: null
+
+experiment:
+  name: train
+  sub_name: local_cm4_samudra
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  gantry: false
+  cluster_data_dir: will_be_replaced
+  wandb:
+    mode: disabled
+    project: 3D_ocean_emu_CM4
+    entity: suryadheeshjith
+  network: convnextunet
+  exp_num_in: '3D_5'
+  exp_num_extra: '3D_5'
+  exp_num_out: '3D_5'
+data:
+  data_path: cm4_piControl_ocean_200yr_full.zarr
+  data_means_path: 2024-11-12-cm4-piControl-ocean-200yr-dataset-stats/centering.nc
+  data_stds_path: 2024-11-12-cm4-piControl-ocean-200yr-dataset-stats/scaling-full-field.nc
+  scaling_residuals_file: null
+  depth_mode: all
+  time_delta: 5
+  num_workers: 4
+  hist: 0
+
+
+unet:
+  ch_width: [157, 200, 250, 300, 400]
+  n_out: 77
+  dilation: [1, 2, 4, 8]
+  n_layers: [1, 1, 1, 1]
+  pred_residuals: false
+  last_kernel_size: 3
+  pad: "circular"
+
+  core_block:
+    block_type: "conv_next_block"
+    kernel_size: 3
+    activation: "capped_gelu"
+    upscale_factor: 4
+    norm: "batch"
+
+  corrector:
+    non_negative_corrector_names:
+      - "so"
+
+  down_sampling_block: "avg_pool"
+  up_sampling_block: "bilinear_upsample"

--- a/configs/train_cm4.test.yaml
+++ b/configs/train_cm4.test.yaml
@@ -5,7 +5,7 @@ disk_mode: true
 pin_mem: false
 save_freq: 5
 epochs: 120
-batch_size: 2 # 4
+batch_size: 1
 learning_rate: 0.0001
 scheduler: false
 loss: mse
@@ -15,15 +15,15 @@ inference_epochs: [-1]
 data_percent: 1.0
 train:
   start_time: '1969-08-15'
-  end_time: '1969-08-30'
+  end_time: '1969-08-20'
 val:
-  start_time: '1969-09-01'
-  end_time: '1969-09-05'
+  start_time: '1969-09-04'
+  end_time: '1969-09-09'
 inference:
   - start_time: '1969-09-06'
-    end_time: '1969-09-12'
+    end_time: '1969-09-14'
 data_stride: [1]
-steps: [4]
+steps: [1]
 step_transition: []
 
 distributed:
@@ -50,9 +50,9 @@ experiment:
   exp_num_extra: '3D_5'
   exp_num_out: '3D_5'
 data:
-  data_path: fake/data/path/cm4_piControl_ocean_200yr_full.zarr
-  data_means_path: fake/data/path/cm4-piControl-ocean-200yr-dataset-stats/centering.nc
-  data_stds_path: fake/data/path/piControl-ocean-200yr-dataset-stats/scaling-full-field.nc
+  data_path: fake/path/to/data
+  data_means_path: fake/path/to/means
+  data_stds_path: fake/path/to/stds
   scaling_residuals_file: null
   depth_mode: all
   time_delta: 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ markers = [
   "manual: marks tests as manually run (deselect with '-m \"not manual\"').",
   "cuda: marks tests that need a CUDA-enabled device to run (deselect with '-m \"not cuda\"').",
 ]
+pythonpath = [
+  "src",
+]
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,6 @@ import xarray as xr
 import constants as c
 from config import TrainConfig
 
-PROJ_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
-
 
 class DataSource(TypedDict):
     """In-memory `xarray.Dataset`s needed for tests."""
@@ -104,7 +102,9 @@ def data_source() -> DataSource:
 
 # TODO(alxmrs): Consider yielding multiple test configs.
 @pytest.fixture(scope="session")
-def train_config(data_source: DataSource) -> Generator[TrainConfig, Any, None]:
+def train_config(
+    data_source: DataSource, pytestconfig: pytest.Config
+) -> Generator[TrainConfig, Any, None]:
     with tempfile.TemporaryDirectory() as tmpdir:
 
         def _make_path(name_with_ext: str) -> str:
@@ -116,7 +116,7 @@ def train_config(data_source: DataSource) -> Generator[TrainConfig, Any, None]:
         data_source["stds"].to_netcdf(_make_path("stds.netcdf"))
 
         # Open default training script; modify it so it uses the temporary directory.
-        default_config = os.path.join(PROJ_ROOT, "configs", "train_cm4.test.yaml")
+        default_config = pytestconfig.rootpath / "configs" / "train_cm4.test.yaml"
         trainer = TrainConfig.from_yaml(default_config)
         data_config = dataclasses.replace(
             trainer.data,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def device(request):
 def data_source() -> DataSource:
     """Returns in-memory `xarray.Dataset`s for tests."""
     summer_of_love = xr.cftime_range(
-        "1969-08-10", "1969-10-01", freq="D", calendar="noleap"
+        "1969-08-10", "1969-12-31", freq="5D", calendar="noleap"
     )
 
     coords = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,25 @@
+import dataclasses
+import os
+import tempfile
+from typing import Any, Generator, TypedDict
+
+import numpy as np
 import pytest
 import torch
+import xarray as xr
+
+import constants as c
+from config import TrainConfig
+
+PROJ_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), os.pardir)
+
+
+class DataSource(TypedDict):
+    """In-memory `xarray.Dataset`s needed for tests."""
+
+    data: xr.Dataset
+    means: xr.Dataset
+    stds: xr.Dataset
 
 
 def pytest_addoption(parser):
@@ -25,3 +45,94 @@ def model2_path(request):
 @pytest.fixture(params=["cpu", pytest.param("cuda", marks=pytest.mark.cuda)])
 def device(request):
     return torch.device(request.param)
+
+
+@pytest.fixture(scope="session")
+def data_source() -> DataSource:
+    """Returns in-memory `xarray.Dataset`s for tests."""
+    out = {}
+
+    summer_of_love = xr.cftime_range(
+        "1969-08-10", "1969-10-01", freq="D", calendar="noleap"
+    )
+
+    coords = {
+        "lon": xr.DataArray(np.arange(0.5, 360, 1), dims=["lon"]),
+        "lat": xr.DataArray(np.arange(-89.24, 90, 1), dims=["lat"]),
+        "time": xr.DataArray(summer_of_love, dims=["time"]),
+    }
+
+    normal = np.random.normal(
+        size=(lat := len(coords["lat"]), lon := len(coords["lon"]))
+    )
+
+    ds = xr.Dataset(
+        {
+            # 2D variables
+            var: xr.DataArray(
+                np.random.random([len(summer_of_love), lat, lon]),
+                dims=["time", "lat", "lon"],
+            )
+            for var in ["hfds", "tauuo", "tauvo", "zos"]
+        }
+        | {
+            # 3D variables
+            f"{var}_{lev}": xr.DataArray(
+                np.random.random([len(summer_of_love), lat, lon]),
+                dims=["time", "lat", "lon"],
+            )
+            for var in ["so", "thetao", "uo", "vo"]
+            for lev in c.DEPTH_I_LEVELS
+        }
+        | {
+            # Masks -- make a binary circle mask.
+            f"mask_{lev}": xr.DataArray(
+                np.where(normal > 0.5**lev, 1, 0),
+                dims=["lat", "lon"],
+            )
+            for lev in range(len(c.DEPTH_I_LEVELS))
+        },
+        coords=coords,
+    )
+
+    out["data"] = ds
+    out["means"] = ds.mean("time")
+    out["stds"] = ds.std("time")
+
+    return out
+
+
+# TODO(alxmrs): Consider yielding multiple test configs.
+@pytest.fixture(scope="session")
+def train_config(data_source: DataSource) -> Generator[TrainConfig, Any, None]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+
+        def _make_path(name_with_ext: str) -> str:
+            return os.path.join(tmpdir, name_with_ext)
+
+        # Write test data to a temporary directory.
+        data_source["data"].to_zarr(_make_path("data.zarr"))
+        data_source["means"].to_netcdf(_make_path("means.netcdf"))
+        data_source["stds"].to_netcdf(_make_path("stds.netcdf"))
+
+        # Open default training script; modify it so it uses the temporary directory.
+        default_config = os.path.join(PROJ_ROOT, "configs", "train_cm4.test.yaml")
+        trainer = TrainConfig.from_yaml(default_config)
+        data_config = dataclasses.replace(
+            trainer.data,
+            data_path=_make_path("data.zarr"),
+            data_means_path=_make_path("means.netcdf"),
+            data_stds_path=_make_path("stds.netcdf"),
+        )
+        experiment_config = dataclasses.replace(
+            trainer.experiment,
+            cluster_data_dir=os.path.join(tmpdir, "cluster_data"),
+        )
+        test_data_trainer = dataclasses.replace(
+            trainer,
+            data=data_config,
+            experiment=experiment_config,
+        )
+
+        # After contextmanager closes, all test data will be automatically cleaned up.
+        yield test_data_trainer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,8 +48,6 @@ def device(request):
 @pytest.fixture(scope="session")
 def data_source() -> DataSource:
     """Returns in-memory `xarray.Dataset`s for tests."""
-    out = {}
-
     summer_of_love = xr.cftime_range(
         "1969-08-10", "1969-10-01", freq="D", calendar="noleap"
     )
@@ -64,7 +62,7 @@ def data_source() -> DataSource:
         size=(lat := len(coords["lat"]), lon := len(coords["lon"]))
     )
 
-    ds = xr.Dataset(
+    ds: xr.Dataset = xr.Dataset(
         {
             # 2D variables
             var: xr.DataArray(
@@ -93,11 +91,7 @@ def data_source() -> DataSource:
         coords=coords,
     )
 
-    out["data"] = ds
-    out["means"] = ds.mean("time")
-    out["stds"] = ds.std("time")
-
-    return out
+    return {"data": ds, "means": ds.mean("time"), "stds": ds.std("time")}
 
 
 # TODO(alxmrs): Consider yielding multiple test configs.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,7 +1,5 @@
 """Test core Datasets and DataLoaders."""
 
-from typing import Tuple
-
 import numpy as np
 import pytest
 from torch.utils.data import DataLoader
@@ -15,7 +13,7 @@ from train_3D import Trainer
 # these fixtures allow us to isolate data loader tests from their setup.
 
 TrainPair = tuple[TrainConfig, Trainer]
-LoaderPair = Tuple[TrainConfig, DataLoader]
+LoaderPair = tuple[TrainConfig, DataLoader]
 
 
 # This micro-fixture is cached by pytest. Thus, we don't have to change
@@ -48,7 +46,7 @@ def inference_loader_pair(trainer_pair: TrainPair) -> LoaderPair:
     return cfg, trainer.inference_loader
 
 
-def extract_sample_arrays(td: TrainData, steps: int) -> Tuple[np.ndarray, np.ndarray]:
+def extract_sample_arrays(td: TrainData, steps: int) -> tuple[np.ndarray, np.ndarray]:
     """Extract underlying X, y pairs from TrainData object."""
     x_arrays = [td.get_input(s).numpy(force=True) for s in range(steps)]
     y_arrays = [td.get_label(s).numpy(force=True) for s in range(steps)]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -46,6 +46,7 @@ def extract_sample_arrays(td: TrainData, steps: int) -> Tuple[np.ndarray, np.nda
 
 
 # TODO(alxmrs): How can we determine `n_samples` from the input config? Timeslice?
+#  Changing the "hist" parameter breaks this test.
 def test_train__loads_correct_number_of_samples(train_loader_pair):
     cfg, loader = train_loader_pair
     n_samples = 6
@@ -59,9 +60,12 @@ def test_train__data_shape(train_loader_pair):
 
     exp = cfg.experiment
     batch_size = cfg.batch_size
+    hist = cfg.data.hist + 1
 
-    input_var_dim = len(INPT_VARS[exp.exp_num_in]) + len(EXTRA_VARS[exp.exp_num_extra])
-    output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out])
+    input_var_dim = len(INPT_VARS[exp.exp_num_in]) * hist + len(
+        EXTRA_VARS[exp.exp_num_extra]
+    )
+    output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out]) * hist
 
     for sample in loader:
         X, y = extract_sample_arrays(sample, cfg.steps[0])
@@ -70,6 +74,7 @@ def test_train__data_shape(train_loader_pair):
 
 
 # TODO(alxmrs): How can we determine `n_samples` from the input config? Timeslice?
+#  Changing the "hist" parameter breaks this test.
 def test_val__loads_correct_number_of_samples(val_loader_pair):
     cfg, loader = val_loader_pair
     n_samples = 2
@@ -83,9 +88,12 @@ def test_val__data_shape(val_loader_pair):
 
     exp = cfg.experiment
     batch_size = cfg.batch_size
+    hist = cfg.data.hist + 1
 
-    input_var_dim = len(INPT_VARS[exp.exp_num_in]) + len(EXTRA_VARS[exp.exp_num_extra])
-    output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out])
+    input_var_dim = len(INPT_VARS[exp.exp_num_in]) * hist + len(
+        EXTRA_VARS[exp.exp_num_extra]
+    )
+    output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out]) * hist
 
     for sample in loader:
         X, y = extract_sample_arrays(sample, 1)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -56,7 +56,7 @@ def extract_sample_arrays(td: TrainData, steps: int) -> Tuple[np.ndarray, np.nda
 #  Changing the "hist" parameter breaks this test.
 def test_train__loads_correct_number_of_samples(train_loader_pair):
     cfg, loader = train_loader_pair
-    n_samples = 5
+    n_samples = 13
     assert (
         len(list(loader)) == n_samples
     ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,93 @@
+"""Test core Datasets and DataLoaders."""
+
+from typing import Tuple
+
+import numpy as np
+import pytest
+
+from constants import EXTRA_VARS, INPT_VARS, OUT_VARS
+from datasets import TrainData
+from train_3D import Trainer
+
+# Note: Refactoring data loaders is planned for the near-term. Ideally,
+# these fixtures allow us to isolate data loader tests from their setup.
+
+
+# This micro-fixture is cached by pytest. Thus, we don't have to change
+# the factory methods that throw errors during double initialization.
+@pytest.fixture(scope="session")
+def trainer_pair(train_config):
+    trainer = Trainer(train_config)
+
+    # cur_step will set the number of pairs in the input/output sample
+    trainer.init_data_loaders(cur_step=train_config.steps[0])
+
+    return train_config, trainer
+
+
+@pytest.fixture
+def train_loader_pair(trainer_pair):
+    cfg, trainer = trainer_pair
+    return cfg, trainer.train_loader
+
+
+@pytest.fixture
+def val_loader_pair(trainer_pair):
+    cfg, trainer = trainer_pair
+    return cfg, trainer.val_loader
+
+
+def extract_sample_arrays(td: TrainData, steps: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Extract underlying X, y pairs from TrainData object."""
+    x_arrays = [td.get_input(s).numpy(force=True) for s in range(steps)]
+    y_arrays = [td.get_label(s).numpy(force=True) for s in range(steps)]
+
+    return np.stack(x_arrays, axis=0), np.stack(y_arrays, axis=0)
+
+
+# TODO(alxmrs): How can we determine `n_samples` from the input config? Timeslice?
+def test_train__loads_correct_number_of_samples(train_loader_pair):
+    cfg, loader = train_loader_pair
+    n_samples = 6
+    assert (
+        len(list(loader)) == n_samples
+    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+
+
+# TODO(alxmrs): What does the "2" dimension represent? Where is it in the config?
+def test_train__data_shape(train_loader_pair):
+    cfg, loader = train_loader_pair
+
+    exp = cfg.experiment
+
+    input_var_dim = len(INPT_VARS[exp.exp_num_in]) + len(EXTRA_VARS[exp.exp_num_extra])
+    output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out])
+
+    for sample in loader:
+        X, y = extract_sample_arrays(sample, cfg.steps[0])
+        assert X.shape == (cfg.steps[0], 2, input_var_dim, 180, 360)
+        assert y.shape == (cfg.steps[0], 2, output_var_dim, 180, 360)
+
+
+# TODO(alxmrs): How can we determine `n_samples` from the input config? Timeslice?
+def test_val__loads_correct_number_of_samples(val_loader_pair):
+    cfg, loader = val_loader_pair
+    n_samples = 2
+    assert (
+        len(list(loader)) == n_samples
+    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+
+
+# TODO(alxmrs): What does the "2" dimension represent? Where is it in the config?
+def test_val__data_shape(val_loader_pair):
+    cfg, loader = val_loader_pair
+
+    exp = cfg.experiment
+
+    input_var_dim = len(INPT_VARS[exp.exp_num_in]) + len(EXTRA_VARS[exp.exp_num_extra])
+    output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out])
+
+    for sample in loader:
+        X, y = extract_sample_arrays(sample, 1)
+        assert X.shape == (1, 2, input_var_dim, 180, 360)
+        assert y.shape == (1, 2, output_var_dim, 180, 360)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,7 +4,9 @@ from typing import Tuple
 
 import numpy as np
 import pytest
+from torch.utils.data import DataLoader
 
+from config import TrainConfig
 from constants import EXTRA_VARS, INPT_VARS, OUT_VARS
 from datasets import TrainData
 from train_3D import Trainer
@@ -12,11 +14,14 @@ from train_3D import Trainer
 # Note: Refactoring data loaders is planned for the near-term. Ideally,
 # these fixtures allow us to isolate data loader tests from their setup.
 
+TrainPair = tuple[TrainConfig, Trainer]
+LoaderPair = Tuple[TrainConfig, DataLoader]
+
 
 # This micro-fixture is cached by pytest. Thus, we don't have to change
 # the factory methods that throw errors during double initialization.
 @pytest.fixture(scope="session")
-def trainer_pair(train_config):
+def trainer_pair(train_config: TrainConfig) -> TrainPair:
     trainer = Trainer(train_config)
 
     # cur_step will set the number of pairs in the input/output sample
@@ -26,21 +31,20 @@ def trainer_pair(train_config):
 
 
 @pytest.fixture
-def train_loader_pair(trainer_pair):
+def train_loader_pair(trainer_pair: TrainPair) -> LoaderPair:
     cfg, trainer = trainer_pair
     return cfg, trainer.train_loader
 
 
 @pytest.fixture
-def val_loader_pair(trainer_pair):
+def val_loader_pair(trainer_pair: TrainPair) -> LoaderPair:
     cfg, trainer = trainer_pair
     return cfg, trainer.val_loader
 
 
 @pytest.fixture
-def inference_loader_pair(trainer_pair):
+def inference_loader_pair(trainer_pair: TrainPair) -> LoaderPair:
     cfg, trainer = trainer_pair
-
     return cfg, trainer.inference_loader
 
 
@@ -54,7 +58,7 @@ def extract_sample_arrays(td: TrainData, steps: int) -> Tuple[np.ndarray, np.nda
 
 # TODO(alxmrs): How can we determine `n_samples` from the input config? Timeslice?
 #  Changing the "hist" parameter breaks this test.
-def test_train__loads_correct_number_of_samples(train_loader_pair):
+def test_train__loads_correct_number_of_samples(train_loader_pair: LoaderPair):
     cfg, loader = train_loader_pair
     n_samples = 13
     assert (
@@ -62,7 +66,7 @@ def test_train__loads_correct_number_of_samples(train_loader_pair):
     ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
 
 
-def test_train__data_shape(train_loader_pair):
+def test_train__data_shape(train_loader_pair: LoaderPair):
     cfg, loader = train_loader_pair
 
     exp = cfg.experiment
@@ -90,7 +94,7 @@ def test_val__loads_correct_number_of_samples(val_loader_pair):
     ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
 
 
-def test_val__data_shape(val_loader_pair):
+def test_val__data_shape(val_loader_pair: LoaderPair):
     cfg, loader = val_loader_pair
 
     exp = cfg.experiment
@@ -108,7 +112,7 @@ def test_val__data_shape(val_loader_pair):
         assert y.shape == (1, batch_size, output_var_dim, 180, 360)
 
 
-def test_inference__loads_correct_number_of_samples(inference_loader_pair):
+def test_inference__loads_correct_number_of_samples(inference_loader_pair: LoaderPair):
     cfg, loader = inference_loader_pair
     n_samples = 1
     assert (
@@ -116,7 +120,7 @@ def test_inference__loads_correct_number_of_samples(inference_loader_pair):
     ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
 
 
-def test_inference__data_shape(inference_loader_pair):
+def test_inference__data_shape(inference_loader_pair: LoaderPair):
     cfg, loader = inference_loader_pair
 
     exp = cfg.experiment

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -37,6 +37,13 @@ def val_loader_pair(trainer_pair):
     return cfg, trainer.val_loader
 
 
+@pytest.fixture
+def inference_loader_pair(trainer_pair):
+    cfg, trainer = trainer_pair
+
+    return cfg, trainer.inference_loader
+
+
 def extract_sample_arrays(td: TrainData, steps: int) -> Tuple[np.ndarray, np.ndarray]:
     """Extract underlying X, y pairs from TrainData object."""
     x_arrays = [td.get_input(s).numpy(force=True) for s in range(steps)]
@@ -99,3 +106,30 @@ def test_val__data_shape(val_loader_pair):
         X, y = extract_sample_arrays(sample, 1)
         assert X.shape == (1, batch_size, input_var_dim, 180, 360)
         assert y.shape == (1, batch_size, output_var_dim, 180, 360)
+
+
+def test_inference__loads_correct_number_of_samples(inference_loader_pair):
+    cfg, loader = inference_loader_pair
+    n_samples = 1
+    assert (
+        len(list(loader)) == n_samples
+    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+
+
+def test_inference__data_shape(inference_loader_pair):
+    cfg, loader = inference_loader_pair
+
+    exp = cfg.experiment
+    batch_size = cfg.batch_size
+    hist = cfg.data.hist + 1
+
+    input_var_dim = len(INPT_VARS[exp.exp_num_in]) * hist + len(
+        EXTRA_VARS[exp.exp_num_extra]
+    )
+    output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out]) * hist
+
+    for sample in loader:
+        inference_dataset, n = sample
+        for X, y in inference_dataset:
+            assert X.shape == (batch_size, input_var_dim, 180, 360)
+            assert y.shape == (batch_size, output_var_dim, 180, 360)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -49,7 +49,7 @@ def extract_sample_arrays(td: TrainData, steps: int) -> Tuple[np.ndarray, np.nda
 #  Changing the "hist" parameter breaks this test.
 def test_train__loads_correct_number_of_samples(train_loader_pair):
     cfg, loader = train_loader_pair
-    n_samples = 6
+    n_samples = 5
     assert (
         len(list(loader)) == n_samples
     ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
@@ -77,7 +77,7 @@ def test_train__data_shape(train_loader_pair):
 #  Changing the "hist" parameter breaks this test.
 def test_val__loads_correct_number_of_samples(val_loader_pair):
     cfg, loader = val_loader_pair
-    n_samples = 2
+    n_samples = 5
     assert (
         len(list(loader)) == n_samples
     ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -54,19 +54,19 @@ def test_train__loads_correct_number_of_samples(train_loader_pair):
     ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
 
 
-# TODO(alxmrs): What does the "2" dimension represent? Where is it in the config?
 def test_train__data_shape(train_loader_pair):
     cfg, loader = train_loader_pair
 
     exp = cfg.experiment
+    batch_size = cfg.batch_size
 
     input_var_dim = len(INPT_VARS[exp.exp_num_in]) + len(EXTRA_VARS[exp.exp_num_extra])
     output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out])
 
     for sample in loader:
         X, y = extract_sample_arrays(sample, cfg.steps[0])
-        assert X.shape == (cfg.steps[0], 2, input_var_dim, 180, 360)
-        assert y.shape == (cfg.steps[0], 2, output_var_dim, 180, 360)
+        assert X.shape == (cfg.steps[0], batch_size, input_var_dim, 180, 360)
+        assert y.shape == (cfg.steps[0], batch_size, output_var_dim, 180, 360)
 
 
 # TODO(alxmrs): How can we determine `n_samples` from the input config? Timeslice?
@@ -78,16 +78,16 @@ def test_val__loads_correct_number_of_samples(val_loader_pair):
     ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
 
 
-# TODO(alxmrs): What does the "2" dimension represent? Where is it in the config?
 def test_val__data_shape(val_loader_pair):
     cfg, loader = val_loader_pair
 
     exp = cfg.experiment
+    batch_size = cfg.batch_size
 
     input_var_dim = len(INPT_VARS[exp.exp_num_in]) + len(EXTRA_VARS[exp.exp_num_extra])
     output_var_dim = len(OUT_VARS[cfg.experiment.exp_num_out])
 
     for sample in loader:
         X, y = extract_sample_arrays(sample, 1)
-        assert X.shape == (1, 2, input_var_dim, 180, 360)
-        assert y.shape == (1, 2, output_var_dim, 180, 360)
+        assert X.shape == (1, batch_size, input_var_dim, 180, 360)
+        assert y.shape == (1, batch_size, output_var_dim, 180, 360)

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,7 +1,0 @@
-# TODO(#21): Replace with real project tests.
-import torch
-
-
-def test_placeholder(device):
-    """A placeholder test that should fail when run on GPU."""
-    assert device != torch.device("cuda:0")


### PR DESCRIPTION
This PR creates an in-memory dataset and test config to test the shape of training and validation data loaders. These tests abstract away the details of the data loader setup. Thus, the tests should work even if the codebase is refactored. 