### PR TITLE
uv script to prototype Zarr opening + update to Zarr cloning script.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
   "pytest-benchmark[histogram]>=5.1",
   "pytest-profiling>=1.8.1",
   "snakeviz>=2.2.2",
+  "tenacity>=9",
   "types-pyyaml>=6.0.12.20241230",
 ]
 

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -9,6 +9,7 @@
 #   "aiohttp",
 #   "gcsfs",
 #   "numcodecs>=0.15",
+#   "tenacity",
 # ]
 # ///
 
@@ -19,17 +20,14 @@ import pathlib
 import dask
 import dask.diagnostics
 import xarray as xr
-from xarray.backends.common import robust_getitem
+from tenacity import retry
 
 DATA_ROOT = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
 
 
-class DatasetOpener:
-    def __init__(self, **kwargs):
-        self.kwargs = kwargs
-
-    def __getitem__(self, target):
-        return xr.open_dataset(target, **self.kwargs)
+@retry
+def robust_open_dataset(target: str, **kwargs) -> xr.Dataset:
+    return xr.open_dataset(target, **kwargs)
 
 
 def main(dest_root: str, time_slice: slice, write_time_chunks: int) -> None:
@@ -39,9 +37,6 @@ def main(dest_root: str, time_slice: slice, write_time_chunks: int) -> None:
         pathlib.Path(dest_root).mkdir(parents=True, exist_ok=True)
 
     output_chunks = dict(time=write_time_chunks)
