### PR TITLE
Rework round-tripping/interpretable data with bit fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 dev = [
   "beartype>=0.20",
   "hypothesis[numpy]>=6.127.2",
+  "ipykernel>=6.29.5",
   "pytest>=8.3.4",
   "pytest-benchmark[histogram]>=5.1",
   "pytest-profiling>=1.8.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,17 +28,24 @@ def _trunc(arr: NDArray[np.floating], decimals: int) -> NDArray[np.floating]:
     return np.trunc(arr * factor) / factor
 
 
+HEADER_BIT_OFFSET = 56
+LAT_BIT_OFFSET = 40
+LNG_BIT_OFFSET = 24
+DAYS_BIT_OFFSET = 8
+VAR_BIT_OFFSET = 0
+
+
 @dataclasses.dataclass
 class DataSourceDims:
     """Dimension metadata to produce interpretable `xarray.DataArray`s.
 
-    Each float in the encoded `xarray.DataArray` has the following scheme:
-    (s)AAAAGGGG.TTTDDD
-    - s := Sign (+/-) of the Latitude. All other values are non-negative.
-    - A := Latitude, which ranges from 90.00 <--> -90.00 (only decimals=2).
-    - G := Longitude, which ranges from 000.0 <--> 360.0 (only decimals=1).
-    - T := Time, the number of days since the start time.
-    - D := A int representing the index of the current data variable.
+    Each float in the encoded `xarray.DataArray` is interpreted as a uint64 broken
+    into the following fields, MSB first:
+      * 8 bits fixed as 0100 0000 (a non-NaN exponent)
+      * lat encoded as a float16
+      * lng encoded as a float16
+      * days_since_start encoded as a uint16
+      * data_var_index encoded as a uint8
     """
 
     lat: NDArray[np.float64] = dataclasses.field(
@@ -47,41 +54,32 @@ class DataSourceDims:
     lng: NDArray[np.float64] = dataclasses.field(
         default_factory=lambda: np.arange(0.5, 360, 1, dtype=np.float64)
     )
-    days_since_start: NDArray[np.int32] = dataclasses.field(
-        default_factory=lambda: np.array([0, 5, 10])
+    days_since_start: NDArray[np.uint32] = dataclasses.field(
+        default_factory=lambda: np.array([0, 5, 10], dtype=np.uint32)
     )
     start_day: cftime.datetime = cftime.DatetimeNoLeap.strptime(
         "1969-08-05", "%Y-%m-%d", "noleap"
     )
 
     def __post_init__(self):
-        # In Python, modulus operations preserve the sign _based on the denominator_.
-        # So, to ensure that we can have negative latitudes, we parse the sign value
-        # of the lat array.
-        lat_sgn = np.sign(self.lat)
-        lat_sgn = np.where(lat_sgn == 0, 1, lat_sgn)  # change np.sign(0) to +1, not 0.
-        self.lat = _trunc(self.lat.astype(np.float64), 2)
         if np.any(self.lat < -90.0) or np.any(self.lat > 90.0):
-            raise ValueError("lat values must be between -90 and 90.")
-        self.lat %= lat_sgn * 100
+            raise ValueError("lat values are expected to be between -90 and 90.")
 
-        # All other values in the encoding must be non-negative.
-        self.lng = _trunc(self.lng.astype(np.float64), 1)
         if np.any(self.lng < 0.0) or np.any(self.lng > 360.0):
-            raise ValueError("lng values must be between 0 and 360 degrees.")
-        self.lng %= 1000
+            raise ValueError("lng values are expected to be between 0 and 360 degrees.")
 
-        self.days_since_start = self.days_since_start.astype(np.int32)
-        if np.any(self.days_since_start < 0) or np.any(self.days_since_start > 999):
-            raise ValueError("days_since_start must be between 0 and 999.")
+        if np.any(self.days_since_start < 0) or np.any(
+            self.days_since_start > np.iinfo(np.uint16).max
+        ):
+            raise ValueError("days_since_start values must fit in a uint16.")
 
     def __eq__(self, other) -> bool:
         # lat and lng values will often have floating point rounding errors.
         # So, we declare arrays as equal within a generous tolerance.
         # We can use exact equality with days_since_start since they are ints.
         return (
-            np.allclose(self.lat, other.lat, atol=0.1)
-            and np.allclose(self.lng, other.lng, atol=0.01)
+            np.allclose(self.lat, other.lat, atol=1e-4)
+            and np.allclose(self.lng, other.lng, atol=1e-4)
             and np.array_equal(self.days_since_start, other.days_since_start)
             and self.start_day == other.start_day
         )
@@ -112,40 +110,39 @@ class DataSourceDims:
         }
         return coords
 
-    def encode(self, data_var_index: int = 0) -> xr.DataArray:
+    def encode(self, data_var_index: np.uint8 = 0) -> xr.DataArray:
         """Encodes source data dimensions into an array of interpretable `np.float64`s.
 
         Arguments:
-            data_var_index: int - The index of the data variable. Default is 0. This
-              must be a value between 0 and 999.
+            data_var_index: int - The index of the data variable. Default is 0.
 
         Returns:
             An xarray.DataArray of np.float64 numbers with the above encoding scheme.
         """
-        if data_var_index < 0 or data_var_index > 999:
-            raise ValueError("data_var_index must be between 0 and 999.")
-
-        days_reshaped = self.days_since_start[:, np.newaxis, np.newaxis].astype(
-            np.int32
+        days_reshaped = (
+            self.days_since_start[:, np.newaxis, np.newaxis].astype(np.uint16)
+            << DAYS_BIT_OFFSET
         )  # Float[D, 1, 1]
 
         latlng_grid = np.stack(
             np.meshgrid(self.lat[::-1], self.lng, indexing="ij"),
             axis=0,
         )
-        latlng_grid_3sf = np.around(latlng_grid, decimals=2)
 
-        template_grid = (
-            latlng_grid_3sf[0, :, :] * 1_000_000.0 + latlng_grid_3sf[1, :, :] * 10.0
+        template_grid = (latlng_grid[0, :, :].view(np.uint16) << LAT_BIT_OFFSET) + (
+            latlng_grid[1, :, :].view(np.uint16) << LNG_BIT_OFFSET
         )
         rolled_out_grid = np.repeat(
             template_grid[np.newaxis, :, :], days_reshaped.shape[0], axis=0
         )
 
-        interpretable_grid = rolled_out_grid + (days_reshaped / 1000)
-        data_index_digits = float(data_var_index) / 1_000_000
+        interpretable_grid = rolled_out_grid + days_reshaped
         return xr.DataArray(
-            interpretable_grid + data_index_digits,
+            (
+                interpretable_grid
+                + (data_var_index << VAR_BIT_OFFSET)
+                + (0x402A << HEADER_BIT_OFFSET)
+            ).view(np.float64),
             dims=["time", "lat", "lon"],
             attrs={
                 "start_day": self.start_day.toordinal(),
@@ -157,44 +154,33 @@ class DataSourceDims:
     def decode(cls, da: xr.DataArray) -> tuple[Self, int]:
         """Parse array of encoded floats into its constituent parts.
 
-        AAAAGGGG.TTTDDD -->
-         (
-            DataSourceDims(lat=AA.AA, lng=GGG.G, days_since_start=TTT),
-            DDD,  # data_source_index
-        )
-
         Arguments:
             da: DataArray with encoded floats. See `encode_data_source`.
 
         Returns:
             (DataSourceDims, int) - Parsed dims and data_var index.
         """
-        encoded = da.to_numpy()
-        assert (
-            len(encoded.shape) == 3
-        ), "DataArray must have (time, lat, lng) dimensions."
+        encoded = da.to_numpy().view(np.uint64)
+        assert len(encoded.shape) == 3, (
+            "DataArray must have (time, lat, lng) dimensions."
+        )
 
-        scalar = encoded.flat[0]
+        assert np.all(encoded >> HEADER_BIT_OFFSET == 0x402A), (
+            "Data did not come from `encode_data_source`. "
+        )
+
+        scalar = encoded.flat[0].view(np.uint64)
         tim_dim = encoded[:, 0, 0]
         lat_dim = encoded[0, :, 0][::-1]
         lng_dim = encoded[0, 0, :]
 
-        # Signs are either +1 or -1. If the value is 0, default to +1.
-        lat_sign = np.sign(lat_dim)
-        lat_sign = np.where(lat_sign == 0, 1, lat_sign)
+        days_since_start = (tim_dim >> DAYS_BIT_OFFSET & np.uint64(0xFF)).astype(
+            np.uint8
+        )
+        lat = (lat_dim >> LAT_BIT_OFFSET & np.uint64(0xFFFF)).astype(np.float16)
+        lng = (lng_dim >> LNG_BIT_OFFSET & np.uint64(0xFFFF)).astype(np.float16)
 
-        # In python, the modulus operator preserves the of the _denominator only_.
-        # Thus, we need to parse the sign values for latitude above and include it
-        # in our float arithemetic array processing.
-        # We only need to do this for the lat values because we do not allow any
-        # other values encoded in the float to be negative.
-        days_since_start = ((tim_dim * 1000) % 1000).astype(np.int32)
-        lat = (lat_dim // (lat_sign * 10_000)) / (lat_sign * 100)
-        lng = lng_dim / 10 % 1000
-        # we need both np.round and _trunc because changing magnitude
-        # of very small floating point values (especially, odd numbers)
-        # leads to repeated decimal values.
-        data_var_index = int(np.round(_trunc(scalar, decimals=7) * 1_000_000) % 1000)
+        data_var_index = (scalar >> VAR_BIT_OFFSET & np.uint64(0xFF)).astype(np.uint8)
 
         data_source = cls(
             lat=lat,
@@ -204,7 +190,6 @@ class DataSourceDims:
                 da.attrs.get("start_day"), da.attrs.get("start_day_cal")
             ),
         )
-
         return data_source, data_var_index
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,7 +213,7 @@ class DataSourceDims:
         """Parse array of encoded floats into its constituent parts.
 
         Arguments:
-            da: DataArray with encoded floats. See `encode_data_source`.
+            da: DataArray with encoded floats. See `encode`.
 
         Returns:
             (DataSourceDims, int) - Parsed dims and data_var index.
@@ -225,7 +225,7 @@ class DataSourceDims:
 
         assert np.all(
             cls._header_field.decode_from(encoded) == cls._header_value
-        ), "Data did not come from `encode_data_source`. "
+        ), "Data did not come from `encode`. "
 
         scalar = encoded.flat[0].view(np.uint64)
         tim_dim = encoded[:, 0, 0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,13 +203,13 @@ class DataSourceDims:
             (DataSourceDims, int) - Parsed dims and data_var index.
         """
         encoded = da.to_numpy().view(np.uint64)
-        assert len(encoded.shape) == 3, (
-            "DataArray must have (time, lat, lng) dimensions."
-        )
+        assert (
+            len(encoded.shape) == 3
+        ), "DataArray must have (time, lat, lng) dimensions."
 
-        assert np.all(cls._header.decode_from(encoded) == cls._header_value), (
-            "Data did not come from `encode_data_source`. "
-        )
+        assert np.all(
+            cls._header.decode_from(encoded) == cls._header_value
+        ), "Data did not come from `encode_data_source`. "
 
         scalar = encoded.flat[0].view(np.uint64)
         tim_dim = encoded[:, 0, 0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,13 @@ class BitField:
     # numpy implicitly converts scalar types like np.float16 to a dtype when needed,
     # so we do, too
     def __init__(self, offset: int, dtype: np.dtype | type) -> None:
+        """Create a description of a bit field.
+
+        Arguments:
+            offset: int - The offset of the field within the uint64, in bits.
+            dtype: np.dtype | type - The type of the field. The underlying bytes
+            of this type are what is stored in the uint64 at this offset.
+        """
         self.offset = np.uint64(offset)
         self.dtype = np.dtype(dtype)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,11 +28,12 @@ def _trunc(arr: NDArray[np.floating], decimals: int) -> NDArray[np.floating]:
     return np.trunc(arr * factor) / factor
 
 
-HEADER_BIT_OFFSET = 56
-LAT_BIT_OFFSET = 40
-LNG_BIT_OFFSET = 24
-DAYS_BIT_OFFSET = 8
-VAR_BIT_OFFSET = 0
+HEADER = np.uint64(0b01000000)
+HEADER_BIT_OFFSET = np.uint64(56)
+LAT_BIT_OFFSET = np.uint64(40)
+LNG_BIT_OFFSET = np.uint64(24)
+DAYS_BIT_OFFSET = np.uint64(8)
+VAR_BIT_OFFSET = np.uint64(0)
 
 
 @dataclasses.dataclass
@@ -74,12 +75,14 @@ class DataSourceDims:
             raise ValueError("days_since_start values must fit in a uint16.")
 
     def __eq__(self, other) -> bool:
-        # lat and lng values will often have floating point rounding errors.
-        # So, we declare arrays as equal within a generous tolerance.
+        # lat and lng values round-trip via float16s, so declare them equal if they
+        # would encode to the same float16.
         # We can use exact equality with days_since_start since they are ints.
         return (
-            np.allclose(self.lat, other.lat, atol=1e-4)
-            and np.allclose(self.lng, other.lng, atol=1e-4)
+            np.array_equal(self.lat.astype(np.float16), other.lat.astype(np.float16))
+            and np.array_equal(
+                self.lng.astype(np.float16), other.lng.astype(np.float16)
+            )
             and np.array_equal(self.days_since_start, other.days_since_start)
             and self.start_day == other.start_day
         )
@@ -110,7 +113,7 @@ class DataSourceDims:
         }
         return coords
 
-    def encode(self, data_var_index: np.uint8 = 0) -> xr.DataArray:
+    def encode(self, data_var_index: np.uint = 0) -> xr.DataArray:
         """Encodes source data dimensions into an array of interpretable `np.float64`s.
 
         Arguments:
@@ -119,30 +122,43 @@ class DataSourceDims:
         Returns:
             An xarray.DataArray of np.float64 numbers with the above encoding scheme.
         """
-        days_reshaped = (
-            self.days_since_start[:, np.newaxis, np.newaxis].astype(np.uint16)
-            << DAYS_BIT_OFFSET
-        )  # Float[D, 1, 1]
+        assert data_var_index <= np.iinfo(np.uint8).max, (
+            f"data_var_index must fit in a uint8. Got {data_var_index} instead."
+        )
+        data_var_index = np.uint64(data_var_index)
 
-        latlng_grid = np.stack(
-            np.meshgrid(self.lat[::-1], self.lng, indexing="ij"),
-            axis=0,
+        days_reshaped = self.days_since_start[:, np.newaxis, np.newaxis].astype(
+            np.uint64
+        )
+        latlng_grid = (
+            np.stack(
+                np.meshgrid(
+                    self.lat[::-1],
+                    self.lng,
+                    indexing="ij",
+                ),
+                axis=0,
+            )
+            .astype(np.float16)
+            .view(np.uint16)
+            .astype(np.uint64)
         )
 
-        template_grid = (latlng_grid[0, :, :].view(np.uint16) << LAT_BIT_OFFSET) + (
-            latlng_grid[1, :, :].view(np.uint16) << LNG_BIT_OFFSET
+        template_grid = (latlng_grid[0, :, :] << LAT_BIT_OFFSET) + (
+            latlng_grid[1, :, :] << LNG_BIT_OFFSET
         )
         rolled_out_grid = np.repeat(
             template_grid[np.newaxis, :, :], days_reshaped.shape[0], axis=0
         )
 
-        interpretable_grid = rolled_out_grid + days_reshaped
+        interpretable_grid = (
+            rolled_out_grid
+            + (days_reshaped << DAYS_BIT_OFFSET)
+            + (data_var_index << VAR_BIT_OFFSET)
+            + (HEADER << HEADER_BIT_OFFSET)
+        )
         return xr.DataArray(
-            (
-                interpretable_grid
-                + (data_var_index << VAR_BIT_OFFSET)
-                + (0x402A << HEADER_BIT_OFFSET)
-            ).view(np.float64),
+            interpretable_grid.view(np.float64),
             dims=["time", "lat", "lon"],
             attrs={
                 "start_day": self.start_day.toordinal(),
@@ -165,7 +181,7 @@ class DataSourceDims:
             "DataArray must have (time, lat, lng) dimensions."
         )
 
-        assert np.all(encoded >> HEADER_BIT_OFFSET == 0x402A), (
+        assert np.all(encoded >> HEADER_BIT_OFFSET == HEADER), (
             "Data did not come from `encode_data_source`. "
         )
 
@@ -174,11 +190,19 @@ class DataSourceDims:
         lat_dim = encoded[0, :, 0][::-1]
         lng_dim = encoded[0, 0, :]
 
-        days_since_start = (tim_dim >> DAYS_BIT_OFFSET & np.uint64(0xFF)).astype(
-            np.uint8
+        days_since_start = (tim_dim >> DAYS_BIT_OFFSET & np.uint64(0xFFFF)).astype(
+            np.uint16
         )
-        lat = (lat_dim >> LAT_BIT_OFFSET & np.uint64(0xFFFF)).astype(np.float16)
-        lng = (lng_dim >> LNG_BIT_OFFSET & np.uint64(0xFFFF)).astype(np.float16)
+        lat = (
+            ((lat_dim >> LAT_BIT_OFFSET) & np.uint64(0xFFFF))
+            .astype(np.uint16)
+            .view(np.float16)
+        )
+        lng = (
+            ((lng_dim >> LNG_BIT_OFFSET) & np.uint64(0xFFFF))
+            .astype(np.uint16)
+            .view(np.float16)
+        )
 
         data_var_index = (scalar >> VAR_BIT_OFFSET & np.uint64(0xFF)).astype(np.uint8)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,9 @@ class BitField:
 
     def encode(self, value: NDArray) -> NDArray[np.uint64]:
         """Encodes & places the field; caller should + the field into the container."""
+        # Note that just `view(self.uint_type())` is not sufficient -- we need to
+        # extend the value to fill the full uint64 size so when we shift it doesn't
+        # just shift off the end of the (smaller) uint_type.
         return (
             value.astype(self.dtype).view(self.uint_type()).astype(np.uint64)
             << self.offset
@@ -94,6 +97,19 @@ class DataSourceDims:
       * lng encoded as a float16
       * days_since_start encoded as a uint16
       * data_var_index encoded as a uint8
+
+    For example, given lat=90, lng=180, days_since_start=8, data_var_index=7:
+
+        * header: 01000000, hex 0x40
+        * lat: 01010101 10100000, hex 0x55A0 (the float16 encoding of 90.0)
+        * lng: 01011001 10100000, hex 0x59A0 (the float16 encoding of 180.0)
+        * days_since_start: 00000000 00001000, hex 0x0008 (the uint16 encoding of 8)
+        * data_var_index: 00000111, hex 0x07 (the uint8 encoding of 7)
+
+    This produces this uint64: 0x4055A059A0000807
+    Which when interpreted as a float: https://float.exposed/0x4055A059A0000807
+    gives about 86.50.
+
     """
 
     _header_value: ClassVar[np.uint64] = np.uint64(0b01000000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import dataclasses
 import os
 import tempfile
-from typing import Any, Generator
+from typing import Any, ClassVar, Generator
 
 import cftime
 import numpy as np
@@ -23,17 +23,48 @@ class DataSource:
     stds: xr.Dataset
 
 
-def _trunc(arr: NDArray[np.floating], decimals: int) -> NDArray[np.floating]:
-    factor = 10**decimals
-    return np.trunc(arr * factor) / factor
+@dataclasses.dataclass
+class BitField:
+    offset: int
+    dtype: np.dtype
 
+    # numpy implicitly converts scalar types like np.float16 to a dtype when needed,
+    # so we do, too
+    def __init__(self, offset: int, dtype: np.dtype | type) -> None:
+        self.offset = offset
+        self.dtype = np.dtype(dtype)
 
-HEADER = np.uint64(0b01000000)
-HEADER_BIT_OFFSET = np.uint64(56)
-LAT_BIT_OFFSET = np.uint64(40)
-LNG_BIT_OFFSET = np.uint64(24)
-DAYS_BIT_OFFSET = np.uint64(8)
-VAR_BIT_OFFSET = np.uint64(0)
+    def ensure_value_fits(self, value: np.array) -> None:
+        if np.any(value < np.iinfo(self.dtype).min):
+            raise ValueError(
+                f"Value {value} is less than the minimum value for {self.dtype}"
+            )
+        if np.any(value > np.iinfo(self.dtype).max):
+            raise ValueError(
+                f"Value {value} is greater than the maximum value for {self.dtype}"
+            )
+
+    def mask(self) -> np.uint64:
+        return np.uint64((1 << (self.size_in_bytes() * 8)) - 1)
+
+    def size_in_bytes(self) -> int:
+        return np.dtype(self.dtype).itemsize
+
+    def uint_type(self) -> np.dtype:
+        # Yes, this is in bytes for some reason so u4 == uint32
+        return np.dtype(f"u{self.size_in_bytes()}")
+
+    def decode_from(self, container: NDArray[np.uint64]) -> NDArray[np.uint64]:
+        return (
+            ((container >> np.uint64(self.offset)) & self.mask())
+            .astype(self.uint_type())
+            .view(self.dtype)
+        )
+
+    def encode(self, value: NDArray) -> NDArray[np.uint64]:
+        return value.astype(self.dtype).view(self.uint_type()).astype(
+            np.uint64
+        ) << np.uint64(self.offset)
 
 
 @dataclasses.dataclass
@@ -48,6 +79,14 @@ class DataSourceDims:
       * days_since_start encoded as a uint16
       * data_var_index encoded as a uint8
     """
+
+    _header_value: ClassVar[np.uint64] = np.uint64(0b01000000)
+
+    _header: ClassVar[BitField] = BitField(offset=56, dtype=np.uint8)
+    _lat: ClassVar[BitField] = BitField(offset=40, dtype=np.float16)
+    _lng: ClassVar[BitField] = BitField(offset=24, dtype=np.float16)
+    _days_since_start: ClassVar[BitField] = BitField(offset=8, dtype=np.uint16)
+    _data_var_index: ClassVar[BitField] = BitField(offset=0, dtype=np.uint8)
 
     lat: NDArray[np.float64] = dataclasses.field(
         default_factory=lambda: np.arange(-89.24, 90, 1, dtype=np.float64)
@@ -69,10 +108,7 @@ class DataSourceDims:
         if np.any(self.lng < 0.0) or np.any(self.lng > 360.0):
             raise ValueError("lng values are expected to be between 0 and 360 degrees.")
 
-        if np.any(self.days_since_start < 0) or np.any(
-            self.days_since_start > np.iinfo(np.uint16).max
-        ):
-            raise ValueError("days_since_start values must fit in a uint16.")
+        self._days_since_start.ensure_value_fits(self.days_since_start)
 
     def __eq__(self, other) -> bool:
         # lat and lng values round-trip via float16s, so declare them equal if they
@@ -113,7 +149,7 @@ class DataSourceDims:
         }
         return coords
 
-    def encode(self, data_var_index: np.uint = 0) -> xr.DataArray:
+    def encode(self, data_var_index: np.uint | int = 0) -> xr.DataArray:
         """Encodes source data dimensions into an array of interpretable `np.float64`s.
 
         Arguments:
@@ -122,30 +158,20 @@ class DataSourceDims:
         Returns:
             An xarray.DataArray of np.float64 numbers with the above encoding scheme.
         """
-        assert data_var_index <= np.iinfo(np.uint8).max, (
-            f"data_var_index must fit in a uint8. Got {data_var_index} instead."
-        )
-        data_var_index = np.uint64(data_var_index)
+        self._data_var_index.ensure_value_fits(data_var_index)
 
-        days_reshaped = self.days_since_start[:, np.newaxis, np.newaxis].astype(
-            np.uint64
-        )
-        latlng_grid = (
-            np.stack(
-                np.meshgrid(
-                    self.lat[::-1],
-                    self.lng,
-                    indexing="ij",
-                ),
-                axis=0,
-            )
-            .astype(np.float16)
-            .view(np.uint16)
-            .astype(np.uint64)
+        days_reshaped = self.days_since_start[:, np.newaxis, np.newaxis]
+        latlng_grid = np.stack(
+            np.meshgrid(
+                self.lat[::-1],
+                self.lng,
+                indexing="ij",
+            ),
+            axis=0,
         )
 
-        template_grid = (latlng_grid[0, :, :] << LAT_BIT_OFFSET) + (
-            latlng_grid[1, :, :] << LNG_BIT_OFFSET
+        template_grid = self._lat.encode(latlng_grid[0, :, :]) + self._lng.encode(
+            latlng_grid[1, :, :]
         )
         rolled_out_grid = np.repeat(
             template_grid[np.newaxis, :, :], days_reshaped.shape[0], axis=0
@@ -153,9 +179,9 @@ class DataSourceDims:
 
         interpretable_grid = (
             rolled_out_grid
-            + (days_reshaped << DAYS_BIT_OFFSET)
-            + (data_var_index << VAR_BIT_OFFSET)
-            + (HEADER << HEADER_BIT_OFFSET)
+            + self._days_since_start.encode(days_reshaped)
+            + self._data_var_index.encode(np.array(data_var_index))
+            + self._header.encode(self._header_value)
         )
         return xr.DataArray(
             interpretable_grid.view(np.float64),
@@ -181,7 +207,7 @@ class DataSourceDims:
             "DataArray must have (time, lat, lng) dimensions."
         )
 
-        assert np.all(encoded >> HEADER_BIT_OFFSET == HEADER), (
+        assert np.all(cls._header.decode_from(encoded) == cls._header_value), (
             "Data did not come from `encode_data_source`. "
         )
 
@@ -190,21 +216,10 @@ class DataSourceDims:
         lat_dim = encoded[0, :, 0][::-1]
         lng_dim = encoded[0, 0, :]
 
-        days_since_start = (tim_dim >> DAYS_BIT_OFFSET & np.uint64(0xFFFF)).astype(
-            np.uint16
-        )
-        lat = (
-            ((lat_dim >> LAT_BIT_OFFSET) & np.uint64(0xFFFF))
-            .astype(np.uint16)
-            .view(np.float16)
-        )
-        lng = (
-            ((lng_dim >> LNG_BIT_OFFSET) & np.uint64(0xFFFF))
-            .astype(np.uint16)
-            .view(np.float16)
-        )
-
-        data_var_index = (scalar >> VAR_BIT_OFFSET & np.uint64(0xFF)).astype(np.uint8)
+        days_since_start = cls._days_since_start.decode_from(tim_dim)
+        lat = cls._lat.decode_from(lat_dim)
+        lng = cls._lng.decode_from(lng_dim)
+        data_var_index = cls._data_var_index.decode_from(scalar)
 
         data_source = cls(
             lat=lat,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,13 +25,15 @@ class DataSource:
 
 @dataclasses.dataclass
 class BitField:
-    offset: int
+    """Represents a bit field in a uint64."""
+
+    offset: np.uint64
     dtype: np.dtype
 
     # numpy implicitly converts scalar types like np.float16 to a dtype when needed,
     # so we do, too
     def __init__(self, offset: int, dtype: np.dtype | type) -> None:
-        self.offset = offset
+        self.offset = np.uint64(offset)
         self.dtype = np.dtype(dtype)
 
     def ensure_value_fits(self, value: np.array) -> None:
@@ -45,26 +47,32 @@ class BitField:
             )
 
     def mask(self) -> np.uint64:
+        """Returns an all-1s bitmask for the field."""
         return np.uint64((1 << (self.size_in_bytes() * 8)) - 1)
 
     def size_in_bytes(self) -> int:
-        return np.dtype(self.dtype).itemsize
+        """How many bytes does this field take up?"""
+        return self.dtype.itemsize
 
     def uint_type(self) -> np.dtype:
-        # Yes, this is in bytes for some reason so u4 == uint32
+        """A uint type that is the same size as the field's value."""
+        # Yes, this is in bytes, so u4 == uint32
         return np.dtype(f"u{self.size_in_bytes()}")
 
-    def decode_from(self, container: NDArray[np.uint64]) -> NDArray[np.uint64]:
+    def decode_from(self, container: NDArray[np.uint64]) -> NDArray:
+        """Extracts the field from a uint64 container."""
         return (
-            ((container >> np.uint64(self.offset)) & self.mask())
+            ((container >> self.offset) & self.mask())
             .astype(self.uint_type())
             .view(self.dtype)
         )
 
     def encode(self, value: NDArray) -> NDArray[np.uint64]:
-        return value.astype(self.dtype).view(self.uint_type()).astype(
-            np.uint64
-        ) << np.uint64(self.offset)
+        """Encodes & places the field; caller should + the field into the container."""
+        return (
+            value.astype(self.dtype).view(self.uint_type()).astype(np.uint64)
+            << self.offset
+        )
 
 
 @dataclasses.dataclass
@@ -73,7 +81,8 @@ class DataSourceDims:
 
     Each float in the encoded `xarray.DataArray` is interpreted as a uint64 broken
     into the following fields, MSB first:
-      * 8 bits fixed as 0100 0000 (a non-NaN exponent)
+      * 8 bits fixed as 0100 0000
+        * which overlaps with float64 exponent to make it non-NaN and non-subnormal
       * lat encoded as a float16
       * lng encoded as a float16
       * days_since_start encoded as a uint16
@@ -82,11 +91,11 @@ class DataSourceDims:
 
     _header_value: ClassVar[np.uint64] = np.uint64(0b01000000)
 
-    _header: ClassVar[BitField] = BitField(offset=56, dtype=np.uint8)
-    _lat: ClassVar[BitField] = BitField(offset=40, dtype=np.float16)
-    _lng: ClassVar[BitField] = BitField(offset=24, dtype=np.float16)
-    _days_since_start: ClassVar[BitField] = BitField(offset=8, dtype=np.uint16)
-    _data_var_index: ClassVar[BitField] = BitField(offset=0, dtype=np.uint8)
+    _header_field: ClassVar[BitField] = BitField(offset=56, dtype=np.uint8)
+    _lat_field: ClassVar[BitField] = BitField(offset=40, dtype=np.float16)
+    _lng_field: ClassVar[BitField] = BitField(offset=24, dtype=np.float16)
+    _days_since_start_field: ClassVar[BitField] = BitField(offset=8, dtype=np.uint16)
+    _data_var_index_field: ClassVar[BitField] = BitField(offset=0, dtype=np.uint8)
 
     lat: NDArray[np.float64] = dataclasses.field(
         default_factory=lambda: np.arange(-89.24, 90, 1, dtype=np.float64)
@@ -108,7 +117,7 @@ class DataSourceDims:
         if np.any(self.lng < 0.0) or np.any(self.lng > 360.0):
             raise ValueError("lng values are expected to be between 0 and 360 degrees.")
 
-        self._days_since_start.ensure_value_fits(self.days_since_start)
+        self._days_since_start_field.ensure_value_fits(self.days_since_start)
 
     def __eq__(self, other) -> bool:
         # lat and lng values round-trip via float16s, so declare them equal if they
@@ -158,7 +167,7 @@ class DataSourceDims:
         Returns:
             An xarray.DataArray of np.float64 numbers with the above encoding scheme.
         """
-        self._data_var_index.ensure_value_fits(data_var_index)
+        self._data_var_index_field.ensure_value_fits(data_var_index)
 
         days_reshaped = self.days_since_start[:, np.newaxis, np.newaxis]
         latlng_grid = np.stack(
@@ -170,18 +179,18 @@ class DataSourceDims:
             axis=0,
         )
 
-        template_grid = self._lat.encode(latlng_grid[0, :, :]) + self._lng.encode(
-            latlng_grid[1, :, :]
-        )
+        template_grid = self._lat_field.encode(
+            latlng_grid[0, :, :]
+        ) + self._lng_field.encode(latlng_grid[1, :, :])
         rolled_out_grid = np.repeat(
             template_grid[np.newaxis, :, :], days_reshaped.shape[0], axis=0
         )
 
         interpretable_grid = (
             rolled_out_grid
-            + self._days_since_start.encode(days_reshaped)
-            + self._data_var_index.encode(np.array(data_var_index))
-            + self._header.encode(self._header_value)
+            + self._days_since_start_field.encode(days_reshaped)
+            + self._data_var_index_field.encode(np.array(data_var_index))
+            + self._header_field.encode(self._header_value)
         )
         return xr.DataArray(
             interpretable_grid.view(np.float64),
@@ -208,7 +217,7 @@ class DataSourceDims:
         ), "DataArray must have (time, lat, lng) dimensions."
 
         assert np.all(
-            cls._header.decode_from(encoded) == cls._header_value
+            cls._header_field.decode_from(encoded) == cls._header_value
         ), "Data did not come from `encode_data_source`. "
 
         scalar = encoded.flat[0].view(np.uint64)
@@ -216,10 +225,10 @@ class DataSourceDims:
         lat_dim = encoded[0, :, 0][::-1]
         lng_dim = encoded[0, 0, :]
 
-        days_since_start = cls._days_since_start.decode_from(tim_dim)
-        lat = cls._lat.decode_from(lat_dim)
-        lng = cls._lng.decode_from(lng_dim)
-        data_var_index = cls._data_var_index.decode_from(scalar)
+        days_since_start = cls._days_since_start_field.decode_from(tim_dim)
+        lat = cls._lat_field.decode_from(lat_dim)
+        lng = cls._lng_field.decode_from(lng_dim)
+        data_var_index = cls._data_var_index_field.decode_from(scalar)
 
         data_source = cls(
             lat=lat,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -72,7 +72,7 @@ def vector_of(max_vec_size: int, min_vec_size=1):
 
 
 @given(
-    data_var_index=st.integers(min_value=0, max_value=999),
+    data_var_index=st.integers(min_value=0, max_value=255),
     lat=arrays(
         dtype=np.float64,
         shape=vector_of(50),
@@ -100,7 +100,7 @@ def vector_of(max_vec_size: int, min_vec_size=1):
     calendar="noleap",
 )
 @example(
-    data_var_index=999,
+    data_var_index=255,
     lat=np.array([90.00]),
     lng=np.array([360.0]),
     days_since_start=np.array([999]),

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -123,6 +123,14 @@ def vector_of(max_vec_size: int, min_vec_size=1):
     start_day=datetime.datetime(2000, 5, 1, 12),
     calendar="noleap",
 )
+@example(
+    data_var_index=0,
+    lat=np.array([2.0]),
+    lng=np.array([1.375]),
+    days_since_start=np.array([0], dtype=np.int32),
+    start_day=datetime.datetime(2000, 1, 1, 0, 0),
+    calendar="noleap",
+)
 @settings(deadline=1000)
 def test_test_util__data_source_roundtrip(
     data_var_index: int,
@@ -168,9 +176,9 @@ def test_test_util__data_source_roundtrip(
 def test_train__loads_correct_number_of_samples(train_loader_pair: LoaderPair):
     cfg, loader = train_loader_pair
     n_samples = 13
-    assert (
-        len(list(loader)) == n_samples
-    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+    assert len(list(loader)) == n_samples, (
+        f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+    )
 
 
 def test_train__data_shape(train_loader_pair: LoaderPair):
@@ -196,9 +204,9 @@ def test_train__data_shape(train_loader_pair: LoaderPair):
 def test_val__loads_correct_number_of_samples(val_loader_pair):
     cfg, loader = val_loader_pair
     n_samples = 5
-    assert (
-        len(list(loader)) == n_samples
-    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+    assert len(list(loader)) == n_samples, (
+        f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+    )
 
 
 def test_val__data_shape(val_loader_pair: LoaderPair):
@@ -234,9 +242,9 @@ def test_val__data_shape(val_loader_pair: LoaderPair):
 def test_inference__loads_correct_number_of_samples(inference_loader_pair: LoaderPair):
     cfg, loader = inference_loader_pair
     n_samples = 1
-    assert (
-        len(list(loader)) == n_samples
-    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+    assert len(list(loader)) == n_samples, (
+        f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
+    )
 
 
 def test_inference__data_shape(inference_loader_pair: LoaderPair):
@@ -274,15 +282,15 @@ def test_inference__data_is_not_zero(inference_loader_pair: LoaderPair):
     for sample in loader:
         dataset, n = sample
         for X, y in dataset:
-            assert (
-                np.count_nonzero(np.zeros(X.shape)) == 0
-            ), "Sanity check: Zero is zero."
-            assert (
-                np.count_nonzero(X.numpy()) != 0
-            ), "Input data should not be a zeros matrix!"
-            assert (
-                np.count_nonzero(y.numpy()) != 0
-            ), "Label data should not be a zeros matrix!"
+            assert np.count_nonzero(np.zeros(X.shape)) == 0, (
+                "Sanity check: Zero is zero."
+            )
+            assert np.count_nonzero(X.numpy()) != 0, (
+                "Input data should not be a zeros matrix!"
+            )
+            assert np.count_nonzero(y.numpy()) != 0, (
+                "Label data should not be a zeros matrix!"
+            )
 
 
 @pytest.mark.manual

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -176,9 +176,9 @@ def test_test_util__data_source_roundtrip(
 def test_train__loads_correct_number_of_samples(train_loader_pair: LoaderPair):
     cfg, loader = train_loader_pair
     n_samples = 13
-    assert len(list(loader)) == n_samples, (
-        f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
-    )
+    assert (
+        len(list(loader)) == n_samples
+    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
 
 
 def test_train__data_shape(train_loader_pair: LoaderPair):
@@ -204,9 +204,9 @@ def test_train__data_shape(train_loader_pair: LoaderPair):
 def test_val__loads_correct_number_of_samples(val_loader_pair):
     cfg, loader = val_loader_pair
     n_samples = 5
-    assert len(list(loader)) == n_samples, (
-        f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
-    )
+    assert (
+        len(list(loader)) == n_samples
+    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
 
 
 def test_val__data_shape(val_loader_pair: LoaderPair):
@@ -242,9 +242,9 @@ def test_val__data_shape(val_loader_pair: LoaderPair):
 def test_inference__loads_correct_number_of_samples(inference_loader_pair: LoaderPair):
     cfg, loader = inference_loader_pair
     n_samples = 1
-    assert len(list(loader)) == n_samples, (
-        f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
-    )
+    assert (
+        len(list(loader)) == n_samples
+    ), f"Current config {cfg} only supports {n_samples} examples; got {len(loader)}."
 
 
 def test_inference__data_shape(inference_loader_pair: LoaderPair):
@@ -282,15 +282,15 @@ def test_inference__data_is_not_zero(inference_loader_pair: LoaderPair):
     for sample in loader:
         dataset, n = sample
         for X, y in dataset:
-            assert np.count_nonzero(np.zeros(X.shape)) == 0, (
-                "Sanity check: Zero is zero."
-            )
-            assert np.count_nonzero(X.numpy()) != 0, (
-                "Input data should not be a zeros matrix!"
-            )
-            assert np.count_nonzero(y.numpy()) != 0, (
-                "Label data should not be a zeros matrix!"
-            )
+            assert (
+                np.count_nonzero(np.zeros(X.shape)) == 0
+            ), "Sanity check: Zero is zero."
+            assert (
+                np.count_nonzero(X.numpy()) != 0
+            ), "Input data should not be a zeros matrix!"
+            assert (
+                np.count_nonzero(y.numpy()) != 0
+            ), "Label data should not be a zeros matrix!"
 
 
 @pytest.mark.manual

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,24 @@ wheels = [
 ]
 
 [[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321 },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz", hash = "sha256:0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7", size = 61978 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl", hash = "sha256:e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2", size = 26918 },
+]
+
+[[package]]
 name = "attrs"
 version = "25.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -42,6 +60,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+]
+
+[[package]]
+name = "cffi"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/f4/927e3a8899e52a27fa57a48607ff7dc91a9ebe97399b357b85a0c7892e00/cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401", size = 182264 },
+    { url = "https://files.pythonhosted.org/packages/6c/f5/6c3a8efe5f503175aaddcbea6ad0d2c96dad6f5abb205750d1b3df44ef29/cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf", size = 178651 },
+    { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259 },
+    { url = "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41", size = 469200 },
+    { url = "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1", size = 477235 },
+    { url = "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6", size = 459721 },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d", size = 467242 },
+    { url = "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6", size = 477999 },
+    { url = "https://files.pythonhosted.org/packages/44/74/f2a2460684a1a2d00ca799ad880d54652841a780c4c97b87754f660c7603/cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f", size = 454242 },
+    { url = "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b", size = 478604 },
+    { url = "https://files.pythonhosted.org/packages/34/33/e1b8a1ba29025adbdcda5fb3a36f94c03d771c1b7b12f726ff7fef2ebe36/cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655", size = 171727 },
+    { url = "https://files.pythonhosted.org/packages/3d/97/50228be003bb2802627d28ec0627837ac0bf35c90cf769812056f235b2d1/cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0", size = 181400 },
+    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178 },
+    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840 },
+    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803 },
+    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850 },
+    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729 },
+    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256 },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424 },
+    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568 },
+    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736 },
+    { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448 },
+    { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976 },
+    { url = "https://files.pythonhosted.org/packages/8d/f8/dd6c246b148639254dad4d6803eb6a54e8c85c6e11ec9df2cffa87571dbe/cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e", size = 182989 },
+    { url = "https://files.pythonhosted.org/packages/8b/f1/672d303ddf17c24fc83afd712316fda78dc6fce1cd53011b839483e1ecc8/cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2", size = 178802 },
+    { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792 },
+    { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893 },
+    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810 },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200 },
+    { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447 },
+    { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358 },
+    { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469 },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475 },
+    { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009 },
 ]
 
 [[package]]
@@ -149,6 +212,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/a8/fb783cb0abe2b5fded9f55e5703015cdf1c9c85b3669087c538dd15a6a86/comm-0.2.2.tar.gz", hash = "sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e", size = 6210 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl", hash = "sha256:e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3", size = 7180 },
 ]
 
 [[package]]
@@ -292,6 +367,36 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/d4/f35f539e11c9344652f362c22413ec5078f677ac71229dc9b4f6f85ccaa3/debugpy-1.8.13.tar.gz", hash = "sha256:837e7bef95bdefba426ae38b9a94821ebdc5bea55627879cd48165c90b9e50ce", size = 1641193 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/90/dd2fcad8364f0964f476537481985198ce6e879760281ad1cec289f1aa71/debugpy-1.8.13-cp311-cp311-macosx_14_0_universal2.whl", hash = "sha256:eee02b2ed52a563126c97bf04194af48f2fe1f68bb522a312b05935798e922ff", size = 2174802 },
+    { url = "https://files.pythonhosted.org/packages/5c/c9/06ff65f15eb30dbdafd45d1575770b842ce3869ad5580a77f4e5590f1be7/debugpy-1.8.13-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4caca674206e97c85c034c1efab4483f33971d4e02e73081265ecb612af65377", size = 3133620 },
+    { url = "https://files.pythonhosted.org/packages/3b/49/798a4092bde16a4650f17ac5f2301d4d37e1972d65462fb25c80a83b4790/debugpy-1.8.13-cp311-cp311-win32.whl", hash = "sha256:7d9a05efc6973b5aaf076d779cf3a6bbb1199e059a17738a2aa9d27a53bcc888", size = 5104764 },
+    { url = "https://files.pythonhosted.org/packages/cd/d5/3684d7561c8ba2797305cf8259619acccb8d6ebe2117bb33a6897c235eee/debugpy-1.8.13-cp311-cp311-win_amd64.whl", hash = "sha256:62f9b4a861c256f37e163ada8cf5a81f4c8d5148fc17ee31fb46813bd658cdcc", size = 5129670 },
+    { url = "https://files.pythonhosted.org/packages/79/ad/dff929b6b5403feaab0af0e5bb460fd723f9c62538b718a9af819b8fff20/debugpy-1.8.13-cp312-cp312-macosx_14_0_universal2.whl", hash = "sha256:2b8de94c5c78aa0d0ed79023eb27c7c56a64c68217d881bee2ffbcb13951d0c1", size = 2501004 },
+    { url = "https://files.pythonhosted.org/packages/d6/4f/b7d42e6679f0bb525888c278b0c0d2b6dff26ed42795230bb46eaae4f9b3/debugpy-1.8.13-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:887d54276cefbe7290a754424b077e41efa405a3e07122d8897de54709dbe522", size = 4222346 },
+    { url = "https://files.pythonhosted.org/packages/ec/18/d9b3e88e85d41f68f77235112adc31012a784e45a3fcdbb039777d570a0f/debugpy-1.8.13-cp312-cp312-win32.whl", hash = "sha256:3872ce5453b17837ef47fb9f3edc25085ff998ce63543f45ba7af41e7f7d370f", size = 5226639 },
+    { url = "https://files.pythonhosted.org/packages/c9/f7/0df18a4f530ed3cc06f0060f548efe9e3316102101e311739d906f5650be/debugpy-1.8.13-cp312-cp312-win_amd64.whl", hash = "sha256:63ca7670563c320503fea26ac688988d9d6b9c6a12abc8a8cf2e7dd8e5f6b6ea", size = 5268735 },
+    { url = "https://files.pythonhosted.org/packages/b1/db/ae7cd645c1826aae557cebccbc448f0cc9a818d364efb88f8d80e7a03f41/debugpy-1.8.13-cp313-cp313-macosx_14_0_universal2.whl", hash = "sha256:31abc9618be4edad0b3e3a85277bc9ab51a2d9f708ead0d99ffb5bb750e18503", size = 2485416 },
+    { url = "https://files.pythonhosted.org/packages/ec/ed/db4b10ff3b5bb30fe41d9e86444a08bb6448e4d8265e7768450b8408dd36/debugpy-1.8.13-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0bd87557f97bced5513a74088af0b84982b6ccb2e254b9312e29e8a5c4270eb", size = 4218784 },
+    { url = "https://files.pythonhosted.org/packages/82/82/ed81852a8d94086f51664d032d83c7f87cd2b087c6ea70dabec7c1ba813d/debugpy-1.8.13-cp313-cp313-win32.whl", hash = "sha256:5268ae7fdca75f526d04465931cb0bd24577477ff50e8bb03dab90983f4ebd02", size = 5226270 },
+    { url = "https://files.pythonhosted.org/packages/15/63/aa92fb341a78ec40f1c414ec7a7885c2ee17032eee00d12cee0cdc502af4/debugpy-1.8.13-cp313-cp313-win_amd64.whl", hash = "sha256:79ce4ed40966c4c1631d0131606b055a5a2f8e430e3f7bf8fd3744b09943e8e8", size = 5268621 },
+    { url = "https://files.pythonhosted.org/packages/37/4f/0b65410a08b6452bfd3f7ed6f3610f1a31fb127f46836e82d31797065dcb/debugpy-1.8.13-py2.py3-none-any.whl", hash = "sha256:d4ba115cdd0e3a70942bd562adba9ec8c651fe69ddde2298a1be296fc331906f", size = 5229306 },
+]
+
+[[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190 },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.2.18"
 source = { registry = "https://pypi.org/simple" }
@@ -334,6 +439,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e5/81/df4fbe24dff8ba3934af99044188e20a98ed441ad17a274539b74e82e126/einops-0.8.1.tar.gz", hash = "sha256:de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84", size = 54805 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/62/9773de14fe6c45c23649e98b83231fffd7b9892b6cf863251dc2afa73643/einops-0.8.1-py3-none-any.whl", hash = "sha256:919387eb55330f5757c6bea9165c5ff5cfe63a642682ea788a6d472576d81737", size = 64359 },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702 },
 ]
 
 [[package]]
@@ -508,6 +622,64 @@ wheels = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "6.29.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/5c/67594cb0c7055dc50814b21731c22a601101ea3b1b50a9a1b090e11f5d0f/ipykernel-6.29.5.tar.gz", hash = "sha256:f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215", size = 163367 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/5c/368ae6c01c7628438358e6d337c19b05425727fbb221d2a3c4303c372f42/ipykernel-6.29.5-py3-none-any.whl", hash = "sha256:afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5", size = 117173 },
+]
+
+[[package]]
+name = "ipython"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ce/012a0f40ca58a966f87a6e894d6828e2817657cbdf522b02a5d3a87d92ce/ipython-9.0.2.tar.gz", hash = "sha256:ec7b479e3e5656bf4f58c652c120494df1820f4f28f522fb7ca09e213c2aab52", size = 4366102 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/3a/917cb9e72f4e1a4ea13c862533205ae1319bd664119189ee5cc9e4e95ebf/ipython-9.0.2-py3-none-any.whl", hash = "sha256:143ef3ea6fb1e1bffb4c74b114051de653ffb7737a3f7ab1670e657ca6ae8c44", size = 600524 },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074 },
+]
+
+[[package]]
 name = "jaxtyping"
 version = "0.2.38"
 source = { registry = "https://pypi.org/simple" }
@@ -520,6 +692,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278 },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -529,6 +713,36 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/22/bf9f12fdaeae18019a468b68952a60fe6dbab5d67cd2a103cac7659b41ca/jupyter_client-8.6.3.tar.gz", hash = "sha256:35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419", size = 342019 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/85/b0394e0b6fcccd2c1eeefc230978a6f8cb0c5df1e4cd3e7625735a0d7d1e/jupyter_client-8.6.3-py3-none-any.whl", hash = "sha256:e8a19cc986cc45905ac3362915f410f3af85424b4c0905e94fa5f2cb08e8f23f", size = 106105 },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/11/b56381fa6c3f4cc5d2cf54a7dbf98ad9aa0b339ef7a601d6053538b079a7/jupyter_core-5.7.2.tar.gz", hash = "sha256:aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9", size = 87629 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/fb/108ecd1fe961941959ad0ee4e12ee7b8b1477247f30b1fdfd83ceaf017f0/jupyter_core-5.7.2-py3-none-any.whl", hash = "sha256:4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409", size = 28965 },
 ]
 
 [[package]]
@@ -698,12 +912,33 @@ wheels = [
 ]
 
 [[package]]
+name = "matplotlib-inline"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90", size = 8159 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca", size = 9899 },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195 },
 ]
 
 [[package]]
@@ -927,6 +1162,7 @@ dependencies = [
 dev = [
     { name = "beartype" },
     { name = "hypothesis", extra = ["numpy"] },
+    { name = "ipykernel" },
     { name = "pytest" },
     { name = "pytest-benchmark", extra = ["histogram"] },
     { name = "pytest-profiling" },
@@ -954,6 +1190,7 @@ requires-dist = [
 dev = [
     { name = "beartype", specifier = ">=0.20" },
     { name = "hypothesis", extras = ["numpy"], specifier = ">=6.127.2" },
+    { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-benchmark", extras = ["histogram"], specifier = ">=5.1" },
     { name = "pytest-profiling", specifier = ">=1.8.1" },
@@ -1011,6 +1248,15 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
+]
+
+[[package]]
 name = "partd"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1021,6 +1267,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/3f06f34820a31257ddcabdfafc2672c5816be79c7e353b02c1f318daa7d4/partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c", size = 21029 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f", size = 18905 },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772 },
 ]
 
 [[package]]
@@ -1105,6 +1363,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/e1/bd15cb8ffdcfeeb2bdc215de3c3cffca11408d829e4b8416dcfe71ba8854/prompt_toolkit-3.0.50.tar.gz", hash = "sha256:544748f3860a2623ca5cd6d2795e7a14f3d0e1c3c9728359013f79877fc89bab", size = 429087 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/ea/d836f008d33151c7a1f62caf3d8dd782e4d15f6a43897f64480c2b8de2ad/prompt_toolkit-3.0.50-py3-none-any.whl", hash = "sha256:9b6427eb19e479d98acff65196a307c555eb567989e6d88ebbb1b509d9779198", size = 387816 },
+]
+
+[[package]]
 name = "protobuf"
 version = "5.29.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1134,12 +1404,39 @@ wheels = [
 ]
 
 [[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993 },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842 },
+]
+
+[[package]]
 name = "py-cpuinfo"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335 },
+]
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6", size = 172736 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc", size = 117552 },
 ]
 
 [[package]]
@@ -1231,6 +1528,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1310,6 +1616,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "310"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/b1/68aa2986129fb1011dabbe95f0136f44509afaf072b12b8f815905a39f33/pywin32-310-cp311-cp311-win32.whl", hash = "sha256:1e765f9564e83011a63321bb9d27ec456a0ed90d3732c4b2e312b855365ed8bd", size = 8784284 },
+    { url = "https://files.pythonhosted.org/packages/b3/bd/d1592635992dd8db5bb8ace0551bc3a769de1ac8850200cfa517e72739fb/pywin32-310-cp311-cp311-win_amd64.whl", hash = "sha256:126298077a9d7c95c53823934f000599f66ec9296b09167810eb24875f32689c", size = 9520748 },
+    { url = "https://files.pythonhosted.org/packages/90/b1/ac8b1ffce6603849eb45a91cf126c0fa5431f186c2e768bf56889c46f51c/pywin32-310-cp311-cp311-win_arm64.whl", hash = "sha256:19ec5fc9b1d51c4350be7bb00760ffce46e6c95eaf2f0b2f1150657b1a43c582", size = 8455941 },
+    { url = "https://files.pythonhosted.org/packages/6b/ec/4fdbe47932f671d6e348474ea35ed94227fb5df56a7c30cbbb42cd396ed0/pywin32-310-cp312-cp312-win32.whl", hash = "sha256:8a75a5cc3893e83a108c05d82198880704c44bbaee4d06e442e471d3c9ea4f3d", size = 8796239 },
+    { url = "https://files.pythonhosted.org/packages/e3/e5/b0627f8bb84e06991bea89ad8153a9e50ace40b2e1195d68e9dff6b03d0f/pywin32-310-cp312-cp312-win_amd64.whl", hash = "sha256:bf5c397c9a9a19a6f62f3fb821fbf36cac08f03770056711f765ec1503972060", size = 9503839 },
+    { url = "https://files.pythonhosted.org/packages/1f/32/9ccf53748df72301a89713936645a664ec001abd35ecc8578beda593d37d/pywin32-310-cp312-cp312-win_arm64.whl", hash = "sha256:2349cc906eae872d0663d4d6290d13b90621eaf78964bb1578632ff20e152966", size = 8459470 },
+    { url = "https://files.pythonhosted.org/packages/1c/09/9c1b978ffc4ae53999e89c19c77ba882d9fce476729f23ef55211ea1c034/pywin32-310-cp313-cp313-win32.whl", hash = "sha256:5d241a659c496ada3253cd01cfaa779b048e90ce4b2b38cd44168ad555ce74ab", size = 8794384 },
+    { url = "https://files.pythonhosted.org/packages/45/3c/b4640f740ffebadd5d34df35fecba0e1cfef8fde9f3e594df91c28ad9b50/pywin32-310-cp313-cp313-win_amd64.whl", hash = "sha256:667827eb3a90208ddbdcc9e860c81bde63a135710e21e4cb3348968e4bd5249e", size = 9503039 },
+    { url = "https://files.pythonhosted.org/packages/b4/f4/f785020090fb050e7fb6d34b780f2231f302609dc964672f72bfaeb59a28/pywin32-310-cp313-cp313-win_arm64.whl", hash = "sha256:e308f831de771482b7cf692a1f308f8fca701b2d8f9dde6cc440c7da17e47b33", size = 8458152 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1342,6 +1664,63 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597 },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527 },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446 },
+]
+
+[[package]]
+name = "pyzmq"
+version = "26.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/ed/c3876f3b3e8beba336214ce44e1efa1792dd537027cef24192ac2b077d7c/pyzmq-26.3.0.tar.gz", hash = "sha256:f1cd68b8236faab78138a8fc703f7ca0ad431b17a3fcac696358600d4e6243b3", size = 276733 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/75/774e9a4a4291864dd37a03a7bfaf46a82d61cd36c16edd33a5739ad49be3/pyzmq-26.3.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:2833602d9d42c94b9d0d2a44d2b382d3d3a4485be018ba19dddc401a464c617a", size = 1345893 },
+    { url = "https://files.pythonhosted.org/packages/ca/51/d3eedd2bd46ef851bea528d8a2688a5091183b27fc238801fcac70e80dbb/pyzmq-26.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8270d104ec7caa0bdac246d31d48d94472033ceab5ba142881704350b28159c", size = 678261 },
+    { url = "https://files.pythonhosted.org/packages/de/5e/521d7c6613769dcc3ed5e44e7082938b6dab27fffe02755784e54e98e17b/pyzmq-26.3.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c208a977843d18d3bd185f323e4eaa912eb4869cb230947dc6edd8a27a4e558a", size = 915311 },
+    { url = "https://files.pythonhosted.org/packages/78/db/3be86dd82adc638a2eb07c3028c1747ead49a71d7d334980b007f593fd9f/pyzmq-26.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eddc2be28a379c218e0d92e4a432805dcb0ca5870156a90b54c03cd9799f9f8a", size = 873193 },
+    { url = "https://files.pythonhosted.org/packages/63/1a/81a31920d5113113ccd50271649dd2d0cfcfe46925d8f8a196fe560ed0e6/pyzmq-26.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c0b519fa2159c42272f8a244354a0e110d65175647e5185b04008ec00df9f079", size = 867648 },
+    { url = "https://files.pythonhosted.org/packages/55/79/bbf57979ff2d89b5465d7205db08de7222d2560edc11272eb054c5a68cb5/pyzmq-26.3.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1595533de3a80bf8363372c20bafa963ec4bf9f2b8f539b1d9a5017f430b84c9", size = 1208475 },
+    { url = "https://files.pythonhosted.org/packages/50/fc/1246dfc4b165e7ff97ac3c4117bdd3747e03ebb62269f71f65e216bfac8b/pyzmq-26.3.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:bbef99eb8d18ba9a40f00e8836b8040cdcf0f2fa649684cf7a66339599919d21", size = 1519428 },
+    { url = "https://files.pythonhosted.org/packages/5f/9a/143aacb6b372b0e2d812aec73a06fc5df3e169a361d4302226f8563954c6/pyzmq-26.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:979486d444ca3c469cd1c7f6a619ce48ff08b3b595d451937db543754bfacb65", size = 1419530 },
+    { url = "https://files.pythonhosted.org/packages/47/f7/b437e77d496089e17e77866eb126dd97ea47041b58e53892f57e82869198/pyzmq-26.3.0-cp311-cp311-win32.whl", hash = "sha256:4b127cfe10b4c56e4285b69fd4b38ea1d368099ea4273d8fb349163fce3cd598", size = 582538 },
+    { url = "https://files.pythonhosted.org/packages/a1/2c/99a01a2d7865aaf44e47c2182cbdbc15da1f2e4cfee92dc8e1fb5114f993/pyzmq-26.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:cf736cc1298ef15280d9fcf7a25c09b05af016656856dc6fe5626fd8912658dd", size = 647989 },
+    { url = "https://files.pythonhosted.org/packages/60/b3/36ac1cb8fafeadff09935f4bdc1232e511af8f8893d6cebc7ceb93c6753a/pyzmq-26.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:2dc46ec09f5d36f606ac8393303149e69d17121beee13c8dac25e2a2078e31c4", size = 561533 },
+    { url = "https://files.pythonhosted.org/packages/7b/03/7170c3814bb9106c1bca67700c731aaf1cd990fd2f0097c754acb600330e/pyzmq-26.3.0-cp312-cp312-macosx_10_15_universal2.whl", hash = "sha256:c80653332c6136da7f4d4e143975e74ac0fa14f851f716d90583bc19e8945cea", size = 1348354 },
+    { url = "https://files.pythonhosted.org/packages/74/f3/908b17f9111cdc764aef1de3d36026a2984c46ed90c3c2c85f28b66142f0/pyzmq-26.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e317ee1d4528a03506cb1c282cd9db73660a35b3564096de37de7350e7d87a7", size = 671056 },
+    { url = "https://files.pythonhosted.org/packages/02/ad/afcb8484b65ceacd1609f709c2caeed31bd6c49261a7507cd5c175cc105f/pyzmq-26.3.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:943a22ebb3daacb45f76a9bcca9a7b74e7d94608c0c0505da30af900b998ca8d", size = 908597 },
+    { url = "https://files.pythonhosted.org/packages/a1/b5/4eeeae0aaaa6ef0c74cfa8b2273b53382bd858df6d99485f2fc8211e7002/pyzmq-26.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3fc9e71490d989144981ea21ef4fdfaa7b6aa84aff9632d91c736441ce2f6b00", size = 865260 },
+    { url = "https://files.pythonhosted.org/packages/74/6a/63db856e93e3a3c3dc98a1de28a902cf1b21c7b0d3856cd5931d7cfd30af/pyzmq-26.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:e281a8071a06888575a4eb523c4deeefdcd2f5fe4a2d47e02ac8bf3a5b49f695", size = 859916 },
+    { url = "https://files.pythonhosted.org/packages/e1/ce/d522c9b46ee3746d4b98c81969c568c2c6296e931a65f2c87104b645654c/pyzmq-26.3.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:be77efd735bb1064605be8dec6e721141c1421ef0b115ef54e493a64e50e9a52", size = 1201368 },
+    { url = "https://files.pythonhosted.org/packages/5a/56/29dcd3647a39e933eb489fda261a1e2700a59d4a9432889a85166e15651c/pyzmq-26.3.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:7a4ac2ffa34f1212dd586af90f4ba894e424f0cabb3a49cdcff944925640f6ac", size = 1512663 },
+    { url = "https://files.pythonhosted.org/packages/6b/36/7c570698127a43398ed1b1832dada59496e633115016addbce5eda9938a6/pyzmq-26.3.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ba698c7c252af83b6bba9775035263f0df5f807f0404019916d4b71af8161f66", size = 1411693 },
+    { url = "https://files.pythonhosted.org/packages/de/54/51d39bef85a7cdbca36227f7defdbfcdc5011b8361a3bfc0e8df431f5a5d/pyzmq-26.3.0-cp312-cp312-win32.whl", hash = "sha256:214038aaa88e801e54c2ef0cfdb2e6df27eb05f67b477380a452b595c5ecfa37", size = 581244 },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/9512b11a1d0c5648534f03d5ab0c3222f55dc9c192029c1cb00a0ca044e2/pyzmq-26.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:bad7fe0372e505442482ca3ccbc0d6f38dae81b1650f57a0aa6bbee18e7df495", size = 643559 },
+    { url = "https://files.pythonhosted.org/packages/27/9f/faf5c9cf91b61eeb82a5e919d024d3ac28a795c92cce817be264ccd757d3/pyzmq-26.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:b7b578d604e79e99aa39495becea013fd043fa9f36e4b490efa951f3d847a24d", size = 557664 },
+    { url = "https://files.pythonhosted.org/packages/37/16/97b8c5107bfccb39120e611671a452c9ff6e8626fb3f8d4c15afd652b6ae/pyzmq-26.3.0-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:fa85953df84beb7b8b73cb3ec3f5d92b62687a09a8e71525c6734e020edf56fd", size = 1345691 },
+    { url = "https://files.pythonhosted.org/packages/a5/61/d5572d95040c0bb5b31eed5b23f3f0f992d94e4e0de0cea62e3c7f3a85c1/pyzmq-26.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:209d09f0ab6ddbcebe64630d1e6ca940687e736f443c265ae15bc4bfad833597", size = 670622 },
+    { url = "https://files.pythonhosted.org/packages/1c/0c/f0235d27388aacf4ed8bcc1d574f6f2f629da0a20610faa0a8e9d363c2b0/pyzmq-26.3.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d35cc1086f1d4f907df85c6cceb2245cb39a04f69c3f375993363216134d76d4", size = 908683 },
+    { url = "https://files.pythonhosted.org/packages/cb/52/664828f9586c396b857eec088d208230463e3dc991a24df6adbad98fbaa3/pyzmq-26.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b380e9087078ba91e45fb18cdd0c25275ffaa045cf63c947be0ddae6186bc9d9", size = 865212 },
+    { url = "https://files.pythonhosted.org/packages/2b/14/213b2967030b7d7aecc32dd453830f98799b3cbf2b10a40232e9f22a6520/pyzmq-26.3.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6d64e74143587efe7c9522bb74d1448128fdf9897cc9b6d8b9927490922fd558", size = 860068 },
+    { url = "https://files.pythonhosted.org/packages/aa/e5/ff50c8fade69d1c0469652832c626d1910668697642c10cb0e1b6183ef9a/pyzmq-26.3.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:efba4f53ac7752eea6d8ca38a4ddac579e6e742fba78d1e99c12c95cd2acfc64", size = 1201303 },
+    { url = "https://files.pythonhosted.org/packages/9a/e2/fff5e483be95ccc11a05781323e001e63ec15daec1d0f6f08de72ca534db/pyzmq-26.3.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:9b0137a1c40da3b7989839f9b78a44de642cdd1ce20dcef341de174c8d04aa53", size = 1512892 },
+    { url = "https://files.pythonhosted.org/packages/21/75/cc44d276e43136e5692e487c3c019f816e11ed445261e434217c28cc98c4/pyzmq-26.3.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a995404bd3982c089e57b428c74edd5bfc3b0616b3dbcd6a8e270f1ee2110f36", size = 1411736 },
+    { url = "https://files.pythonhosted.org/packages/ee/1c/d070cbc9a7961fe772641c51bb3798d88cb1f8e20ca718407363462624cf/pyzmq-26.3.0-cp313-cp313-win32.whl", hash = "sha256:240b1634b9e530ef6a277d95cbca1a6922f44dfddc5f0a3cd6c722a8de867f14", size = 581214 },
+    { url = "https://files.pythonhosted.org/packages/38/d3/91082f1151ff5b54e0bed40eb1a26f418530ab07ecaec4dbb83e3d9fa9a9/pyzmq-26.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:fe67291775ea4c2883764ba467eb389c29c308c56b86c1e19e49c9e1ed0cbeca", size = 643412 },
+    { url = "https://files.pythonhosted.org/packages/e0/cf/dabe68dfdf3e67bea6152eeec4b251cf899ee5b853cfb5c97e4719f9e6e9/pyzmq-26.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:73ca9ae9a9011b714cf7650450cd9c8b61a135180b708904f1f0a05004543dce", size = 557444 },
+    { url = "https://files.pythonhosted.org/packages/c0/56/e7576ac71c1566da4f4ec586351462a2bb202143fb074bf56df8fe85dcc3/pyzmq-26.3.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:fea7efbd7e49af9d7e5ed6c506dfc7de3d1a628790bd3a35fd0e3c904dc7d464", size = 1340288 },
+    { url = "https://files.pythonhosted.org/packages/f1/ab/0bca97e94d420b5908968bc479e51c3686a9f80d8893450eefcd673b1b1d/pyzmq-26.3.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4430c7cba23bb0e2ee203eee7851c1654167d956fc6d4b3a87909ccaf3c5825", size = 662462 },
+    { url = "https://files.pythonhosted.org/packages/ee/be/99e89b55863808da322ac3ab52d8e135dcf2241094aaa468bfe2923d5194/pyzmq-26.3.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:016d89bee8c7d566fad75516b4e53ec7c81018c062d4c51cd061badf9539be52", size = 896464 },
+    { url = "https://files.pythonhosted.org/packages/38/d4/a4be06a313c8d6a5fe1d92975db30aca85f502e867fca392532e06a28c3c/pyzmq-26.3.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04bfe59852d76d56736bfd10ac1d49d421ab8ed11030b4a0332900691507f557", size = 853432 },
+    { url = "https://files.pythonhosted.org/packages/12/e6/e608b4c34106bbf5b3b382662ea90a43b2e23df0aa9c1f0fd4e21168d523/pyzmq-26.3.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1fe05bd0d633a0f672bb28cb8b4743358d196792e1caf04973b7898a0d70b046", size = 845884 },
+    { url = "https://files.pythonhosted.org/packages/c3/a9/d5e6355308ba529d9cd3576ee8bb3b2e2b726571748f515fbb8559401f5b/pyzmq-26.3.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:2aa1a9f236d5b835fb8642f27de95f9edcfd276c4bc1b6ffc84f27c6fb2e2981", size = 1191454 },
+    { url = "https://files.pythonhosted.org/packages/6a/9a/a21dc6c73ac242e425709c1e0049368d8f5db5de7c1102a45f93f5c492b3/pyzmq-26.3.0-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:21399b31753bf321043ea60c360ed5052cc7be20739785b1dff1820f819e35b3", size = 1500397 },
+    { url = "https://files.pythonhosted.org/packages/87/88/0236056156da0278c9ca2e2562463643597808b5bbd6c34009ba217e7e92/pyzmq-26.3.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d015efcd96aca8882057e7e6f06224f79eecd22cad193d3e6a0a91ec67590d1f", size = 1398401 },
+    { url = "https://files.pythonhosted.org/packages/f4/c6/e36b2a2ff6534cb1d1f6b3fb37901ac54675caf7b2e1239613aa40d1d217/pyzmq-26.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b4fc9903a73c25be9d5fe45c87faababcf3879445efa16140146b08fccfac017", size = 835670 },
+    { url = "https://files.pythonhosted.org/packages/1d/b9/8059c5af94b245068e7f7379c08c7e409ec854139d6021aecf2c111d8547/pyzmq-26.3.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c15b69af22030960ac63567e98ad8221cddf5d720d9cf03d85021dfd452324ef", size = 570838 },
+    { url = "https://files.pythonhosted.org/packages/80/a4/f0a4266ff2d94a87f7c32895b1716f9ac0edc0471d518462beeb0a9a94b5/pyzmq-26.3.0-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2cf9ab0dff4dbaa2e893eb608373c97eb908e53b7d9793ad00ccbd082c0ee12f", size = 799507 },
+    { url = "https://files.pythonhosted.org/packages/78/14/3d7d459f496fab8e487b23423ccba57abf7153a4fde0c3e000500fa02ff8/pyzmq-26.3.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ec332675f6a138db57aad93ae6387953763f85419bdbd18e914cb279ee1c451", size = 758002 },
+    { url = "https://files.pythonhosted.org/packages/22/65/cc1f0e1db1290770285430e36d51767e620487523e6a04094be637e55698/pyzmq-26.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:eb96568a22fe070590942cd4780950e2172e00fb033a8b76e47692583b1bd97c", size = 556425 },
 ]
 
 [[package]]
@@ -1512,6 +1891,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
+]
+
+[[package]]
 name = "sympy"
 version = "1.13.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1597,6 +1990,15 @@ wheels = [
 ]
 
 [[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359 },
+]
+
+[[package]]
 name = "triton"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1675,6 +2077,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/bb/28d94b0369f0055dc4aef704971858a414490f6eb23b9bbfa70d090f4b59/wandb-0.19.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:82a956150e53df0b4c193933b3e62c3e8255dc8b43bb187270939ef35b03fda3", size = 20872380 },
     { url = "https://files.pythonhosted.org/packages/80/82/9d653fe043d48075342bed7a545611391fc62095fb1e77d6574a8f2091e3/wandb-0.19.8-py3-none-win32.whl", hash = "sha256:9d71f153cb9330e307b1b054be01971a1bd164fb9bd4190d7f57989c2d6b86e8", size = 20165481 },
     { url = "https://files.pythonhosted.org/packages/b6/90/038a64abcbe5f991468f057bd21bead84a5c39d9b0409b652893263a47b4/wandb-0.19.8-py3-none-win_amd64.whl", hash = "sha256:f7da8e6fc6693014c72fb7db3ecd5e1116066198d2aca96f6eb7220cea03081c", size = 20165486 },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
 ]
 
 [[package]]


### PR DESCRIPTION
When I went to make another change, this test started failing again, I think because it generated new test cases. Try to resolve the instability by avoiding complexity of rounding and numeric error by packing data as smaller bitfields into the float64. 