### PR TITLE
Compact data during clone.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-  "aiohttp-retry>=2.9.1",
   "beartype>=0.20",
   "fsspec>=2025.3",
   "hypothesis[numpy]>=6.127.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,5 +93,5 @@ addopts = "--jaxtyping-packages=data,datasets,beartype.beartype --strict-markers
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = [ "cftime.*", "scipy.*", "fsspec.*"  ]
+module = [ "cftime.*", "scipy.*", "fsspec.*" ]
 follow_untyped_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "aiohttp-retry>=2.9.1",
   "beartype>=0.20",
+  "fsspec>=2025.3",
   "hypothesis[numpy]>=6.127.2",
   "ipykernel>=6.29.5",
   "mypy>=1.15",
@@ -91,5 +93,5 @@ addopts = "--jaxtyping-packages=data,datasets,beartype.beartype --strict-markers
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]
-module = [ "cftime.*", "scipy.*" ]
+module = [ "cftime.*", "scipy.*", "fsspec.*"  ]
 follow_untyped_imports = true

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -27,13 +27,9 @@ from fsspec.implementations.http import get_client
 
 DATA_ROOT = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
 
-_STATUSES = {x for x in range(100, 600)}
-_STATUSES.discard(200)
-_STATUSES.discard(429)
-
 
 async def _robust_get_client(**kwargs):
-    options = ExponentialRetry(attempts=5, statuses=_STATUSES)
+    options = ExponentialRetry(attempts=5)
     return RetryClient(
         await get_client(**kwargs), raise_for_status=True, retry_options=options
     )

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -9,7 +9,6 @@
 #   "aiohttp",
 #   "gcsfs",
 #   "numcodecs>=0.15",
-#   "aiohttp-retry",
 #   "distributed",
 #   "tenacity",
 # ]

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -16,6 +16,7 @@
 import argparse
 import os
 import pathlib
+from collections import defaultdict
 
 import dask
 import dask.diagnostics
@@ -31,17 +32,36 @@ def robust_open_dataset(target: str, **kwargs) -> xr.Dataset:
 
 
 def compact_dataset(ds: xr.Dataset) -> xr.Dataset:
-    return xr.Dataset()
+    data = ds.copy()
+
+    var_groups = defaultdict(list)
+    for key in data.keys():
+        if "_lev_" in (k := str(key)):
+            base_name = k.split("_lev_")[0]
+            var_groups[base_name].append(k)
+
+    def _parse_level(x) -> float:
+        return float(x.split("_lev_")[1].replace("_", "."))
+
+    for base_var, vars_ in var_groups.items():
+        sorted_vars = sorted(vars_, key=_parse_level)
+        da = xr.concat([data[var] for var in sorted_vars], dim="lev").assign_coords(
+            lev=("lev", data.lev.values)
+        )
+        data[base_var] = da
+        data = data.drop_vars(vars_)
+
+    return data
 
 
 def main(args: argparse.Namespace) -> None:
     """Clones slice of Samudra data at the `dest_root` directory."""
     # Ensure the path/to/dest exists
-    if not args.dest.startswith("gs://"):
+    if not args.dest.startswith("gs://") and not args.dest.startswith("s3://"):
         pathlib.Path(args.dest).mkdir(parents=True, exist_ok=True)
 
     time_slice = slice(args.time_start, args.time_end)