-
-    chunked_opener = DatasetOpener(engine="zarr", chunks={"time": 700})
-    zarr_opener = DatasetOpener(engine="zarr", chunks={})
 
     for name, dest_fmt in [
         ("OM4", "zarr"),
@@ -53,10 +48,10 @@ def main(dest_root: str, time_slice: slice, write_time_chunks: int) -> None:
 
         # Open Xarray Datasets with retries + exponential backoff.
         if name == "OM4":
-            data = robust_getitem(chunked_opener, source)
+            data = robust_open_dataset(source, engine="zarr", chunks={"time": 700})
             data = data.isel(time=time_slice)
         else:
-            data = robust_getitem(zarr_opener, source)
+            data = robust_open_dataset(source, engine="zarr", chunks={})
 
         with dask.diagnostics.ProgressBar():
             if dest_fmt.lower() == "zarr":

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -3,7 +3,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #   "xarray[io]",
-#   "zarr>=3",
+#   "zarr<3",
 #   "dask",
 #   "requests",
 #   "aiohttp",
@@ -15,22 +15,33 @@
 import argparse
 import os
 import pathlib
-from typing import Any
 
 import dask
 import dask.diagnostics
-import numcodecs
-import numcodecs.zarr3
 import xarray as xr
+from xarray.backends.common import robust_getitem
 
 DATA_ROOT = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
 
 
-def main(dest_root: str, time_slice: slice, upgrade_zarr: bool = False) -> None:
+class DatasetOpener:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __getitem__(self, target):
+        return xr.open_dataset(target, **self.kwargs)
+
+
+def main(dest_root: str, time_slice: slice, write_time_chunks: int) -> None:
     """Clones slice of Samudra data at the `dest_root` directory."""
     # Ensure the path/to/dest exists
     if not dest_root.startswith("gs://"):
         pathlib.Path(dest_root).mkdir(parents=True, exist_ok=True)
+
+    output_chunks = dict(time=write_time_chunks)
+
+    chunked_opener = DatasetOpener(engine="zarr", chunks={"time": 700})
+    zarr_opener = DatasetOpener(engine="zarr", chunks={})
 
     for name, dest_fmt in [
         ("OM4", "zarr"),
@@ -40,27 +51,16 @@ def main(dest_root: str, time_slice: slice, upgrade_zarr: bool = False) -> None:
         dest = os.path.join(dest_root, name)
         target = DATA_ROOT + name
 
+        # Open Xarray Datasets with retries + exponential backoff.
         if name == "OM4":
-            data = xr.open_dataset(target, engine="zarr", chunks={"time": 700})
+            data = robust_getitem(chunked_opener, target)
             data = data.isel(time=time_slice)
         else:
-            data = xr.open_dataset(target, engine="zarr", chunks={})
-
-        kwargs: dict[str, Any] = {}
-        if upgrade_zarr:
-            kwargs["zarr_format"] = 3
-            # Bug in Zarr v3 Codecs; using a workaround:
-            # https://github.com/pydata/xarray/issues/9987#issuecomment-2631471771
-            kwargs["encoding"] = {
-                v: {"compressors": [numcodecs.zarr3.Blosc()]}
-                for v in data.data_vars.keys()
-            }
+            data = robust_getitem(zarr_opener, target)
 
         with dask.diagnostics.ProgressBar():
             if dest_fmt.lower() == "zarr":
-                data.chunk(dict(time=1)).to_zarr(
-                    dest + ".zarr", consolidated=False, **kwargs
-                )
+                data.chunk(output_chunks).to_zarr(dest + ".zarr")
             else:
                 data.to_netcdf(dest + ".nc")
 
@@ -82,8 +82,8 @@ if __name__ == "__main__":
         default=None,
         help="end index for data.isel() along time dimension.",
     )
-    parser.add_argument("--migrate_to_zarr_v3", action="store_true")
+    parser.add_argument("--write_time_chunks", type=int, default=1)
     args = parser.parse_args()
 
     time_range = slice(args.time_start, args.time_end)
-    main(args.dest, time_slice=time_range, upgrade_zarr=args.migrate_to_zarr_v3)
+    main(args.dest, time_slice=time_range, write_time_chunks=args.write_time_chunks)

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -1,35 +1,43 @@
 """Script to clone remote Samudra data locally."""
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #   "xarray[io]",
+#   "zarr>=3",
 #   "dask",
 #   "requests",
 #   "aiohttp",
+#   "gcsfs",
+#   "numcodecs>=0.15",
 # ]
 # ///
 
 import argparse
+import os
 import pathlib
+from typing import Any
 
 import dask
 import dask.diagnostics
+import numcodecs
+import numcodecs.zarr3
 import xarray as xr
 
 DATA_ROOT = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
 
 
-def main(dest_root: pathlib.Path, time_slice: slice) -> None:
+def main(dest_root: str, time_slice: slice, upgrade_zarr: bool = False) -> None:
     """Clones slice of Samudra data at the `dest_root` directory."""
     # Ensure the path/to/dest exists
-    dest_root.mkdir(parents=True, exist_ok=True)
+    if not dest_root.startswith("gs://"):
+        pathlib.Path(dest_root).mkdir(parents=True, exist_ok=True)
 
     for name, dest_fmt in [
         ("OM4", "zarr"),
         ("OM4_means", "netcdf"),
         ("OM4_stds", "netcdf"),
     ]:
-        dest = dest_root / name
+        dest = os.path.join(dest_root, name)
         target = DATA_ROOT + name
 
         if name == "OM4":
@@ -38,20 +46,30 @@ def main(dest_root: pathlib.Path, time_slice: slice) -> None:
         else:
             data = xr.open_dataset(target, engine="zarr", chunks={})
 
+        kwargs: dict[str, Any] = {}
+        if upgrade_zarr:
+            kwargs["zarr_format"] = 3
+            # Bug in Zarr v3 Codecs; using a workaround:
+            # https://github.com/pydata/xarray/issues/9987#issuecomment-2631471771
+            kwargs["encoding"] = {
+                v: {"compressors": [numcodecs.zarr3.Blosc()]}
+                for v in data.data_vars.keys()
+            }
+
         with dask.diagnostics.ProgressBar():
             if dest_fmt.lower() == "zarr":
-                data.chunk(dict(time=1)).to_zarr(str(dest) + ".zarr")
+                data.chunk(dict(time=1)).to_zarr(
+                    dest + ".zarr", consolidated=False, **kwargs
+                )
             else:
-                data.to_netcdf(str(dest) + ".nc")
+                data.to_netcdf(dest + ".nc")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        "clone_data", description="Make a local copy of the Samudra dataset (~70 GiBs)."
+        "clone_data", description="Make a copy of the Samudra dataset (~70 GiBs)."
     )
