### PR TITLE
Inline inference refactors

### DIFF
--- a/configs/eval_cm4.yaml
+++ b/configs/eval_cm4.yaml
@@ -5,9 +5,7 @@ inference:
   start_time: 311-01-01
   end_time: 351-01-01
 ckpt_path: /this/path/does/not/exist # Fill in script
-num_model_steps_forward: 20
-record_every: 10
-backend: auto
+num_model_steps_forward: 370
 
 experiment:
   base_name: eval

--- a/configs/eval_om4.yaml
+++ b/configs/eval_om4.yaml
@@ -6,8 +6,7 @@ inference:
   start_time: "2014-10-10"
   end_time: "2022-12-24"
 ckpt_path: /this/path/does/not/exist # Fill in script
-num_model_steps_forward: 20
-record_every: 10
+num_model_steps_forward: -1
 
 experiment:
   base_name: eval
@@ -26,7 +25,7 @@ experiment:
   boundary_vars_key: tau_hfds_hfds_anom
 
 data:
-  data_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anom_104_years_2014_netzerohfds_detrended # 3D_data_OM4_5daily_v0.2.1_with_hfds_anom_100_years_1990_netzerohfds
+  data_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies
   data_means_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies_means
   data_stds_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies_stds
   scaling_residuals_file: null

--- a/configs/gantry_eval_cm4.yaml
+++ b/configs/gantry_eval_cm4.yaml
@@ -5,9 +5,7 @@ inference:
   start_time: "0311-01-01"
   end_time: "0351-01-01"
 ckpt_path: /ckpt.pt
-num_model_steps_forward: 20
-record_every: 10
-backend: auto
+num_model_steps_forward: 370
 
 experiment:
   base_name: eval

--- a/configs/slurm_perlmutter_train_om4.yaml
+++ b/configs/slurm_perlmutter_train_om4.yaml
@@ -1,0 +1,77 @@
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 70
+batch_size: 4
+learning_rate: 0.0002
+scheduler: true
+loss: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: [-1]
+data_percent: 1.0
+train:
+  start_time: "1975-01-03"
+  end_time: "2013-10-05"
+val:
+  start_time: "2013-10-05"
+  end_time: "2014-10-05"
+inference:
+  - start_time: "1975-01-03"
+    end_time: "1985-01-03"
+  - start_time: "1985-01-03"
+    end_time: "1995-01-03"
+  - start_time: "1995-01-03"
+    end_time: "2005-01-03"
+  - start_time: "2004-10-05"
+    end_time: "2014-10-05"
+data_stride: [1]
+steps: [4]
+step_transition: []
+backend: auto
+
+experiment:
+  base_name: train
+  sub_name: om4_samudra
+  rand_seed: 5
+  base_output_dir: train
+  gantry: false
+  cluster_data_dir: /pscratch/sd/s/suryad/data
+  wandb:
+    mode: online
+    project: ocean-emulators
+    entity: m2lines
+    group: samudra-train-om4
+  network: Samudra
+  prognostic_vars_key: thermo_all
+  boundary_vars_key: tau_hfds_hfds_anom
+
+data:
+  data_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies
+  data_means_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies_means
+  data_stds_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies_stds
+  scaling_residuals_file: null
+  time_delta: 5
+  num_workers: 4
+  hist: 1
+  loader_version: om4-torch
+
+samudra:
+  ch_width: [157, 200, 250, 300, 400]
+  n_out: 77
+  dilation: [1, 2, 4, 8]
+  n_layers: [1, 1, 1, 1]
+  pred_residuals: false
+  last_kernel_size: 3
+  pad: "circular"
+
+  core_block:
+    block_type: "conv_next_block"
+    kernel_size: 3
+    activation: "capped_gelu"
+    upscale_factor: 4
+    norm: "batch"
+
+  down_sampling_block: "avg_pool"
+  up_sampling_block: "bilinear_upsample"

--- a/configs/train_cm4.yaml
+++ b/configs/train_cm4.yaml
@@ -1,9 +1,9 @@
-debug: true
+debug: false
 disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 120
-batch_size: 2 # 4
+batch_size: 3 # 4
 learning_rate: 0.0001
 scheduler: false
 loss: mse
@@ -12,8 +12,8 @@ resume_ckpt_path: null
 inference_epochs: [-1]
 data_percent: 1.0
 train:
-  start_time: "0151-01-06"
-  end_time: "0154-01-01"
+  start_time: "0151-06-06"
+  end_time: "0152-01-01"
 val:
   start_time: "0306-01-01"
   end_time: "0307-01-01"
@@ -47,9 +47,10 @@ experiment:
   gantry: false
   cluster_data_dir: null
   wandb:
-    mode: disabled
-    project: 3D_ocean_emu_CM4
-    entity: suryadheeshjith
+    mode: online
+    project: ocean-emulators
+    entity: m2lines
+    group: samudra-train-cm4
   network: Samudra
   prognostic_vars_key: thermo_dynamic_all
   boundary_vars_key: tau_hfds

--- a/configs/train_cm4.yaml
+++ b/configs/train_cm4.yaml
@@ -60,7 +60,7 @@ data:
   scaling_residuals_file: null
   time_delta: 5
   num_workers: 4
-  hist: 0
+  hist: 1
 
 
 samudra:

--- a/scripts/.local-eval
+++ b/scripts/.local-eval
@@ -3,17 +3,17 @@
 # Assumes you have activated the emulator conda environment and
 # set the CLUSTER_NAME and OCEAN_DATA_DIR environment variables
 set -e
-CONFIG_PATH=configs/eval_om4.yaml
+CONFIG_PATH=configs/eval_cm4.yaml
 
-echo 'Running local training on cluster:' $CLUSTER_NAME 'with data directory:' $OCEAN_DATA_DIR_WRITE
+echo 'Running local training on cluster:' $CLUSTER_NAME 'with data directory:' $OCEAN_DATA_DIR
 echo 'Using config file:' $CONFIG_PATH
 
 # Create a temporary config file with updated cluster_data_dir
 TMP_CONFIG_PATH=/tmp/config_temp.yaml
-sed "s|cluster_data_dir:.*|cluster_data_dir: $OCEAN_DATA_DIR_WRITE|" $CONFIG_PATH > $TMP_CONFIG_PATH
+sed "s|cluster_data_dir:.*|cluster_data_dir: $OCEAN_DATA_DIR|" $CONFIG_PATH > $TMP_CONFIG_PATH
 
 uv run src/ocean_emulators/eval.py \
     --config $TMP_CONFIG_PATH \
-    --ckpt_path /pscratch/sd/s/suryad/Ocean_Emulator/.LOCAL/2025-03-21-train-test/saved_nets/convnextunet_epoch_1_best_inference_steps_4_all_Lateral_Data_025_no_smooth.pt \
-    --subname "om4-test" \
+    --ckpt_path /pscratch/sd/s/suryad/Ocean_Emulator/.LOCAL/2025-04-03-train-test/saved_nets/best_inference_ckpt.pt \
+    --subname "cm4-test" \
     --save_zarr