-    output_chunks = dict(time=args.write_time_chunks)
+    output_chunks = dict(time=args.write_time_chunks, lev=19)
 
     for name, dest_fmt in [
         ("OM4", "zarr"),
@@ -55,6 +75,8 @@ def main(args: argparse.Namespace) -> None:
         if name == "OM4":
             data = robust_open_dataset(source, engine="zarr", chunks={"time": 700})
             data = data.isel(time=time_slice)
+            if args.compact_variables:
+                data = compact_dataset(data)
         else:
             data = robust_open_dataset(source, engine="zarr", chunks={})
 

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -11,6 +11,7 @@
 #   "numcodecs>=0.15",
 #   "aiohttp-retry",
 #   "distributed",
+#   "tenacity",
 # ]
 # ///
 
@@ -21,26 +22,16 @@ from collections import defaultdict
 
 import dask
 import dask.diagnostics
-import fsspec
 import xarray as xr
-from aiohttp_retry import ExponentialRetry, RetryClient
 from dask.distributed import LocalCluster
-from fsspec.implementations.http import get_client
+from tenacity import retry
 
 DATA_ROOT = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
 
 
-async def _robust_get_client(**kwargs):
-    options = ExponentialRetry(attempts=5)
-    return RetryClient(
-        await get_client(**kwargs), raise_for_status=True, retry_options=options
-    )
-
-
+@retry
 def robust_open_dataset(target: str, **kwargs) -> xr.Dataset:
-    fs = fsspec.filesystem("http", get_client=_robust_get_client)
-    mapper = fs.get_mapper(target)
-    return xr.open_dataset(mapper, **kwargs)
+    return xr.open_dataset(target, **kwargs)
 
 
 def compact_dataset(ds: xr.Dataset) -> xr.Dataset:

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -94,8 +94,6 @@ def main(args: argparse.Namespace) -> None:
         else:
             data = robust_open_dataset(source, engine="zarr", chunks={})
 
-        data.load()
-
         with dask.diagnostics.ProgressBar():
             if dest_fmt.lower() == "zarr":
                 data.chunk(output_chunks).to_zarr(dest + ".zarr")

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -10,6 +10,7 @@
 #   "gcsfs",
 #   "numcodecs>=0.15",
 #   "aiohttp-retry",
+#   "distributed",
 # ]
 # ///
 
@@ -23,6 +24,7 @@ import dask.diagnostics
 import fsspec
 import xarray as xr
 from aiohttp_retry import ExponentialRetry, RetryClient
+from dask.distributed import LocalCluster
 from fsspec.implementations.http import get_client
 
 DATA_ROOT = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
@@ -66,6 +68,10 @@ def compact_dataset(ds: xr.Dataset) -> xr.Dataset:
 
 def main(args: argparse.Namespace) -> None:
     """Clones slice of Samudra data at the `dest_root` directory."""
+    if args.local_cluster:
+        cluster = LocalCluster()
+        client = cluster.get_client()  # noqa: F841
+
     # Ensure the path/to/dest exists
     if not args.dest.startswith("gs://") and not args.dest.startswith("s3://"):
         pathlib.Path(args.dest).mkdir(parents=True, exist_ok=True)
@@ -116,5 +122,6 @@ if __name__ == "__main__":
     )
     parser.add_argument("--write_time_chunks", type=int, default=10)
     parser.add_argument("--compact_variables", action="store_true")
+    parser.add_argument("--local_cluster", action="store_true")
 
     main(parser.parse_args())

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -30,20 +30,25 @@ def robust_open_dataset(target: str, **kwargs) -> xr.Dataset:
     return xr.open_dataset(target, **kwargs)
 
 
-def main(dest_root: str, time_slice: slice, write_time_chunks: int) -> None:
+def compact_dataset(ds: xr.Dataset) -> xr.Dataset:
+    return xr.Dataset()
+
+
+def main(args: argparse.Namespace) -> None:
     """Clones slice of Samudra data at the `dest_root` directory."""
     # Ensure the path/to/dest exists
-    if not dest_root.startswith("gs://"):
-        pathlib.Path(dest_root).mkdir(parents=True, exist_ok=True)
+    if not args.dest.startswith("gs://"):
+        pathlib.Path(args.dest).mkdir(parents=True, exist_ok=True)
 
-    output_chunks = dict(time=write_time_chunks)
+    time_slice = slice(args.time_start, args.time_end)
+    output_chunks = dict(time=args.write_time_chunks)
 
     for name, dest_fmt in [
         ("OM4", "zarr"),
         ("OM4_means", "netcdf"),
         ("OM4_stds", "netcdf"),
     ]:
-        dest = os.path.join(dest_root, name)
+        dest = os.path.join(args.dest, name)
         source = DATA_ROOT + name
 
         # Open Xarray Datasets with retries + exponential backoff.
