### PR TITLE
[Draft] Test duration experiments: I think we need to change Zarr chunks at the dataset storage time

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -22,7 +22,7 @@ from ocean_emulators.constants import (
 from ocean_emulators.utils.data import Normalize
 from ocean_emulators.utils.device import get_device, using_gpu
 
-Example = tuple[TotalInput, Label]
+Example = list[TotalInput | Label]
 
 
 class InferenceDataset(Dataset):
@@ -230,7 +230,7 @@ class TrainData:
         self.steps = 0
 
     def insert(self, input_: TotalInput, label: Label):
-        self.td_dict[self.steps] = (input_, label)
+        self.td_dict[self.steps] = [input_, label]
         self.steps += 1
 
     def get_initial_input(self) -> TotalInput:
@@ -256,10 +256,10 @@ class TrainData:
 
     def to(self, device: torch.device) -> None:
         for step in self.td_dict:
-            self.td_dict[step] = (
+            self.td_dict[step] = [
                 self.td_dict[step][0].to(device),
                 self.td_dict[step][1].to(device),
-            )
+            ]
 
 
 class TrainDataset(Dataset):

--- a/src/ocean_emulators/train_3D.py
+++ b/src/ocean_emulators/train_3D.py
@@ -164,12 +164,12 @@ class Trainer:
             self.data = xr.open_mfdataset(
                 os.path.join(self.data_dir, self.data_path),
                 engine="netcdf4",
-                chunks={"time": 1, "lat": 180, "lon": 360},
+                chunks={"time": 700, "lat": 180, "lon": 360},
             )
         else:
             self.data = xr.open_zarr(
                 os.path.join(self.data_dir, self.data_path),
-                chunks={},
+                chunks=dict(time=700),
                 consolidated=True,
             )
         self.data_mean = xr.open_dataset(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,7 +370,6 @@ def data_source() -> DataSource:
         for lev in range(len(c.DEPTH_I_LEVELS))
     }
     ds = xr.Dataset(vars_2d | vars_3d | masks, coords=coords)
-    ds = ds.chunk({"time": 700})
 
     return DataSource(data=ds, means=ds.mean(), stds=ds.std())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -370,6 +370,7 @@ def data_source() -> DataSource:
         for lev in range(len(c.DEPTH_I_LEVELS))
     }
     ds = xr.Dataset(vars_2d | vars_3d | masks, coords=coords)
+    ds = ds.chunk({"time": 700})
 
     return DataSource(data=ds, means=ds.mean(), stds=ds.std())
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,6 +6,7 @@ import itertools
 import cftime
 import numpy as np
 import pytest
+import torch
 from hypothesis import example, given, settings
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
@@ -53,13 +54,13 @@ def td_loader_pair(request, train_loader_pair, val_loader_pair) -> LoaderPair:
         return val_loader_pair
 
 
-def extract_sample_arrays(td: TrainData) -> tuple[np.ndarray, np.ndarray]:
+def extract_sample_arrays(td: TrainData) -> tuple[torch.Tensor, torch.Tensor]:
     """Extract underlying X, y pairs from TrainData object."""
     steps = len(td)
-    x_arrays = [td.get_input(s).numpy(force=True) for s in range(steps)]
-    y_arrays = [td.get_label(s).numpy(force=True) for s in range(steps)]
+    x_arrays = [td.get_input(s) for s in range(steps)]
+    y_arrays = [td.get_label(s) for s in range(steps)]
 
-    return np.stack(x_arrays, axis=0), np.stack(y_arrays, axis=0)
+    return torch.stack(x_arrays, dim=0), torch.stack(y_arrays, dim=0)
 
 
 def vector_of(max_vec_size: int, min_vec_size=1):
@@ -271,9 +272,11 @@ def test__data_is_not_zeros(td_loader_pair: LoaderPair):
 
     for sample in loader:
         X, y = extract_sample_arrays(sample)
-        assert np.count_nonzero(np.zeros(X.shape)) == 0, "Sanity check: Zero is zero."
-        assert np.count_nonzero(X) != 0, "Input data should not be a zeros matrix!"
-        assert np.count_nonzero(y) != 0, "Label data should not be a zeros matrix!"
+        assert (
+            torch.count_nonzero(torch.zeros(X.shape)) == 0
+        ), "Sanity check: Zero is zero."
+        assert torch.count_nonzero(X) != 0, "Input data should not be a zeros matrix!"
+        assert torch.count_nonzero(y) != 0, "Label data should not be a zeros matrix!"
 
 
 def test_inference__data_is_not_zero(inference_loader_pair: LoaderPair):


