### PR TITLE
Speed up tests

### DIFF
--- a/configs/train_cm4_2step.test.yaml
+++ b/configs/train_cm4_2step.test.yaml
@@ -4,7 +4,7 @@ debug: false
 disk_mode: true
 pin_mem: true
 save_freq: 5
-epochs: 2
+epochs: 1
 batch_size: 1
 learning_rate: 0.0001
 scheduler: false
@@ -14,14 +14,14 @@ resume_ckpt_path: null
 inference_epochs: [-1]
 data_percent: 1.0
 train:
-  start_time: '1969-08-15'
-  end_time: '1969-10-20'
+  start_time: "1969-08-15"
+  end_time: "1969-09-20"
 val:
-  start_time: '1969-10-20'
-  end_time: '1969-11-20'
+  start_time: "1969-10-20"
+  end_time: "1969-10-30"
 inference:
-  - start_time: '1969-11-20'
-    end_time: '1969-12-15'
+  - start_time: "1969-10-30"
+    end_time: "1969-11-15"
 data_stride: [1]
 steps: [2]
 step_transition: []
@@ -38,9 +38,9 @@ experiment:
     entity: m2lines
     group: samudra-train-om4
   network: convnextunet
-  exp_num_in: '3D_5'
-  exp_num_extra: '3D_5'
-  exp_num_out: '3D_5'
+  exp_num_in: "3D_5"
+  exp_num_extra: "3D_5"
+  exp_num_out: "3D_5"
 data:
   data_path: fake/path/to/data
   data_means_path: fake/path/to/means
@@ -50,7 +50,6 @@ data:
   time_delta: 5
   num_workers: 4
   hist: 0
-
 
 unet:
   ch_width: [2, 3]


### PR DESCRIPTION
Cuts test time on my machine from 1:45 to :40. This does change the benchmark test run, I could break out a separate config for that if desired to keep it consistent. WDYT @alxmrs?

Before:
```
==================================================================================== slowest durations =====================================================================================
67.17s call     tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
6.48s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-train]
6.42s call     tests/test_datasets.py::test_train__data_shape[train_cm4.test.yaml-cpu]
6.26s call     tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
2.57s call     tests/test_datasets.py::test_inference__data_is_not_zero[train_cm4.test.yaml-cpu]
2.48s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-val]
2.41s call     tests/test_datasets.py::test_inference__data_shape[train_cm4.test.yaml-cpu]
2.37s call     tests/test_datasets.py::test_val__data_shape[train_cm4.test.yaml-cpu]
2.23s call     tests/test_datasets.py::test_val__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
1.86s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
1.61s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4_2step.test.yaml-cpu]
0.79s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
0.36s call     tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
0.28s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4_2step.test.yaml-cpu]
0.14s teardown tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]

(65 durations < 0.005s hidden.  Use -vv to show these durations.)
========================================================== 16 passed, 16 skipped, 52 deselected, 17 warnings in 104.09s (0:01:44) ==========================================================
pytest -m 'not cuda and not manual' --durations=0  326.39s user 636.78s system 914% cpu 1:45.30 total'
```

After:
```
==================================================================================== slowest durations =====================================================================================
18.48s call     tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
2.46s call     tests/test_datasets.py::test_train__data_shape[train_cm4.test.yaml-cpu]
2.40s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-train]
2.27s call     tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
1.80s call     tests/test_datasets.py::test_val__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
1.78s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-val]
1.76s call     tests/test_datasets.py::test_inference__data_is_not_zero[train_cm4.test.yaml-cpu]
1.75s call     tests/test_datasets.py::test_val__data_shape[train_cm4.test.yaml-cpu]
1.65s call     tests/test_datasets.py::test_inference__data_shape[train_cm4.test.yaml-cpu]
1.26s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
0.92s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4_2step.test.yaml-cpu]
0.86s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
0.66s call     tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
0.28s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4_2step.test.yaml-cpu]
0.08s teardown tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]

(65 durations < 0.005s hidden.  Use -vv to show these durations.)
=============================================================== 16 passed, 16 skipped, 52 deselected, 15 warnings in 39.08s ================================================================
pytest -m 'not cuda and not manual' --durations=0  138.88s user 226.06s system 906% cpu 40.267 total
```