### PR TITLE
Fix bug in detection of broken test config, fix test_trainer__mini_2step

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -382,8 +382,9 @@ class TrainData:
 
     def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
         input, _ = self.td_dict[step]
-        input[:, : self.num_prognostic_channels] = prognostic
-        return input
+        merged = input.clone()
+        merged[:, : self.num_prognostic_channels] = prognostic
+        return merged
 
     def __getitem__(self, step: int) -> Example:
         """Converts index (step) into (data, label) tuple."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,15 +300,16 @@ def check_skip_configs(request, config_name):
     """
     only_configs = request.node.get_closest_marker("only_configs")
     if only_configs:
+        for desired_config in only_configs.args:
+            if desired_config not in ALL_CONFIGS:
+                raise ValueError(
+                    f"Test config {desired_config} is not"
+                    f" in the list of all configs: {ALL_CONFIGS}"
+                )
         if config_name not in only_configs.args:
             pytest.skip(
                 f"Skipping test for {config_name} because"
                 f" it is not in {only_configs.args}"
-            )
-        if config_name not in ALL_CONFIGS:
-            raise ValueError(
-                f"Test config {config_name} is not"
-                f" in the list of all configs: {ALL_CONFIGS}"
             )
     else:
         all_configs = request.node.get_closest_marker("all_configs")

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -15,7 +15,7 @@ def test_trainer__mini_benchmark(trainer_pair: TrainPair, caplog, benchmark):
         trainer.run()
 
 
-@pytest.mark.only_configs("train_cm4_2step.test.yaml")
+@pytest.mark.only_configs("train_default_2step.test.yaml")
 def test_trainer__mini_2step(trainer_pair: TrainPair, caplog):
     caplog.set_level(logging.INFO)
     _, trainer = trainer_pair


### PR DESCRIPTION
Our check to see if the "only_configs" were real was (a) not running and (b) broken. Fixed the check and also this test which wasn't running and was broken in config and also exercised a subtle bug in the new lazy loader.