### PR TITLE
Torch-first data loader without dask

### DIFF
--- a/configs/train_om4.yaml
+++ b/configs/train_om4.yaml
@@ -1,5 +1,5 @@
 
-debug: true
+debug: false
 disk_mode: true
 pin_mem: true
 save_freq: 5

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -41,7 +41,6 @@ class DataConfig:
     num_workers: int = 4
     hist: int = 1
     loader_version: str = str(LoaderVersion.OM4_EAGER.value)
-    use_dask: bool = True
 
 
 @dataclass

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -190,6 +190,7 @@ def construct_metadata(data: xr.Dataset) -> Dict[str, Dict[str, str]]:
 class LoaderVersion(enum.Enum):
     OM4_EAGER = "om4-eager"
     OM4_LAZY = "om4-lazy"
+    OM4_TORCH = "om4-torch"
 
 
 # TODO(#95): See if this can be removed and replaced.

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -594,3 +594,172 @@ class TrainDataset(Dataset):
         label = torch.from_numpy(label).float()
         label = torch.where(self.wet, label, 0.0)
         return label
+
+
+class TorchTrainDataset(Dataset):
+    """
+    This class is used for training and validation.
+
+    It creates rolling indices to keep track of histories/past states. But different
+    from InferenceDataset, as it creates rolling indices based on stride. By default,
+    the sliding window / stride is 1.
+
+    We make use of TrainData class to store a single sample.
+
+    For example,
+    Hist=0 ; TD: step=0->[0, 1]; step=1->[1, 2]; step=2->[2, 3]; step=3->[3, 4]
+    Hist=1 ; TD: step=0->[[0, 1], [2, 3]]; step=1->[[2, 3], [4, 5]];
+            step=2->[[4, 5], [6, 7]]; step=3->[[6, 7], [8, 9]]
+    Hist=2 ; TD: step=0->[[0, 1, 2], [3, 4, 5]];
+            step=1->[[3, 4, 5], [6, 7, 8]];
+            step=2->[[6, 7, 8], [9, 10, 11]];
+            step=3->[[9, 10, 11], [12, 13, 14]]
+    """
+
+    FLAG = LoaderVersion.OM4_TORCH
+
+    def __init__(
+        self,
+        data: xr.Dataset,
+        prognostic_var_names: PrognosticVarNames,
+        boundary_var_names: BoundaryVarNames,
+        wet: PrognosticMask,
+        wet_surface: GridMask,
+        hist: int,
+        steps: int,
+        stride: int = 1,
+    ):
+        super().__init__()
+        self.device = get_device()
+
+        self.hist: int = hist
+        self.steps: int = steps
+        self.stride: int = stride
+
+        self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
+        self._prognostic_vars: xr.Dataset = data[prognostic_var_names]
+        self._boundary_vars: xr.Dataset = data[boundary_var_names]
+
+        # This class will be used only for training
+        total_steps: int = 2 * self.hist + 2
+
+        # Calculate the number of windows
+        num_windows = data.time.size - (total_steps - 1) * self.stride
+
+        # Create base indices
+        indices = np.arange(num_windows)
+        indices_da = xr.DataArray(indices, dims=["window_dim"])
+
+        # Create window dimension
+        window_dim = xr.DataArray(np.arange(total_steps), dims=["time"])
+
+        # Construct rolling indices
+        self.rolling_indices: Float[xr.DataArray, "window_dim time"] = (
+            indices_da + stride * window_dim
+        )
+
+        self.wet = wet.bool()
+        self.wet_surface = wet_surface.bool()
+
+        self.size: int = (
+            data.time.size
+            - self.steps * (self.hist + 1) * self.stride
+            - self.hist * self.stride
+        )
+
+        if using_gpu():
+            self.wet = self.wet.pin_memory()
+            self.wet_surface = self.wet_surface.pin_memory()
+
+    def __len__(self) -> int:
+        return self.size
+
+    def __getitem__(self, idx: int):
+        TD = TrainData(self.num_prognostic_channels)
+        prev_rolling_idx = None
+        for step in range(self.steps):
+            x_index = self._get_x_index(idx, step, prev_rolling_idx)
+
+            prognostic_all = torch.from_numpy(
+                self._prognostic_vars.isel(time=x_index)
+                .to_array()
+                .transpose(
+                    "variable", "time", "lat", "lon"
+                )  # this should be a no-op, for documentation
+                .to_numpy()
+            )
+            boundary = torch.from_numpy(
+                self._boundary_vars.isel(time=x_index)
+                .isel(time=self.hist, drop=True)
+                .to_array()
+                .transpose("variable", "lat", "lon")
+                .to_numpy()
+            )
+
+            input_, label = self._get_input_and_label(prognostic_all, boundary)
+
+            TD.insert(
+                input_=input_,
+                label=label,
+            )
+
+        return TD
+
+    def _get_input_and_label(
+        self,
+        # time includes (self.hist + 1) past steps and the (label) future steps
+        prognostic_all: Float[torch.Tensor, "variable time lat lon"],
+        boundary: Float[torch.Tensor, "variable lat lon"],
+    ) -> tuple[Input, Prognostic]:
+        normalize = Normalize.get_instance()
+
+        # grab past steps and prep for model
+        input_ = self._prep_prognostic_steps(prognostic_all[:, : self.hist + 1, :, :])
+
+        # add in boundary to final input
+        boundary = normalize.normalize_tensor_boundary(boundary).float()
+        boundary = torch.where(self.wet_surface, boundary, 0.0)
+        total_input = torch.cat((input_, boundary), dim=0)
+
+        # grab future steps, repeat as we do for input
+        label = self._prep_prognostic_steps(prognostic_all[:, self.hist + 1 :, :, :])
+        return total_input, label
+
+    def _prep_prognostic_steps(
+        self, prognostic_steps: Float[torch.Tensor, "variable time lat lon"]
+    ) -> Input:
+        normalize = Normalize.get_instance()
+        prognostic_steps = rearrange(
+            prognostic_steps,
+            "variable time lat lon -> time variable lat lon",
+        )
+
+        # normalize expects variables in second dimension
+        prognostic_steps = normalize.normalize_tensor_prognostic(
+            prognostic_steps
+        ).float()
+
+        # flatten time and variable dimensions into a set of channels for model
+        prognostic_steps = rearrange(
+            prognostic_steps,
+            "time variable lat lon -> (time variable) lat lon",
+        )
+
+        # post-normalize, mask out values where there is no ocean
+        prognostic_steps = torch.where(self.wet, prognostic_steps, 0.0)
+
+        return prognostic_steps
+
+    def _get_x_index(
+        self, idx: int, step: int, prev_rolling_idx: int | None
+    ) -> xr.Variable:
+        assert isinstance(idx, int)
+        if idx < 0:
+            raise IndexError("Sorry, negative indexing is not supported!")
+        if idx >= len(self):
+            raise IndexError("Index out of range")
+
+        window_index = idx + step * (self.hist + 1) * self.stride
+        rolling_idx = self.rolling_indices.isel(window_dim=window_index, drop=True)
+        x_index = xr.Variable(["time"], rolling_idx)
+        return x_index

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -640,7 +640,7 @@ class TorchTrainDataset(Dataset):
         self._prognostic_vars: xr.Dataset = data[prognostic_var_names]
         self._boundary_vars: xr.Dataset = data[boundary_var_names]
 
