### PR TITLE
Torch arrays should be floats, not doubles.

### DIFF
--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -51,8 +51,8 @@ def collate_om4(examples: Sequence[Example]) -> TrainData:
         "lon",
     ).compute()
 
-    input_tensor = torch.from_numpy(inputs.to_numpy())
-    labels_tensor = torch.from_numpy(labels.to_numpy())
+    input_tensor = torch.from_numpy(inputs.to_numpy()).float()
+    labels_tensor = torch.from_numpy(labels.to_numpy()).float()
 
     # TODO(#126): Remove TrainData interface (eventually)
     batch = TrainData(labels.shape[2])  # len(prognostic_vars)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -352,6 +352,9 @@ def test_om4__is_equal_to_v1_data_loader(train_loader_pair: LoaderPair):
     )
 
     for (x_orig, y_orig), (x_new, y_new) in zip(original_samples, om4_samples):
+        assert x_orig.dtype == x_new.dtype, "Input data types do not match."
+        assert y_orig.dtype == y_new.dtype, "Output data types do not match."
+
         x_not_close = np.isclose(x_orig, x_new) == False  # noqa: E712
         y_not_close = np.isclose(y_orig, y_new) == False  # noqa: E712
 


### PR DESCRIPTION
This should fix the broken benchmark run.