@@ -77,8 +82,7 @@ if __name__ == "__main__":
         default=None,
         help="end index for data.isel() along time dimension.",
     )
-    parser.add_argument("--write_time_chunks", type=int, default=1)
-    args = parser.parse_args()
+    parser.add_argument("--write_time_chunks", type=int, default=10)
+    parser.add_argument("--compact_variables", action="store_true")
 
-    time_range = slice(args.time_start, args.time_end)
-    main(args.dest, time_slice=time_range, write_time_chunks=args.write_time_chunks)
+    main(parser.parse_args())

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -9,7 +9,7 @@
 #   "aiohttp",
 #   "gcsfs",
 #   "numcodecs>=0.15",
-#   "tenacity",
+#   "aiohttp-retry",
 # ]
 # ///
 
@@ -20,15 +20,29 @@ from collections import defaultdict
 
 import dask
 import dask.diagnostics
+import fsspec
 import xarray as xr
-from tenacity import retry
+from aiohttp_retry import ExponentialRetry, RetryClient
+from fsspec.implementations.http import get_client
 
 DATA_ROOT = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
 
+_STATUSES = {x for x in range(100, 600)}
+_STATUSES.discard(200)
+_STATUSES.discard(429)
 
-@retry
+
+async def _robust_get_client(**kwargs):
+    options = ExponentialRetry(attempts=5, statuses=_STATUSES)
+    return RetryClient(
+        await get_client(**kwargs), raise_for_status=True, retry_options=options
+    )
+
+
 def robust_open_dataset(target: str, **kwargs) -> xr.Dataset:
-    return xr.open_dataset(target, **kwargs)
+    fs = fsspec.filesystem("http", get_client=_robust_get_client)
+    mapper = fs.get_mapper(target)
+    return xr.open_dataset(mapper, **kwargs)
 
 
 def compact_dataset(ds: xr.Dataset) -> xr.Dataset:
@@ -79,6 +93,8 @@ def main(args: argparse.Namespace) -> None:
                 data = compact_dataset(data)
         else:
             data = robust_open_dataset(source, engine="zarr", chunks={})
+
+        data.load()
 
         with dask.diagnostics.ProgressBar():
             if dest_fmt.lower() == "zarr":

--- a/uv.lock
+++ b/uv.lock
@@ -83,6 +83,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-retry"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981 },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1344,7 +1356,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiohttp-retry" },
     { name = "beartype" },
+    { name = "fsspec" },
     { name = "hypothesis", extra = ["numpy"] },
     { name = "ipykernel" },
     { name = "mypy" },
@@ -1379,7 +1393,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiohttp-retry", specifier = ">=2.9.1" },
     { name = "beartype", specifier = ">=0.20" },
+    { name = "fsspec", specifier = ">=2025.3.0" },
     { name = "hypothesis", extras = ["numpy"], specifier = ">=6.127.2" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "mypy", specifier = ">=1.15" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'linux'",
@@ -80,18 +79,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/cd/68030356eb9a7d57b3e2823c8a852709d437abb0fbff41a61ebc351b7625/aiohttp-3.11.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b992778d95b60a21c4d8d4a5f15aaab2bd3c3e16466a72d7f9bfd86e8cea0d4b", size = 1673166 },
     { url = "https://files.pythonhosted.org/packages/03/61/425397a9a2839c609d09fdb53d940472f316a2dbeaa77a35b2628dae6284/aiohttp-3.11.13-cp313-cp313-win32.whl", hash = "sha256:507ab05d90586dacb4f26a001c3abf912eb719d05635cbfad930bdbeb469b36c", size = 410615 },
     { url = "https://files.pythonhosted.org/packages/9c/54/ebb815bc0fe057d8e7a11c086c479e972e827082f39aeebc6019dd4f0862/aiohttp-3.11.13-cp313-cp313-win_amd64.whl", hash = "sha256:5ceb81a4db2decdfa087381b5fc5847aa448244f973e5da232610304e199e7b2", size = 436452 },
-]
-
-[[package]]
-name = "aiohttp-retry"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/61/ebda4d8e3d8cfa1fd3db0fb428db2dd7461d5742cea35178277ad180b033/aiohttp_retry-2.9.1.tar.gz", hash = "sha256:8eb75e904ed4ee5c2ec242fefe85bf04240f685391c4879d8f541d6028ff01f1", size = 13608 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/99/84ba7273339d0f3dfa57901b846489d2e5c2cd731470167757f1935fffbd/aiohttp_retry-2.9.1-py3-none-any.whl", hash = "sha256:66d2759d1921838256a05a3f80ad7e724936f083e35be5abb5e16eed6be6dc54", size = 9981 },
 ]
 
 [[package]]
