### PR TITLE
Turn off dask by default

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -41,6 +41,7 @@ class DataConfig:
     num_workers: int = 4
     hist: int = 1
     loader_version: str = str(LoaderVersion.OM4_EAGER.value)
+    use_dask: bool = False
 
 
 @dataclass

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -157,6 +157,11 @@ class Trainer:
         self.data_stds_path = cfg.data.data_stds_path
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
+        if cfg.data.use_dask:
+            chunks: dict[str, int] | None = {}
+        else:
+            chunks = None
+
         if "*" in self.data_path:
             data = xr.open_mfdataset(
                 os.path.join(self.data_dir, self.data_path),
@@ -166,18 +171,18 @@ class Trainer:
         else:
             data = xr.open_zarr(
                 os.path.join(self.data_dir, self.data_path),
-                chunks={},
+                chunks=chunks,
                 consolidated=True,
             )
         data_mean = xr.open_dataset(
             os.path.join(self.data_dir, self.data_means_path),
             engine="netcdf4" if self.data_means_path.endswith(".nc") else "zarr",
-            chunks={},
+            chunks=chunks,
         )
         data_std = xr.open_dataset(
             os.path.join(self.data_dir, self.data_stds_path),
             engine="netcdf4" if self.data_stds_path.endswith(".nc") else "zarr",
-            chunks={},
+            chunks=chunks,
         )
 
         self.data, self.data_mean, self.data_std = validate_data(


### PR DESCRIPTION
According to [results here](https://github.com/suryadheeshjith/Ocean_Emulator/issues/105#issuecomment-2773940880), turning off dask is 20x faster for the eager data loader and 10x faster for the lazy data loader. This disables dask by default but you can toggle it back on. 