-    parser.add_argument(
-        "dest", type=pathlib.Path, help="Root directory for local copy of datasets."
-    )
+    parser.add_argument("dest", type=str, help="Root directory for copy of datasets.")
     parser.add_argument(
         "--time_start",
         type=int,
@@ -64,7 +82,8 @@ if __name__ == "__main__":
         default=None,
         help="end index for data.isel() along time dimension.",
     )
+    parser.add_argument("--migrate_to_zarr_v3", action="store_true")
     args = parser.parse_args()
 
     time_range = slice(args.time_start, args.time_end)
-    main(args.dest, time_slice=time_range)
+    main(args.dest, time_slice=time_range, upgrade_zarr=args.migrate_to_zarr_v3)

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -49,14 +49,14 @@ def main(dest_root: str, time_slice: slice, write_time_chunks: int) -> None:
         ("OM4_stds", "netcdf"),
     ]:
         dest = os.path.join(dest_root, name)
-        target = DATA_ROOT + name
+        source = DATA_ROOT + name
 
         # Open Xarray Datasets with retries + exponential backoff.
         if name == "OM4":
-            data = robust_getitem(chunked_opener, target)
+            data = robust_getitem(chunked_opener, source)
             data = data.isel(time=time_slice)
         else:
-            data = robust_getitem(zarr_opener, target)
+            data = robust_getitem(zarr_opener, source)
 
         with dask.diagnostics.ProgressBar():
             if dest_fmt.lower() == "zarr":

--- a/scripts/open_zarr_tuning.py
+++ b/scripts/open_zarr_tuning.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #   "xarray[io]",
-#   "zarr>=3",   # Zarr v2 --> change to `zarr<3`; Zarr v3 --> change to `zarr>=3`.
+#   "zarr<3",   # Zarr v2 --> change to `zarr<3`; Zarr v3 --> change to `zarr>=3`.
 #   "dask",
 #   "requests",
 #   "aiohttp",
@@ -27,7 +27,7 @@ import time
 from typing import Any
 
 import xarray as xr
-import zarr
+import zarr  # type: ignore
 
 REMOTE_DATA = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/OM4"
 
@@ -42,8 +42,8 @@ def main(args: argparse.Namespace) -> float:
 
     write_kwargs: dict[str, Any] = dict(consolidated=False)
     if zarr.__version__.startswith("3"):
-        import numcodecs
-        import numcodecs.zarr3
+        import numcodecs  # type: ignore
+        import numcodecs.zarr3  # type: ignore
 
         # Bug in Zarr v3 Codecs; using a workaround:
         # https://github.com/pydata/xarray/issues/9987#issuecomment-2631471771

