### PR TITLE
[Draft] profiling logging code

### DIFF
--- a/configs/train_default_wblogs.test.yaml
+++ b/configs/train_default_wblogs.test.yaml
@@ -1,0 +1,71 @@
+# A config file to test training.
+# Used in automated tests.
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 2
+batch_size: 1
+learning_rate: 0.0001
+scheduler: false
+loss: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: [-1]
+data_percent: 1.0
+train:
+  start_time: '1975-08-15'
+  end_time: '1975-10-25'
+val:
+  start_time: '1975-10-20'
+  end_time: '1975-11-25'
+inference:
+  - start_time: '1975-11-20'
+    end_time: '1975-12-20'
+data_stride: [1]
+steps: [1]
+step_transition: []
+backend: auto
+
+experiment:
+  base_name: train
+  sub_name: test
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: online
+    project: ocean-emulators
+    entity: test_wblog_overhead
+    group: samudra-train-om4
+  network: Samudra
+  prognostic_vars_key: thermo_dynamic_5
+  boundary_vars_key: tau_hfds
+  cluster_data_dir: .data_cache/
+data:
+  data_path: data.zarr
+  data_means_path: means.nc
+  data_stds_path: stds.nc
+  scaling_residuals_file: null
+  time_delta: 5
+  num_workers: 4
+  hist: 0
+
+
+samudra:
+  ch_width: [2, 3]
+  n_out: 4
+  dilation: [1, 2]
+  n_layers: [1, 1]
+  pred_residuals: false
+  last_kernel_size: 3
+  pad: "circular"
+
+  core_block:
+    block_type: "conv_next_block"
+    kernel_size: 3
+    activation: "capped_gelu"
+    upscale_factor: 2
+    norm: "batch"
+
+  down_sampling_block: "avg_pool"
+  up_sampling_block: "bilinear_upsample"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
   "hypothesis[numpy]>=6.127.2",
   "ipykernel>=6.29.5",
   "mypy>=1.15",
+  "py-spy>=0.4",
   "pytest>=8.3.4",
   "pytest-benchmark[histogram]>=5.1",
   "pytest-profiling>=1.8.1",

--- a/src/ocean_emulators/aggregator/validate/main.py
+++ b/src/ocean_emulators/aggregator/validate/main.py
@@ -6,7 +6,6 @@ from ocean_emulators.aggregator.loss import LossAggregator
 from ocean_emulators.aggregator.train import TrainAggregator
 from ocean_emulators.aggregator.validate.map import MapAggregator
 from ocean_emulators.aggregator.validate.reduced import MeanAggregator
-from ocean_emulators.aggregator.validate.snapshot import SnapshotAggregator
 from ocean_emulators.aggregator.validate.sub_aggregator import ValidateSubAggregator
 from ocean_emulators.utils.data import Normalize, get_norm_unnorm_dicts
 from ocean_emulators.utils.model import ValOutput
@@ -25,8 +24,9 @@ class ValidateAggregator(TrainAggregator):
     ):
         super().__init__()
 
+        # SnapshotAggregator causes such significant performance issues. Please
+        # fix before adding back!
         val_aggregators: dict[str, ValidateSubAggregator] = {
-            "snapshot": SnapshotAggregator(metadata, hist),
             "mean_map": MapAggregator(metadata, hist),
             "reduced": MeanAggregator(area_weights, hist),
         }

--- a/src/ocean_emulators/aggregator/validate/main.py
+++ b/src/ocean_emulators/aggregator/validate/main.py
@@ -4,7 +4,6 @@ import torch
 
 from ocean_emulators.aggregator.loss import LossAggregator
 from ocean_emulators.aggregator.train import TrainAggregator
-from ocean_emulators.aggregator.validate.map import MapAggregator
 from ocean_emulators.aggregator.validate.reduced import MeanAggregator
 from ocean_emulators.aggregator.validate.sub_aggregator import ValidateSubAggregator
 from ocean_emulators.utils.data import Normalize, get_norm_unnorm_dicts
@@ -24,10 +23,10 @@ class ValidateAggregator(TrainAggregator):
     ):
         super().__init__()
 
-        # SnapshotAggregator causes such significant performance issues. Please
-        # fix before adding back!
+        # SnapshotAggregator and MapAggregator causes such significant performance
+        # issues. Please fix before adding back!
+        # Specifically: plot_paneled_data is really inefficient!
         val_aggregators: dict[str, ValidateSubAggregator] = {
-            "mean_map": MapAggregator(metadata, hist),
             "reduced": MeanAggregator(area_weights, hist),
         }
         self._aggregators = val_aggregators

--- a/src/ocean_emulators/aggregator/validate/snapshot.py
+++ b/src/ocean_emulators/aggregator/validate/snapshot.py
@@ -87,6 +87,7 @@ class SnapshotAggregator(ValidateSubAggregator):
                 else:
                     diverging = False
                 caption = self._get_caption(key, name)
+                # WARNING: THESE PLOTS CAUSE SUBSTANTIAL MEMORY/PERFORMANCE ISSUES!
                 wandb_image = plot_paneled_data(data, diverging, caption=caption)
                 image_logs[f"image-{key}/{name}"] = wandb_image
         image_logs = {f"{label}/{key}": image_logs[key] for key in image_logs}

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -240,7 +240,9 @@ class InferenceDataset(Dataset):
         return data[:, : self.num_prognostic_channels]
 
     def inference_target(self, step: int):