@@ -1356,7 +1343,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "aiohttp-retry" },
     { name = "beartype" },
     { name = "fsspec" },
     { name = "hypothesis", extra = ["numpy"] },
@@ -1393,9 +1379,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aiohttp-retry", specifier = ">=2.9.1" },
     { name = "beartype", specifier = ">=0.20" },
-    { name = "fsspec", specifier = ">=2025.3.0" },
+    { name = "fsspec", specifier = ">=2025.3" },
     { name = "hypothesis", extras = ["numpy"], specifier = ">=6.127.2" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "mypy", specifier = ">=1.15" },


### PR DESCRIPTION
Added an option to data cloning script to compact variables. Here is what a sample output looks like: 

```
<xarray.Dataset> Size: 74GB
Dimensions:         (y: 180, x: 360, lev: 19, time: 3504, y_b: 181, x_b: 361)
Coordinates:
    areacello       (y, x) float64 518kB dask.array<chunksize=(90, 360), meta=np.ndarray>
    dz              (lev) int64 152B dask.array<chunksize=(19,), meta=np.ndarray>
    lat             (y, x) float64 518kB dask.array<chunksize=(90, 360), meta=np.ndarray>
    lat_b           (y_b, x_b) float64 523kB dask.array<chunksize=(91, 361), meta=np.ndarray>
  * lev             (lev) float64 152B 2.5 10.0 22.5 40.0 ... 4e+03 5e+03 6e+03
    lon             (y, x) float64 518kB dask.array<chunksize=(90, 360), meta=np.ndarray>
    lon_b           (y_b, x_b) float64 523kB dask.array<chunksize=(91, 361), meta=np.ndarray>
    ocean_fraction  (lev, y, x) float64 10MB dask.array<chunksize=(19, 180, 360), meta=np.ndarray>
  * time            (time) object 28kB 1975-01-03 12:00:00 ... 2022-12-29 12:...
    wetmask         (lev, y, x) bool 1MB dask.array<chunksize=(19, 90, 360), meta=np.ndarray>
  * x               (x) float64 3kB 0.5 1.5 2.5 3.5 ... 356.5 357.5 358.5 359.5
  * y               (y) float64 1kB -89.24 -88.25 -87.25 ... 87.25 88.25 89.24
Dimensions without coordinates: y_b, x_b
Data variables:
    hfds            (time, y, x) float32 908MB dask.array<chunksize=(50, 180, 360), meta=np.ndarray>
    hfds_anomalies  (time, y, x) float32 908MB dask.array<chunksize=(50, 180, 360), meta=np.ndarray>
    tauuo           (time, y, x) float32 908MB dask.array<chunksize=(50, 180, 360), meta=np.ndarray>
    tauvo           (time, y, x) float32 908MB dask.array<chunksize=(50, 180, 360), meta=np.ndarray>
    zos             (time, y, x) float32 908MB dask.array<chunksize=(50, 180, 360), meta=np.ndarray>
    so              (lev, time, y, x) float32 17GB dask.array<chunksize=(19, 50, 180, 360), meta=np.ndarray>
    thetao          (lev, time, y, x) float32 17GB dask.array<chunksize=(19, 50, 180, 360), meta=np.ndarray>
    uo              (lev, time, y, x) float32 17GB dask.array<chunksize=(19, 50, 180, 360), meta=np.ndarray>
    vo              (lev, time, y, x) float32 17GB dask.array<chunksize=(19, 50, 180, 360), meta=np.ndarray
```

This script defaults to reading all levels as one chunk. This makes the recommended chunking heuristic ~50-60 time chunks.