--- a/scripts/.local-eval
+++ b/scripts/.local-eval
@@ -3,7 +3,7 @@
 # Assumes you have activated the emulator conda environment and
 # set the CLUSTER_NAME and OCEAN_DATA_DIR environment variables
 set -e
-CONFIG_PATH=configs/eval_cm4.yaml
+CONFIG_PATH=configs/eval_om4.yaml
 
 echo 'Running local training on cluster:' $CLUSTER_NAME 'with data directory:' $OCEAN_DATA_DIR
 echo 'Using config file:' $CONFIG_PATH
@@ -14,6 +14,6 @@ sed "s|cluster_data_dir:.*|cluster_data_dir: $OCEAN_DATA_DIR|" $CONFIG_PATH > $T
 
 uv run src/ocean_emulators/eval.py \
     --config $TMP_CONFIG_PATH \
-    --ckpt_path /pscratch/sd/s/suryad/Ocean_Emulator/.LOCAL/2025-04-03-train-test/saved_nets/best_inference_ckpt.pt \
-    --subname "cm4-test" \
+    --ckpt_path /pscratch/sd/s/suryad/Ocean_Emulator/.LOCAL/2025-04-05-train-test/saved_nets/best_validation_ckpt.pt \
+    --subname "om4-speed-test-optimized-removed-cond" \
     --save_zarr

--- a/scripts/.local-train
+++ b/scripts/.local-train
@@ -3,7 +3,7 @@
 # Assumes you have activated the emulator conda environment and
 # set the CLUSTER_NAME and OCEAN_DATA_DIR environment variables
 set -e
-CONFIG_PATH=configs/train_om4.yaml
+CONFIG_PATH=configs/train_cm4.yaml
 
 echo 'Running local training on cluster:' $CLUSTER_NAME 'with data directory:' $OCEAN_DATA_DIR
 echo 'Using config file:' $CONFIG_PATH

--- a/scripts/.slurm-perlmutter-train
+++ b/scripts/.slurm-perlmutter-train
@@ -1,23 +1,22 @@
 #!/bin/bash
-#SBATCH --job-name=samudra-maskstos-perlmutter
+#SBATCH --job-name=samudra-perlmutter-om4-speed-inlineinf-torch
 #SBATCH --output=train/logs/slurm-%j.out
 #SBATCH --error=train/logs/slurm-%j.err
 #SBATCH --constraint=gpu&hbm80g
 #SBATCH --account=m4874
-#SBATCH --qos=regular
+#SBATCH --qos=debug
 #SBATCH --mem=110G
-#SBATCH --nodes=4
+#SBATCH --nodes=2
 #SBATCH --ntasks-per-node=2
 #SBATCH --cpus-per-task=32
 #SBATCH --gpus-per-task=1
 #SBATCH --gpu-bind=none     # This ensures all GPUs are visible to all tasks
-#SBATCH --time=48:00:00
+#SBATCH --time=00:20:00
 
 set -e
 
 # Load conda environment
-module load conda
-conda activate emulator
+source .venv/bin/activate
 
 # Set master node information
 export MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)
@@ -32,6 +31,6 @@ echo "SLURM_NNODES: $SLURM_NNODES"
 
 # Run the training script
 srun --cpu-bind=cores \
-     python src/train.py \
-     --config configs/slurm_perlmutter_train_cm4.yaml \
+     python src/ocean_emulators/train.py \
+     --config configs/slurm_perlmutter_train_om4.yaml \
      --subname $SLURM_JOB_NAME

--- a/src/ocean_emulators/aggregator/inference/main.py
+++ b/src/ocean_emulators/aggregator/inference/main.py
@@ -104,7 +104,6 @@ class InferenceEvaluatorAggregator:
         if len(data.target) == 0:
             raise ValueError("No target values in data")
         total_len = len(data.time)
