### PR TITLE
Allow specifying which backend we want to use for tests and in config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,6 +168,8 @@ And to exclude all cuda-marked tests, run:
 pytest -m "not cuda"
 ```
 
+Note that for now you can't run both cuda and non-cuda tests together, see [#87](https://github.com/suryadheeshjith/Ocean_Emulator/issues/87).
+
 "manual" tests are not run in continuous integration (CI), but are useful checks during the development process. For
 example, evaluating if two model weights are equal is marked `manual`. All manual tests can be run like so:
 

--- a/configs/eval_cm4.yaml
+++ b/configs/eval_cm4.yaml
@@ -7,6 +7,7 @@ inference:
 ckpt_path: /this/path/does/not/exist # Fill in script
 num_model_steps_forward: 20
 record_every: 10
+backend: auto
 
 experiment:
   name: eval

--- a/configs/gantry_eval_cm4.yaml
+++ b/configs/gantry_eval_cm4.yaml
@@ -7,6 +7,7 @@ inference:
 ckpt_path: /ckpt.pt
 num_model_steps_forward: 20
 record_every: 10
+backend: auto
 
 experiment:
   name: eval

--- a/configs/gantry_train_cm4.yaml
+++ b/configs/gantry_train_cm4.yaml
@@ -37,14 +37,7 @@ inference:
 data_stride: [1]
 steps: [4]
 step_transition: []
-
-distributed:
-  enabled: true
-  dist_url: null
-  world_size: null
-  rank: null
-  gpu: null
-  dist_backend: null
+backend: auto
 
 experiment:
   name: train

--- a/configs/slurm_empireai_train_cm4.yaml
+++ b/configs/slurm_empireai_train_cm4.yaml
@@ -5,6 +5,7 @@ base_output_dir: train_3D
 debug: false
 gantry: false
 cluster_data_dir: /mnt/home/sd5313/data/
+backend: auto
 
 wandb:
   mode: online

--- a/configs/slurm_perlmutter_train_cm4.yaml
+++ b/configs/slurm_perlmutter_train_cm4.yaml
@@ -37,14 +37,7 @@ inference:
 data_stride: [1]
 steps: [4]
 step_transition: []
-
-distributed:
-  enabled: true
-  dist_url: null
-  world_size: null
-  rank: null
-  gpu: null
-  dist_backend: null
+backend: auto
 
 experiment:
   name: train

--- a/configs/train_cm4.test.yaml
+++ b/configs/train_cm4.test.yaml
@@ -25,7 +25,7 @@ inference:
 data_stride: [1]
 steps: [1]
 step_transition: []
-backend: cpu
+backend: auto
 
 experiment:
   name: train

--- a/configs/train_cm4.test.yaml
+++ b/configs/train_cm4.test.yaml
@@ -25,14 +25,7 @@ inference:
 data_stride: [1]
 steps: [1]
 step_transition: []
-
-distributed:
-  enabled: true
-  dist_url: null
-  world_size: null
-  rank: null
-  gpu: null
-  dist_backend: null
+backend: cpu
 
 experiment:
   name: train

--- a/configs/train_cm4.yaml
+++ b/configs/train_cm4.yaml
@@ -37,14 +37,7 @@ inference:
 data_stride: [1]
 steps: [4]
 step_transition: []
-
-distributed:
-  enabled: true
-  dist_url: null
-  world_size: null
-  rank: null
-  gpu: null
-  dist_backend: null
+backend: auto
 
 experiment:
   name: train

--- a/src/backend.py
+++ b/src/backend.py
@@ -1,0 +1,61 @@
+import logging
+
+import torch
+
+from config import DistributedConfig, EvalBackendConfig, TrainBackendConfig
+from utils.distributed import init_distributed_mode
+
+
+def init_train_backend(
+    backend: TrainBackendConfig,
+) -> tuple[torch.device, DistributedConfig | None]:
+    """Given backend config, get the device and (if any) distributed configuration."""
+    match backend:
+        case "cpu":
+            device = torch.device("cpu")
+            dist_cfg = None
+        case "cuda":
+            device = torch.device("cuda")
+            dist_cfg = None
+        case "nccl":
+            device = torch.device("cuda")
+            dist_cfg = init_distributed_mode()
+        case "auto" if torch.cuda.is_available():
+            logging.info("auto backend detected CUDA")
+            device = torch.device("cuda")
+            try:
+                dist_cfg = init_distributed_mode()
+                logging.info("succeeded in initializing distributed mode")
+            except RuntimeError as e:
+                logging.info(
+                    f"Failed to initialize distributed mode, running on single node.",
+                    exc_info=e,
+                )
+                dist_cfg = None
+        case "auto":
+            logging.info("auto backend: cuda not found, using CPU")
+            device = torch.device("cpu")
+            dist_cfg = None
+        case _:
+            raise ValueError(f"Invalid backend: {backend}")
+
+    return device, dist_cfg
+
+
+def init_eval_backend(backend: EvalBackendConfig) -> torch.device:
+    """Given evaluation backend config, get the device."""
+    match backend:
+        case "cpu":
+            device = torch.device("cpu")
+        case "cuda":
+            device = torch.device("cuda")
+        case "auto" if torch.cuda.is_available():
+            logging.info("auto backend detected CUDA")
+            device = torch.device("cuda")
+        case "auto":
+            logging.info("auto backend: cuda not found, using CPU")
+            device = torch.device("cpu")
+        case _:
+            raise ValueError(f"Invalid backend: {backend}")
+
+    return device

--- a/src/backend.py
+++ b/src/backend.py
@@ -40,6 +40,8 @@ def init_train_backend(
         case _:
             raise ValueError(f"Invalid backend: {backend}")
 
+    # We set this globally so we don't need to hand the device around.
+    # See https://github.com/suryadheeshjith/Ocean_Emulator/issues/87.
     set_device(device)
 
     return device, dist_cfg

--- a/src/backend.py
+++ b/src/backend.py
@@ -3,6 +3,7 @@ import logging
 import torch
 
 from config import DistributedConfig, EvalBackendConfig, TrainBackendConfig
+from utils.device import set_device
 from utils.distributed import init_distributed_mode
 
 
@@ -38,6 +39,8 @@ def init_train_backend(
             dist_cfg = None
         case _:
             raise ValueError(f"Invalid backend: {backend}")
+
+    set_device(device)
 
     return device, dist_cfg
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import yaml
 from dacite import Config as DaciteConfig
@@ -70,7 +70,6 @@ class UNetConfig:
 
 @dataclass
 class DistributedConfig:
-    enabled: bool = True
     dist_url: Optional[str] = None
     world_size: Optional[int] = None
     rank: Optional[int] = None
@@ -105,6 +104,10 @@ class ExperimentConfig:
             self.data_dir = Path(self.cluster_data_dir)
 
 
+# See backend.py for how these are turned into concrete devices
+TrainBackendConfig = Literal["cpu", "cuda", "nccl", "auto"]
+
+
 @dataclass
 class TrainConfig:
     # Training parameters
@@ -119,6 +122,7 @@ class TrainConfig:
     finetune: bool = False
     resume_ckpt_path: Optional[str] = None
     debug: bool = False
+    backend: TrainBackendConfig = "auto"
 
     # Data parameters at root level
     data_percent: float = 1.0
@@ -135,7 +139,6 @@ class TrainConfig:
     inference: List[TimeConfig] = field(default_factory=list)
 
     # Config components
-    distributed: DistributedConfig = field(default_factory=DistributedConfig)
     experiment: ExperimentConfig = field(default_factory=ExperimentConfig)
     data: DataConfig = field(default_factory=DataConfig)
     unet: UNetConfig = field(default_factory=UNetConfig)
@@ -172,6 +175,7 @@ class TrainConfig:
             "loss": self.loss,
             "finetune": self.finetune,
             "resume_ckpt_path": self.resume_ckpt_path,
+            "backend": self.backend,
             "data_percent": self.data_percent,
             "data_stride": self.data_stride,
             "steps": self.steps,
@@ -180,7 +184,6 @@ class TrainConfig:
             "train": self.train.__dict__,
             "val": self.val.__dict__,
             "inference": [t.__dict__ for t in self.inference],
-            "distributed": self.distributed.__dict__,
             "experiment": self.experiment.__dict__,
             "data": self.data.__dict__,
             "unet": {
@@ -194,6 +197,10 @@ class TrainConfig:
             yaml.dump(config_dict, f, default_flow_style=False)
 
 
+# See backend.py for how these are turned into concrete devices
+EvalBackendConfig = Literal["cpu", "cuda", "auto"]
+
+
 @dataclass
 class EvalConfig:
     # Basic parameters
@@ -203,6 +210,8 @@ class EvalConfig:
     ckpt_path: str = ""
     num_model_steps_forward: int = 200
     record_every: int = 10
+    backend: EvalBackendConfig = "auto"
+
     # Config components
     inference: TimeConfig = field(
         default_factory=lambda: TimeConfig("311-01-01", "351-01-01")

--- a/src/eval.py
+++ b/src/eval.py
@@ -8,11 +8,11 @@ import torch
 import xarray as xr
 
 from aggregator import Aggregator
+from backend import init_eval_backend
 from config import EvalConfig
 from constants import EXTRA_VARS, INPT_VARS, OUT_VARS, TensorMap, construct_metadata
 from datasets import InferenceDataset
 from models.unet import UNet
-from src.backend import init_eval_backend
 from stepper import Stepper
 from utils.data import (
     Normalize,

--- a/src/eval.py
+++ b/src/eval.py
@@ -20,7 +20,7 @@ from utils.data import (
     get_time_slice,
     spherical_area_weights,
 )
-from utils.device import get_device, using_gpu
+from utils.device import using_gpu
 from utils.distributed import is_main_process, set_seed
 from utils.logging import handle_logging, handle_warnings
 from utils.model import get_model_summary
@@ -32,7 +32,7 @@ class Eval:
         self.device = init_eval_backend(cfg.backend)
 
         # Adjust workers and memory pinning based on device
-        if self.device.type == "cpu":
+        if not using_gpu():
             cfg.data.num_workers = 0  # Disable multi-processing on CPU
         elif cfg.disk_mode:
             cfg.data.num_workers = torch.cuda.device_count() * cfg.data.num_workers

--- a/src/eval.py
+++ b/src/eval.py
@@ -12,6 +12,7 @@ from config import EvalConfig
 from constants import EXTRA_VARS, INPT_VARS, OUT_VARS, TensorMap, construct_metadata
 from datasets import InferenceDataset
 from models.unet import UNet
+from src.backend import init_eval_backend
 from stepper import Stepper
 from utils.data import (
     Normalize,
@@ -27,16 +28,14 @@ from utils.wandb import WandBLogger
 
 
 class Eval:
-    def __init__(self, cfg) -> None:
-        self.device = get_device()
+    def __init__(self, cfg: EvalConfig) -> None:
+        self.device = init_eval_backend(cfg.backend)
 
         # Adjust workers and memory pinning based on device
-        if not using_gpu():
+        if self.device.type == "cpu":
             cfg.data.num_workers = 0  # Disable multi-processing on CPU
-            cfg.pin_mem = False
         elif cfg.disk_mode:
             cfg.data.num_workers = torch.cuda.device_count() * cfg.data.num_workers
-            cfg.pin_mem = True
 
         # Set seeds
         set_seed(cfg.experiment.rand_seed)

--- a/src/stepper.py
+++ b/src/stepper.py
@@ -5,7 +5,7 @@ import torch
 
 from aggregator import InferenceEvaluatorAggregator
 from datasets import InferenceDataset, TrainData
-from src.models.base import BaseModel
+from models.base import BaseModel
 from utils.model import InfOutput, TrainOutput, ValOutput
 from utils.wandb import get_record_to_wandb
 from utils.writer import ZarrWriter

--- a/src/stepper.py
+++ b/src/stepper.py
@@ -6,6 +6,7 @@ import torch
 from aggregator import InferenceEvaluatorAggregator
 from datasets import InferenceDataset, TrainData
 from utils.device import using_gpu
+from src.models.base import BaseModel
 from utils.model import InfOutput, TrainOutput, ValOutput
 from utils.wandb import get_record_to_wandb
 from utils.writer import ZarrWriter
@@ -26,12 +27,20 @@ class Stepper:
     @staticmethod
     @torch.no_grad()
     def validate_step(
-        model: torch.nn.Module, batch: TrainData, loss_fn: Callable
+        model: BaseModel | torch.nn.parallel.DistributedDataParallel,
+        batch: TrainData,
+        loss_fn: Callable,
     ) -> ValOutput:
         assert len(batch) == 1  # Assert we are using one step of input and output
         input = batch.get_input(0)
         label = batch.get_label(0)
-        model = model.module if using_gpu() else model
+        # TODO(jder): we need the underlying model so we can use forward_once;
+        # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/51
+        model = (
+            model.module
+            if isinstance(model, torch.nn.parallel.DistributedDataParallel)
+            else model
+        )
         outs = model.forward_once(input)
         loss_per_channel = loss_fn(outs, label)
         loss = torch.mean(loss_per_channel)

--- a/src/stepper.py
+++ b/src/stepper.py
@@ -5,7 +5,6 @@ import torch
 
 from aggregator import InferenceEvaluatorAggregator
 from datasets import InferenceDataset, TrainData
-from utils.device import using_gpu
 from src.models.base import BaseModel
 from utils.model import InfOutput, TrainOutput, ValOutput
 from utils.wandb import get_record_to_wandb

--- a/src/train_3D.py
+++ b/src/train_3D.py
@@ -80,8 +80,9 @@ class Trainer:
         self.outputs = OUT_VARS[cfg.experiment.exp_num_out]
 
         # TODO: The codebase currently contains code that depends on this
-        assert self.inputs == self.outputs, "Input and output "
-        "variables must be the same"
+        assert (
+            self.inputs == self.outputs
+        ), "Input and output variables must be the same"
 
         levels = cfg.experiment.exp_num_in.split("_")[-1]
         if "all" in levels:
@@ -349,7 +350,7 @@ class Trainer:
             inference_datasets, num_steps_inf_set
         )
 
-        if using_gpu():
+        if self.distributed is not None:
             self.inference_sampler = DistributedSampler(
                 inference_data_combined, shuffle=True
             )
@@ -634,7 +635,7 @@ class Trainer:
 
         logging.info("Instantiating torch loaders")
 
-        if using_gpu():
+        if self.distributed is not None:
             self.train_sampler = DistributedSampler(train_data, shuffle=True)
             self.val_sampler = DistributedSampler(val_data, shuffle=False)
         else:

--- a/src/train_3D.py
+++ b/src/train_3D.py
@@ -27,11 +27,11 @@ from torch.utils.data import (
 )
 
 from aggregator import Aggregator, LossAggregator
+from backend import init_train_backend
 from config import TrainConfig
 from constants import EXTRA_VARS, INPT_VARS, OUT_VARS, TensorMap, construct_metadata
 from datasets import InferenceDataset, InferenceDatasets, TrainDataset
 from models.unet import UNet
-from src.backend import init_train_backend
 from stepper import Stepper, TrainOutput, ValOutput
 from utils.data import (
     Normalize,

--- a/src/train_3D.py
+++ b/src/train_3D.py
@@ -31,6 +31,7 @@ from config import TrainConfig
 from constants import EXTRA_VARS, INPT_VARS, OUT_VARS, TensorMap, construct_metadata
 from datasets import InferenceDataset, InferenceDatasets, TrainDataset
 from models.unet import UNet
+from src.backend import init_train_backend
 from stepper import Stepper, TrainOutput, ValOutput
 from utils.data import (
     Normalize,
@@ -38,14 +39,8 @@ from utils.data import (
     get_time_slice,
     spherical_area_weights,
 )
-from utils.device import get_device, using_gpu
-from utils.distributed import (
-    all_reduce_mean,
-    get_world_size,
-    init_distributed_mode,
-    is_main_process,
-    set_seed,
-)
+from utils.device import using_gpu
+from utils.distributed import all_reduce_mean, get_world_size, is_main_process, set_seed
 from utils.logging import MetricLogger, SmoothedValue, handle_logging, handle_warnings
 from utils.loss import (
     decomposed_mse,
@@ -60,12 +55,10 @@ from utils.wandb import WandBLogger
 
 
 class Trainer:
-    def __init__(self, cfg) -> None:
-        if not using_gpu():
-            logging.info("No GPU available, using CPU")
-            cfg.distributed.enabled = False
+    model: UNet | nn.parallel.DistributedDataParallel
 
-        self.device = get_device()
+    def __init__(self, cfg: TrainConfig) -> None:
+        self.device, self.distributed = init_train_backend(cfg.backend)
 
         # Adjust workers and memory pinning based on device
         if not using_gpu():
@@ -76,7 +69,6 @@ class Trainer:
             cfg.pin_mem = True
 
         # Distributed mode
-        init_distributed_mode(cfg.distributed)
         dask.config.set(scheduler="synchronous")
 
         # Set seeds
@@ -280,10 +272,10 @@ class Trainer:
             self.start_epoch = 1
 
         # Modify DDP setup based on device
-        if using_gpu():
-            self.model = nn.SyncBatchNorm.convert_sync_batchnorm(self.model)
+        if self.distributed is not None:
             self.model = nn.parallel.DistributedDataParallel(
-                self.model, device_ids=[cfg.distributed.gpu]
+                nn.SyncBatchNorm.convert_sync_batchnorm(self.model),
+                device_ids=[self.distributed.gpu],
             )
 
         # Training
@@ -541,7 +533,11 @@ class Trainer:
             )
 
             Stepper.inference(
-                model=self.model.module if using_gpu() else self.model,
+                # TODO(jder): we need the underlying model so we can use forward_once;
+                # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/51
+                model=self.model.module
+                if isinstance(self.model, torch.nn.parallel.DistributedDataParallel)
+                else self.model,
                 dataset=inference_dataset,
                 inf_aggregator=inf_aggregator,
                 epoch=epoch,
@@ -736,10 +732,7 @@ class Trainer:
             logging.info(f"Optimizer LR: {self.optimizer.param_groups[-1]['lr']}")
 
     def is_wandb_enabled(self):
-        if using_gpu():
-            return self.wandb_logger.enabled and is_main_process()
-        else:
-            return self.wandb_logger.enabled
+        return self.wandb_logger.enabled and is_main_process()
 
     def finish(self):
         self.wandb_logger.finish()

--- a/src/utils/device.py
+++ b/src/utils/device.py
@@ -1,11 +1,28 @@
 import torch
 
+_CHOSEN_DEVICE: torch.device | None = None
+
 
 def using_gpu() -> bool:
     return get_device().type == "cuda"
 
 
+# TODO(jder): We'd like to remove this (and other global singletons)
+# by moving to some training framework + context objects once we have
+# benchmarking set up.
+def set_device(device: torch.device) -> None:
+    _CHOSEN_DEVICE = device
+
+
 def get_device() -> torch.device:
+    """The primary device for inference.
+
+    We avoid setting this as torch.device so we can choose when
+    to shuttle tensors to the device.
+    """
+    if _CHOSEN_DEVICE is not None:
+        return _CHOSEN_DEVICE
+
     if torch.cuda.is_available():
         return torch.device("cuda")
     else:

--- a/src/utils/distributed.py
+++ b/src/utils/distributed.py
@@ -9,7 +9,7 @@ import torch
 import torch.backends.cudnn as cudnn
 import torch.distributed as dist
 
-from src.config import DistributedConfig
+from config import DistributedConfig
 
 
 def set_seed(seed):

--- a/src/utils/distributed.py
+++ b/src/utils/distributed.py
@@ -97,7 +97,8 @@ def init_distributed_mode() -> DistributedConfig:
             cfg.dist_url = "tcp://localhost:40000"
     else:
         raise RuntimeError(
-            "Distributed mode requires SLURM or RANK environment variables."
+            "Distributed mode requires SLURM or RANK environment variables;"
+            " did you mean to use `torchrun`?"
         )
 
     cfg.dist_backend = "nccl"

--- a/src/utils/distributed.py
+++ b/src/utils/distributed.py
@@ -9,6 +9,8 @@ import torch
 import torch.backends.cudnn as cudnn
 import torch.distributed as dist
 
+from src.config import DistributedConfig
+
 
 def set_seed(seed):
     np.random.seed(seed)
@@ -74,9 +76,8 @@ def is_main_process():
     return get_rank() == 0
 
 
-def init_distributed_mode(cfg):
-    if not cfg.enabled:
-        return
+def init_distributed_mode() -> DistributedConfig:
+    cfg = DistributedConfig()
 
     if "RANK" in os.environ:
         cfg.rank = int(os.environ["RANK"])
@@ -94,6 +95,10 @@ def init_distributed_mode(cfg):
             cfg.dist_url = "env://"
         else:
             cfg.dist_url = "tcp://localhost:40000"
+    else:
+        raise RuntimeError(
+            "Distributed mode requires SLURM or RANK environment variables."
+        )
 
     cfg.dist_backend = "nccl"
     torch.distributed.init_process_group(
@@ -110,6 +115,8 @@ def init_distributed_mode(cfg):
     torch.distributed.barrier()
     suppress_prints(cfg.rank == 0)
     suppress_logging(cfg.rank == 0)
+
+    return cfg
 
 
 def all_reduce_mean(x):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ import xarray as xr
 
 import constants as c
 from config import TrainConfig
+from src.config import TrainBackendConfig
 
 
 class DataSource(TypedDict):
@@ -46,12 +47,13 @@ def model2_path(request):
 
 
 # Run a test for both CPU and GPU, and allows selecting or skipping CUDA tests.
-# TODO(jder): At the moment, we can't use this because Trainer can only be
-# inited once per process. Once that is we should accept it in `train_config` below.
+# TODO(jder): Note that due to singletons, we can't use both cuda and non-cuda
+# tests in the same test run. You should run the tests separately.
+# See https://github.com/suryadheeshjith/Ocean_Emulator/issues/87
 @pytest.fixture(
     params=["cpu", pytest.param("cuda", marks=pytest.mark.cuda)], scope="session"
 )
-def backend(request):
+def backend(request) -> TrainBackendConfig:
     return request.param
 
 
@@ -161,10 +163,9 @@ def parse_encoded_float(encoded: np.float64) -> GridPoint:
     )
 
 
-# TODO(alxmrs): Consider yielding multiple test configs.
 @pytest.fixture(scope="session")
 def train_config(
-    data_source: DataSource, pytestconfig: pytest.Config
+    data_source: DataSource, pytestconfig: pytest.Config, backend: TrainBackendConfig
 ) -> Generator[TrainConfig, Any, None]:
     with tempfile.TemporaryDirectory() as tmpdir:
 
@@ -193,6 +194,7 @@ def train_config(
             trainer,
             data=data_config,
             experiment=experiment_config,
+            backend=backend,
         )
 
         # After contextmanager closes, all test data will be automatically cleaned up.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ from typing import Any, Generator, TypedDict
 
 import numpy as np
 import pytest
-import torch
 import xarray as xr
 
 import constants as c
@@ -47,9 +46,13 @@ def model2_path(request):
 
 
 # Run a test for both CPU and GPU, and allows selecting or skipping CUDA tests.
-@pytest.fixture(params=["cpu", pytest.param("cuda", marks=pytest.mark.cuda)])
-def device(request):
-    return torch.device(request.param)
+# TODO(jder): At the moment, we can't use this because Trainer can only be
+# inited once per process. Once that is we should accept it in `train_config` below.
+@pytest.fixture(
+    params=["cpu", pytest.param("cuda", marks=pytest.mark.cuda)], scope="session"
+)
+def backend(request):
+    return request.param
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,7 @@ import pytest
 import xarray as xr
 
 import constants as c
-from config import TrainConfig
-from src.config import TrainBackendConfig
+from config import TrainBackendConfig, TrainConfig
 
 
 class DataSource(TypedDict):


### PR DESCRIPTION
Code previously assumed if you had a GPU you wanted to have distributed = true and (AFAICT) have the right env vars set for that. This tries to let you pick if you want cpu, gpu, or distributed. (Or try to detect automatically.) 

This now lets us run tests on CPUs in CI. Next we'll set up GPU tests and run both.