### PR TITLE
fix build, not sure how this was working in CI before

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,6 @@ dev = [
   "types-pyyaml>=6.0.12.20241230",
 ]
 
-[tool.setuptools.dynamic]
-dependencies = { file = "requirements.txt" }
-
-[tool.setuptools.packages]
-find = {}
-
 [tool.ruff]
 lint.select = [ "D", "E", "F", "I", "W" ]
 # F722: https://docs.kidger.site/jaxtyping/faq/#flake8-or-ruff-are-throwing-an-error


### PR DESCRIPTION
Currently, `uv run python` doesn't let you run `import ocean_emulators`. This fixes that. 