### PR TITLE
Cover loader versions and hist>0 in test fixtures.

### DIFF
--- a/configs/train_default.test.yaml
+++ b/configs/train_default.test.yaml
@@ -15,13 +15,13 @@ inference_epochs: [-1]
 data_percent: 1.0
 train:
   start_time: '1975-08-15'
-  end_time: '1975-10-20'
+  end_time: '1975-10-25'
 val:
   start_time: '1975-10-20'
-  end_time: '1975-11-20'
+  end_time: '1975-11-25'
 inference:
   - start_time: '1975-11-20'
-    end_time: '1975-12-15'
+    end_time: '1975-12-20'
 data_stride: [1]
 steps: [1]
 step_transition: []

--- a/configs/train_default_2step.test.yaml
+++ b/configs/train_default_2step.test.yaml
@@ -16,13 +16,13 @@ inference_epochs: [-1]
 data_percent: 1.0
 train:
   start_time: "1975-08-15"
-  end_time: "1975-09-20"
+  end_time: "1975-09-25"
 val:
   start_time: "1975-10-20"
-  end_time: "1975-10-30"
+  end_time: "1975-11-20"
 inference:
   - start_time: "1975-10-30"
-    end_time: "1975-11-15"
+    end_time: "1975-12-20"
 data_stride: [1]
 steps: [2]
 step_transition: []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,6 +280,16 @@ def config_name(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
+@pytest.fixture(scope="session", params=[str(e.value) for e in c.LoaderVersion])
+def loader_version(request: pytest.FixtureRequest) -> str:
+    return request.param
+
+
+@pytest.fixture(scope="session", params=[0, 1, 2])
+def history(request: pytest.FixtureRequest) -> int:
+    return request.param
+
+
 @pytest.fixture(autouse=True)
 def check_skip_configs(request, config_name):
     """Decide if we run a test given only_configs and all_configs marks.
@@ -470,6 +480,8 @@ def train_config(
     data_source: DataSource,
     pytestconfig: pytest.Config,
     config_name: str,
+    loader_version: str,
+    history: int,
     backend: TrainBackendConfig,
 ) -> TrainConfig:
     # Write test data to the cache directory if they aren't already there.
@@ -478,12 +490,18 @@ def train_config(
 
     # Open default training script; modify it as necessary.
     trainer = TrainConfig.from_yaml(pytestconfig.rootpath / "configs" / config_name)
+    data_config = dataclasses.replace(
+        trainer.data,
+        hist=history,
+        loader_version=loader_version,
+    )
     experiment_config = dataclasses.replace(
         trainer.experiment,
         cluster_data_dir=str(cache / data_source.name),
     )
     test_data_config = dataclasses.replace(
         trainer,
+        data=data_config,
         experiment=experiment_config,
         backend=backend,
     )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -283,6 +283,7 @@ def test_inference__data_shape(inference_loader_pair: LoaderPair):
             assert y.shape == (batch_size, output_var_dim, 180, 360)
 
 
+@pytest.mark.all_configs
 def test__data_is_not_zeros(td_loader_pair: LoaderPair):
     cfg, loader = td_loader_pair
 


### PR DESCRIPTION
These increase combinatorially increase the number of tests covered by also checking for hist values from 0-2 as well as checking different loader versions. These tests were originally found in #151.