--- a/scripts/open_zarr_tuning.py
+++ b/scripts/open_zarr_tuning.py
@@ -1,0 +1,95 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "xarray[io]",
+#   "zarr>=3",   # Zarr v2 --> change to `zarr<3`; Zarr v3 --> change to `zarr>=3`.
+#   "dask",
+#   "requests",
+#   "aiohttp",
+#   "numcodecs>=0.15",
+# ]
+# ///
+"""Experimenting with optimal ways to open the OM4 Zarr.
+
+Using techniques from this blog post:
+- https://earthmover.io/blog/xarray-open-zarr-improvements
+
+How to run experiments:
+- Change the Zarr version (above) to compare ZarrV2 vs ZarrV3.
+- Configure: `uv run scripts/open_zarr_tuning.py --help`
+"""
+
+import argparse
+import pathlib
+import sys
+import tempfile
+import time
+from typing import Any
+
+import xarray as xr
+import zarr
+
+REMOTE_DATA = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/OM4"
+
+
+def main(args: argparse.Namespace) -> float:
+    """Calculates elapsed time to open Zarr target over several iterations."""
+    target = args.target or REMOTE_DATA
+
+    chunks = {}
+    if tc := args.time_chunks:
+        chunks["time"] = tc
+
+    write_kwargs: dict[str, Any] = dict(consolidated=False)
+    if zarr.__version__.startswith("3"):
+        import numcodecs
+        import numcodecs.zarr3
+
+        # Bug in Zarr v3 Codecs; using a workaround:
+        # https://github.com/pydata/xarray/issues/9987#issuecomment-2631471771
+        write_kwargs["encoding"] = {"zos": {"compressors": [numcodecs.zarr3.Blosc()]}}
+
+    start_time = time.perf_counter()
+    for _ in range(args.n_iters):
+        # Zarr v3 has a runtime config contextmanager.
+        if zc := args.zarr_concurrency:
+            with zarr.config.set({"async.concurrency": zc}):
+                ds = xr.open_zarr(target, chunks=chunks, consolidated=True)
+        # Zarr v2 does not.
+        else:
+            ds = xr.open_zarr(target, chunks=chunks, consolidated=True)
+
+        if args.write_test_data:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                ds.zos.isel(time=slice(0, 1024)).to_zarr(
+                    tmpdir + "OM4.zarr", **write_kwargs
+                )
+    end_time = time.perf_counter()
+
+    return end_time - start_time
+
+
+def Target(candidate: str) -> pathlib.Path | str:
+    """Target can either be a local file or a remote URL."""
+    if "://" in candidate:
+        return candidate
+    return pathlib.Path(candidate)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Experiments to tune OpenZarr")
+    parser.add_argument("--target", type=Target, default=None)
+    parser.add_argument("--n_iters", type=int, default=8)
+    parser.add_argument(
+        "--zarr_concurrency",
+        type=int,
+        default=getattr(zarr, "config", {}).get("async.concurrency"),
+    )
+    parser.add_argument("--time_chunks", type=int, default=None)
+    parser.add_argument("--write_test_data", action="store_true")
+    args = parser.parse_args()
+
+    print(sys.version)
+    print(f"zarr-version={zarr.__version__},xarray-version={xr.__version__}")
+    elapsed = main(args)
+    print(f"ELAPSED: {elapsed:.4f}s. Config: {args}")

--- a/scripts/open_zarr_tuning.py
+++ b/scripts/open_zarr_tuning.py
@@ -33,8 +33,8 @@ REMOTE_DATA = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/OM4"
 
 
 def main(args: argparse.Namespace) -> float:
-    """Calculates elapsed time to open Zarr target over several iterations."""
-    target = args.target or REMOTE_DATA
+    """Calculates elapsed time to open Zarr source over several iterations."""
+    source = args.source or REMOTE_DATA
 
     chunks = {}
     if tc := args.time_chunks:
@@ -54,10 +54,10 @@ def main(args: argparse.Namespace) -> float:
         # Zarr v3 has a runtime config contextmanager.
         if zc := args.zarr_concurrency:
             with zarr.config.set({"async.concurrency": zc}):
-                ds = xr.open_zarr(target, chunks=chunks, consolidated=True)
+                ds = xr.open_zarr(source, chunks=chunks, consolidated=True)
         # Zarr v2 does not.
         else:
-            ds = xr.open_zarr(target, chunks=chunks, consolidated=True)
+            ds = xr.open_zarr(source, chunks=chunks, consolidated=True)
 
         if args.write_test_data:
             with tempfile.TemporaryDirectory() as tmpdir:
@@ -69,8 +69,8 @@ def main(args: argparse.Namespace) -> float:
     return end_time - start_time
 
 