-        assert data.prediction.shape == data.target.shape
         assert data.prediction.shape[0] == total_len // (self.hist + 1)
         target_norm_dict, target_unnorm_dict = get_norm_unnorm_dicts(
             data.target,

--- a/src/ocean_emulators/aggregator/inference/main.py
+++ b/src/ocean_emulators/aggregator/inference/main.py
@@ -103,14 +103,19 @@ class InferenceEvaluatorAggregator:
             raise ValueError("No prediction values in data")
         if len(data.target) == 0:
             raise ValueError("No target values in data")
+        total_len = len(data.time)
+        assert data.prediction.shape == data.target.shape
+        assert data.prediction.shape[0] == total_len // (self.hist + 1)
         target_norm_dict, target_unnorm_dict = get_norm_unnorm_dicts(
             data.target,
+            long_rollout=True,
             input_type="target",
             num_prognostic_channels=self.num_prognostic_channels,
             hist=self.hist,
         )
         gen_norm_dict, gen_unnorm_dict = get_norm_unnorm_dicts(
             data.prediction,
+            long_rollout=True,
             input_type="input",
             num_prognostic_channels=self.num_prognostic_channels,
             hist=self.hist,
@@ -151,6 +156,7 @@ class InferenceEvaluatorAggregator:
 
         data_norm_dict, data_unnorm_dict = get_norm_unnorm_dicts(
             initial_prognostic,
+            long_rollout=True,
             input_type="input",
             num_prognostic_channels=self.num_prognostic_channels,
             hist=self.hist,
@@ -257,8 +263,12 @@ class InferenceAggregator:
         if len(data.data) == 0:
             raise ValueError("data is empty")
 
+        total_len = len(data.time)
+        assert data.data.shape[0] == total_len // (self.hist + 1)
+
         _, data_unnorm_dict = get_norm_unnorm_dicts(
             data.data,
+            long_rollout=True,
             input_type="gen",
             num_prognostic_channels=self.num_prognostic_channels,
             hist=self.hist,
@@ -288,6 +298,7 @@ class InferenceAggregator:
             )
         _, data_unnorm_dict = get_norm_unnorm_dicts(
             initial_prognostic,
+            long_rollout=True,
             input_type="input",
             num_prognostic_channels=self.num_prognostic_channels,
             hist=self.hist,

--- a/src/ocean_emulators/aggregator/validate/main.py
+++ b/src/ocean_emulators/aggregator/validate/main.py
@@ -52,8 +52,11 @@ class ValidateAggregator(TrainAggregator):
         if len(batch.gen_data) == 0:
             raise ValueError("No data in gen_data")
 
+        assert batch.target_data.shape == batch.gen_data.shape
+        assert batch.target_data.shape[1] == self.num_prognostic_channels
         target_data_dict, target_data_unnorm_dict = get_norm_unnorm_dicts(
             batch.target_data,
+            long_rollout=False,
             input_type="target",
             num_prognostic_channels=self.num_prognostic_channels,
             hist=self.hist,
@@ -61,12 +64,14 @@ class ValidateAggregator(TrainAggregator):
 
         gen_data_dict, gen_data_unnorm_dict = get_norm_unnorm_dicts(
             batch.gen_data,
+            long_rollout=False,
             input_type="gen",
             num_prognostic_channels=self.num_prognostic_channels,
             hist=self.hist,
         )
         input_data_dict, input_data_unnorm_dict = get_norm_unnorm_dicts(
             batch.input_data,
+            long_rollout=False,
             input_type="input",
             num_prognostic_channels=self.num_prognostic_channels,
             hist=self.hist,

--- a/src/ocean_emulators/aggregator/validate/main.py
+++ b/src/ocean_emulators/aggregator/validate/main.py
@@ -52,7 +52,6 @@ class ValidateAggregator(TrainAggregator):
         if len(batch.gen_data) == 0:
             raise ValueError("No data in gen_data")
 
-        assert batch.target_data.shape == batch.gen_data.shape
         assert batch.target_data.shape[1] == self.num_prognostic_channels
         target_data_dict, target_data_unnorm_dict = get_norm_unnorm_dicts(
             batch.target_data,

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -227,7 +227,6 @@ class EvalConfig:
     disk_mode: bool = True
     ckpt_path: str = ""
     num_model_steps_forward: int = 200
-    record_every: int = 10
     backend: EvalBackendConfig = "auto"
 
     # Config components
@@ -269,7 +268,6 @@ class EvalConfig:
             "disk_mode": self.disk_mode,
             "ckpt_path": self.ckpt_path,
             "num_model_steps_forward": self.num_model_steps_forward,
-            "record_every": self.record_every,
             "inference": self.inference.__dict__,
             "experiment": self.experiment.__dict__,
             "data": self.data.__dict__,

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -102,6 +102,7 @@ MASK_VARS = [
 
 PrognosticVarNames = list[str]
 PROGNOSTIC_VARS: dict[str, PrognosticVarNames] = {
+    "thetao_surface": [f"thetao_{DEPTH_I_LEVELS[0]}"],
     "thermo_dynamic_5": [
         k + str(j) for k in ["uo_", "vo_", "thetao_", "so_"] for j in DEPTH_I_LEVELS[:5]
     ]
@@ -115,6 +116,7 @@ PROGNOSTIC_VARS: dict[str, PrognosticVarNames] = {
 }
 BoundaryVarNames = list[str]
 BOUNDARY_VARS: dict[str, BoundaryVarNames] = {
+    "hfds": ["hfds"],
     "tau_hfds": ["tauuo", "tauvo", "hfds"],
     "tau_hfds_hfds_anom": ["tauuo", "tauvo", "hfds", "hfds_anomalies"],
 }

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -31,6 +31,8 @@ Example = tuple[Input, Prognostic] | tuple[xr.Dataset, xr.Dataset]
 GridMask = Bool[Array, "180 360"]
 PrognosticMask = Bool[GridMask, "prognostic_vars"]
 
+MAX_TRAIN_MODEL_STEPS_FORWARD = 2000
+
 # Experiment prognostic and boundary variables
 # Assumption that all 3D variables are appended with depth_i_levels
 # and all 2D variables do not have any digits / underscores in their names

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -279,9 +279,9 @@ class InferenceDataset(Dataset):
     def _get_x_index(self, idx):
         if isinstance(idx, slice):
             if (
-                (idx.start and idx.start < 0)
-                or (idx.stop and idx.stop < 0)
-                or (idx.step and idx.step < 0)
+                (idx.start is not None and idx.start < 0)
+                or (idx.stop is not None and idx.stop < 0)
+                or (idx.step is not None and idx.step < 0)
             ):
                 raise IndexError("Sorry, negative indexing is not supported!")
             if idx.step is None:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -195,6 +195,7 @@ class InferenceDataset(Dataset):
         self.num_prognostic_channels = (hist + 1) * len(prognostic_var_names)
         self._prognostic_vars = data[prognostic_var_names]
         self._boundary_vars = data[boundary_var_names]
+        self._times = data.time
 
         time_indices = np.arange(data.time.size)
         indices = xr.DataArray(
@@ -236,19 +237,23 @@ class InferenceDataset(Dataset):
 
     @property
     def initial_prognostic(self):
-        data = self.__getitem__(0)[0]
-        return data[:, : self.num_prognostic_channels]
+        x_index = self._get_x_index(0)
+        data_in = self._get_prognostic(x_index)
+        return data_in
 
-    def inference_target(self, step: int):
-        return self.__getitem__(step)[1]
+    def inference_target(self, step: int | slice):
+        x_index = self._get_x_index(step)
+        label = self._get_label(x_index)
+        return label
 
     def get_initial_input(self):
         data = self.__getitem__(0)[0]
         return data
 
     # TODO: This is a placeholder for now since time returned is incorrect
-    def get_input_time(self, step: int):
-        return self._prognostic_vars.time[step]
+    def get_input_time(self, step: int | slice):
+        x_index = self._get_x_index(step)
+        return self._times[x_index]
 
     def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
         x_index = self._get_x_index(step)
@@ -266,16 +271,20 @@ class InferenceDataset(Dataset):
 
     def _get_x_index(self, idx):
         if isinstance(idx, slice):
-            if idx.start < 0 or idx.stop < 0 or idx.step < 0:
+            if (
+                (idx.start and idx.start < 0)
+                or (idx.stop and idx.stop < 0)
+                or (idx.step and idx.step < 0)
+            ):
                 raise IndexError("Sorry, negative indexing is not supported!")
-            elif idx.start >= self.size or idx.stop >= self.size:
-                raise IndexError(f"Index {idx} out of range with size {self.size}")
             elif idx.start is None and idx.stop is None:
                 idx = slice(0, self.size, idx.step)
             elif idx.start is None:
                 idx = slice(0, idx.stop, idx.step)
             elif idx.stop is None:
                 idx = slice(idx.start, self.size, idx.step)
+            elif idx.step is None:
+                idx = slice(idx.start, idx.stop, 1)
         elif isinstance(idx, int):
             if idx < 0:
                 raise IndexError("Sorry, negative indexing is not supported!")

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -250,10 +250,17 @@ class InferenceDataset(Dataset):
         data = self.__getitem__(0)[0]
         return data
 
-    # TODO: This is a placeholder for now since time returned is incorrect
-    def get_input_time(self, step: int | slice):
-        x_index = self._get_x_index(step)
-        return self._times[x_index]
+    def get_target_time(self, start_step: int, num_steps: int):
+        x_index = self._get_x_index(start_step)
+        batch_index = x_index.values[0]
+        steps_predicted = len(batch_index) // 2
+        start_target_index = batch_index[steps_predicted]
+
+        return self._times.isel(
+            time=slice(
+                start_target_index, start_target_index + num_steps * steps_predicted
+            )
+        )
 
     def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
         x_index = self._get_x_index(step)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -532,16 +532,6 @@ class TrainDataset(Dataset):
         # Create a slice for similar indexing as in InferenceDataset
         idx_slice = slice(start, end)
         rolling_idx = self.rolling_indices.isel(window_dim=idx_slice)
-        # Convert to tests, tests are outdated since changing time definition
-        # if prev_rolling_idx is not None:
-        #     assert (
-        #         prev_rolling_idx.isel(time=slice(self.hist + 1, None))
-        #         - rolling_idx.isel(time=slice(0, self.hist + 1))
-        #     ).sum() == 0  # Prev output = Cur Input
-        #     assert (
-        #         rolling_idx.diff("time") == self.stride
-        #     ).all()  # Stride is maintained
-        #     assert rolling_idx.isel(time=-1) < self.size  # Last index check
 
         x_index = xr.Variable(["window_dim", "time"], rolling_idx)
         return x_index

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -350,7 +350,6 @@ class InferenceDataset(Dataset):
             "window_dim time variable lat lon -> window_dim (time variable) lat lon",
         )
         label = torch.from_numpy(label).float()
-        # label = label * self.wet
         label = torch.where(self.wet, label, 0.0)
         return label
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -277,14 +277,14 @@ class InferenceDataset(Dataset):
                 or (idx.step and idx.step < 0)
             ):
                 raise IndexError("Sorry, negative indexing is not supported!")
-            elif idx.start is None and idx.stop is None:
+            if idx.step is None:
+                idx = slice(idx.start, idx.stop, 1)
+            if idx.start is None and idx.stop is None:
                 idx = slice(0, self.size, idx.step)
             elif idx.start is None:
                 idx = slice(0, idx.stop, idx.step)
             elif idx.stop is None:
                 idx = slice(idx.start, self.size, idx.step)
-            elif idx.step is None:
-                idx = slice(idx.start, idx.stop, 1)
         elif isinstance(idx, int):
             if idx < 0:
                 raise IndexError("Sorry, negative indexing is not supported!")

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -181,7 +181,6 @@ class Eval:
         self.num_workers = cfg.data.num_workers
         self.inference_time = cfg.inference
         self.time_delta = cfg.data.time_delta
-        self.record_every = cfg.record_every
         self.num_model_steps_forward = cfg.num_model_steps_forward
         self.save_zarr = cfg.save_zarr
         self.model_path = cfg.ckpt_path
@@ -250,7 +249,6 @@ class Eval:
             output_dir=self.output_dir,
             model_path=self.model_path,
             num_model_steps_forward=self.num_model_steps_forward,
-            record_every=self.record_every,
             save_zarr=self.save_zarr,
         )
         logs = inf_aggregator.get_summary_logs()

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -104,7 +104,7 @@ class BaseModel(torch.nn.Module):
                 )
             else:
                 input_tensor = dataset.merge_prognostic_and_boundary(
-                    prognostic=pred_tensor[-1].unsqueeze(0),
+                    prognostic=pred_tensor[step - 1].unsqueeze(0),
                     step=steps_completed + step,
                 )
 

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -88,6 +88,7 @@ class BaseModel(torch.nn.Module):
 
         pred_tensor = torch.zeros(out_shape, device=get_device())
         initial_time = dataset.get_input_time(steps_completed)
+        initial_prognostic = initial_prognostic.to(get_device())
 
         for step in range(num_steps):
             logging.info(

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -84,7 +84,6 @@ class BaseModel(torch.nn.Module):
         num_steps=None,
         epoch=None,
     ) -> InfOutput:
-        print(num_steps)
         out_shape = (num_steps, *dataset[0][1].shape[1:])
 
         pred_tensor = torch.zeros(out_shape, device=get_device())
@@ -119,9 +118,6 @@ class BaseModel(torch.nn.Module):
                 )
             else:
                 pred = decodings
-
-            print(pred.shape)
-            print(pred_tensor[step].shape)
 
             pred_tensor[step] = pred
 

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -79,11 +79,12 @@ class BaseModel(torch.nn.Module):
     def inference(
         self,
         dataset: InferenceDataset,
-        initial_prognostic=None,
+        initial_prognostic: torch.Tensor,
         steps_completed=0,
         num_steps=None,
         epoch=None,
     ) -> InfOutput:
+        print(num_steps)
         out_shape = (num_steps, *dataset[0][1].shape[1:])
 
         pred_tensor = torch.zeros(out_shape, device=get_device())
@@ -94,10 +95,7 @@ class BaseModel(torch.nn.Module):
                 f"Inference [epoch {epoch}]: Rollout step {steps_completed + step} "
                 f"of {steps_completed + num_steps - 1}."
             )
-            if step == 0 and steps_completed == 0:
-                input_tensor = dataset.get_initial_input().to(device=get_device())
-
-            elif step == 0 and steps_completed > 0:
+            if step == 0:
                 input_tensor = dataset.merge_prognostic_and_boundary(
                     prognostic=initial_prognostic,
                     step=steps_completed,
@@ -121,6 +119,9 @@ class BaseModel(torch.nn.Module):
                 )
             else:
                 pred = decodings
+
+            print(pred.shape)
+            print(pred_tensor[step].shape)
 
             pred_tensor[step] = pred
 

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -87,8 +87,8 @@ class BaseModel(torch.nn.Module):
         out_shape = (num_steps, *dataset[0][1].shape[1:])
 
         pred_tensor = torch.zeros(out_shape, device=get_device())
-        initial_time = dataset.get_input_time(steps_completed)
         initial_prognostic = initial_prognostic.to(get_device())
+        target_time = dataset.get_target_time(steps_completed, num_steps)
 
         for step in range(num_steps):
             logging.info(
@@ -126,5 +126,5 @@ class BaseModel(torch.nn.Module):
             slice(steps_completed, steps_completed + num_steps)
         ).to(device=get_device())
 
-        IO = InfOutput(pred_tensor, target_tensor, initial_time)
+        IO = InfOutput(pred_tensor, target_tensor, target_time)
         return IO

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -7,6 +7,7 @@ import torch
 
 from ocean_emulators.datasets import InferenceDataset, TrainData
 from ocean_emulators.utils.device import get_device
+from ocean_emulators.utils.model import InfOutput
 
 
 class BaseModel(torch.nn.Module):
@@ -82,8 +83,12 @@ class BaseModel(torch.nn.Module):
         steps_completed=0,
         num_steps=None,
         epoch=None,
-    ) -> list[torch.Tensor]:
-        outputs: list[torch.Tensor] = []
+    ) -> InfOutput:
+        out_shape = (num_steps, *dataset[0][1].shape[1:])
+
+        pred_tensor = torch.zeros(out_shape, device=get_device())
+        initial_time = dataset.get_input_time(steps_completed)
+
         for step in range(num_steps):
             logging.info(
                 f"Inference [epoch {epoch}]: Rollout step {steps_completed + step} "
@@ -99,7 +104,7 @@ class BaseModel(torch.nn.Module):
                 )
             else:
                 input_tensor = dataset.merge_prognostic_and_boundary(
-                    prognostic=outputs[-1],
+                    prognostic=pred_tensor[-1].unsqueeze(0),
                     step=steps_completed + step,
                 )
 
@@ -117,6 +122,11 @@ class BaseModel(torch.nn.Module):
             else:
                 pred = decodings
 
-            outputs.append(pred)
+            pred_tensor[step] = pred
 
-        return outputs
+        target_tensor = dataset.inference_target(
+            slice(steps_completed, steps_completed + num_steps)
+        ).to(device=get_device())
+
+        IO = InfOutput(pred_tensor, target_tensor, initial_time)
+        return IO

--- a/src/ocean_emulators/stepper.py
+++ b/src/ocean_emulators/stepper.py
@@ -96,7 +96,7 @@ class Stepper:
                 num_steps_list = [num_model_steps]
 
         num_loops = len(num_steps_list)
-        initial_prognostic = None
+        initial_prognostic = dataset.initial_prognostic
         step = 0
         for loop, num_steps in enumerate(num_steps_list):
             logging.info(

--- a/src/ocean_emulators/stepper.py
+++ b/src/ocean_emulators/stepper.py
@@ -1,13 +1,13 @@
 import logging
 from os import PathLike
-from typing import Callable, Dict, Optional
+from typing import Callable, Optional
 
 import torch
 
 from ocean_emulators.aggregator import InferenceEvaluatorAggregator
 from ocean_emulators.datasets import InferenceDataset, TrainData
 from ocean_emulators.models.base import BaseModel
-from ocean_emulators.utils.model import InfOutput, TrainOutput, ValOutput
+from ocean_emulators.utils.model import TrainOutput, ValOutput
 from ocean_emulators.utils.wandb import get_record_to_wandb
 from ocean_emulators.utils.writer import ZarrWriter
 
@@ -56,7 +56,6 @@ class Stepper:
         output_dir: Optional[str | PathLike] = None,
         model_path: Optional[str | PathLike] = None,
         num_model_steps_forward: int = 200,
-        record_every: int = 10,
         save_zarr: bool = False,
     ) -> None:
         if save_zarr:
@@ -104,7 +103,7 @@ class Stepper:
                 f"Inference [epoch {epoch}]: loop {loop} of {num_loops - 1}. "
                 f"Stepping {num_steps} steps forward."
             )
-            outs = model.inference(
+            IO = model.inference(
                 dataset,
                 initial_prognostic=initial_prognostic,
                 steps_completed=step,
@@ -112,36 +111,11 @@ class Stepper:
                 epoch=epoch,
             )
             # Setting initial prognostic for next loop
-            initial_prognostic = outs[-1].clone()
+            initial_prognostic = IO.prediction[-1].unsqueeze(0).clone()
+            if writer:
+                writer.record_batch(IO)
+                writer.write()
 
-            all_logs: list[Dict[str, float | int | str]] = []
-            for i in range(num_steps):
-                logging.info(
-                    f"Inference [epoch {epoch}]: recording output window {i + step} of "
-                    f"{num_model_steps - 1}."
-                )
-                IO = InfOutput(
-                    prediction=outs[i],
-                    target=dataset.inference_target(step + i).to(
-                        outs[i].device
-                    ),  # TODO: Pack with input
-                    time=dataset.get_input_time(step + i),
-                )  # time-dependent aggs dont work, time is incorrect as well
-                if writer:
-                    writer.record_batch(IO)
-                logs = inf_aggregator.record_batch(IO)
-                all_logs.extend(logs)
-                if (i + 1) % record_every == 0:
-                    logging.info(f"Inference [epoch {epoch}]: wandb logging...")
-                    record_logs(all_logs)
-                    if writer:
-                        writer.write()
-                    all_logs = []
-
-            if len(all_logs) > 0:
-                logging.info(f"Inference [epoch {epoch}]: wandb logging...")
-                record_logs(all_logs)
-                if writer:
-                    writer.write()
-
+            logs = inf_aggregator.record_batch(IO)
+            record_logs(logs)
             step += num_steps

--- a/src/ocean_emulators/stepper.py
+++ b/src/ocean_emulators/stepper.py
@@ -113,9 +113,12 @@ class Stepper:
             # Setting initial prognostic for next loop
             initial_prognostic = IO.prediction[-1].unsqueeze(0).clone()
             if writer:
+                logging.info(f"Writing to zarr...")
                 writer.record_batch(IO)
                 writer.write()
 
+            logging.info(f"Recording logs...")
             logs = inf_aggregator.record_batch(IO)
+            logging.info(f"Logging to wandb...")
             record_logs(logs)
             step += num_steps

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -597,7 +597,7 @@ class Trainer:
                     dataset=inference_dataset,
                     inf_aggregator=inf_aggregator,
                     epoch=epoch,
-                    num_model_steps_forward=num_steps,
+                    num_model_steps_forward=num_steps // 2,
                 )
         logs = inf_aggregator.get_summary_logs()
         return {f"inference/{k}": v for k, v in logs.items()}

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -30,6 +30,7 @@ from ocean_emulators.backend import init_train_backend
 from ocean_emulators.config import TrainConfig
 from ocean_emulators.constants import (
     BOUNDARY_VARS,
+    MAX_TRAIN_MODEL_STEPS_FORWARD,
     PROGNOSTIC_VARS,
     BoundaryVarNames,
     Grid,
@@ -352,6 +353,9 @@ class Trainer:
         self.time_delta: int = cfg.data.time_delta
         self.num_batches_seen = 0
         self.ckpt_paths = CheckpointPaths(self.nets_dir)
+        self.max_train_model_steps_forward = MAX_TRAIN_MODEL_STEPS_FORWARD // (
+            self.hist + 1
+        )
 
         assert self.tensor_map is not None
         self.loss_aggregator = LossAggregator.init_instance()
@@ -597,7 +601,9 @@ class Trainer:
                     dataset=inference_dataset,
                     inf_aggregator=inf_aggregator,
                     epoch=epoch,
-                    num_model_steps_forward=num_steps // 2,
+                    num_model_steps_forward=min(
+                        num_steps // 2, self.max_train_model_steps_forward
+                    ),
                 )
         logs = inf_aggregator.get_summary_logs()
         return {f"inference/{k}": v for k, v in logs.items()}

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -180,6 +180,7 @@ def convert_tensor_out_to_dict(tensor_out: torch.Tensor) -> Dict[str, torch.Tens
 
 def get_norm_unnorm_dicts(
     data: torch.Tensor,
+    long_rollout: bool,
     input_type: str = "target",
     num_prognostic_channels: int = 0,
     hist: int = 1,
@@ -190,8 +191,12 @@ def get_norm_unnorm_dicts(
         data = data[:, :num_prognostic_channels]
 
     # Separate history from channels
-    data_reshaped = rearrange(data, "n (hi c) h w -> (n hi) c h w", hi=hist + 1)
-    data_reshaped = data_reshaped.unsqueeze(0)  # batch dim for minimal code-change
+    if long_rollout:
+        data_reshaped = rearrange(data, "n (hi c) h w -> (n hi) c h w", hi=hist + 1)
+        data_reshaped = data_reshaped.unsqueeze(0)  # add artificial batch dim
+    else:
+        data_reshaped = rearrange(data, "n (hi c) h w -> n hi c h w", hi=hist + 1)
+
     # Get normalized dict
     data_dict = convert_tensor_out_to_dict(data_reshaped)
     # Unnormalize

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -190,7 +190,8 @@ def get_norm_unnorm_dicts(
         data = data[:, :num_prognostic_channels]
 
     # Separate history from channels
-    data_reshaped = rearrange(data, "n (hi c) h w -> n hi c h w", hi=hist + 1)
+    data_reshaped = rearrange(data, "n (hi c) h w -> (n hi) c h w", hi=hist + 1)
+    data_reshaped = data_reshaped.unsqueeze(0)  # batch dim for minimal code-change
     # Get normalized dict
     data_dict = convert_tensor_out_to_dict(data_reshaped)
     # Unnormalize

--- a/src/ocean_emulators/utils/model.py
+++ b/src/ocean_emulators/utils/model.py
@@ -29,6 +29,7 @@ class ValOutput(TrainOutput):
         gen_data: torch.Tensor,
     ):
         super().__init__(loss, loss_per_channel)
+        assert target_data.shape == gen_data.shape
         self.input_data = input_data
         self.target_data = target_data
         self.gen_data = gen_data
@@ -41,6 +42,7 @@ class InfOutput:
         target: torch.Tensor,
         time: xr.DataArray,
     ):
+        assert prediction.shape == target.shape
         self.prediction = prediction
         self.target = target
         self.time = time

--- a/src/ocean_emulators/utils/model.py
+++ b/src/ocean_emulators/utils/model.py
@@ -2,6 +2,7 @@ import logging
 
 import numpy as np
 import torch
+import xarray as xr
 from torchinfo import summary
 
 
@@ -38,7 +39,7 @@ class InfOutput:
         self,
         prediction: torch.Tensor,
         target: torch.Tensor,
-        time: torch.Tensor,
+        time: xr.DataArray,
     ):
         self.prediction = prediction
         self.target = target

--- a/src/ocean_emulators/utils/writer.py
+++ b/src/ocean_emulators/utils/writer.py
@@ -29,8 +29,9 @@ class ZarrWriter:
 
     def record_batch(self, IO: InfOutput):
         pred_tensor = IO.prediction
-        pred_tensor = pred_tensor.squeeze(0)
-        pred_tensor = rearrange(pred_tensor, "(n c) h w -> n c h w", n=self.hist + 1)
+        pred_tensor = rearrange(
+            pred_tensor, "n (hi c) h w -> (n hi) c h w", hi=self.hist + 1
+        )
         pred_tensor = self.normalize.unnormalize_tensor_prognostic(
             pred_tensor, fill_value=0.0
         )

--- a/src/ocean_emulators/utils/writer.py
+++ b/src/ocean_emulators/utils/writer.py
@@ -21,6 +21,7 @@ class ZarrWriter:
         self.pred_path = os.path.join(output_dir, "predictions.zarr")
         self.hist = hist
         self.buffer: torch.Tensor | None = None
+        self.time_buffer: xr.DataArray | None = None
         self.coords = coords
         self.model_path = model_path
 
@@ -29,6 +30,7 @@ class ZarrWriter:
 
     def record_batch(self, IO: InfOutput):
         pred_tensor = IO.prediction
+        pred_time = IO.time
         pred_tensor = rearrange(
             pred_tensor, "n (hi c) h w -> (n hi) c h w", hi=self.hist + 1
         )
@@ -40,14 +42,21 @@ class ZarrWriter:
         else:
             self.buffer = torch.cat([self.buffer, pred_tensor], dim=0)
 
+        if self.time_buffer is None:
+            self.time_buffer = pred_time
+        else:
+            self.time_buffer = xr.concat([self.time_buffer, pred_time], dim="time")
+
     def write(self):
         # Write to zarr
         if self.buffer is None:
             raise ValueError("No tensor to write")
 
+        if self.time_buffer is None:
+            raise ValueError("No time buffer to write")
+
         coords: Dict[str, Any] = {k: v for k, v in self.coords.items()}
-        # TODO: Replace by actual time so I dont need to fix this downstream
-        coords["time"] = range(self.buffer.shape[0])
+        coords["time"] = self.time_buffer
         ds = xr.Dataset(
             data_vars={
                 var: (["time", "lat", "lon"], self.buffer[:, i, :, :].cpu().numpy())
@@ -68,3 +77,4 @@ class ZarrWriter:
 
         # Reset
         self.buffer = None
+        self.time_buffer = None

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -82,7 +82,7 @@ def inf_data_init(hist: int):
         yield inference_dataset
 
 
-class ModelRetBoundary(BaseModel):
+class MockModel(BaseModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -140,7 +140,7 @@ def test_inference_dataset(inf_data_init, hist):
 @pytest.mark.parametrize("num_steps", [1, 2, 3])
 def test_inference_rollout(inf_data_init, hist, num_steps):
     inference_dataset = inf_data_init
-    model = ModelRetBoundary(
+    model = MockModel(
         ch_width=[1],
         n_out=inference_dataset.num_prognostic_channels,
         wet=inference_dataset.wet,
@@ -193,7 +193,7 @@ def test_inference_rollout(inf_data_init, hist, num_steps):
 @pytest.mark.parametrize("merge_step", [1, 2, 3])
 def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     inference_dataset = inf_data_init
-    model = ModelRetBoundary(
+    model = MockModel(
         ch_width=[1],
         n_out=inference_dataset.num_prognostic_channels,
         wet=inference_dataset.wet,

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -234,4 +234,25 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     assert torch.equal(merged_input_tensor.flatten(), expected_merged_input)
 
 
-# TODO: Add test for time returned
+@pytest.mark.parametrize("hist", [0, 1, 2, 3])
+@pytest.mark.parametrize("num_steps", [1, 2, 3])
+@pytest.mark.parametrize("start_time", [0, 6, 15])
+def test_inference_rollout_time(inf_data_init, hist, num_steps, start_time):
+    inference_dataset = inf_data_init
+    target_time = inference_dataset.get_target_time(start_time, num_steps)
+
+    # Base time
+    # Hist = 0, start_time = 0, base_time = 1
+    # Hist = 0, start_time = 1, base_time = 2
+    # Hist = 1, start_time = 0, base_time = 2
+    # Hist = 1, start_time = 2, base_time = 6
+    # Hist = 2, start_time = 0, base_time = 3
+    base_time = (start_time + 1) * (hist + 1)
+    times = [i for i in range(base_time, base_time + num_steps * (hist + 1))]
+    expected_target_time = xr.DataArray(
+        data=times,
+        dims=["time"],
+        coords={"time": times},
+    )
+    assert target_time.size == expected_target_time.size
+    assert target_time.equals(expected_target_time)

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -151,7 +151,10 @@ def test_inference_rollout(inf_data_init, hist, num_steps):
     )
 
     model.eval()
-    IO = model.inference(inference_dataset, num_steps=num_steps, epoch=0)
+    initial_prognostic = inference_dataset.initial_prognostic
+    IO = model.inference(
+        inference_dataset, initial_prognostic, num_steps=num_steps, epoch=0
+    )
     prediction = IO.prediction
     target = IO.target
 
@@ -225,3 +228,6 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
         device=merged_input_tensor.device,
     )
     assert torch.equal(merged_input_tensor.flatten(), expected_merged_input)
+
+
+# TODO: Add test for time returned

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -87,7 +87,7 @@ class ModelRetBoundary(BaseModel):
         super().__init__(*args, **kwargs)
 
     def forward_once(self, x):
-        return x[:, :-1] * 0.0 + x[:, -1]
+        return x[:, :-1] * 10.0 + x[:, -1]
 
 
 # These tests will fail with OHC PR
@@ -137,7 +137,7 @@ def test_inference_dataset(inf_data_init, hist):
 
 
 @pytest.mark.parametrize("hist", [0, 1, 2, 3, 4])
-@pytest.mark.parametrize("num_steps", [1, 2, 3, 10])
+@pytest.mark.parametrize("num_steps", [1, 2, 3])
 def test_inference_rollout(inf_data_init, hist, num_steps):
     inference_dataset = inf_data_init
     model = ModelRetBoundary(
@@ -171,18 +171,20 @@ def test_inference_rollout(inf_data_init, hist, num_steps):
 
     # Test if we are extracting the correct boundary values
     # The model returns the boundary condition at the latest step for each step
-    # For hist = 0, prediction is [1, 3, 5]
-    # For hist = 1, prediction is [3, 3, 7, 7, 11, 11]
-    # For hist = 2, prediction is [5, 5, 5, 11, 11, 11, 17, 17, 17]
+    # For hist = 0, prediction is [0*10+1=1, 1*10+3=13, 13*10+5=135]
+    # For hist = 1, prediction is [0*10+3=3, 2*10+3=23, 3*10+7=37, 23*10+7=237, ...]
+    # For hist = 2, prediction is [0*10+5=5, 2*10+5=25, 4*10+5=45, 5*10+11=61, ...]
 
-    start = 2 * (hist + 1) - 1
-    diff_step = (hist + 1) * 2
-    repeat = hist + 1
-    base = torch.arange(
-        start, start + diff_step * num_steps, diff_step, device=prediction.device
+    expected_prediction = torch.tensor(
+        [20 * i for i in range(hist + 1)], device=prediction.device
     )
-    base = base.repeat_interleave(repeat)
-    expected_prediction = torch.tensor(base, device=prediction.device)
+    expected_prediction = expected_prediction + 2 * hist + 1
+    base = expected_prediction.clone()
+    for i in range(1, num_steps):
+        cur_acc = 2 * hist + 1 + 2 * i * (hist + 1)
+        base = 10 * base + cur_acc
+        expected_prediction = torch.cat((expected_prediction, base))
+
     assert torch.equal(prediction.flatten(), expected_prediction)
 
 
@@ -214,7 +216,9 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
 
     pred = model.forward_once(input_tensor)
     assert pred.shape == (1, num_prognostic_channels, 1, 1)
-    expected_pred = torch.tensor([2 * hist + 1] * (hist + 1), device=pred.device)
+    expected_pred = torch.tensor(
+        [2 * hist + 1 + 2 * i * 10 for i in range((hist + 1))], device=pred.device
+    )
     assert torch.equal(pred.flatten(), expected_pred)
 
     merged_input_tensor = inference_dataset.merge_prognostic_and_boundary(
@@ -223,7 +227,7 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     )
     assert merged_input_tensor.shape == (1, num_input_channels, 1, 1)
     expected_merged_input = torch.tensor(
-        [2 * hist + 1] * (hist + 1)
+        [2 * hist + 1 + 2 * i * 10 for i in range((hist + 1))]
         + [(merge_step + 1) * (num_prognostic_channels * 2) - 1],
         device=merged_input_tensor.device,
     )

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -1,0 +1,227 @@
+import numpy as np
+import pytest
+import torch
+import xarray as xr
+
+from ocean_emulators.constants import DEPTH_LEVELS, TensorMap
+from ocean_emulators.datasets import InferenceDataset
+from ocean_emulators.models.base import BaseModel
+from ocean_emulators.utils.data import Normalize, extract_wet_mask, validate_data
+from ocean_emulators.utils.multiton import MultitonScope
+
+
+@pytest.fixture
+def inf_data_init(hist: int):
+    with MultitonScope():
+        levels = 19
+        lats = 1
+        lons = 1
+        total_time_steps = 100
+
+        tensor_map = TensorMap.init_instance("thetao_surface", "hfds")
+
+        # Even thetao, odd hfds for every time step
+        # Ex, timestep 0: thetao = 0, hfds = 1
+        # Ex, timestep 1: thetao = 2, hfds = 3
+        # Ex, timestep 2: thetao = 4, hfds = 5
+        # ...
+        data = xr.Dataset(
+            {
+                **{
+                    f"thetao_{lev}": (
+                        ["time", "lat", "lon"],
+                        np.tile(
+                            np.arange(total_time_steps)[:, None, None] * 2,
+                            (1, lats, lons),
+                        ),
+                    )
+                    for lev in range(levels)
+                },
+                "hfds": (
+                    ["time", "lat", "lon"],
+                    np.tile(
+                        np.arange(total_time_steps)[:, None, None] * 2 + 1,
+                        (1, lats, lons),
+                    ),
+                ),
+                "wetmask": (
+                    ["time", "lev", "lat", "lon"],
+                    np.ones((total_time_steps, levels, lats, lons)),
+                ),
+            },
+            coords={
+                "time": np.arange(total_time_steps),
+                "lev": DEPTH_LEVELS,
+                "lat": np.arange(lats),
+                "lon": np.arange(lons),
+            },
+        )
+        data_mean = data.mean() * 0.0
+        data_std = data.std() * 0.0 + 1.0
+        data, data_mean, data_std = validate_data(data, data_mean, data_std)
+        wet, wet_surface = extract_wet_mask(data, tensor_map.prognostic_var_names, hist)
+        wet_without_hist, _ = extract_wet_mask(data, tensor_map.prognostic_var_names, 0)
+
+        _ = Normalize.init_instance(
+            data_mean=data_mean,
+            data_std=data_std,
+            prognostic_var_names=tensor_map.prognostic_var_names,
+            boundary_var_names=tensor_map.boundary_var_names,
+            wet_mask=wet_without_hist,
+        )
+        inference_dataset = InferenceDataset(
+            data,
+            tensor_map.prognostic_var_names,
+            tensor_map.boundary_var_names,
+            wet,
+            wet_surface,
+            hist,
+            long_rollout=True,
+        )
+
+        yield inference_dataset
+
+
+class ModelRetBoundary(BaseModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def forward_once(self, x):
+        return x[:, :-1] * 0.0 + x[:, -1]
+
+
+# These tests will fail with OHC PR
+@pytest.mark.parametrize("hist", [0, 1, 2, 3, 4])
+def test_inference_dataset(inf_data_init, hist):
+    inference_dataset = inf_data_init
+    num_input_channels = (hist + 1) + 1  # thetao * (hist + 1) + hfds
+    num_prognostic_channels = hist + 1  # thetao * (hist + 1)
+
+    input_0, target_0 = inference_dataset[0]
+
+    # Index 0 test
+    # For hist = 0, input is [0, 1]
+    # For hist = 1, input is [0, 2, 3]
+    assert input_0.shape == (1, num_input_channels, 1, 1)
+    expected_input = torch.tensor(
+        [2 * i for i in range(hist + 1)] + [2 * hist + 1], device=input_0.device
+    )
+    assert torch.equal(input_0.flatten(), expected_input)
+
+    # For hist = 0, target is [2]
+    # For hist = 1, target is [4, 6]
+    assert target_0.shape == (1, num_prognostic_channels, 1, 1)
+    expected_target = torch.tensor(
+        [2 * i for i in range(hist + 1, (hist + 1) * 2)], device=target_0.device
+    )
+    assert torch.equal(target_0.flatten(), expected_target)
+
+    # Loop test
+    for cur_step in range(1, len(inference_dataset)):
+        base_step = cur_step * (hist + 1)
+        input_cur, target_cur = inference_dataset[cur_step]
+        assert input_cur.shape == (1, num_input_channels, 1, 1)
+        expected_input = torch.tensor(
+            [2 * i for i in range(base_step, base_step + hist + 1)]
+            + [2 * (base_step + hist) + 1],
+            device=input_0.device,
+        )
+        assert torch.equal(input_cur.flatten(), expected_input)
+
+        assert target_cur.shape == (1, num_prognostic_channels, 1, 1)
+        expected_target = torch.tensor(
+            [2 * i for i in range(base_step + hist + 1, base_step + 2 * (hist + 1))],
+            device=target_0.device,
+        )
+        assert torch.equal(target_cur.flatten(), expected_target)
+
+
+@pytest.mark.parametrize("hist", [0, 1, 2, 3, 4])
+@pytest.mark.parametrize("num_steps", [1, 2, 3, 10])
+def test_inference_rollout(inf_data_init, hist, num_steps):
+    inference_dataset = inf_data_init
+    model = ModelRetBoundary(
+        ch_width=[1],
+        n_out=inference_dataset.num_prognostic_channels,
+        wet=inference_dataset.wet,
+        hist=hist,
+        pred_residuals=False,
+        last_kernel_size=3,
+        pad="circular",
+    )
+
+    model.eval()
+    IO = model.inference(inference_dataset, num_steps=num_steps, epoch=0)
+    prediction = IO.prediction
+    target = IO.target
+
+    assert prediction.shape == target.shape
+
+    # Test if we are extracting the correct targets
+    # For hist = 0, target is [2, 4, 6]
+    # For hist = 1, target is [4, 6, 8, 10, 12, 14]
+    expected_target = torch.tensor(
+        [2 * i for i in range(hist + 1, hist + 1 + num_steps * (hist + 1))],
+        device=target.device,
+    )
+    assert torch.equal(target.flatten(), expected_target)
+
+    # Test if we are extracting the correct boundary values
+    # The model returns the boundary condition at the latest step for each step
+    # For hist = 0, prediction is [1, 3, 5]
+    # For hist = 1, prediction is [3, 3, 7, 7, 11, 11]
+    # For hist = 2, prediction is [5, 5, 5, 11, 11, 11, 17, 17, 17]
+
+    start = 2 * (hist + 1) - 1
+    diff_step = (hist + 1) * 2
+    repeat = hist + 1
+    base = torch.arange(
+        start, start + diff_step * num_steps, diff_step, device=prediction.device
+    )
+    base = base.repeat_interleave(repeat)
+    expected_prediction = torch.tensor(base, device=prediction.device)
+    assert torch.equal(prediction.flatten(), expected_prediction)
+
+
+# These tests will fail with OHC PR
+@pytest.mark.parametrize("hist", [0, 1, 2, 3, 4])
+@pytest.mark.parametrize("merge_step", [1, 2, 3])
+def test_inference_rollout_methods(inf_data_init, hist, merge_step):
+    inference_dataset = inf_data_init
+    model = ModelRetBoundary(
+        ch_width=[1],
+        n_out=inference_dataset.num_prognostic_channels,
+        wet=inference_dataset.wet,
+        hist=hist,
+        pred_residuals=False,
+        last_kernel_size=3,
+        pad="circular",
+    )
+
+    model.eval()
+    num_input_channels = (hist + 1) + 1  # thetao * (hist + 1) + hfds
+    num_prognostic_channels = hist + 1  # thetao * (hist + 1)
+    input_tensor = inference_dataset.get_initial_input()
+
+    assert input_tensor.shape == (1, num_input_channels, 1, 1)
+    expected_input = torch.tensor(
+        [2 * i for i in range(hist + 1)] + [2 * hist + 1], device=input_tensor.device
+    )
+    assert torch.equal(input_tensor.flatten(), expected_input)
+
+    pred = model.forward_once(input_tensor)
+    assert pred.shape == (1, num_prognostic_channels, 1, 1)
+    expected_pred = torch.tensor([2 * hist + 1] * (hist + 1), device=pred.device)
+    assert torch.equal(pred.flatten(), expected_pred)
+
+    merged_input_tensor = inference_dataset.merge_prognostic_and_boundary(
+        prognostic=pred,
+        step=merge_step,
+    )
+    assert merged_input_tensor.shape == (1, num_input_channels, 1, 1)
+    expected_merged_input = torch.tensor(
+        [2 * hist + 1] * (hist + 1)
+        + [(merge_step + 1) * (num_prognostic_channels * 2) - 1],
+        device=merged_input_tensor.device,
+    )
+    assert torch.equal(merged_input_tensor.flatten(), expected_merged_input)


### PR DESCRIPTION
Components — target extraction, aggregator recording, wandb logging, and writing — are now handled in batches rather than singular timesteps. This allowed me to remove the record_every parameter as well. Additionally, some other minor optimizations were made.

Here is a comparison of the time taken in minutes, before and after optimization:

| Dataset (Period) | Old Inference (With Write) | Old Inference (Without Write)  | Optimized Inference (With Write) | Optimized Inference (Without Write) |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| OM4 (~8 years)  | [14:08](https://wandb.ai/m2lines/ocean-emulators/runs/pjzsf71m) | [13:14](https://wandb.ai/m2lines/ocean-emulators/runs/025m3u3s) | [03:52](https://wandb.ai/m2lines/ocean-emulators/runs/rubapmx5)  |  [02:54](https://wandb.ai/m2lines/ocean-emulators/runs/i9kkjb85) |
| CM4 (20 years)  | [24:52](https://wandb.ai/m2lines/ocean-emulators/runs/zcbmfvme) | [22:45](https://wandb.ai/m2lines/ocean-emulators/runs/v8zazvdi) | [05:27 ](https://wandb.ai/m2lines/ocean-emulators/runs/1ziu9lrt) | [03:17](https://wandb.ai/m2lines/ocean-emulators/runs/mxk43iwq)  |

I made a comparison between writing the actual zarr and skipping write because during train we don't actually save the data produced by the inference rollout but in standalone inference, we do.
 
Training should now be cut down from ~4 days to 2.5 days and Inference should now go from 1152 SYPD (~100x) to 4800 SYPD (400x). 

Add tests
- [x] Ensure correct data fed to model (Use time indexed values for data)
- [x] ~~Check if batched output metrics are different from single output metrics~~ This test is not needed since Alex caught my bug
- [x] Fix time returned so we save appropriate time in zarr


NOTE: The above times with the optimization actually had a minor bug in choosing the next prognostic but there is no change in performance because I just had to change an index. See this [comment](https://github.com/suryadheeshjith/Ocean_Emulator/pull/193#discussion_r2037893244). A fixed run with OM4 with write is logged [here](https://wandb.ai/m2lines/ocean-emulators/runs/b3qznqb0) and time taken was: 03:46

Closes #182 