### PR TITLE
Setting scope where it's needed to omit unnecessary test combinations.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -529,13 +529,3 @@ def trainer_pair(train_config: TrainConfig):
         trainer.init_data_loaders(cur_step=train_config.steps[0])
 
     return train_config, trainer
-
-
-@pytest.fixture(autouse=True, scope="function")
-def set_scope(train_config: TrainConfig):
-    """Automatically sets up the correct Multiton scope for each test.
-
-    NB you must still do this manually for session-scoped fixtures.
-    """
-    with getattr(train_config, "_multiton_scope"):
-        yield

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -28,6 +28,16 @@ LoaderPair = tuple[TrainConfig, DataLoader]
 TrainPair = tuple[TrainConfig, Trainer]
 
 
+@pytest.fixture(autouse=True, scope="function")
+def set_scope(train_config: TrainConfig):
+    """Automatically sets up the correct Multiton scope for each test.
+
+    NB you must still do this manually for session-scoped fixtures.
+    """
+    with getattr(train_config, "_multiton_scope"):
+        yield
+
+
 @pytest.fixture
 def train_loader_pair(trainer_pair: TrainPair) -> LoaderPair:
     cfg, trainer = trainer_pair

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -2,7 +2,18 @@ import logging
 
 import pytest
 
+from ocean_emulators.config import TrainConfig
 from tests.test_datasets import TrainPair
+
+
+@pytest.fixture(autouse=True, scope="function")
+def set_scope(train_config: TrainConfig):
+    """Automatically sets up the correct Multiton scope for each test.
+
+    NB you must still do this manually for session-scoped fixtures.
+    """
+    with getattr(train_config, "_multiton_scope"):
+        yield
 
 
 @pytest.mark.manual


### PR DESCRIPTION
This ensures that multiton scope is only applies in the datasets and trainer tests, where `TrainConfig` is already in use.