-        # This class will be used only for training
+        # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
 
         # Calculate the number of windows
@@ -676,9 +676,8 @@ class TorchTrainDataset(Dataset):
 
     def __getitem__(self, idx: int):
         TD = TrainData(self.num_prognostic_channels)
-        prev_rolling_idx = None
         for step in range(self.steps):
-            x_index = self._get_x_index(idx, step, prev_rolling_idx)
+            x_index = self._get_x_index(idx, step)
 
             prognostic_all = torch.from_numpy(
                 self._prognostic_vars.isel(time=x_index)
@@ -750,9 +749,7 @@ class TorchTrainDataset(Dataset):
 
         return prognostic_steps
 
-    def _get_x_index(
-        self, idx: int, step: int, prev_rolling_idx: int | None
-    ) -> xr.Variable:
+    def _get_x_index(self, idx: int, step: int) -> xr.Variable:
         assert isinstance(idx, int)
         if idx < 0:
             raise IndexError("Sorry, negative indexing is not supported!")

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -42,6 +42,7 @@ from ocean_emulators.datasets import (
     InferenceDataset,
     InferenceDatasets,
     OM4Dataset,
+    TorchTrainDataset,
     TrainData,
     TrainDataset,
 )
@@ -159,7 +160,8 @@ class Trainer:
         self.data_stds_path = cfg.data.data_stds_path
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
-        if cfg.data.use_dask:
+        self.use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
+        if self.use_dask:
             chunks: dict[str, int] | None = {}
         else:
             chunks = None
@@ -699,6 +701,39 @@ class Trainer:
                         for stride in self.data_stride
                     ]
                 )
