### PR TITLE
Update base image to speed up CI, give instructions on how to do this

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -31,7 +31,9 @@ jobs:
           # It is easiest if this cuda version (cu121) matches the cuda version below.
           # (We could relax this since installing torch below pulls in the right version of cuda
           # libraries, but then you have a mismatch between the cuda toolkit and those libraries, which seems possibly bad.)
-          image: pytorch-2-2-cu121-v20250205-ubuntu-2204-conda
+          # You can find the latest image from:
+          # gcloud compute images list --project deeplearning-platform-release --no-standard-images --format="value(NAME)" --filter="name~'pytorch-2-2-cu121-v.*-ubuntu-2204-conda'"
+          image: pytorch-2-2-cu121-v20250327-ubuntu-2204-conda
           machine_zone: "us-central1-a"
           machine_type: "g2-standard-8"
           disk_size: "200GB"


### PR DESCRIPTION
We could consider just making this always be the latest image but that would also be a bit brittle. 

You can see the first "install nvidia drivers" step takes about 2 minutes extra here https://github.com/suryadheeshjith/Ocean_Emulator/actions/runs/14336583301/job/40185301143 because it's waiting for automated upgrades to complete; this should reduce that.