### PR TITLE
Lazy data loader now supports history>0.

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -7,6 +7,7 @@ import xarray as xr
 from einops import rearrange
 from jaxtyping import Float, Integer
 from torch.utils.data import Dataset
+from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 
 from ocean_emulators.constants import (
     Boundary,
@@ -134,15 +135,38 @@ class OM4Dataset(Dataset):
             # This point in time splits the training data and the label data!
             time_split = self.hist + 1
 
-            prognostic = self.prognostic.isel(time=window).isel(
-                time=slice(None, time_split)
-            )
-            boundary = self.boundary.isel(time=window).isel(time=self.hist)
-            input_ = xr.merge(
-                [prognostic, boundary], compat="no_conflicts"
-            )  # Combines variables.
+            # TODO(alxmrs): Tune dask parallelization
+            # https://tutorial.xarray.dev/advanced/apply_ufunc/dask_apply_ufunc.html
 
-            label = self.prognostic.isel(time=window).isel(time=slice(time_split, None))
+            prognostic = (
+                self.prognostic.isel(time=window)
+                .isel(time=slice(None, time_split))
+                .to_array(name="prognostic")
+                .einops.rearrange("window (time variable)=var lat lon", dask="allowed")
+                .drop_vars("var", errors="ignore")
+            )
+            boundary = (
+                self.boundary.isel(time=window)
+                .isel(time=self.hist)
+                .to_array("var", "boundary")
+                .transpose("window", "var", "lat", "lon")
+                .drop_vars("var", errors="ignore")
+            )
+            # Combine prognostic and boundary data
+            input_ = xr.concat([prognostic, boundary], dim="var").rename(
+                {"var": "variable"}
+            )
+
+            label = (
+                self.prognostic.isel(time=window)
+                .isel(time=slice(time_split, None))
+                .to_array()
+                .einops.rearrange(
+                    "window (time variable)=var lat lon",
+                    dask="allowed",
+                )
+                .rename({"var": "variable"})
+            )
 
             inputs.append(input_)
             labels.append(label)

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -33,18 +33,22 @@ def collate_train_data(data: Sequence[TrainData]) -> TrainData:
 
 def collate_om4(examples: Sequence[Example]) -> TrainData:
     """Combine several deferred Examples into single a `torch.Tensor` example pair."""
-    inputs_batch = xr.concat([x.to_array() for x, _ in examples], dim="step")
-    labels_batch = xr.concat([y.to_array() for _, y in examples], dim="step")
+    inputs_batch = xr.concat([x for x, _ in examples], dim="step")
+    labels_batch = xr.concat([y for _, y in examples], dim="step")
 
-    # TODO(alxmrs): Tune dask parallelization
-    # https://tutorial.xarray.dev/advanced/apply_ufunc/dask_apply_ufunc.html
-    inputs: Input = inputs_batch.einops.rearrange(
-        "step window (time variable) lat lon",
-        dask="allowed",
+    inputs: Input = inputs_batch.transpose(
+        "step",
+        "window",
+        "variable",
+        "lat",
+        "lon",
     ).compute()
-    labels: Prognostic = labels_batch.einops.rearrange(
-        "step window (time variable) lat lon",
-        dask="allowed",
+    labels: Prognostic = labels_batch.transpose(
+        "step",
+        "window",
+        "variable",
+        "lat",
+        "lon",
     ).compute()
 
     input_tensor = torch.from_numpy(inputs.to_numpy())

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -55,7 +55,7 @@ def collate_om4(examples: Sequence[Example]) -> TrainData:
     labels_tensor = torch.from_numpy(labels.to_numpy())
 
     # TODO(#126): Remove TrainData interface (eventually)
-    batch = TrainData(labels[0].shape[2])  # len(prognostic_vars)
+    batch = TrainData(labels.shape[2])  # len(prognostic_vars)
     steps = input_tensor.shape[0]
     for step in range(steps):
         batch.insert(input_tensor[step], labels_tensor[step])


### PR DESCRIPTION
These fixes were found during #151; I've extracted the fixes into a smaller, reviewable PR. These changes mimic the original data loader implementation, but do all the work in Xarray, and thus are still lazily evaluated. This fix (and a couple other ones floating around) are necessary to perform an e2e performance test.