+            case TorchTrainDataset.FLAG:
+                train_data = ConcatDataset(
+                    [
+                        TorchTrainDataset(
+                            data=self.data.sel(time=self.train_times.time_slice),
+                            prognostic_var_names=self.prognostic_var_names,
+                            boundary_var_names=self.boundary_var_names,
+                            wet=self.wet,
+                            wet_surface=self.wet_surface,
+                            hist=self.hist,
+                            steps=cur_step,
+                            stride=stride,
+                        )
+                        for stride in self.data_stride
+                    ]
+                )
+
+                val_data = ConcatDataset(
+                    [
+                        TorchTrainDataset(
+                            data=self.data.sel(time=self.val_times.time_slice),
+                            prognostic_var_names=self.prognostic_var_names,
+                            boundary_var_names=self.boundary_var_names,
+                            wet=self.wet,
+                            wet_surface=self.wet_surface,
+                            hist=self.hist,
+                            steps=1,  # current_step set to 1 for validation
+                            stride=stride,
+                        )
+                        for stride in self.data_stride
+                    ]
+                )
+
             case _:
                 raise NotImplementedError(
                     f"Loader version {self.loader_version} not supported."
@@ -718,6 +753,8 @@ class Trainer:
                 collate_fn: Callable[[Sequence[Any]], TrainData] = collate_train_data
             case OM4Dataset.FLAG:
                 collate_fn = collate_om4
+            case TorchTrainDataset.FLAG:
+                collate_fn = collate_train_data
             case _:
                 raise NotImplementedError(
                     f"Collate function not defined for loader version "

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -391,3 +391,22 @@ class Normalize(Multiton):
         unnorm = torch.where(self.wet_mask.to(data.device) == 0, fill_value, unnorm)
         unnorm = unnorm.to(data.dtype)
         return unnorm
+
+    def normalize_tensor_boundary(
+        self, data: torch.Tensor, fill_nan=True, fill_value=0.0
+    ) -> torch.Tensor:
+        """Normalize boundary tensor."""
+        tensor_mean = self._to_tensor(self._boundary_mean_np, data.device)
+        tensor_std = self._to_tensor(self._boundary_std_np, data.device)
+
+        if data.ndim == 3:
+            tensor_mean = tensor_mean.reshape([-1, 1, 1])
+            tensor_std = tensor_std.reshape([-1, 1, 1])
+        else:
+            raise ValueError(f"Invalid data shape: {data.shape}")
+
+        norm = (data - tensor_mean) / tensor_std
+        if fill_nan:
+            norm = norm.nan_to_num(nan=fill_value)
+        norm = norm.to(data.dtype)
+        return norm

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -473,8 +473,9 @@ def test_profile__loader__1gb(train_config, loader_version, benchmark):
 
         @benchmark
         def bench():
-            for sample in loader:
-                _ = sample
+            indices = np.random.randint(0, len(loader), size=len(loader))
+            for idx in indices:
+                _ = loader.dataset[int(idx)]
 
 
 @pytest.mark.manual

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -26,6 +26,7 @@ from ocean_emulators.constants import (
 from ocean_emulators.datasets import (
     InferenceDataset,
     OM4Dataset,
+    TorchTrainDataset,
     TrainData,
     TrainDataset,
 )
@@ -51,12 +52,18 @@ def make_loader(
     if time_slice is None:
         time_slice = cfg.train.time_slice
 
-    ds = xr.open_dataset(cfg.experiment.data_dir / cfg.data.data_path, chunks={})
+    use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
+    if use_dask:
+        chunks: dict[str, int] | None = {}
+    else:
+        chunks = None
+
+    ds = xr.open_dataset(cfg.experiment.data_dir / cfg.data.data_path, chunks=chunks)
     ds_means = xr.open_dataset(
-        cfg.experiment.data_dir / cfg.data.data_means_path, chunks={}
+        cfg.experiment.data_dir / cfg.data.data_means_path, chunks=chunks
     )
     ds_stds = xr.open_dataset(
-        cfg.experiment.data_dir / cfg.data.data_stds_path, chunks={}
+        cfg.experiment.data_dir / cfg.data.data_stds_path, chunks=chunks
     )
 
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]
@@ -103,6 +110,23 @@ def make_loader(
                     ]
                 )
                 collate_fn = collate_om4
+            case LoaderVersion.OM4_TORCH:
+                data = ConcatDataset(
+                    [
+                        TorchTrainDataset(
+                            data=ds_.sel(time=time_slice),
+                            prognostic_var_names=prognostic,
+                            boundary_var_names=boundary,
+                            wet=wet,
+                            wet_surface=wet_surface,
+                            hist=cfg.data.hist,
+                            steps=cfg.steps[0],
+                            stride=stride,
+                        )
+                        for stride in cfg.data_stride
+                    ]
+                )
+                collate_fn = collate_train_data
             case _:
                 raise ValueError(f"Unknown loader version: {version}")
 
@@ -347,10 +371,17 @@ def test_inference__data_is_not_zero(inference_loader_pair):
             )
 
 
-def test_om4__is_equal_to_v1_data_loader(train_config):
+ORIGINAL_LOADER_VERSION = LoaderVersion.OM4_EAGER
+
+
+@pytest.mark.parametrize(
+    "loader_version", [v for v in LoaderVersion if v != ORIGINAL_LOADER_VERSION]
+)
+@pytest.mark.parametrize("data_source", ["mock"], indirect=True)
+def test_new_loaders__are_equal_to_v1_data_loader(train_config, loader_version):
     with (
-        make_loader(train_config) as loader,
-        make_loader(train_config, version=LoaderVersion.OM4_LAZY) as om4_loader,
+        make_loader(train_config, version=ORIGINAL_LOADER_VERSION) as original_loader,
+        make_loader(train_config, version=loader_version) as test_loader,
     ):
 
         def key(x):
@@ -360,10 +391,10 @@ def test_om4__is_equal_to_v1_data_loader(train_config):
         # So we use sorting as a simple way to compare the two loaders (without having
         # to monkeypatch the train loader fixture).
         original_samples = sorted(
-            [extract_sample_arrays(sample) for sample in loader], key=key
+            [extract_sample_arrays(sample) for sample in original_loader], key=key
         )
         om4_samples = sorted(
-            [extract_sample_arrays(sample) for sample in om4_loader], key=key
+            [extract_sample_arrays(sample) for sample in test_loader], key=key
         )
 
         for (x_orig, y_orig), (x_new, y_new) in zip(original_samples, om4_samples):


### PR DESCRIPTION
I did some profiling and continue to see a huge amount of time spent in xarray indexing. I built a dataloader which goes as quickly as possible into (CPU) torch and does not use dask. On my laptop this is 3x faster than the eager data loader, and on my test GPU machine it's about 5x faster in the data loader benchmarks. Also seems to eliminate any waiting for data on my GPU machine with 4 workers when running with batch size == 2. 

I manually verified this produces the same data as the eager loader in the debugger -- hoping to add a test for this once @alxmrs is done refactoring the test configuration story a little. 

- [x] add tests for matching old behavior, shape, etc before merging
- [x] should we be masking with NaN?