### PR TITLE
Automatically omit extra benchmarks.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,15 +41,17 @@ def pytest_collection_modifyitems(config, items):
             # Check if this test item has parameters that don't match the desired ones
             # Add skip marker to benchmark tests that don't match.
             for param, desired_value in desired_params.items():
-                if param in item.fixturenames and param in item.callspec.params:
-                    current_value = item.callspec.params[param]
-                    if current_value != desired_value:
-                        skip_reason = (
-                            f"Skipping benchmark with {param}={current_value}, "
-                            f"only running with {param}={desired_value}"
-                        )
-                        item.add_marker(pytest.mark.skip(reason=skip_reason))
-                        break
+                if param not in item.fixturenames or param not in item.callspec.params:
+                    continue
+
+                current_value = item.callspec.params[param]
+                if current_value != desired_value:
+                    skip_reason = (
+                        f"Skipping benchmark with {param}={current_value}, "
+                        f"only running with {param}={desired_value}"
+                    )
+                    item.add_marker(pytest.mark.skip(reason=skip_reason))
+                    break
 
 
 @dataclasses.dataclass
@@ -568,7 +570,7 @@ def trainer_pair(
     This fixture sets up the correct Multiton scope and skipping rules for this
     config/trainer pair.
 
-    By default tests are run with one config. You can run them for multiple
+    By default, tests are run with one config. You can run them for multiple
     configs by marking them with `only_configs` or `all_configs`.
 
     eg:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,34 @@ DEFAULT_CONFIG = "train_default.test.yaml"
 ALL_CONFIGS = [DEFAULT_CONFIG, "train_default_2step.test.yaml"]
 
 
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        # Filter out excessive benchmark combinations
+        if "benchmark" in item.fixturenames:
+            desired_params = {
+                "history": 0,
+                "data_source": "mock",
+                "td_loader_pair": "train",  # fixture only present in test_datasets
+            }
+
+            # Only process tests that have parameterized fixtures
+            if not hasattr(item, "callspec") or not hasattr(item.callspec, "params"):
+                continue
+
+            # Check if this test item has parameters that don't match the desired ones
+            # Add skip marker to benchmark tests that don't match.
+            for param, desired_value in desired_params.items():
+                if param in item.fixturenames and param in item.callspec.params:
+                    current_value = item.callspec.params[param]
+                    if current_value != desired_value:
+                        skip_reason = (
+                            f"Skipping benchmark with {param}={current_value}, "
+                            f"only running with {param}={desired_value}"
+                        )
+                        item.add_marker(pytest.mark.skip(reason=skip_reason))
+                        break
+
+
 @dataclasses.dataclass
 class DataSource:
     """In-memory `xarray.Dataset`s needed for tests."""


### PR DESCRIPTION
Adding a hook into all generated test combinations. For benchmarks, I add skip marks to all tests that don't fit the happy path test conditions. 

I think this infrastructure could be useful to omit testing other unwanted fixture combinations.