-        return self.__getitem__(step)[1]
+        x_index = self._get_x_index(step)
+        label = self._get_label(x_index)
+        return label
 
     def get_initial_input(self):
         data = self.__getitem__(0)[0]

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -28,3 +28,15 @@ def test_trainer__mini_2step(trainer_pair: TrainPair, caplog):
     _, trainer = trainer_pair
 
     trainer.run()
+
+
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("remote-om4", "train_default_wblogs.test.yaml")],
+    indirect=True,
+)
+def test_trainer__mini_2step__log_overhead(trainer_pair: TrainPair, caplog):
+    caplog.set_level(logging.INFO)
+    _, trainer = trainer_pair
+
+    trainer.run()

--- a/uv.lock
+++ b/uv.lock
@@ -1358,6 +1358,7 @@ dev = [
     { name = "hypothesis", extra = ["numpy"] },
     { name = "ipykernel" },
     { name = "mypy" },
+    { name = "py-spy" },
     { name = "pytest" },
     { name = "pytest-benchmark", extra = ["histogram"] },
     { name = "pytest-profiling" },
@@ -1395,6 +1396,7 @@ dev = [
     { name = "hypothesis", extras = ["numpy"], specifier = ">=6.127.2" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "mypy", specifier = ">=1.15" },
+    { name = "py-spy", specifier = ">=0.4.0" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-benchmark", extras = ["histogram"], specifier = ">=5.1" },
     { name = "pytest-profiling", specifier = ">=1.8.1" },
@@ -1707,6 +1709,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335 },
+]
+
+[[package]]
+name = "py-spy"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/cd/9dacc04604dc4398ce5bed77ed59918ad0940f15165954d4aaa651cc640c/py_spy-0.4.0.tar.gz", hash = "sha256:806602ce7972782cc9c1e383f339bfc27bfb822d42485e6a3e0530ae5040e1f0", size = 253236 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/7e/02ca3ee68507db47afce769504060d71b4dc1455f0f9faa8d32fc7762221/py_spy-0.4.0-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:f2cf3f7130e7d780471faa5957441d3b4e0ec39a79b2c00f4c33d494f7728428", size = 3617847 },
+    { url = "https://files.pythonhosted.org/packages/65/7c/d9e26cc4c8e91f96a3a65de04d2e2e4131fbcaf6830d10917d4fab9d6788/py_spy-0.4.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:47cdda4c34d9b6cb01f3aaeceb2e88faf57da880207fe72ff6ff97e9bb6cc8a9", size = 1761955 },
+    { url = "https://files.pythonhosted.org/packages/d2/e4/8fbfd219b7f282b80e6b2e74c9197850d2c51db8555705567bb65507b060/py_spy-0.4.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eee3d0bde85ca5cf4f01f012d461180ca76c24835a96f7b5c4ded64eb6a008ab", size = 2059471 },
+    { url = "https://files.pythonhosted.org/packages/a7/1d/79a94a5ace810c13b730ce96765ca465c171b4952034f1be7402d8accbc1/py_spy-0.4.0-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c5f06ffce4c9c98b7fc9f5e67e5e7db591173f1351837633f3f23d9378b1d18a", size = 2067486 },
+    { url = "https://files.pythonhosted.org/packages/6d/90/fbbb038f826a83ed15ebc4ae606815d6cad6c5c6399c86c7ab96f6c60817/py_spy-0.4.0-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:87573e64dbfdfc89ba2e0f5e2f525aa84e0299c7eb6454b47ea335fde583a7a0", size = 2141433 },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/5e012669ebb687e546dc99fcfc4861ebfcf3a337b7a41af945df23140bb5/py_spy-0.4.0-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8bf2f3702cef367a489faa45177b41a6c31b2a3e5bd78c978d44e29340152f5a", size = 2732951 },
+    { url = "https://files.pythonhosted.org/packages/74/8b/dd8490660019a6b0be28d9ffd2bf1db967604b19f3f2719c0e283a16ac7f/py_spy-0.4.0-py2.py3-none-win_amd64.whl", hash = "sha256:77d8f637ade38367d944874776f45b703b7ac5938b1f7be8891f3a5876ddbb96", size = 1810770 },
 ]
 
 [[package]]


### PR DESCRIPTION
When logs are turned on, ~33% of the training time loop is taken up by GC related to generating images plots of data for W&B. When I get rid of the log aggregators related to plotting images, then the result is most of the time is taken up by torch/NN operations.

Before: 
![Screenshot 2025-04-10 at 3 36 40 PM](https://github.com/user-attachments/assets/1daafa0d-fd5d-49d1-be02-9ff76d1c275c)
![Screenshot 2025-04-10 at 3 37 15 PM](https://github.com/user-attachments/assets/0c1deb2c-0d92-4ebc-9bb1-d895147868cc)



After [862dc92](https://github.com/suryadheeshjith/Ocean_Emulator/pull/195/commits/862dc92bf4acd65965962923b71e1449968f47fe)
![Screenshot 2025-04-10 at 4 35 04 PM](https://github.com/user-attachments/assets/84353530-065b-4d4b-bb49-c26005069722)
![Screenshot 2025-04-10 at 4 38 40 PM](https://github.com/user-attachments/assets/0d63e772-051f-44b3-a96c-d2c652a0c47c)


