### PR TITLE
Restore benchmarks to old behavior

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -67,10 +67,10 @@ jobs:
           python-version: "3.11"
 
       - name: Run CPU benchmarks
-        run: uv run --locked pytest --benchmark-only --benchmark-json output-cpu.json
+        run: uv run --locked pytest -m "not cuda" --benchmark-only --benchmark-json output-cpu.json
 
       - name: Run GPU benchmarks
-        run: uv run --locked pytest --benchmark-only --benchmark-json output-gpu.json
+        run: uv run --locked pytest -m "cuda" --benchmark-only --benchmark-json output-gpu.json
 
       # Avoid issues checking out the gh-pages branch (eg uv.lock updated)
       - name: Stash

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,7 +66,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Run benchmarks
+      - name: Run CPU benchmarks
+        run: uv run --locked pytest --benchmark-only --benchmark-json output-cpu.json
+
+      - name: Run GPU benchmarks
         run: uv run --locked pytest --benchmark-only --benchmark-json output-gpu.json
 
       # Avoid issues checking out the gh-pages branch (eg uv.lock updated)


### PR DESCRIPTION
This was a silly bug but after looking at this we probably want to leave them separate so the benchmark web format doesn't change. 