### PR TITLE
fix benchmarks when run together

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from typing_extensions import Self
 
 import constants as c
 from config import TrainBackendConfig, TrainConfig
+from train_3D import Trainer
 
 
 @dataclasses.dataclass
@@ -300,3 +301,18 @@ def train_config(
 
         # After contextmanager closes, all test data will be automatically cleaned up.
         yield test_data_trainer
+
+
+TrainPair = tuple[TrainConfig, Trainer]
+
+
+# This micro-fixture is cached by pytest. Thus, we don't have to change
+# the factory methods that throw errors during double initialization.
+@pytest.fixture(scope="session")
+def trainer_pair(train_config: TrainConfig) -> TrainPair:
+    trainer = Trainer(train_config)
+
+    # cur_step will set the number of pairs in the input/output sample
+    trainer.init_data_loaders(cur_step=train_config.steps[0])
+
+    return train_config, trainer

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,7 +5,7 @@ import datetime
 import cftime
 import numpy as np
 import pytest
-from conftest import DataSourceDims
+from conftest import DataSourceDims, TrainPair
 from hypothesis import example, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
@@ -15,25 +15,11 @@ from torch.utils.data import DataLoader
 from config import TrainConfig
 from constants import EXTRA_VARS, INPT_VARS, OUT_VARS
 from datasets import TrainData
-from train_3D import Trainer
 
 # Note: Refactoring data loaders is planned for the near-term. Ideally,
 # these fixtures allow us to isolate data loader tests from their setup.
 
-TrainPair = tuple[TrainConfig, Trainer]
 LoaderPair = tuple[TrainConfig, DataLoader]
-
-
-# This micro-fixture is cached by pytest. Thus, we don't have to change
-# the factory methods that throw errors during double initialization.
-@pytest.fixture(scope="session")
-def trainer_pair(train_config: TrainConfig) -> TrainPair:
-    trainer = Trainer(train_config)
-
-    # cur_step will set the number of pairs in the input/output sample
-    trainer.init_data_loaders(cur_step=train_config.steps[0])
-
-    return train_config, trainer
 
 
 @pytest.fixture

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,15 +1,13 @@
 import logging
 
 import pytest
-
-from config import TrainConfig
-from train_3D import Trainer
+from test_datasets import TrainPair
 
 
 @pytest.mark.manual
-def test_trainer__mini_benchmark(train_config: TrainConfig, caplog, benchmark):
+def test_trainer__mini_benchmark(trainer_pair: TrainPair, caplog, benchmark):
     caplog.set_level(logging.INFO)
-    trainer = Trainer(train_config)
+    _, trainer = trainer_pair
 
     @benchmark
     def run():


### PR DESCRIPTION
Sorry, I clearly [did not test](https://github.com/suryadheeshjith/Ocean_Emulator/actions/runs/13708924698/job/38341018074) the benchmarks well enough when run together with the new trainer benchmark. 

Today we can't create more than one trainer in a process. It's on my plate to fix (https://github.com/suryadheeshjith/Ocean_Emulator/issues/87) but in the meantime let's unbreak the benchmark by re-using the existing trainer.