### PR TITLE
Fix multi-step training

### DIFF
--- a/configs/train_cm4_2step.test.yaml
+++ b/configs/train_cm4_2step.test.yaml
@@ -1,0 +1,72 @@
+# A config file to test training.
+# Used in automated tests.
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 2
+batch_size: 1
+learning_rate: 0.0001
+scheduler: false
+loss: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: [-1]
+data_percent: 1.0
+train:
+  start_time: '1969-08-15'
+  end_time: '1969-10-20'
+val:
+  start_time: '1969-10-20'
+  end_time: '1969-11-20'
+inference:
+  - start_time: '1969-11-20'
+    end_time: '1969-12-15'
+data_stride: [1]
+steps: [2]
+step_transition: []
+backend: auto
+
+experiment:
+  base_name: train
+  sub_name: test
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: ocean-emulators
+    entity: m2lines
+    group: samudra-train-om4
+  network: convnextunet
+  exp_num_in: '3D_5'
+  exp_num_extra: '3D_5'
+  exp_num_out: '3D_5'
+data:
+  data_path: fake/path/to/data
+  data_means_path: fake/path/to/means
+  data_stds_path: fake/path/to/stds
+  scaling_residuals_file: null
+  depth_mode: all
+  time_delta: 5
+  num_workers: 4
+  hist: 0
+
+
+unet:
+  ch_width: [2, 3]
+  n_out: 4
+  dilation: [1, 2]
+  n_layers: [1, 1]
+  pred_residuals: false
+  last_kernel_size: 3
+  pad: "circular"
+
+  core_block:
+    block_type: "conv_next_block"
+    kernel_size: 3
+    activation: "capped_gelu"
+    upscale_factor: 2
+    norm: "batch"
+
+  down_sampling_block: "avg_pool"
+  up_sampling_block: "bilinear_upsample"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ lint.pydocstyle.convention = "google"
 markers = [
   "manual: marks tests as manually run (deselect with '-m \"not manual\"').",
   "cuda: marks tests that need a CUDA-enabled device to run (deselect with '-m \"not cuda\"').",
+  "only_configs: used to mark tests that only run on specific configs (not used on command line)",
+  "all_configs: used to mark tests that run on all configs (not used on command line)",
 ]
 pythonpath = [ "src" ]
 testpaths = [ "tests" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ markers = [
 ]
 pythonpath = [ "src" ]
 testpaths = [ "tests" ]
-addopts = "--jaxtyping-packages=data,datasets,beartype.beartype"
+addopts = "--jaxtyping-packages=data,datasets,beartype.beartype --strict-markers"
 
 [tool.mypy]
 check_untyped_defs = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,6 +267,41 @@ class DataSourceDims:
         return data_source, data_var_index
 
 
+DEFAULT_CONFIG = "train_cm4.test.yaml"
+ALL_CONFIGS = [DEFAULT_CONFIG, "train_cm4_2step.test.yaml"]
+
+
+@pytest.fixture(scope="session", params=ALL_CONFIGS)
+def config_name(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture(autouse=True)
+def check_skip_configs(request, config_name):
+    only_configs = request.node.get_closest_marker("only_configs")
+    if only_configs:
+        if config_name not in only_configs.args:
+            pytest.skip(
+                f"Skipping test for {config_name} because"
+                " it is not in {only_configs.args}"
+            )
+        if config_name not in ALL_CONFIGS:
+            raise ValueError(
+                f"Test config {config_name} is not"
+                " in the list of all configs: {ALL_CONFIGS}"
+            )
+
+    all_configs = request.node.get_closest_marker("all_configs")
+    if all_configs is None:
+        # If the test is not marked with all_configs, skip all configs except the one
+        # specified in the test.
+        if config_name != DEFAULT_CONFIG:
+            pytest.skip(
+                f"Skipping test for {config_name}"
+                " because it is not marked with all_configs"
+            )
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--model1", action="store", help="Path to the first model .pt file"
@@ -331,7 +366,10 @@ def data_source() -> DataSource:
 
 @pytest.fixture(scope="session")
 def train_config(
-    data_source: DataSource, pytestconfig: pytest.Config, backend: TrainBackendConfig
+    data_source: DataSource,
+    pytestconfig: pytest.Config,
+    config_name: str,
+    backend: TrainBackendConfig,
 ) -> Generator[TrainConfig, Any, None]:
     with tempfile.TemporaryDirectory() as tmpdir:
 
@@ -344,8 +382,7 @@ def train_config(
         data_source.stds.to_netcdf(_make_path("stds.netcdf"))
 
         # Open default training script; modify it so it uses the temporary directory.
-        default_config = pytestconfig.rootpath / "configs" / "train_cm4.test.yaml"
-        trainer = TrainConfig.from_yaml(default_config)
+        trainer = TrainConfig.from_yaml(pytestconfig.rootpath / "configs" / config_name)
         data_config = dataclasses.replace(
             trainer.data,
             data_path=_make_path("data.zarr"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -278,28 +278,38 @@ def config_name(request: pytest.FixtureRequest) -> str:
 
 @pytest.fixture(autouse=True)
 def check_skip_configs(request, config_name):
+    """Decide if we run a test given only_configs and all_configs marks.
+
+    * If there is an only_configs mark, that overrides all_configs.
+      We run all configs in only_configs in that case.
+    * If there is no only_configs mark, and there is an all_configs mark,
+      we run all configs.
+    * If there is no only_configs or all_configs mark, we run the test for the
+      default config.
+
+    """
     only_configs = request.node.get_closest_marker("only_configs")
     if only_configs:
         if config_name not in only_configs.args:
             pytest.skip(
                 f"Skipping test for {config_name} because"
-                " it is not in {only_configs.args}"
+                f" it is not in {only_configs.args}"
             )
         if config_name not in ALL_CONFIGS:
             raise ValueError(
                 f"Test config {config_name} is not"
-                " in the list of all configs: {ALL_CONFIGS}"
+                f" in the list of all configs: {ALL_CONFIGS}"
             )
-
-    all_configs = request.node.get_closest_marker("all_configs")
-    if all_configs is None:
-        # If the test is not marked with all_configs, skip all configs except the one
-        # specified in the test.
-        if config_name != DEFAULT_CONFIG:
-            pytest.skip(
-                f"Skipping test for {config_name}"
-                " because it is not marked with all_configs"
-            )
+    else:
+        all_configs = request.node.get_closest_marker("all_configs")
+        if all_configs is None:
+            # If the test is not marked with all_configs, skip all configs except
+            # the default config.
+            if config_name != DEFAULT_CONFIG:
+                pytest.skip(
+                    f"Skipping test for {config_name}"
+                    " because it is not marked with all_configs"
+                )
 
 
 def pytest_addoption(parser):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -225,14 +225,14 @@ def test_val__data_shape(val_loader_pair: LoaderPair):
     for i, sample in enumerate(loader):
         X, y = extract_sample_arrays(sample)
 
+        assert X.shape[0] == 1  # validation always has 1 step
         # Last validation batch may have fewer samples
-        assert X.shape[0] == cfg.steps[0]
         assert X.shape[1] == batch_size or (
             i == num_samples - 1 and X.shape[1] < batch_size
         )
         assert X.shape[2:] == (input_var_dim, 180, 360)
 
-        assert y.shape[0] == cfg.steps[0]
+        assert y.shape[0] == 1
         assert y.shape[1] == batch_size or (
             i == num_samples - 1 and y.shape[1] < batch_size
         )

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -13,3 +13,11 @@ def test_trainer__mini_benchmark(trainer_pair: TrainPair, caplog, benchmark):
     @benchmark
     def run():
         trainer.run()
+
+
+@pytest.mark.only_configs("train_cm4_2step.test.yaml")
+def test_trainer__mini_2step(trainer_pair: TrainPair, caplog):
+    caplog.set_level(logging.INFO)
+    _, trainer = trainer_pair
+
+    trainer.run()


### PR DESCRIPTION
Make sure our mini training test runs multi-step training, fix bug this was hiding. 

Our validation tests were expecting the same number of steps but AFAICT validation always uses 1 step, so corrected this.

This lets us run tests for the current train config (the default), or for a specific one, or all configs. 

Fixes #127 