-def Target(candidate: str) -> pathlib.Path | str:
-    """Target can either be a local file or a remote URL."""
+def Source(candidate: str) -> pathlib.Path | str:
+    """Data Source can either be a local file or a remote URL."""
     if "://" in candidate:
         return candidate
     return pathlib.Path(candidate)
@@ -78,7 +78,7 @@ def Target(candidate: str) -> pathlib.Path | str:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Experiments to tune OpenZarr")
-    parser.add_argument("--target", type=Target, default=None)
+    parser.add_argument("--source", type=Source, default=None)
     parser.add_argument("--n_iters", type=int, default=8)
     parser.add_argument(
         "--zarr_concurrency",

--- a/uv.lock
+++ b/uv.lock
@@ -1023,46 +1023,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/bc/f6339726c627bd7ca1ce0fa56c9ae2d0144604a319e0e339bdadafbbb599/mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f", size = 10662338 },
-    { url = "https://files.pythonhosted.org/packages/e2/90/8dcf506ca1a09b0d17555cc00cd69aee402c203911410136cd716559efe7/mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5", size = 9787540 },
-    { url = "https://files.pythonhosted.org/packages/05/05/a10f9479681e5da09ef2f9426f650d7b550d4bafbef683b69aad1ba87457/mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e", size = 11538051 },
-    { url = "https://files.pythonhosted.org/packages/e9/9a/1f7d18b30edd57441a6411fcbc0c6869448d1a4bacbaee60656ac0fc29c8/mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c", size = 12286751 },
-    { url = "https://files.pythonhosted.org/packages/72/af/19ff499b6f1dafcaf56f9881f7a965ac2f474f69f6f618b5175b044299f5/mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f", size = 12421783 },
-    { url = "https://files.pythonhosted.org/packages/96/39/11b57431a1f686c1aed54bf794870efe0f6aeca11aca281a0bd87a5ad42c/mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f", size = 9265618 },
-    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981 },
-    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175 },
-    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675 },
-    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020 },
-    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582 },
-    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614 },
-    { url = "https://files.pythonhosted.org/packages/6a/9b/fd2e05d6ffff24d912f150b87db9e364fa8282045c875654ce7e32fffa66/mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445", size = 10788592 },
-    { url = "https://files.pythonhosted.org/packages/74/37/b246d711c28a03ead1fd906bbc7106659aed7c089d55fe40dd58db812628/mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d", size = 9753611 },
-    { url = "https://files.pythonhosted.org/packages/a6/ac/395808a92e10cfdac8003c3de9a2ab6dc7cde6c0d2a4df3df1b815ffd067/mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5", size = 11438443 },
-    { url = "https://files.pythonhosted.org/packages/d2/8b/801aa06445d2de3895f59e476f38f3f8d610ef5d6908245f07d002676cbf/mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036", size = 12402541 },
-    { url = "https://files.pythonhosted.org/packages/c7/67/5a4268782eb77344cc613a4cf23540928e41f018a9a1ec4c6882baf20ab8/mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357", size = 12494348 },
-    { url = "https://files.pythonhosted.org/packages/83/3e/57bb447f7bbbfaabf1712d96f9df142624a386d98fb026a761532526057e/mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf", size = 9373648 },
-    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
-]
-
-[[package]]
 name = "multidict"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1114,6 +1074,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/38/e0/4f5855037a72cd8a7a2f60a3952d9aa45feedb37ae7831642102604e8a37/multidict-6.1.0-cp313-cp313-win32.whl", hash = "sha256:3a37ffb35399029b45c6cc33640a92bef403c9fd388acce75cdc88f58bd19a81", size = 26426 },
     { url = "https://files.pythonhosted.org/packages/7e/a5/17ee3a4db1e310b7405f5d25834460073a8ccd86198ce044dfaf69eac073/multidict-6.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:e9aa71e15d9d9beaad2c6b9319edcdc0a49a43ef5c0a4c8265ca9ee7d6c67774", size = 28531 },
     { url = "https://files.pythonhosted.org/packages/99/b7/b9e70fde2c0f0c9af4cc5277782a89b66d35948ea3369ec9f598358c3ac5/multidict-6.1.0-py3-none-any.whl", hash = "sha256:48e171e52d1c4d33888e529b999e5900356b9ae588c2f09a52dcefb158b27506", size = 10051 },