### PR DESCRIPTION
Profiling command: `pytest -m 'not cuda and not manual' -k 'not benchmark' --durations=0`

Before: 

```
65.68s call     tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
6.17s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-train]
5.83s call     tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
5.78s call     tests/test_datasets.py::test_train__data_shape[train_cm4.test.yaml-cpu]
2.26s call     tests/test_datasets.py::test_inference__data_is_not_zero[train_cm4.test.yaml-cpu]
2.25s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-val]
2.21s call     tests/test_datasets.py::test_inference__data_shape[train_cm4.test.yaml-cpu]
2.18s call     tests/test_datasets.py::test_val__data_shape[train_cm4.test.yaml-cpu]
2.10s call     tests/test_datasets.py::test_val__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
1.87s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
1.58s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4_2step.test.yaml-cpu]
0.94s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
0.57s call     tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
0.26s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4_2step.test.yaml-cpu]
0.22s teardown tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
```

After 55eede5470ffee3412da12e00c35dda59f4b2db7:

```
64.33s call     tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
6.62s call     tests/test_datasets.py::test_train__data_shape[train_cm4.test.yaml-cpu]
6.14s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-train]
5.80s call     tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
3.32s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
2.46s call     tests/test_datasets.py::test_inference__data_is_not_zero[train_cm4.test.yaml-cpu]
2.32s call     tests/test_datasets.py::test_inference__data_shape[train_cm4.test.yaml-cpu]
2.30s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-val]
2.28s call     tests/test_datasets.py::test_val__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
2.21s call     tests/test_datasets.py::test_val__data_shape[train_cm4.test.yaml-cpu]
1.49s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4_2step.test.yaml-cpu]
1.48s call     tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
0.96s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
0.25s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4_2step.test.yaml-cpu]
0.18s teardown tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
```

After 1176f1f3913eebed02f735682385ae9dc6d32098 (❗)

```
49.13s call     tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
3.97s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-train]
3.82s call     tests/test_datasets.py::test_train__data_shape[train_cm4.test.yaml-cpu]
3.51s call     tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
2.04s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
1.56s call     tests/test_datasets.py::test_val__data_shape[train_cm4.test.yaml-cpu]
1.49s call     tests/test_datasets.py::test_val__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
1.45s call     tests/test_datasets.py::test_inference__data_shape[train_cm4.test.yaml-cpu]
1.38s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-val]
1.25s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4_2step.test.yaml-cpu]
1.10s call     tests/test_datasets.py::test_inference__data_is_not_zero[train_cm4.test.yaml-cpu]
0.80s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
0.72s call     tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
0.23s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4_2step.test.yaml-cpu]
0.02s teardown tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
```

After 2b219853da2d8d1953fe526c5dab5accb496724f

```
============================================================================ slowest durations ============================================================================
77.57s call     tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
8.80s call     tests/test_datasets.py::test_train__data_shape[train_cm4.test.yaml-cpu]
8.39s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-train]
7.22s call     tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
3.07s call     tests/test_datasets.py::test_inference__data_shape[train_cm4.test.yaml-cpu]
2.77s call     tests/test_datasets.py::test_inference__data_is_not_zero[train_cm4.test.yaml-cpu]
2.44s call     tests/test_datasets.py::test_val__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
2.39s call     tests/test_datasets.py::test_val__data_shape[train_cm4.test.yaml-cpu]
2.38s call     tests/test_datasets.py::test__data_is_not_zeros[train_cm4.test.yaml-cpu-val]
2.23s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
1.70s setup    tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4_2step.test.yaml-cpu]
1.03s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4.test.yaml-cpu]
0.72s call     tests/test_datasets.py::test_test_util__data_source_roundtrip[train_cm4.test.yaml-cpu]
0.33s setup    tests/test_datasets.py::test_train__loads_correct_number_of_samples[train_cm4_2step.test.yaml-cpu]
0.13s teardown tests/test_trainer.py::test_trainer__mini_2step[train_cm4_2step.test.yaml-cpu]
```

## Lessons Learned
My takeaway here is that we should consider re-writing the OM4 dataset to store data in larger chunks, not just do it upon the open_dataset call. Am I reading the results correctly? Let's discuss this.