### PR TITLE
Re-enable dask by default

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -41,7 +41,7 @@ class DataConfig:
     num_workers: int = 4
     hist: int = 1
     loader_version: str = str(LoaderVersion.OM4_EAGER.value)
-    use_dask: bool = False
+    use_dask: bool = True
 
 
 @dataclass


### PR DESCRIPTION
Setting use_dask = false was effectively just loading the whole dataset into memory at the start (during normalization) which is why it was so fast. If we disable normalization (for diagnosis) or delay normalization until data loading time (ie in `__getitem__`) then `use_dask: false` is 2x slower than `use_dask: true`. 