+]
+
+[[package]]
+name = "mypy"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/bc/f6339726c627bd7ca1ce0fa56c9ae2d0144604a319e0e339bdadafbbb599/mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f", size = 10662338 },
+    { url = "https://files.pythonhosted.org/packages/e2/90/8dcf506ca1a09b0d17555cc00cd69aee402c203911410136cd716559efe7/mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5", size = 9787540 },
+    { url = "https://files.pythonhosted.org/packages/05/05/a10f9479681e5da09ef2f9426f650d7b550d4bafbef683b69aad1ba87457/mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e", size = 11538051 },
+    { url = "https://files.pythonhosted.org/packages/e9/9a/1f7d18b30edd57441a6411fcbc0c6869448d1a4bacbaee60656ac0fc29c8/mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c", size = 12286751 },
+    { url = "https://files.pythonhosted.org/packages/72/af/19ff499b6f1dafcaf56f9881f7a965ac2f474f69f6f618b5175b044299f5/mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f", size = 12421783 },
+    { url = "https://files.pythonhosted.org/packages/96/39/11b57431a1f686c1aed54bf794870efe0f6aeca11aca281a0bd87a5ad42c/mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f", size = 9265618 },
+    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981 },
+    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175 },
+    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675 },
+    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020 },
+    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582 },
+    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614 },
+    { url = "https://files.pythonhosted.org/packages/6a/9b/fd2e05d6ffff24d912f150b87db9e364fa8282045c875654ce7e32fffa66/mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445", size = 10788592 },
+    { url = "https://files.pythonhosted.org/packages/74/37/b246d711c28a03ead1fd906bbc7106659aed7c089d55fe40dd58db812628/mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d", size = 9753611 },
+    { url = "https://files.pythonhosted.org/packages/a6/ac/395808a92e10cfdac8003c3de9a2ab6dc7cde6c0d2a4df3df1b815ffd067/mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5", size = 11438443 },
+    { url = "https://files.pythonhosted.org/packages/d2/8b/801aa06445d2de3895f59e476f38f3f8d610ef5d6908245f07d002676cbf/mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036", size = 12402541 },
+    { url = "https://files.pythonhosted.org/packages/c7/67/5a4268782eb77344cc613a4cf23540928e41f018a9a1ec4c6882baf20ab8/mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357", size = 12494348 },
+    { url = "https://files.pythonhosted.org/packages/83/3e/57bb447f7bbbfaabf1712d96f9df142624a386d98fb026a761532526057e/mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf", size = 9373648 },
+    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
 ]
 
 [[package]]
@@ -1350,6 +1350,7 @@ dev = [
     { name = "pytest-benchmark", extra = ["histogram"] },
     { name = "pytest-profiling" },
     { name = "snakeviz" },
+    { name = "tenacity" },
     { name = "types-pyyaml" },
 ]
 
@@ -1369,7 +1370,7 @@ requires-dist = [
     { name = "torchinfo", specifier = ">=1.8" },
     { name = "wandb", specifier = ">=0.19.8" },
     { name = "xarray", extras = ["io"], specifier = ">=2025.1.2" },
-    { name = "xarray-einstats", extras = ["einops"], specifier = ">=0.8.0" },
+    { name = "xarray-einstats", extras = ["einops"], specifier = ">=0.8" },
     { name = "zarr", specifier = "<3" },
 ]
 
@@ -1383,6 +1384,7 @@ dev = [
     { name = "pytest-benchmark", extras = ["histogram"], specifier = ">=5.1" },
     { name = "pytest-profiling", specifier = ">=1.8.1" },
     { name = "snakeviz", specifier = ">=2.2.2" },
+    { name = "tenacity", specifier = ">=9.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20241230" },
 ]
 
@@ -2176,6 +2178,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/11/8a/5a7fd6284fa8caac23a26c9ddf9c30485a48169344b4bd3b0f02fef1890f/sympy-1.13.3.tar.gz", hash = "sha256:b27fd2c6530e0ab39e275fc9b683895367e51d5da91baa8d3d64db2565fec4d9", size = 7533196 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/ff/c87e0622b1dadea79d2fb0b25ade9ed98954c9033722eb707053d310d4f3/sympy-1.13.3-py3-none-any.whl", hash = "sha256:54612cf55a62755ee71824ce692986f23c88ffa77207b30c1368eda4a7060f73", size = 6189483 },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b", size = 47421 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539", size = 28169 },
 ]
 
 [[package]]


### PR DESCRIPTION
# Experiments

So far, it looks like we _should_ be using Zarr v2 + time_chunks=700, as this is the fastest way to open this particular dataset!

## Opening Remote OM4 data
```
# Zarr v2 (I think this uses consolidated=True by default!)
uv run scripts/open_zarr_tuning.py                        
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=2.18.4,xarray-version=2025.1.2
ELAPSED: 7.5452s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=None, time_chunks=None)

# Zarr v2 + time=10
uv run scripts/open_zarr_tuning.py --time_chunks=10
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=2.18.4,xarray-version=2025.1.2
ELAPSED: 7.1839s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=None, time_chunks=10)

# Zarr v2 + time=100
uv run scripts/open_zarr_tuning.py --time_chunks=100
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=2.18.4,xarray-version=2025.1.2
ELAPSED: 7.1952s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=None, time_chunks=100)

# Zarr v2 + time=700
uv run scripts/open_zarr_tuning.py --time_chunks=700
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=2.18.4,xarray-version=2025.1.2
ELAPSED: 7.0575s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=None, time_chunks=700)



# Zarr v3 (defaults)
uv run scripts/open_zarr_tuning.py 
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=3.0.5,xarray-version=2025.1.2
ELAPSED: 11.2039s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=10, time_chunks=None)

# Zarr v3 + manually setting `consolidated=True`
 uv run scripts/open_zarr_tuning.py 
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=3.0.5,xarray-version=2025.1.2
ELAPSED: 11.2342s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=10, time_chunks=None)

# Zarr v3 + concurrency=50
uv run scripts/open_zarr_tuning.py --zarr_concurrency=50
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=3.0.5,xarray-version=2025.1.2
ELAPSED: 10.9889s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=50, time_chunks=None)

# Zarr v3 + concurrency=100
uv run scripts/open_zarr_tuning.py --zarr_concurrency=100
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=3.0.5,xarray-version=2025.1.2
ELAPSED: 11.0583s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=100, time_chunks=None)

# Zarr v3 + time=10
uv run scripts/open_zarr_tuning.py --time_chunks=10   
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=3.0.5,xarray-version=2025.1.2
ELAPSED: 10.9641s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=10, time_chunks=10)

# Zarr v3 + time=100
uv run scripts/open_zarr_tuning.py --time_chunks=100
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=3.0.5,xarray-version=2025.1.2
ELAPSED: 10.7012s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=10, time_chunks=100)

# Zarr v3 + time=700
uv run scripts/open_zarr_tuning.py --time_chunks=700
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=3.0.5,xarray-version=2025.1.2
ELAPSED: 10.7541s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=10, time_chunks=700)

# Zarr v3 + time=700 + concurrency=100
uv run scripts/open_zarr_tuning.py --time_chunks=700 --zarr_concurrency=100
3.11.11 (main, Jan 14 2025, 23:36:41) [Clang 19.1.6 ]
zarr-version=3.0.5,xarray-version=2025.1.2
ELAPSED: 10.7544s. Config: Namespace(target=None, n_iters=8, zarr_concurrency=100, time_chunks=700)
```

**TBD: Opening locally cloned OM4 data...**