### PR TITLE
Introducing `DataSource` to train and eval scripts.

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 from typing import Any
 
@@ -20,7 +21,7 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import Normalize
+from ocean_emulators.utils.data import Normalize, DataSource, to_tensor, normalize, normalize_tensor
 from ocean_emulators.utils.device import get_device, using_gpu
 
 
@@ -40,7 +41,7 @@ class InferenceDataset(Dataset):
 
     def __init__(
         self,
-        data,
+        src: DataSource,
         prognostic_var_names,
         boundary_var_names,
         wet,
@@ -52,10 +53,14 @@ class InferenceDataset(Dataset):
         self.device = get_device()
 
         self.hist = hist
+        self.src = src
+        data = src.data
 
         self.num_prognostic_channels = (hist + 1) * len(prognostic_var_names)
-        self._prognostic_vars = data[prognostic_var_names]
-        self._boundary_vars = data[boundary_var_names]
+        self._prog_src = src.filter(prognostic_var_names)
+        self._bound_src = src.filter(boundary_var_names)
+        self._prognostic_vars = self._prog_src.data
+        self._boundary_vars = self._bound_src.data
         self._times = data.time
 
         time_indices = np.arange(data.time.size)
@@ -85,8 +90,8 @@ class InferenceDataset(Dataset):
                 )
             )
 
-        self.wet = wet.bool()
-        self.wet_surface = wet_surface.bool()
+        self.wet: torch.Tensor = wet.bool()
+        self.wet_surface: torch.Tensor = wet_surface.bool()
         self.size = len(self.rolling_indices)
 
         if using_gpu():
@@ -169,9 +174,8 @@ class InferenceDataset(Dataset):
         data_in_ds: xr.Dataset = self._prognostic_vars.isel(time=x_index).isel(
             time=slice(None, self.hist + 1)
         )
-        data_in_ds = Normalize.get_instance().normalize_prognostic(
-            data_in_ds
-        )  # TODO: Weird error when I get_instance in init
+        src_in = dataclasses.replace(self._prog_src, data=data_in_ds)
+        data_in_ds = normalize(src_in)
         data_in_np: np.ndarray = (
             data_in_ds.to_array()
             .transpose("window_dim", "time", "variable", "lat", "lon")
@@ -195,9 +199,8 @@ class InferenceDataset(Dataset):
         data_in_boundary_ds: xr.Dataset = self._boundary_vars.isel(time=x_index).isel(
             time=self.hist
         )
-        data_in_boundary_ds = Normalize.get_instance().normalize_boundary(
-            data_in_boundary_ds
-        )
+        src_in_boundary = dataclasses.replace(self._bound_src, data=data_in_boundary_ds)
+        data_in_boundary_ds = normalize(src_in_boundary)
         data_in_boundary_np: np.ndarray = (
             data_in_boundary_ds.to_array()
             .transpose("window_dim", "variable", "lat", "lon")
@@ -211,7 +214,8 @@ class InferenceDataset(Dataset):
         label_ds: xr.Dataset = self._prognostic_vars.isel(time=x_index).isel(
             time=slice(self.hist + 1, None)
         )
-        label_ds = Normalize.get_instance().normalize_prognostic(label_ds)
+        src_label = dataclasses.replace(self._prog_src, data=label_ds)
+        label_ds = normalize(src_label)
         label_np: np.ndarray = (
             label_ds.to_array()
             .transpose("window_dim", "time", "variable", "lat", "lon")
@@ -305,7 +309,7 @@ class TrainDataset(Dataset):
 
     def __init__(
         self,
-        data: xr.Dataset,
+        src: DataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
         wet: PrognosticMask,
@@ -320,10 +324,11 @@ class TrainDataset(Dataset):
         self.hist: int = hist
         self.steps: int = steps
         self.stride: int = stride
+        data = src.data
+        self._prog_src = src.filter(prognostic_var_names)
+        self._bound_src = src.filter(boundary_var_names)
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
-        self._prognostic_vars: xr.Dataset = data[prognostic_var_names]
-        self._boundary_vars: xr.Dataset = data[boundary_var_names]
 
         # This class will be used only for training
         total_steps: int = 2 * self.hist + 2
@@ -359,10 +364,8 @@ class TrainDataset(Dataset):
         # Normalize
         logging.info("Normalizing inputs")
         self.normalize = Normalize.get_instance()
-        self._prognostic_vars = self.normalize.normalize_prognostic(
-            self._prognostic_vars
-        )
-        self._boundary_vars = self.normalize.normalize_boundary(self._boundary_vars)
+        self._prognostic_vars = normalize(self._prog_src)
+        self._boundary_vars = normalize(self._bound_src)
 
     def __len__(self) -> int:
         return self.size
@@ -490,7 +493,7 @@ class TorchTrainDataset(Dataset):
 
     def __init__(
         self,
-        data: xr.Dataset,
+        src: DataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
         wet: PrognosticMask,
@@ -507,8 +510,16 @@ class TorchTrainDataset(Dataset):
         self.stride: int = stride
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
-        self._prognostic_vars: xr.Dataset = data[prognostic_var_names]
-        self._boundary_vars: xr.Dataset = data[boundary_var_names]
+        self.src = src
+        data = src.data
+        self._prog_src = src.filter(prognostic_var_names)
+        self._bound_src = src.filter(boundary_var_names)
+        self._prognostic_vars: xr.Dataset = self._prog_src.data
+        self._boundary_vars: xr.Dataset = self._bound_src.data
+
+        # cache tensors for faster access during training.
+        to_tensor(self._prog_src, device=self.device)
+        to_tensor(self._bound_src, device=self.device)
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
@@ -581,15 +592,21 @@ class TorchTrainDataset(Dataset):
         prognostic_all: Float[torch.Tensor, "step variable time lat lon"],
         boundary: Float[torch.Tensor, "step variable lat lon"],
     ) -> tuple[Input, Prognostic]:
-        normalize = Normalize.get_instance()
-
         # grab past steps and prep for model
         input_ = self._prep_prognostic_steps(
             prognostic_all[:, :, : self.hist + 1, :, :]
         )
 
         # add in boundary to final input
-        boundary = normalize.normalize_tensor_boundary(boundary).float()
+        _, boundary_means, boundary_stds = to_tensor(
+            self._bound_src, device=self.device
+        )
+        boundary = normalize_tensor(
+            boundary,
+            boundary_means.reshape([-1, 1, 1]),
+            boundary_stds.reshape([-1, 1, 1]),
+        ).float()
+
         boundary = torch.where(self.wet_surface, boundary, 0.0)
         total_input = torch.cat((input_, boundary), dim=1)  # dim=1 -> variables
 
@@ -600,7 +617,6 @@ class TorchTrainDataset(Dataset):
     def _prep_prognostic_steps(
         self, prognostic_steps: Float[torch.Tensor, "step variable time lat lon"]
     ) -> Input:
-        normalize = Normalize.get_instance()
         # Time needs to be before step for normalization to work (even though it would
         # make more sense for `step` to the be first dimension). Don't worry: we fix
         # this later.
@@ -609,9 +625,13 @@ class TorchTrainDataset(Dataset):
             "step variable time lat lon -> time step variable lat lon",
         )
 
+        _, prog_means, prog_stds = to_tensor(self._prog_src, device=self.device)
+
         # normalize expects variables in third dimension
-        prognostic_steps = normalize.normalize_tensor_prognostic(
-            prognostic_steps
+        prognostic_steps = normalize_tensor(
+            prognostic_steps,
+            prog_means.reshape([1, -1, 1, 1]),
+            prog_stds.reshape([1, -1, 1, 1]),
         ).float()
 
         # flatten time and variable dimensions into a set of channels for model

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -52,13 +52,11 @@ class InferenceDataset(Dataset):
         self.device = get_device()
 
         self.hist = hist
-        data = src.data
 
         self.num_prognostic_channels = (hist + 1) * len(prognostic_var_names)
+        data = src.data
         self._prognostic_src = src.filter(prognostic_var_names)
         self._boundary_src = src.filter(boundary_var_names)
-        self._prognostic_vars = self._prognostic_src.data
-        self._boundary_vars = self._boundary_src.data
         self._times = data.time
 
         time_indices = np.arange(data.time.size)
@@ -169,10 +167,10 @@ class InferenceDataset(Dataset):
         return x_index
 
     def _get_prognostic(self, x_index):
-        data_in_ds: xr.Dataset = self._prognostic_vars.isel(time=x_index).isel(
-            time=slice(None, self.hist + 1)
+        data_in_src = self._prognostic_src.map_data(
+            lambda ds: ds.isel(time=x_index).isel(time=slice(None, self.hist + 1))
         )
-        data_in_ds = self._prognostic_src.normalize(data_in_ds)
+        data_in_ds = data_in_src.normalize()
         data_in_np: np.ndarray = (
             data_in_ds.to_array()
             .transpose("window_dim", "time", "variable", "lat", "lon")
@@ -193,10 +191,10 @@ class InferenceDataset(Dataset):
         With hist > 0, the boundary condition considered is always the last step of
         the input.
         """
-        data_in_boundary_ds: xr.Dataset = self._boundary_vars.isel(time=x_index).isel(
-            time=self.hist
+        data_in_boundary_src = self._boundary_src.map_data(
+            lambda ds: ds.isel(time=x_index).isel(time=self.hist)
         )
-        data_in_boundary_ds = self._boundary_src.normalize(data_in_boundary_ds)
+        data_in_boundary_ds = data_in_boundary_src.normalize()
         data_in_boundary_np: np.ndarray = (
             data_in_boundary_ds.to_array()
             .transpose("window_dim", "variable", "lat", "lon")
@@ -207,10 +205,10 @@ class InferenceDataset(Dataset):
         return data_in_boundary
 
     def _get_label(self, x_index):
-        label_ds: xr.Dataset = self._prognostic_vars.isel(time=x_index).isel(
-            time=slice(self.hist + 1, None)
+        label_src = self._prognostic_src.map_data(
+            lambda ds: ds.isel(time=x_index).isel(time=slice(self.hist + 1, None))
         )
-        label_ds = self._prognostic_src.normalize(label_ds)
+        label_ds = label_src.normalize()
         label_np: np.ndarray = (
             label_ds.to_array()
             .transpose("window_dim", "time", "variable", "lat", "lon")
@@ -225,7 +223,9 @@ class InferenceDataset(Dataset):
         return label
 
     def get_coords_dict(self):
-        return {co: self._prognostic_vars[co] for co in self._prognostic_vars.coords}
+        return {
+            co: self._prognostic_src.data[co] for co in self._prognostic_src.data.coords
+        }
 
 
 class InferenceDatasets(Dataset):
@@ -507,8 +507,6 @@ class TorchTrainDataset(Dataset):
         data = src.data
         self._prognostic_src = src.filter(prognostic_var_names)
         self._boundary_src = src.filter(boundary_var_names)
-        self._prognostic_vars: xr.Dataset = self._prognostic_src.data
-        self._boundary_vars: xr.Dataset = self._boundary_src.data
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
@@ -550,17 +548,18 @@ class TorchTrainDataset(Dataset):
         x_index = xr.concat(x_indexes, dim="step")
 
         prognostic_all = torch.from_numpy(
-            self._prognostic_vars.isel(time=x_index)
-            .to_array()
+            self._prognostic_src.map_data(lambda ds: ds.isel(time=x_index))
+            .data.to_array()
             .transpose(
                 "step", "variable", "time", "lat", "lon"
             )  # this should be a no-op, for documentation
             .to_numpy()
         )
         boundary = torch.from_numpy(
-            self._boundary_vars.isel(time=x_index)
-            .isel(time=self.hist, drop=True)
-            .to_array()
+            self._boundary_src.map_data(
+                lambda ds: ds.isel(time=x_index).isel(time=self.hist, drop=True)
+            )
+            .data.to_array()
             .transpose("step", "variable", "lat", "lon")
             .to_numpy()
         )

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -585,9 +585,7 @@ class TorchTrainDataset(Dataset):
         )
 
         # add in boundary to final input
-        boundary = self._boundary_src.normalize_tensor(
-            boundary, variable_axis=1
-        ).float()
+        boundary = self._boundary_src.norm_of(boundary, variable_axis=1).float()
 
         boundary = torch.where(self.wet_surface, boundary, 0.0)
         total_input = torch.cat((input_, boundary), dim=1)  # dim=1 -> variables
@@ -600,7 +598,7 @@ class TorchTrainDataset(Dataset):
         self, prognostic_steps: Float[torch.Tensor, "step variable time lat lon"]
     ) -> Input:
         # normalize expects variables in third dimension
-        prognostic_steps = self._prognostic_src.normalize_tensor(
+        prognostic_steps = self._prognostic_src.norm_of(
             prognostic_steps, variable_axis=1
         ).float()
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -522,8 +522,8 @@ class TorchTrainDataset(Dataset):
         self._boundary_vars: xr.Dataset = self._bound_src.data
 
         # cache tensors for faster access during training.
-        to_tensor(self._prog_src, device=self.device)
-        to_tensor(self._bound_src, device=self.device)
+        to_tensor(self._prog_src, device=torch.device("cpu"))
+        to_tensor(self._bound_src, device=torch.device("cpu"))
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
@@ -603,7 +603,7 @@ class TorchTrainDataset(Dataset):
 
         # add in boundary to final input
         _, boundary_means, boundary_stds = to_tensor(
-            self._bound_src, device=self.device
+            self._bound_src, device=boundary.device
         )
         boundary = normalize_tensor(
             boundary,
@@ -629,7 +629,9 @@ class TorchTrainDataset(Dataset):
             "step variable time lat lon -> time step variable lat lon",
         )
 
-        _, prog_means, prog_stds = to_tensor(self._prog_src, device=self.device)
+        _, prog_means, prog_stds = to_tensor(
+            self._prog_src, device=prognostic_steps.device
+        )
 
         # normalize expects variables in third dimension
         prognostic_steps = normalize_tensor(

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -52,7 +52,6 @@ class InferenceDataset(Dataset):
         self.device = get_device()
 
         self.hist = hist
-        self.src = src
         data = src.data
 
         self.num_prognostic_channels = (hist + 1) * len(prognostic_var_names)
@@ -505,7 +504,6 @@ class TorchTrainDataset(Dataset):
         self.stride: int = stride
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
-        self.src = src
         data = src.data
         self._prognostic_src = src.filter(prognostic_var_names)
         self._boundary_src = src.filter(boundary_var_names)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -56,10 +56,10 @@ class InferenceDataset(Dataset):
         data = src.data
 
         self.num_prognostic_channels = (hist + 1) * len(prognostic_var_names)
-        self._prog_src = src.filter(prognostic_var_names)
-        self._bound_src = src.filter(boundary_var_names)
-        self._prognostic_vars = self._prog_src.data
-        self._boundary_vars = self._bound_src.data
+        self._prognostic_src = src.filter(prognostic_var_names)
+        self._boundary_src = src.filter(boundary_var_names)
+        self._prognostic_vars = self._prognostic_src.data
+        self._boundary_vars = self._boundary_src.data
         self._times = data.time
 
         time_indices = np.arange(data.time.size)
@@ -173,7 +173,7 @@ class InferenceDataset(Dataset):
         data_in_ds: xr.Dataset = self._prognostic_vars.isel(time=x_index).isel(
             time=slice(None, self.hist + 1)
         )
-        data_in_ds = self._prog_src.normalize(data_in_ds)
+        data_in_ds = self._prognostic_src.normalize(data_in_ds)
         data_in_np: np.ndarray = (
             data_in_ds.to_array()
             .transpose("window_dim", "time", "variable", "lat", "lon")
@@ -197,7 +197,7 @@ class InferenceDataset(Dataset):
         data_in_boundary_ds: xr.Dataset = self._boundary_vars.isel(time=x_index).isel(
             time=self.hist
         )
-        data_in_boundary_ds = self._bound_src.normalize(data_in_boundary_ds)
+        data_in_boundary_ds = self._boundary_src.normalize(data_in_boundary_ds)
         data_in_boundary_np: np.ndarray = (
             data_in_boundary_ds.to_array()
             .transpose("window_dim", "variable", "lat", "lon")
@@ -211,7 +211,7 @@ class InferenceDataset(Dataset):
         label_ds: xr.Dataset = self._prognostic_vars.isel(time=x_index).isel(
             time=slice(self.hist + 1, None)
         )
-        label_ds = self._prog_src.normalize(label_ds)
+        label_ds = self._prognostic_src.normalize(label_ds)
         label_np: np.ndarray = (
             label_ds.to_array()
             .transpose("window_dim", "time", "variable", "lat", "lon")
@@ -321,8 +321,8 @@ class TrainDataset(Dataset):
         self.steps: int = steps
         self.stride: int = stride
         data = src.data
-        self._prog_src = src.filter(prognostic_var_names)
-        self._bound_src = src.filter(boundary_var_names)
+        self._prognostic_src = src.filter(prognostic_var_names)
+        self._boundary_src = src.filter(boundary_var_names)
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
 
@@ -359,8 +359,8 @@ class TrainDataset(Dataset):
 
         # Normalize
         logging.info("Normalizing inputs")
-        self._prognostic_vars = self._prog_src.normalize()
-        self._boundary_vars = self._bound_src.normalize()
+        self._prognostic_vars = self._prognostic_src.normalize()
+        self._boundary_vars = self._boundary_src.normalize()
 
     def __len__(self) -> int:
         return self.size
@@ -507,14 +507,14 @@ class TorchTrainDataset(Dataset):
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
         self.src = src
         data = src.data
-        self._prog_src = src.filter(prognostic_var_names)
-        self._bound_src = src.filter(boundary_var_names)
-        self._prognostic_vars: xr.Dataset = self._prog_src.data
-        self._boundary_vars: xr.Dataset = self._bound_src.data
+        self._prognostic_src = src.filter(prognostic_var_names)
+        self._boundary_src = src.filter(boundary_var_names)
+        self._prognostic_vars: xr.Dataset = self._prognostic_src.data
+        self._boundary_vars: xr.Dataset = self._boundary_src.data
 
         # cache tensors for faster access during training.
-        to_tensor(self._prog_src, device=torch.device("cpu"))
-        to_tensor(self._bound_src, device=torch.device("cpu"))
+        to_tensor(self._prognostic_src, device=torch.device("cpu"))
+        to_tensor(self._boundary_src, device=torch.device("cpu"))
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
@@ -594,7 +594,7 @@ class TorchTrainDataset(Dataset):
 
         # add in boundary to final input
         _, boundary_means, boundary_stds = to_tensor(
-            self._bound_src, device=boundary.device
+            self._boundary_src, device=boundary.device
         )
         boundary = normalize_tensor(
             boundary,
@@ -621,7 +621,7 @@ class TorchTrainDataset(Dataset):
         )
 
         _, prog_means, prog_stds = to_tensor(
-            self._prog_src, device=prognostic_steps.device
+            self._prognostic_src, device=prognostic_steps.device
         )
 
         # normalize expects variables in third dimension

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -586,7 +586,9 @@ class TorchTrainDataset(Dataset):
         )
 
         # add in boundary to final input
-        boundary = self._boundary_src.normalize_tensor(boundary).float()
+        boundary = self._boundary_src.normalize_tensor(
+            boundary, variable_axis=1
+        ).float()
 
         boundary = torch.where(self.wet_surface, boundary, 0.0)
         total_input = torch.cat((input_, boundary), dim=1)  # dim=1 -> variables
@@ -598,23 +600,20 @@ class TorchTrainDataset(Dataset):
     def _prep_prognostic_steps(
         self, prognostic_steps: Float[torch.Tensor, "step variable time lat lon"]
     ) -> Input:
-        # Time needs to be before step for normalization to work (even though it would
-        # make more sense for `step` to the be first dimension). Don't worry: we fix
-        # this later.
         prognostic_steps = rearrange(
             prognostic_steps,
-            "step variable time lat lon -> time step variable lat lon",
+            "step variable time lat lon -> step time variable lat lon",
         )
 
         # normalize expects variables in third dimension
         prognostic_steps = self._prognostic_src.normalize_tensor(
-            prognostic_steps, variable_axis=1
+            prognostic_steps, variable_axis=2
         ).float()
 
         # flatten time and variable dimensions into a set of channels for model
         prognostic_steps = rearrange(
             prognostic_steps,
-            "time step variable lat lon -> step (time variable) lat lon",
+            "step time variable lat lon -> step (time variable) lat lon",
         )
 
         # post-normalize, mask out values where there is no ocean

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -599,20 +599,15 @@ class TorchTrainDataset(Dataset):
     def _prep_prognostic_steps(
         self, prognostic_steps: Float[torch.Tensor, "step variable time lat lon"]
     ) -> Input:
-        prognostic_steps = rearrange(
-            prognostic_steps,
-            "step variable time lat lon -> step time variable lat lon",
-        )
-
         # normalize expects variables in third dimension
         prognostic_steps = self._prognostic_src.normalize_tensor(
-            prognostic_steps, variable_axis=2
+            prognostic_steps, variable_axis=1
         ).float()
 
         # flatten time and variable dimensions into a set of channels for model
         prognostic_steps = rearrange(
             prognostic_steps,
-            "step time variable lat lon -> step (time variable) lat lon",
+            "step variable time lat lon -> step (time variable) lat lon",
         )
 
         # post-normalize, mask out values where there is no ocean

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 from typing import Any
 
@@ -21,12 +20,7 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import (
-    DataSource,
-    normalize,
-    normalize_tensor,
-    to_tensor,
-)
+from ocean_emulators.utils.data import DataSource, normalize_tensor, to_tensor
 from ocean_emulators.utils.device import get_device, using_gpu
 
 
@@ -179,8 +173,7 @@ class InferenceDataset(Dataset):
         data_in_ds: xr.Dataset = self._prognostic_vars.isel(time=x_index).isel(
             time=slice(None, self.hist + 1)
         )
-        src_in = dataclasses.replace(self._prog_src, data=data_in_ds)
-        data_in_ds = normalize(src_in)
+        data_in_ds = self._prog_src.normalize(data_in_ds)
         data_in_np: np.ndarray = (
             data_in_ds.to_array()
             .transpose("window_dim", "time", "variable", "lat", "lon")
@@ -204,8 +197,7 @@ class InferenceDataset(Dataset):
         data_in_boundary_ds: xr.Dataset = self._boundary_vars.isel(time=x_index).isel(
             time=self.hist
         )
-        src_in_boundary = dataclasses.replace(self._bound_src, data=data_in_boundary_ds)
-        data_in_boundary_ds = normalize(src_in_boundary)
+        data_in_boundary_ds = self._bound_src.normalize(data_in_boundary_ds)
         data_in_boundary_np: np.ndarray = (
             data_in_boundary_ds.to_array()
             .transpose("window_dim", "variable", "lat", "lon")
@@ -219,8 +211,7 @@ class InferenceDataset(Dataset):
         label_ds: xr.Dataset = self._prognostic_vars.isel(time=x_index).isel(
             time=slice(self.hist + 1, None)
         )
-        src_label = dataclasses.replace(self._prog_src, data=label_ds)
-        label_ds = normalize(src_label)
+        label_ds = self._prog_src.normalize(label_ds)
         label_np: np.ndarray = (
             label_ds.to_array()
             .transpose("window_dim", "time", "variable", "lat", "lon")
@@ -368,8 +359,8 @@ class TrainDataset(Dataset):
 
         # Normalize
         logging.info("Normalizing inputs")
-        self._prognostic_vars = normalize(self._prog_src)
-        self._boundary_vars = normalize(self._bound_src)
+        self._prognostic_vars = self._prog_src.normalize()
+        self._boundary_vars = self._bound_src.normalize()
 
     def __len__(self) -> int:
         return self.size

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -21,7 +21,12 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import Normalize, DataSource, to_tensor, normalize, normalize_tensor
+from ocean_emulators.utils.data import (
+    DataSource,
+    normalize,
+    normalize_tensor,
+    to_tensor,
+)
 from ocean_emulators.utils.device import get_device, using_gpu
 
 
@@ -363,7 +368,6 @@ class TrainDataset(Dataset):
 
         # Normalize
         logging.info("Normalizing inputs")
-        self.normalize = Normalize.get_instance()
         self._prognostic_vars = normalize(self._prog_src)
         self._boundary_vars = normalize(self._bound_src)
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -55,8 +55,8 @@ class InferenceDataset(Dataset):
 
         self.num_prognostic_channels = (hist + 1) * len(prognostic_var_names)
         data = src.data
-        self._prognostic_src = src.filter(prognostic_var_names)
-        self._boundary_src = src.filter(boundary_var_names)
+        self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
+        self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
         self._times = data.time
 
         time_indices = np.arange(data.time.size)
@@ -320,8 +320,8 @@ class TrainDataset(Dataset):
         self.steps: int = steps
         self.stride: int = stride
         data = src.data
-        self._prognostic_src = src.filter(prognostic_var_names)
-        self._boundary_src = src.filter(boundary_var_names)
+        self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
+        self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
 
@@ -505,8 +505,8 @@ class TorchTrainDataset(Dataset):
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
         data = src.data
-        self._prognostic_src = src.filter(prognostic_var_names)
-        self._boundary_src = src.filter(boundary_var_names)
+        self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
+        self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -20,7 +20,7 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import DataSource, normalize_tensor, to_tensor
+from ocean_emulators.utils.data import DataSource, to_tensor
 from ocean_emulators.utils.device import get_device, using_gpu
 
 
@@ -593,14 +593,7 @@ class TorchTrainDataset(Dataset):
         )
 
         # add in boundary to final input
-        _, boundary_means, boundary_stds = to_tensor(
-            self._boundary_src, device=boundary.device
-        )
-        boundary = normalize_tensor(
-            boundary,
-            boundary_means.reshape([-1, 1, 1]),
-            boundary_stds.reshape([-1, 1, 1]),
-        ).float()
+        boundary = self._boundary_src.normalize_tensor(boundary).float()
 
         boundary = torch.where(self.wet_surface, boundary, 0.0)
         total_input = torch.cat((input_, boundary), dim=1)  # dim=1 -> variables
@@ -620,15 +613,9 @@ class TorchTrainDataset(Dataset):
             "step variable time lat lon -> time step variable lat lon",
         )
 
-        _, prog_means, prog_stds = to_tensor(
-            self._prognostic_src, device=prognostic_steps.device
-        )
-
         # normalize expects variables in third dimension
-        prognostic_steps = normalize_tensor(
-            prognostic_steps,
-            prog_means.reshape([1, -1, 1, 1]),
-            prog_stds.reshape([1, -1, 1, 1]),
+        prognostic_steps = self._prognostic_src.normalize_tensor(
+            prognostic_steps, variable_axis=1
         ).float()
 
         # flatten time and variable dimensions into a set of channels for model

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -20,7 +20,7 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import DataSource, to_tensor
+from ocean_emulators.utils.data import DataSource
 from ocean_emulators.utils.device import get_device, using_gpu
 
 
@@ -511,10 +511,6 @@ class TorchTrainDataset(Dataset):
         self._boundary_src = src.filter(boundary_var_names)
         self._prognostic_vars: xr.Dataset = self._prognostic_src.data
         self._boundary_vars: xr.Dataset = self._boundary_src.data
-
-        # cache tensors for faster access during training.
-        to_tensor(self._prognostic_src, device=torch.device("cpu"))
-        to_tensor(self._boundary_src, device=torch.device("cpu"))
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -548,18 +548,17 @@ class TorchTrainDataset(Dataset):
         x_index = xr.concat(x_indexes, dim="step")
 
         prognostic_all = torch.from_numpy(
-            self._prognostic_src.map_data(lambda ds: ds.isel(time=x_index))
-            .data.to_array()
+            self._prognostic_src.data.isel(time=x_index)
+            .to_array()
             .transpose(
                 "step", "variable", "time", "lat", "lon"
             )  # this should be a no-op, for documentation
             .to_numpy()
         )
         boundary = torch.from_numpy(
-            self._boundary_src.map_data(
-                lambda ds: ds.isel(time=x_index).isel(time=self.hist, drop=True)
-            )
-            .data.to_array()
+            self._boundary_src.data.isel(time=x_index)
+            .isel(time=self.hist, drop=True)
+            .to_array()
             .transpose("step", "variable", "lat", "lon")
             .to_numpy()
         )

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -585,7 +585,7 @@ class TorchTrainDataset(Dataset):
         )
 
         # add in boundary to final input
-        boundary = self._boundary_src.norm_of(boundary, variable_axis=1).float()
+        boundary = self._boundary_src.normalize_with(boundary, variable_axis=1).float()
 
         boundary = torch.where(self.wet_surface, boundary, 0.0)
         total_input = torch.cat((input_, boundary), dim=1)  # dim=1 -> variables
@@ -598,7 +598,7 @@ class TorchTrainDataset(Dataset):
         self, prognostic_steps: Float[torch.Tensor, "step variable time lat lon"]
     ) -> Input:
         # normalize expects variables in third dimension
-        prognostic_steps = self._prognostic_src.norm_of(
+        prognostic_steps = self._prognostic_src.normalize_with(
             prognostic_steps, variable_axis=1
         ).float()
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -320,8 +320,13 @@ class TrainDataset(Dataset):
         self.steps: int = steps
         self.stride: int = stride
         data = src.data
-        self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
-        self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
+        _prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
+        _boundary_src = src.filter(boundary_var_names, prefix="boundary")
+
+        # Normalize
+        logging.info("Normalizing inputs")
+        self._prognostic_vars = _prognostic_src.normalize()
+        self._boundary_vars = _boundary_src.normalize()
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
 
@@ -355,11 +360,6 @@ class TrainDataset(Dataset):
         if using_gpu():
             self.wet = self.wet.pin_memory()
             self.wet_surface = self.wet_surface.pin_memory()
-
-        # Normalize
-        logging.info("Normalizing inputs")
-        self._prognostic_vars = self._prognostic_src.normalize()
-        self._boundary_vars = self._boundary_src.normalize()
 
     def __len__(self) -> int:
         return self.size

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -24,6 +24,7 @@ from ocean_emulators.datasets import InferenceDataset
 from ocean_emulators.models.samudra import Samudra
 from ocean_emulators.stepper import Stepper
 from ocean_emulators.utils.data import (
+    DataSource,
     Normalize,
     extract_wet_mask,
     get_inference_steps,
@@ -118,9 +119,9 @@ class Eval:
             chunks={},
         )
 
-        self.data, self.data_mean, self.data_std = validate_data(
-            data, data_mean, data_std
-        )
+        raw_data = DataSource(name="raw", data=data, means=data_mean, stds=data_std)
+        val = validate_data(raw_data)
+        self.data, self.data_mean, self.data_std = val.data, val.means, val.stds
 
         self.metadata = construct_metadata(self.data)
         self.wet, self.wet_surface = extract_wet_mask(

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -1,12 +1,10 @@
 import argparse
 import datetime
 import logging
-import os
 import time
 from collections import OrderedDict
 
 import torch
-import xarray as xr
 
 from ocean_emulators.aggregator import Aggregator
 from ocean_emulators.backend import init_eval_backend
@@ -100,27 +98,8 @@ class Eval:
         self.data_stds_path = cfg.data.data_stds_path
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
-        if "*" in self.data_path:
-            data = xr.open_mfdataset(
-                os.path.join(self.data_dir, self.data_path),
-                engine="netcdf4",
-                chunks={"time": 1, "lat": 180, "lon": 360},
-            )
-        else:
-            data = xr.open_zarr(os.path.join(self.data_dir, self.data_path), chunks={})
-        data_mean = xr.open_dataset(
-            os.path.join(self.data_dir, self.data_means_path),
-            engine="netcdf4" if self.data_means_path.endswith(".nc") else "zarr",
-            chunks={},
-        )
-        data_std = xr.open_dataset(
-            os.path.join(self.data_dir, self.data_stds_path),
-            engine="netcdf4" if self.data_stds_path.endswith(".nc") else "zarr",
-            chunks={},
-        )
-
-        raw_data = DataSource(name="raw", data=data, means=data_mean, stds=data_std)
-        val = validate_data(raw_data)
+        raw = DataSource.from_config(cfg)
+        val = self.src = validate_data(raw)
         self.data, self.data_mean, self.data_std = val.data, val.means, val.stds
 
         self.metadata = construct_metadata(self.data)
@@ -208,9 +187,8 @@ class Eval:
             time_delta=self.time_delta,
             hist=self.hist,
         )
-        inference_data = self.data.sel(time=self.inference_time.time_slice)
         self.inference_dataset = InferenceDataset(
-            data=inference_data,
+            src=self.src.slice(self.inference_time.time_slice),
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
             wet=self.wet,

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -98,7 +98,7 @@ class Eval:
         self.data_stds_path = cfg.data.data_stds_path
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
-        raw = DataSource.from_config(cfg)
+        raw = DataSource.from_config(cfg, use_dask=True)
         self.src = validate_data(raw)
         self.data = self.src.data
 

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -134,8 +134,7 @@ class Eval:
         self.area_weights = self.area_weights.to(self.device)
 
         self.normalize = Normalize.init_instance(
-            data_mean=self.data_mean,
-            data_std=self.data_std,
+            val,
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
             wet_mask=wet_without_hist_cpu,

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -188,7 +188,7 @@ class Eval:
             hist=self.hist,
         )
         self.inference_dataset = InferenceDataset(
-            src=self.src.slice(self.inference_time.time_slice),
+            src=self.src.slice(self.inference_time),
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
             wet=self.wet,

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -99,8 +99,8 @@ class Eval:
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
         raw = DataSource.from_config(cfg)
-        val = self.src = validate_data(raw)
-        self.data, self.data_mean, self.data_std = val.data, val.means, val.stds
+        self.src = validate_data(raw)
+        self.data = self.src.data
 
         self.metadata = construct_metadata(self.data)
         self.wet, self.wet_surface = extract_wet_mask(
@@ -113,7 +113,7 @@ class Eval:
         self.area_weights = self.area_weights.to(self.device)
 
         self.normalize = Normalize.init_instance(
-            val,
+            self.src,
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
             wet_mask=wet_without_hist_cpu,

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -49,6 +49,7 @@ from ocean_emulators.datasets import (
 from ocean_emulators.models.samudra import Samudra
 from ocean_emulators.stepper import Stepper, TrainBatchOutput, ValBatchOutput
 from ocean_emulators.utils.data import (
+    DataSource,
     Normalize,
     extract_wet_mask,
     get_inference_steps,
@@ -156,43 +157,11 @@ class Trainer:
         logger.info(f"Loading data")
         self.loader_version = LoaderVersion(cfg.data.loader_version)
         self.data_dir = cfg.experiment.data_dir
-        self.data_path = cfg.data.data_path
-        self.data_means_path = cfg.data.data_means_path
-        self.data_stds_path = cfg.data.data_stds_path
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
-        self.use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
-        if self.use_dask:
-            chunks: dict[str, int] | None = {}
-        else:
-            chunks = None
-
-        if "*" in self.data_path:
-            data = xr.open_mfdataset(
-                os.path.join(self.data_dir, self.data_path),
-                engine="netcdf4",
-                chunks={"time": 1, "lat": 180, "lon": 360},
-            )
-        else:
-            data = xr.open_zarr(
-                os.path.join(self.data_dir, self.data_path),
-                chunks=chunks,
-                consolidated=True,
-            )
-        data_mean = xr.open_dataset(
-            os.path.join(self.data_dir, self.data_means_path),
-            engine="netcdf4" if self.data_means_path.endswith(".nc") else "zarr",
-            chunks=chunks,
-        )
-        data_std = xr.open_dataset(
-            os.path.join(self.data_dir, self.data_stds_path),
-            engine="netcdf4" if self.data_stds_path.endswith(".nc") else "zarr",
-            chunks=chunks,
-        )
-
-        self.data, self.data_mean, self.data_std = validate_data(
-            data, data_mean, data_std
-        )
+        raw = DataSource.from_config(cfg)
+        val = validate_data(raw)
+        self.data, self.data_mean, self.data_std = val.data, val.means, val.stds
 
         self.metadata = construct_metadata(self.data)
         self.wet, self.wet_surface = extract_wet_mask(

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -159,7 +159,8 @@ class Trainer:
         self.data_dir = cfg.experiment.data_dir
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
-        raw = DataSource.from_config(cfg)
+        use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
+        raw = DataSource.from_config(cfg, use_dask=use_dask)
         self.src = validate_data(raw)
         self.data = self.src.data
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -160,7 +160,7 @@ class Trainer:
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
         raw = DataSource.from_config(cfg)
-        val = validate_data(raw)
+        val = self.src = validate_data(raw)
         self.data, self.data_mean, self.data_std = val.data, val.means, val.stds
 
         self.metadata = construct_metadata(self.data)
@@ -358,9 +358,8 @@ class Trainer:
                 time_delta=self.time_delta,
                 hist=self.hist,
             )
-            inference_data = self.data.sel(time=self.inference_times[i].time_slice)
             inference_dataset = InferenceDataset(
-                data=inference_data,
+                src=self.src.slice(self.inference_times[i].time_slice),
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 wet=self.wet,
@@ -629,7 +628,7 @@ class Trainer:
                 train_data: ConcatDataset = ConcatDataset(
                     [
                         TrainDataset(
-                            data=self.data.sel(time=self.train_times.time_slice),
+                            src=self.src.slice(self.train_times.time_slice),
                             prognostic_var_names=self.prognostic_var_names,
                             boundary_var_names=self.boundary_var_names,
                             wet=self.wet,
@@ -645,7 +644,7 @@ class Trainer:
                 val_data: ConcatDataset = ConcatDataset(
                     [
                         TrainDataset(
-                            data=self.data.sel(time=self.val_times.time_slice),
+                            src=self.src.slice(self.val_times.time_slice),
                             prognostic_var_names=self.prognostic_var_names,
                             boundary_var_names=self.boundary_var_names,
                             wet=self.wet,
@@ -661,7 +660,7 @@ class Trainer:
                 train_data = ConcatDataset(
                     [
                         TorchTrainDataset(
-                            data=self.data.sel(time=self.train_times.time_slice),
+                            src=self.src.slice(self.train_times.time_slice),
                             prognostic_var_names=self.prognostic_var_names,
                             boundary_var_names=self.boundary_var_names,
                             wet=self.wet,
@@ -677,7 +676,7 @@ class Trainer:
                 val_data = ConcatDataset(
                     [
                         TorchTrainDataset(
-                            data=self.data.sel(time=self.val_times.time_slice),
+                            src=self.src.slice(self.val_times.time_slice),
                             prognostic_var_names=self.prognostic_var_names,
                             boundary_var_names=self.boundary_var_names,
                             wet=self.wet,

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -160,8 +160,8 @@ class Trainer:
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
         raw = DataSource.from_config(cfg)
-        val = self.src = validate_data(raw)
-        self.data, self.data_mean, self.data_std = val.data, val.means, val.stds
+        self.src = validate_data(raw)
+        self.data = self.src.data
 
         self.metadata = construct_metadata(self.data)
         self.wet, self.wet_surface = extract_wet_mask(
@@ -175,7 +175,7 @@ class Trainer:
         self.area_weights = self.area_weights.to(self.device)
 
         self.normalize = Normalize.init_instance(
-            val,
+            self.src,
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
             wet_mask=wet_without_hist_cpu,
@@ -234,7 +234,7 @@ class Trainer:
             )
             scale = torch.from_numpy(
                 (
-                    self.data_std[self.prognostic_var_names]
+                    self.src.stds[self.prognostic_var_names]
                     / scaling_residuals[self.prognostic_var_names]
                 )
                 .compute()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -175,8 +175,7 @@ class Trainer:
         self.area_weights = self.area_weights.to(self.device)
 
         self.normalize = Normalize.init_instance(
-            data_mean=self.data_mean,
-            data_std=self.data_std,
+            val,
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
             wet_mask=wet_without_hist_cpu,

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -359,7 +359,7 @@ class Trainer:
                 hist=self.hist,
             )
             inference_dataset = InferenceDataset(
-                src=self.src.slice(self.inference_times[i].time_slice),
+                src=self.src.slice(self.inference_times[i]),
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 wet=self.wet,
@@ -628,7 +628,7 @@ class Trainer:
                 train_data: ConcatDataset = ConcatDataset(
                     [
                         TrainDataset(
-                            src=self.src.slice(self.train_times.time_slice),
+                            src=self.src.slice(self.train_times),
                             prognostic_var_names=self.prognostic_var_names,
                             boundary_var_names=self.boundary_var_names,
                             wet=self.wet,
@@ -644,7 +644,7 @@ class Trainer:
                 val_data: ConcatDataset = ConcatDataset(
                     [
                         TrainDataset(
-                            src=self.src.slice(self.val_times.time_slice),
+                            src=self.src.slice(self.val_times),
                             prognostic_var_names=self.prognostic_var_names,
                             boundary_var_names=self.boundary_var_names,
                             wet=self.wet,
@@ -660,7 +660,7 @@ class Trainer:
                 train_data = ConcatDataset(
                     [
                         TorchTrainDataset(
-                            src=self.src.slice(self.train_times.time_slice),
+                            src=self.src.slice(self.train_times),
                             prognostic_var_names=self.prognostic_var_names,
                             boundary_var_names=self.boundary_var_names,
                             wet=self.wet,
@@ -676,7 +676,7 @@ class Trainer:
                 val_data = ConcatDataset(
                     [
                         TorchTrainDataset(
-                            src=self.src.slice(self.val_times.time_slice),
+                            src=self.src.slice(self.val_times),
                             prognostic_var_names=self.prognostic_var_names,
                             boundary_var_names=self.boundary_var_names,
                             wet=self.wet,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -38,21 +38,6 @@ class DataSource:
     means: xr.Dataset
     stds: xr.Dataset
 
-    def __hash__(self) -> int:
-        """Hashing good enough for dictionary keys."""
-
-        def _shape_hash(ds: xr.Dataset) -> int:
-            return hash(
-                tuple((k, v, d) for k, da in ds.items() for v, d in da.sizes.items())
-            )
-
-        return (
-            hash(self.name)
-            + _shape_hash(self.data)
-            + _shape_hash(self.means)
-            + _shape_hash(self.stds)
-        )
-
     def filter(
         self,
         var_names: PrognosticVarNames | BoundaryVarNames,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -42,7 +42,7 @@ class DataSource:
         self,
         var_names: PrognosticVarNames | BoundaryVarNames,
         *,
-        name: str | None = None,
+        prefix: str,
     ) -> Self:
         """Filter the data source to only include the specified variables."""
         data = self.data[var_names]
@@ -50,7 +50,7 @@ class DataSource:
         stds = self.stds[var_names]
 
         return dataclasses.replace(
-            self, name=name or self.name, data=data, means=means, stds=stds
+            self, name=f"{prefix}[{self.name}]", data=data, means=means, stds=stds
         )
 
     def map(
@@ -60,27 +60,28 @@ class DataSource:
             tuple[xr.Dataset, xr.Dataset, xr.Dataset],
         ],
         *,
-        name: str | None = None,
+        suffix: str,
     ) -> Self:
         """Map the function over the data source."""
         data, means, stds = func(self.data.copy(), self.means.copy(), self.stds.copy())
 
         return dataclasses.replace(
-            self, name=name or self.name, data=data, means=means, stds=stds
+            self, name=f"{self.name}_{suffix}", data=data, means=means, stds=stds
         )
 
     def map_data(
-        self, func: Callable[[xr.Dataset], xr.Dataset], *, name: str | None = None
+        self, func: Callable[[xr.Dataset], xr.Dataset], *, suffix: str | None = None
     ) -> Self:
         """Map the function over just data in DataSource."""
+        if suffix is None:
+            suffix = func.__qualname__
         data = func(self.data.copy())
-        return dataclasses.replace(self, name=name or self.name, data=data)
+        return dataclasses.replace(self, name=f"{self.name}_{suffix}", data=data)
 
-    def slice(self, time_slice: slice, *, name: str | None = None) -> Self:
+    def slice(self, time: TimeConfig) -> Self:
         """Slice the data source to only include the specified time slice."""
-        data = self.data.sel(time=time_slice)
-
-        return dataclasses.replace(self, name=name or self.name, data=data)
+        data = self.data.sel(time=time.time_slice)
+        return dataclasses.replace(self, name=f"{time=}[{self.name}]", data=data)
 
     def normalize(self, fill_nan=True, fill_value=0.0) -> xr.Dataset:
         """Normalize input data."""
@@ -333,7 +334,7 @@ def compute_anomalies(
                 stds[var] = data[var].std().compute()
         return data, means, stds
 
-    return data_src.map(_anom, name=data_src.name + "_anomalies")
+    return data_src.map(_anom, suffix="anomalies")
 
 
 def with_level_index_vars(data: xr.Dataset) -> xr.Dataset:
@@ -386,7 +387,7 @@ def validate_data(src: DataSource) -> DataSource:
         stds = with_level_index_vars(stds)
         return data, means, stds
 
-    src_ = src.map(_rename, name=src.name + "_validated")
+    src_ = src.map(_rename, suffix="validated")
 
     # Check if any anomalies are needed to be computed
     tensor_map = TensorMap.get_instance()
@@ -407,12 +408,12 @@ class Normalize(Multiton):
         wet_mask: torch.Tensor,
     ) -> None:
         """Store normalization parameters and pre-compute numpy arrays."""
-        prog_src = src.filter(prognostic_var_names)
-        bound_src = src.filter(boundary_var_names)
-        self.prognostic_mean = prog_src.means
-        self.prognostic_std = prog_src.stds
-        self.boundary_mean = bound_src.means
-        self.boundary_std = bound_src.stds
+        prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
+        boundary_src = src.filter(boundary_var_names, prefix="boundary")
+        self.prognostic_mean = prognostic_src.means
+        self.prognostic_std = prognostic_src.stds
+        self.boundary_mean = boundary_src.means
+        self.boundary_std = boundary_src.stds
         self.wet_mask = wet_mask
 
         # Pre-compute numpy arrays for faster access

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -82,11 +82,9 @@ class DataSource:
 
         return dataclasses.replace(self, name=name or self.name, data=data)
 
-    def normalize(
-        self, data: xr.Dataset | None = None, fill_nan=True, fill_value=0.0
-    ) -> xr.Dataset:
+    def normalize(self, fill_nan=True, fill_value=0.0) -> xr.Dataset:
         """Normalize input data."""
-        norm = ((data or self.data) - self.means) / self.stds
+        norm = (self.data - self.means) / self.stds
         if fill_nan:
             norm = norm.fillna(fill_value)
         return norm

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -44,13 +44,12 @@ class DataSource:
 
         def _shape_hash(ds: xr.Dataset) -> int:
             return hash(
-                "_".join(
-                    [
-                        f"{k}-{v}:{d}"
-                        for k, da in ds.items()
-                        for v, d in da.sizes.items()
-                    ]
+                tuple(
+                    (k, v, d)
+                    for k, da in ds.items()
+                    for v, d in da.sizes.items()
                 )
+            )
             )
 
         return (

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -97,15 +97,14 @@ class DataSource:
         fill_value=0.0,
     ) -> torch.Tensor:
         """Normalize input data treated as torch Tensors."""
-        device = data.device
         reshape_vars = [1] * data.ndim
         reshape_vars[variable_axis] = -1
 
         # TODO(alxmrs): Do we have to reshape twice?
         means_np = self.means.to_array().to_numpy().reshape(-1)
         stds_np = self.stds.to_array().to_numpy().reshape(-1)
-        means = torch.from_numpy(means_np).to(device).reshape(reshape_vars)
-        stds = torch.from_numpy(stds_np).to(device).reshape(reshape_vars)
+        means = torch.from_numpy(means_np).reshape(reshape_vars)
+        stds = torch.from_numpy(stds_np).reshape(reshape_vars)
 
         norm = (data - means) / stds
         if fill_nan:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -89,7 +89,7 @@ class DataSource:
             norm = norm.fillna(fill_value)
         return norm
 
-    def norm_of(
+    def normalize_with(
         self,
         data: torch.Tensor,
         variable_axis: int = 0,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from typing import Any, Literal, Self
+from typing import Any, Callable, Literal, Self
 
 import cftime
 import numpy as np
@@ -52,6 +52,29 @@ class DataSource:
         return dataclasses.replace(
             self, name=name or self.name, data=data, means=means, stds=stds
         )
+
+    def map(
+        self,
+        func: Callable[
+            [xr.Dataset, xr.Dataset, xr.Dataset],
+            tuple[xr.Dataset, xr.Dataset, xr.Dataset],
+        ],
+        *,
+        name: str | None = None,
+    ) -> Self:
+        """Map the function over the data source."""
+        data, means, stds = func(self.data.copy(), self.means.copy(), self.stds.copy())
+
+        return dataclasses.replace(
+            self, name=name or self.name, data=data, means=means, stds=stds
+        )
+
+    def map_data(
+        self, func: Callable[[xr.Dataset], xr.Dataset], *, name: str | None = None
+    ) -> Self:
+        """Map the function over just data in DataSource."""
+        data = func(self.data.copy())
+        return dataclasses.replace(self, name=name or self.name, data=data)
 
     def slice(self, time_slice: slice, *, name: str | None = None) -> Self:
         """Slice the data source to only include the specified time slice."""

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -329,17 +329,16 @@ def validate_data(src: DataSource) -> DataSource:
 class Normalize(Multiton):
     def _initialize(
         self,
-        data_mean: xr.Dataset,
-        data_std: xr.Dataset,
+        src: DataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
         wet_mask: torch.Tensor,
     ) -> None:
         """Store normalization parameters and pre-compute numpy arrays."""
-        self.prognostic_mean = data_mean[prognostic_var_names]
-        self.prognostic_std = data_std[prognostic_var_names]
-        self.boundary_mean = data_mean[boundary_var_names]
-        self.boundary_std = data_std[boundary_var_names]
+        self.prognostic_mean = src.means[prognostic_var_names]
+        self.prognostic_std = src.stds[prognostic_var_names]
+        self.boundary_mean = src.means[boundary_var_names]
+        self.boundary_std = src.stds[boundary_var_names]
         self.wet_mask = wet_mask
 
         # Pre-compute numpy arrays for faster access

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -19,7 +19,6 @@ from ocean_emulators.constants import (
     Grid,
     GridMask,
     Input,
-    LoaderVersion,
     Prognostic,
     PrognosticMask,
     PrognosticVarNames,
@@ -116,10 +115,8 @@ class DataSource:
 
     @classmethod
     def from_config(
-        cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool | None = None
+        cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool = False
     ) -> Self:
-        if use_dask is None:
-            use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
         chunks: dict[str, int] | None = {} if use_dask else None
 
         root = cfg.experiment.data_dir

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -1,5 +1,6 @@
+import dataclasses
 import logging
-from typing import Literal
+from typing import Any, Self, Literal
 
 import cftime
 import numpy as np
@@ -7,7 +8,7 @@ import torch
 import xarray as xr
 from einops import rearrange
 
-from ocean_emulators.config import TimeConfig
+from ocean_emulators.config import TimeConfig, TrainConfig
 from ocean_emulators.constants import (
     DEPTH_I_LEVELS,
     DEPTH_LEVELS,
@@ -19,12 +20,64 @@ from ocean_emulators.constants import (
     GridMask,
     Input,
     Prognostic,
+    LoaderVersion,
     PrognosticMask,
     PrognosticVarNames,
     SingleTimeSeriesOutput,
     TensorMap,
 )
 from ocean_emulators.utils.multiton import Multiton
+
+
+@dataclasses.dataclass
+class DataSource:
+    """Data source for the model."""
+
+    name: str
+    data: xr.Dataset
+    means: xr.Dataset
+    stds: xr.Dataset
+
+    def copy(self, new_name: str | None = None) -> Self:
+        """Return a copy (of underlying `xr.Dataset`) of the DataSource."""
+        return dataclasses.replace(
+            self,
+            name=new_name or self.name,
+            data=self.data.copy(),
+            means=self.means.copy(),
+            stds=self.stds.copy(),
+        )
+
+    @classmethod
+    def from_config(cls, cfg: TrainConfig) -> Self:
+        use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
+        if use_dask:
+            chunks: dict[str, int] | None = {}
+        else:
+            chunks = None
+
+        root = cfg.experiment.data_dir
+
+        if "*" in cfg.data.data_path:
+            kwargs: dict[str, Any] = dict(
+                engine="netcdf4", chunks={"time": 1, "lat": 180, "lon": 360}
+            )
+        else:
+            kwargs = dict(chunks=chunks, consolidated=True)
+        data = xr.open_dataset(root / cfg.data.data_path, **kwargs)
+
+        means = xr.open_dataset(
+            root / cfg.data.data_means_path,
+            engine="netcdf4" if cfg.data.data_means_path.endswith(".nc") else "zarr",
+            chunks=chunks,
+        )
+        stds = xr.open_dataset(
+            root / cfg.data.data_stds_path,
+            engine="netcdf4" if cfg.data.data_stds_path.endswith(".nc") else "zarr",
+            chunks=chunks,
+        )
+
+        return cls(name="raw", data=data, means=means, stds=stds)
 
 
 def extract_wet_mask(
@@ -186,33 +239,30 @@ def get_anomalies_vars(var_names: BoundaryVarNames) -> tuple[str, ...]:
 
 
 def compute_anomalies(
-    data: xr.Dataset,
-    data_mean: xr.Dataset,
-    data_std: xr.Dataset,
-    anomalies_vars: tuple[str, ...],
-) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]:
+    data_src: DataSource, anomalies_vars: tuple[str, ...]
+) -> DataSource:
     """
     Compute anomalies for the given variables.
     """
-    data_copy = data.copy()
-    data_mean_copy = data_mean.copy()
-    data_std_copy = data_std.copy()
+    src = data_src.copy(data_src.name + "_anomalies")
+
     for var in anomalies_vars:
         base_var = var.replace("_anomalies", "")
-        if var not in data_copy.variables and base_var in data_copy.variables:
+        if var not in src.data.variables and base_var in src.data.variables:
             logging.info(f"Computing anomalies for {base_var}")
             climatology = (
-                data_copy[base_var].groupby("time.dayofyear").mean("time").compute()
+                src.data[base_var].groupby("time.dayofyear").mean("time").compute()
             )
             # Remove the seasonal cycle (climatology) from the detrended data
-            day_of_year = data_copy[base_var]["time"].dt.dayofyear
-            data_copy[var] = (
-                data_copy[base_var] - climatology.sel(dayofyear=day_of_year)
+            day_of_year = src.data[base_var]["time"].dt.dayofyear
+            src.data[var] = (
+                src.data[base_var] - climatology.sel(dayofyear=day_of_year)
             ).compute()
-            data_copy = data_copy.drop(["dayofyear"])
-            data_mean_copy[var] = data_copy[var].mean().compute()
-            data_std_copy[var] = data_copy[var].std().compute()
-    return data_copy, data_mean_copy, data_std_copy
+            src.data = src.data.drop(["dayofyear"])
+            src.means[var] = src.data[var].mean().compute()
+            src.stds[var] = src.data[var].std().compute()
+
+    return src
 
 
 def with_level_index_vars(data: xr.Dataset) -> xr.Dataset:
@@ -249,35 +299,30 @@ def with_lat_lon_coords(data: xr.Dataset) -> xr.Dataset:
     return data_copy
 
 
-def validate_data(
-    data: xr.Dataset,
-    data_mean: xr.Dataset,
-    data_std: xr.Dataset,
-) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]:
+def validate_data(src: DataSource) -> DataSource:
     """
     Validate the data such that we have the correct format for training.
     """
-    data_copy = (
-        data.copy()
-        .pipe(flatten_masks)
+    src_ = src.copy("validated")
+
+    src_.data = (
+        src_.data.pipe(flatten_masks)
         .pipe(with_level_index_vars)
         .pipe(with_lat_lon_coords)
     )
 
     # Check if data variables are in the right format
     # This check is to ensure we convert data to the correct format
-    data_mean_copy = with_level_index_vars(data_mean.copy())
-    data_std_copy = with_level_index_vars(data_std.copy())
+    src_.means = with_level_index_vars(src_.means)
+    src_.stds = with_level_index_vars(src_.stds)
 
     # Check if any anomalies are needed to be computed
     tensor_map = TensorMap.get_instance()
     anomalies_vars = get_anomalies_vars(tensor_map.boundary_var_names)
-    if anomalies_vars:
-        data_copy, data_mean_copy, data_std_copy = compute_anomalies(
-            data_copy, data_mean_copy, data_std_copy, anomalies_vars
-        )
 
-    return data_copy, data_mean_copy, data_std_copy
+    out = compute_anomalies(src_, anomalies_vars) if anomalies_vars else src_
+
+    return out
 
 
 # TODO: Repetitive code. Refactor

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -114,9 +114,7 @@ class DataSource:
         return norm
 
     @classmethod
-    def from_config(
-        cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool = False
-    ) -> Self:
+    def from_config(cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool) -> Self:
         chunks: dict[str, int] | None = {} if use_dask else None
 
         root = cfg.experiment.data_dir

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 from functools import cache
-from typing import Any, Self, Literal
+from typing import Any, Literal, Self
 
 import cftime
 import numpy as np
@@ -20,8 +20,8 @@ from ocean_emulators.constants import (
     Grid,
     GridMask,
     Input,
-    Prognostic,
     LoaderVersion,
+    Prognostic,
     PrognosticMask,
     PrognosticVarNames,
     SingleTimeSeriesOutput,
@@ -92,12 +92,12 @@ class DataSource:
         )
 
     @classmethod
-    def from_config(cls, cfg: TrainConfig | EvalConfig) -> Self:
-        use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
-        if use_dask:
-            chunks: dict[str, int] | None = {}
-        else:
-            chunks = None
+    def from_config(
+        cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool | None = None
+    ) -> Self:
+        if use_dask is None:
+            use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
+        chunks: dict[str, int] | None = {} if use_dask else None
 
         root = cfg.experiment.data_dir
 
@@ -120,8 +120,10 @@ class DataSource:
             chunks=chunks,
         )
 
+        dask = "with_dask" if use_dask else "without_dask"
+
         return cls(
-            name=f"raw-{cfg.experiment.name}-{cfg.experiment.data_dir.name}",
+            name=f"raw-{cfg.experiment.name}-{cfg.experiment.data_dir.name}-{dask}",
             data=data,
             means=means,
             stds=stds,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -145,7 +145,7 @@ class DataSource:
         dask = "with_dask" if use_dask else "without_dask"
 
         return cls(
-            name=f"raw-{cfg.experiment.name}-{cfg.experiment.data_dir.name}-{dask}",
+            name=f"{cfg.experiment.name}-{cfg.experiment.data_dir.name}-{dask}",
             data=data,
             means=means,
             stds=stds,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from typing import Any, Callable, Literal, Self
+from typing import Callable, Literal, Self
 
 import cftime
 import numpy as np
@@ -119,12 +119,15 @@ class DataSource:
         root = cfg.experiment.data_dir
 
         if "*" in cfg.data.data_path:
-            kwargs: dict[str, Any] = dict(
-                engine="netcdf4", chunks={"time": 1, "lat": 180, "lon": 360}
+            data = xr.open_dataset(
+                root / cfg.data.data_path,
+                engine="netcdf4",
+                chunks={"time": 1, "lat": 180, "lon": 360},
             )
         else:
-            kwargs = dict(chunks=chunks, consolidated=True)
-        data = xr.open_dataset(root / cfg.data.data_path, **kwargs)
+            data = xr.open_dataset(
+                root / cfg.data.data_path, chunks=chunks, consolidated=True
+            )
 
         means = xr.open_dataset(
             root / cfg.data.data_means_path,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -44,12 +44,7 @@ class DataSource:
 
         def _shape_hash(ds: xr.Dataset) -> int:
             return hash(
-                tuple(
-                    (k, v, d)
-                    for k, da in ds.items()
-                    for v, d in da.sizes.items()
-                )
-            )
+                tuple((k, v, d) for k, da in ds.items() for v, d in da.sizes.items())
             )
 
         return (

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -86,12 +86,40 @@ class DataSource:
         )
 
     def normalize(
-        self, target: xr.Dataset | None = None, fill_nan=True, fill_value=0.0
+        self, data: xr.Dataset | None = None, fill_nan=True, fill_value=0.0
     ) -> xr.Dataset:
         """Normalize input data."""
-        norm = ((target or self.data) - self.means) / self.stds
+        norm = ((data or self.data) - self.means) / self.stds
         if fill_nan:
             norm = norm.fillna(fill_value)
+        return norm
+
+    def normalize_tensor(
+        self,
+        data: torch.Tensor | None = None,
+        variable_axis: int = 0,
+        fill_nan=True,
+        fill_value=0.0,
+    ) -> torch.Tensor:
+        """Normalize input data treated as torch Tensors."""
+        device = (data or self.data).device
+        reshape_vars = [1] * (data or self.data).ndim
+        reshape_vars[variable_axis] = -1
+
+        if data is None:
+            data_np = self.data.to_array().to_numpy().reshape(-1)
+            data = torch.from_numpy(data_np).to(device).reshape(reshape_vars)
+
+        # TODO(alxmrs): Do we have to reshape twice?
+        means_np = self.means.to_array().to_numpy().reshape(-1)
+        stds_np = self.stds.to_array().to_numpy().reshape(-1)
+        means = torch.from_numpy(means_np).to(device).reshape(reshape_vars)
+        stds = torch.from_numpy(stds_np).to(device).reshape(reshape_vars)
+
+        norm = (data - means) / stds
+        if fill_nan:
+            norm = norm.nan_to_num(nan=fill_value)
+        norm = norm.to(data.dtype)
         return norm
 
     @classmethod

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -438,12 +438,12 @@ class Normalize(Multiton):
         wet_mask: torch.Tensor,
     ) -> None:
         """Store normalization parameters and pre-compute numpy arrays."""
-        _prog_src = src.filter(prognostic_var_names)
-        _bound_src = src.filter(boundary_var_names)
-        self.prognostic_mean = _prog_src.means
-        self.prognostic_std = _prog_src.stds
-        self.boundary_mean = _bound_src.means
-        self.boundary_std = _bound_src.stds
+        prog_src = src.filter(prognostic_var_names)
+        bound_src = src.filter(boundary_var_names)
+        self.prognostic_mean = prog_src.means
+        self.prognostic_std = prog_src.stds
+        self.boundary_mean = bound_src.means
+        self.boundary_std = bound_src.stds
         self.wet_mask = wet_mask
 
         # Pre-compute numpy arrays for faster access

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -91,19 +91,15 @@ class DataSource:
 
     def normalize_tensor(
         self,
-        data: torch.Tensor | None = None,
+        data: torch.Tensor,
         variable_axis: int = 0,
         fill_nan=True,
         fill_value=0.0,
     ) -> torch.Tensor:
         """Normalize input data treated as torch Tensors."""
-        device = (data or self.data).device
-        reshape_vars = [1] * (data or self.data).ndim
+        device = data.device
+        reshape_vars = [1] * data.ndim
         reshape_vars[variable_axis] = -1
-
-        if data is None:
-            data_np = self.data.to_array().to_numpy().reshape(-1)
-            data = torch.from_numpy(data_np).to(device).reshape(reshape_vars)
 
         # TODO(alxmrs): Do we have to reshape twice?
         means_np = self.means.to_array().to_numpy().reshape(-1)

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+from functools import cache
 from typing import Any, Self, Literal
 
 import cftime
@@ -8,7 +9,7 @@ import torch
 import xarray as xr
 from einops import rearrange
 
-from ocean_emulators.config import TimeConfig, TrainConfig
+from ocean_emulators.config import EvalConfig, TimeConfig, TrainConfig
 from ocean_emulators.constants import (
     DEPTH_I_LEVELS,
     DEPTH_LEVELS,
@@ -38,18 +39,60 @@ class DataSource:
     means: xr.Dataset
     stds: xr.Dataset
 
-    def copy(self, new_name: str | None = None) -> Self:
+    def __hash__(self) -> int:
+        """Hashing good enough for dictionary keys."""
+
+        def _shape_hash(ds: xr.Dataset) -> int:
+            return hash(
+                "_".join(
+                    [
+                        f"{k}-{v}:{d}"
+                        for k, da in ds.items()
+                        for v, d in da.sizes.items()
+                    ]
+                )
+            )
+
+        return (
+            hash(self.name)
+            + _shape_hash(self.data)
+            + _shape_hash(self.means)
+            + _shape_hash(self.stds)
+        )
+
+    def filter(
+        self,
+        var_names: PrognosticVarNames | BoundaryVarNames,
+        *,
+        name: str | None = None,
+    ) -> Self:
+        """Filter the data source to only include the specified variables."""
+        data = self.data[var_names]
+        means = self.means[var_names]
+        stds = self.stds[var_names]
+
+        return dataclasses.replace(
+            self, name=name or self.name, data=data, means=means, stds=stds
+        )
+
+    def slice(self, time_slice: slice, *, name: str | None = None) -> Self:
+        """Slice the data source to only include the specified time slice."""
+        data = self.data.sel(time=time_slice)
+
+        return dataclasses.replace(self, name=name or self.name, data=data)
+
+    def copy(self, *, name: str | None = None) -> Self:
         """Return a copy (of underlying `xr.Dataset`) of the DataSource."""
         return dataclasses.replace(
             self,
-            name=new_name or self.name,
+            name=name or self.name,
             data=self.data.copy(),
             means=self.means.copy(),
             stds=self.stds.copy(),
         )
 
     @classmethod
-    def from_config(cls, cfg: TrainConfig) -> Self:
+    def from_config(cls, cfg: TrainConfig | EvalConfig) -> Self:
         use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
         if use_dask:
             chunks: dict[str, int] | None = {}
@@ -77,7 +120,12 @@ class DataSource:
             chunks=chunks,
         )
 
-        return cls(name="raw", data=data, means=means, stds=stds)
+        return cls(
+            name=f"raw-{cfg.experiment.name}-{cfg.experiment.data_dir.name}",
+            data=data,
+            means=means,
+            stds=stds,
+        )
 
 
 def extract_wet_mask(
@@ -244,7 +292,7 @@ def compute_anomalies(
     """
     Compute anomalies for the given variables.
     """
-    src = data_src.copy(data_src.name + "_anomalies")
+    src = data_src.copy(name=data_src.name + "_anomalies")
 
     for var in anomalies_vars:
         base_var = var.replace("_anomalies", "")
@@ -303,7 +351,7 @@ def validate_data(src: DataSource) -> DataSource:
     """
     Validate the data such that we have the correct format for training.
     """
-    src_ = src.copy("validated")
+    src_ = src.copy(name=src.name + "_validated")
 
     src_.data = (
         src_.data.pipe(flatten_masks)
@@ -323,6 +371,59 @@ def validate_data(src: DataSource) -> DataSource:
     out = compute_anomalies(src_, anomalies_vars) if anomalies_vars else src_
 
     return out
+
+
+@cache
+def to_tensor(
+    src: DataSource, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Convert data source to tensors (with caching)."""
+    data_np = src.data.to_array().to_numpy().reshape(-1)
+    means_np = src.means.to_array().to_numpy().reshape(-1)
+    stds_np = src.stds.to_array().to_numpy().reshape(-1)
+
+    data_tensor = torch.from_numpy(data_np).to(device)
+    means_tensor = torch.from_numpy(means_np).to(device)
+    stds_tensor = torch.from_numpy(stds_np).to(device)
+
+    return data_tensor, means_tensor, stds_tensor
+
+
+def normalize(src: DataSource, fill_nan=True, fill_value=0.0) -> xr.Dataset:
+    """Normalize input data source."""
+    norm = (src.data - src.means) / src.stds
+    if fill_nan:
+        norm = norm.fillna(fill_value)
+    return norm
+
+
+def normalize_tensor(
+    data: torch.Tensor,
+    means: torch.Tensor,
+    stds: torch.Tensor,
+    fill_nan=True,
+    fill_value=0.0,
+) -> torch.Tensor:
+    """Normalize data treated as torch Tensors."""
+    norm = (data - means) / stds
+    if fill_nan:
+        norm = norm.nan_to_num(nan=fill_value)
+    norm = norm.to(data.dtype)
+    return norm
+
+
+def unnormalize_tensor(
+    data: torch.Tensor, means: torch.Tensor, stds: torch.Tensor
+) -> torch.Tensor:
+    unnorm = data * stds + means
+    unnorm = unnorm.to(data.dtype)
+    return unnorm
+
+
+def mask_tensor(
+    data: torch.Tensor, wet_mask: torch.Tensor, fill_value=float("nan")
+) -> torch.Tensor:
+    return torch.where(wet_mask.to(data.device) == 0, fill_value, data)
 
 
 # TODO: Repetitive code. Refactor
@@ -353,24 +454,6 @@ class Normalize(Multiton):
     def _to_tensor(self, array: np.ndarray, device: torch.device) -> torch.Tensor:
         """Convert numpy array to tensor on specified device."""
         return torch.from_numpy(array).to(device)
-
-    def normalize_prognostic(
-        self, data: xr.Dataset, fill_nan=True, fill_value=0.0
-    ) -> xr.Dataset:
-        """Normalize input dataset."""
-        norm = (data - self.prognostic_mean) / self.prognostic_std
-        if fill_nan:
-            norm = norm.fillna(fill_value)
-        return norm
-
-    def normalize_boundary(
-        self, data: xr.Dataset, fill_nan=True, fill_value=0.0
-    ) -> xr.Dataset:
-        """Normalize boundary conditions."""
-        norm = (data - self.boundary_mean) / self.boundary_std
-        if fill_nan:
-            norm = norm.fillna(fill_value)
-        return norm
 
     def normalize_tensor_prognostic(
         self, data: torch.Tensor, fill_nan=True, fill_value=0.0
@@ -413,25 +496,3 @@ class Normalize(Multiton):
         unnorm = torch.where(self.wet_mask.to(data.device) == 0, fill_value, unnorm)
         unnorm = unnorm.to(data.dtype)
         return unnorm
-
-    def normalize_tensor_boundary(
-        self, data: torch.Tensor, fill_nan=True, fill_value=0.0
-    ) -> torch.Tensor:
-        """Normalize boundary tensor."""
-        tensor_mean = self._to_tensor(self._boundary_mean_np, data.device)
-        tensor_std = self._to_tensor(self._boundary_std_np, data.device)
-
-        if data.ndim == 3:
-            tensor_mean = tensor_mean.reshape([-1, 1, 1])
-            tensor_std = tensor_std.reshape([-1, 1, 1])
-        elif data.ndim == 4:
-            tensor_mean = tensor_mean.reshape([1, -1, 1, 1])
-            tensor_std = tensor_std.reshape([1, -1, 1, 1])
-        else:
-            raise ValueError(f"Invalid data shape: {data.shape}")
-
-        norm = (data - tensor_mean) / tensor_std
-        if fill_nan:
-            norm = norm.nan_to_num(nan=fill_value)
-        norm = norm.to(data.dtype)
-        return norm

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -89,7 +89,7 @@ class DataSource:
             norm = norm.fillna(fill_value)
         return norm
 
-    def normalize_tensor(
+    def norm_of(
         self,
         data: torch.Tensor,
         variable_axis: int = 0,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-from functools import cache
 from typing import Any, Literal, Self
 
 import cftime
@@ -404,37 +403,6 @@ def validate_data(src: DataSource) -> DataSource:
     out = compute_anomalies(src_, anomalies_vars) if anomalies_vars else src_
 
     return out
-
-
-@cache
-def to_tensor(
-    src: DataSource, device: torch.device
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Convert data source to tensors (with caching)."""
-    data_np = src.data.to_array().to_numpy().reshape(-1)
-    means_np = src.means.to_array().to_numpy().reshape(-1)
-    stds_np = src.stds.to_array().to_numpy().reshape(-1)
-
-    data_tensor = torch.from_numpy(data_np).to(device)
-    means_tensor = torch.from_numpy(means_np).to(device)
-    stds_tensor = torch.from_numpy(stds_np).to(device)
-
-    return data_tensor, means_tensor, stds_tensor
-
-
-def normalize_tensor(
-    data: torch.Tensor,
-    means: torch.Tensor,
-    stds: torch.Tensor,
-    fill_nan=True,
-    fill_value=0.0,
-) -> torch.Tensor:
-    """Normalize data treated as torch Tensors."""
-    norm = (data - means) / stds
-    if fill_nan:
-        norm = norm.nan_to_num(nan=fill_value)
-    norm = norm.to(data.dtype)
-    return norm
 
 
 # TODO: Repetitive code. Refactor

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -438,10 +438,12 @@ class Normalize(Multiton):
         wet_mask: torch.Tensor,
     ) -> None:
         """Store normalization parameters and pre-compute numpy arrays."""
-        self.prognostic_mean = src.means[prognostic_var_names]
-        self.prognostic_std = src.stds[prognostic_var_names]
-        self.boundary_mean = src.means[boundary_var_names]
-        self.boundary_std = src.stds[boundary_var_names]
+        _prog_src = src.filter(prognostic_var_names)
+        _bound_src = src.filter(boundary_var_names)
+        self.prognostic_mean = _prog_src.means
+        self.prognostic_std = _prog_src.stds
+        self.boundary_mean = _bound_src.means
+        self.boundary_std = _bound_src.stds
         self.wet_mask = wet_mask
 
         # Pre-compute numpy arrays for faster access

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -85,6 +85,15 @@ class DataSource:
             stds=self.stds.copy(),
         )
 
+    def normalize(
+        self, target: xr.Dataset | None = None, fill_nan=True, fill_value=0.0
+    ) -> xr.Dataset:
+        """Normalize input data."""
+        norm = ((target or self.data) - self.means) / self.stds
+        if fill_nan:
+            norm = norm.fillna(fill_value)
+        return norm
+
     @classmethod
     def from_config(
         cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool | None = None
@@ -383,14 +392,6 @@ def to_tensor(
     stds_tensor = torch.from_numpy(stds_np).to(device)
 
     return data_tensor, means_tensor, stds_tensor
-
-
-def normalize(src: DataSource, fill_nan=True, fill_value=0.0) -> xr.Dataset:
-    """Normalize input data source."""
-    norm = (src.data - src.means) / src.stds
-    if fill_nan:
-        norm = norm.fillna(fill_value)
-    return norm
 
 
 def normalize_tensor(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -408,20 +408,6 @@ def normalize_tensor(
     return norm
 
 
-def unnormalize_tensor(
-    data: torch.Tensor, means: torch.Tensor, stds: torch.Tensor
-) -> torch.Tensor:
-    unnorm = data * stds + means
-    unnorm = unnorm.to(data.dtype)
-    return unnorm
-
-
-def mask_tensor(
-    data: torch.Tensor, wet_mask: torch.Tensor, fill_value=float("nan")
-) -> torch.Tensor:
-    return torch.where(wet_mask.to(data.device) == 0, fill_value, data)
-
-
 # TODO: Repetitive code. Refactor
 class Normalize(Multiton):
     def _initialize(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -82,16 +82,6 @@ class DataSource:
 
         return dataclasses.replace(self, name=name or self.name, data=data)
 
-    def copy(self, *, name: str | None = None) -> Self:
-        """Return a copy (of underlying `xr.Dataset`) of the DataSource."""
-        return dataclasses.replace(
-            self,
-            name=name or self.name,
-            data=self.data.copy(),
-            means=self.means.copy(),
-            stds=self.stds.copy(),
-        )
-
     def normalize(
         self, data: xr.Dataset | None = None, fill_nan=True, fill_value=0.0
     ) -> xr.Dataset:
@@ -329,28 +319,27 @@ def get_anomalies_vars(var_names: BoundaryVarNames) -> tuple[str, ...]:
 def compute_anomalies(
     data_src: DataSource, anomalies_vars: tuple[str, ...]
 ) -> DataSource:
-    """
-    Compute anomalies for the given variables.
-    """
-    src = data_src.copy(name=data_src.name + "_anomalies")
+    """Compute anomalies for the given variables."""
 
-    for var in anomalies_vars:
-        base_var = var.replace("_anomalies", "")
-        if var not in src.data.variables and base_var in src.data.variables:
-            logging.info(f"Computing anomalies for {base_var}")
-            climatology = (
-                src.data[base_var].groupby("time.dayofyear").mean("time").compute()
-            )
-            # Remove the seasonal cycle (climatology) from the detrended data
-            day_of_year = src.data[base_var]["time"].dt.dayofyear
-            src.data[var] = (
-                src.data[base_var] - climatology.sel(dayofyear=day_of_year)
-            ).compute()
-            src.data = src.data.drop(["dayofyear"])
-            src.means[var] = src.data[var].mean().compute()
-            src.stds[var] = src.data[var].std().compute()
+    def _anom(data, means, stds):
+        for var in anomalies_vars:
+            base_var = var.replace("_anomalies", "")
+            if var not in data.variables and base_var in data.variables:
+                logging.info(f"Computing anomalies for {base_var}")
+                climatology = (
+                    data[base_var].groupby("time.dayofyear").mean("time").compute()
+                )
+                # Remove the seasonal cycle (climatology) from the detrended data
+                day_of_year = data[base_var]["time"].dt.dayofyear
+                data[var] = (
+                    data[base_var] - climatology.sel(dayofyear=day_of_year)
+                ).compute()
+                data = data.drop(["dayofyear"])
+                means[var] = data[var].mean().compute()
+                stds[var] = data[var].std().compute()
+        return data, means, stds
 
-    return src
+    return data_src.map(_anom, name=data_src.name + "_anomalies")
 
 
 def with_level_index_vars(data: xr.Dataset) -> xr.Dataset:
@@ -388,21 +377,22 @@ def with_lat_lon_coords(data: xr.Dataset) -> xr.Dataset:
 
 
 def validate_data(src: DataSource) -> DataSource:
-    """
-    Validate the data such that we have the correct format for training.
-    """
-    src_ = src.copy(name=src.name + "_validated")
+    """Validate the data such that we have the correct format for training."""
 
-    src_.data = (
-        src_.data.pipe(flatten_masks)
-        .pipe(with_level_index_vars)
-        .pipe(with_lat_lon_coords)
-    )
+    def _rename(data, means, stds):
+        data = (
+            data.pipe(flatten_masks)
+            .pipe(with_level_index_vars)
+            .pipe(with_lat_lon_coords)
+        )
 
-    # Check if data variables are in the right format
-    # This check is to ensure we convert data to the correct format
-    src_.means = with_level_index_vars(src_.means)
-    src_.stds = with_level_index_vars(src_.stds)
+        # Check if data variables are in the right format
+        # This check is to ensure we convert data to the correct format
+        means = with_level_index_vars(means)
+        stds = with_level_index_vars(stds)
+        return data, means, stds
+
+    src_ = src.map(_rename, name=src.name + "_validated")
 
     # Check if any anomalies are needed to be computed
     tensor_map = TensorMap.get_instance()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from typing_extensions import Self
 import ocean_emulators.constants as c
 from ocean_emulators.config import TrainBackendConfig, TrainConfig
 from ocean_emulators.train import Trainer
+from ocean_emulators.utils.data import DataSource
 from ocean_emulators.utils.multiton import MultitonScope
 
 REMOTE_DATA = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
@@ -22,16 +23,6 @@ DEFAULT_CONFIG = "train_default.test.yaml"
 ALL_CONFIGS = [DEFAULT_CONFIG, "train_default_2step.test.yaml"]
 
 TrainPair = tuple[TrainConfig, Trainer]
-
-
-@dataclasses.dataclass
-class DataSource:
-    """In-memory `xarray.Dataset`s needed for tests."""
-
-    name: str
-    data: xr.Dataset
-    means: xr.Dataset
-    stds: xr.Dataset
 
 
 @dataclasses.dataclass

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -66,14 +66,15 @@ def make_loader(
         )
         val = validate_data(raw)
         wet, wet_surface = extract_wet_mask(val.data, prognostic, cfg.data.hist)
-        Normalize.init_instance(val, prognostic, boundary, wet)
+        wet_without_hist, _ = extract_wet_mask(val.data, prognostic, 0)
+        Normalize.init_instance(val, prognostic, boundary, wet_without_hist)
 
         match version:
             case LoaderVersion.OM4_EAGER:
                 data: ConcatDataset | InferenceDataset = ConcatDataset(
                     [
                         TrainDataset(
-                            data=val.data.sel(time=time_slice),
+                            src=val.slice(time_slice),
                             prognostic_var_names=prognostic,
                             boundary_var_names=boundary,
                             wet=wet,
@@ -90,7 +91,7 @@ def make_loader(
                 data = ConcatDataset(
                     [
                         TorchTrainDataset(
-                            data=val.data.sel(time=time_slice),
+                            src=val.slice(time_slice),
                             prognostic_var_names=prognostic,
                             boundary_var_names=boundary,
                             wet=wet,
@@ -435,7 +436,7 @@ def traindataset_input():
             wet_mask=wet,
         )
         traindataset = TrainDataset(
-            data=test.data,
+            src=test,
             prognostic_var_names=prognostic_var_names,
             boundary_var_names=boundary_var_names,
             wet=wet,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -65,15 +65,15 @@ def make_loader(
         TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
         )
-        val = validate_data(raw)
-        wet, wet_surface = extract_wet_mask(val.data, prognostic, cfg.data.hist)
+        src = validate_data(raw)
+        wet, wet_surface = extract_wet_mask(src.data, prognostic, cfg.data.hist)
 
         match version:
             case LoaderVersion.OM4_EAGER:
                 data: ConcatDataset | InferenceDataset = ConcatDataset(
                     [
                         TrainDataset(
-                            src=val.slice(time_slice),
+                            src=src.slice(time_slice),
                             prognostic_var_names=prognostic,
                             boundary_var_names=boundary,
                             wet=wet,
@@ -90,7 +90,7 @@ def make_loader(
                 data = ConcatDataset(
                     [
                         TorchTrainDataset(
-                            src=val.slice(time_slice),
+                            src=src.slice(time_slice),
                             prognostic_var_names=prognostic,
                             boundary_var_names=boundary,
                             wet=wet,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -16,7 +16,7 @@ from hypothesis.extra.numpy import arrays
 from numpy.typing import NDArray
 from torch.utils.data import ConcatDataset, DataLoader
 
-from ocean_emulators.config import TrainConfig
+from ocean_emulators.config import TimeConfig, TrainConfig
 from ocean_emulators.constants import (
     BOUNDARY_VARS,
     PROGNOSTIC_VARS,
@@ -49,12 +49,12 @@ def inference_loader_pair(trainer_pair: TrainPair) -> tuple[TrainConfig, DataLoa
 @contextlib.contextmanager
 def make_loader(
     cfg,
-    time_slice: slice | None = None,
+    time_slice: TimeConfig | None = None,
     drop_last: bool = True,
     version: LoaderVersion = LoaderVersion.OM4_EAGER,
 ) -> Generator[DataLoader, None, None]:
     if time_slice is None:
-        time_slice = cfg.train.time_slice
+        time_slice = cfg.train
 
     raw = DataSource.from_config(cfg)
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -66,8 +66,6 @@ def make_loader(
         )
         val = validate_data(raw)
         wet, wet_surface = extract_wet_mask(val.data, prognostic, cfg.data.hist)
-        wet_without_hist, _ = extract_wet_mask(val.data, prognostic, 0)
-        Normalize.init_instance(val, prognostic, boundary, wet_without_hist)
 
         match version:
             case LoaderVersion.OM4_EAGER:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -66,7 +66,7 @@ def make_loader(
         )
         val = validate_data(raw)
         wet, wet_surface = extract_wet_mask(val.data, prognostic, cfg.data.hist)
-        Normalize.init_instance(val.means, val.stds, prognostic, boundary, wet)
+        Normalize.init_instance(val, prognostic, boundary, wet)
 
         match version:
             case LoaderVersion.OM4_EAGER:
@@ -421,20 +421,21 @@ def traindataset_input():
         coords={"lat": [0], "lon": [0]},
     )
 
+    test = DataSource("test", data, data_mean, data_std)
+
     wet = torch.ones(2, 2, 2)
     wet_surface = torch.ones(2, 2)
 
     # Initialize and yield within the MultitonScope
     with MultitonScope():
         _ = Normalize.init_instance(
-            data_mean=data_mean,
-            data_std=data_std,
+            test,
             prognostic_var_names=["prognostic1", "prognostic2"],
             boundary_var_names=["boundary1", "boundary2"],
             wet_mask=wet,
         )
         traindataset = TrainDataset(
-            data=data,
+            data=test.data,
             prognostic_var_names=prognostic_var_names,
             boundary_var_names=boundary_var_names,
             wet=wet,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -49,12 +49,12 @@ def inference_loader_pair(trainer_pair: TrainPair) -> tuple[TrainConfig, DataLoa
 @contextlib.contextmanager
 def make_loader(
     cfg,
-    time_slice: TimeConfig | None = None,
+    time_config: TimeConfig | None = None,
     drop_last: bool = True,
     version: LoaderVersion = LoaderVersion.OM4_EAGER,
 ) -> Generator[DataLoader, None, None]:
-    if time_slice is None:
-        time_slice = cfg.train
+    if time_config is None:
+        time_config = cfg.train
 
     use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
     raw = DataSource.from_config(cfg, use_dask=use_dask)
@@ -73,7 +73,7 @@ def make_loader(
                 data: ConcatDataset | InferenceDataset = ConcatDataset(
                     [
                         TrainDataset(
-                            src=src.slice(time_slice),
+                            src=src.slice(time_config),
                             prognostic_var_names=prognostic,
                             boundary_var_names=boundary,
                             wet=wet,
@@ -90,7 +90,7 @@ def make_loader(
                 data = ConcatDataset(
                     [
                         TorchTrainDataset(
-                            src=src.slice(time_slice),
+                            src=src.slice(time_config),
                             prognostic_var_names=prognostic,
                             boundary_var_names=boundary,
                             wet=wet,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -29,7 +29,12 @@ from ocean_emulators.datasets import (
     TrainData,
     TrainDataset,
 )
-from ocean_emulators.utils.data import Normalize, extract_wet_mask, validate_data
+from ocean_emulators.utils.data import (
+    DataSource,
+    Normalize,
+    extract_wet_mask,
+    validate_data,
+)
 from ocean_emulators.utils.multiton import MultitonScope
 from ocean_emulators.utils.train import collate_train_data
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair
@@ -51,20 +56,7 @@ def make_loader(
     if time_slice is None:
         time_slice = cfg.train.time_slice
 
-    use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
-    if use_dask:
-        chunks: dict[str, int] | None = {}
-    else:
-        chunks = None
-
-    ds = xr.open_dataset(cfg.experiment.data_dir / cfg.data.data_path, chunks=chunks)
-    ds_means = xr.open_dataset(
-        cfg.experiment.data_dir / cfg.data.data_means_path, chunks=chunks
-    )
-    ds_stds = xr.open_dataset(
-        cfg.experiment.data_dir / cfg.data.data_stds_path, chunks=chunks
-    )
-
+    raw = DataSource.from_config(cfg)
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]
     boundary = BOUNDARY_VARS[cfg.experiment.boundary_vars_key]
 
@@ -72,16 +64,16 @@ def make_loader(
         TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
         )
-        ds_, means_, stds_ = validate_data(ds, ds_means, ds_stds)
-        wet, wet_surface = extract_wet_mask(ds_, prognostic, cfg.data.hist)
-        Normalize.init_instance(means_, stds_, prognostic, boundary, wet)
+        val = validate_data(raw)
+        wet, wet_surface = extract_wet_mask(val.data, prognostic, cfg.data.hist)
+        Normalize.init_instance(val.means, val.stds, prognostic, boundary, wet)
 
         match version:
             case LoaderVersion.OM4_EAGER:
                 data: ConcatDataset | InferenceDataset = ConcatDataset(
                     [
                         TrainDataset(
-                            data=ds_.sel(time=time_slice),
+                            data=val.data.sel(time=time_slice),
                             prognostic_var_names=prognostic,
                             boundary_var_names=boundary,
                             wet=wet,
@@ -98,7 +90,7 @@ def make_loader(
                 data = ConcatDataset(
                     [
                         TorchTrainDataset(
-                            data=ds_.sel(time=time_slice),
+                            data=val.data.sel(time=time_slice),
                             prognostic_var_names=prognostic,
                             boundary_var_names=boundary,
                             wet=wet,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -56,7 +56,8 @@ def make_loader(
     if time_slice is None:
         time_slice = cfg.train
 
-    raw = DataSource.from_config(cfg)
+    use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
+    raw = DataSource.from_config(cfg, use_dask=use_dask)
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]
     boundary = BOUNDARY_VARS[cfg.experiment.boundary_vars_key]
 

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -73,8 +73,7 @@ def inf_data_init(hist: int):
         )
 
         _ = Normalize.init_instance(
-            data_mean=val.means,
-            data_std=val.stds,
+            val,
             prognostic_var_names=tensor_map.prognostic_var_names,
             boundary_var_names=tensor_map.boundary_var_names,
             wet_mask=wet_without_hist,

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -79,7 +79,7 @@ def inf_data_init(hist: int):
             wet_mask=wet_without_hist,
         )
         inference_dataset = InferenceDataset(
-            val.data,
+            val,
             tensor_map.prognostic_var_names,
             tensor_map.boundary_var_names,
             wet,

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -6,7 +6,12 @@ import xarray as xr
 from ocean_emulators.constants import DEPTH_LEVELS, TensorMap
 from ocean_emulators.datasets import InferenceDataset
 from ocean_emulators.models.base import BaseModel
-from ocean_emulators.utils.data import Normalize, extract_wet_mask, validate_data
+from ocean_emulators.utils.data import (
+    DataSource,
+    Normalize,
+    extract_wet_mask,
+    validate_data,
+)
 from ocean_emulators.utils.multiton import MultitonScope
 
 
@@ -56,21 +61,26 @@ def inf_data_init(hist: int):
                 "lon": np.arange(lons),
             },
         )
-        data_mean = data.mean() * 0.0
-        data_std = data.std() * 0.0 + 1.0
-        data, data_mean, data_std = validate_data(data, data_mean, data_std)
-        wet, wet_surface = extract_wet_mask(data, tensor_map.prognostic_var_names, hist)
-        wet_without_hist, _ = extract_wet_mask(data, tensor_map.prognostic_var_names, 0)
+        data_mean: xr.Dataset = data.mean() * 0.0
+        data_std: xr.Dataset = data.std() * 0.0 + 1.0
+        test_data = DataSource("test-data", data, data_mean, data_std)
+        val = validate_data(test_data)
+        wet, wet_surface = extract_wet_mask(
+            val.data, tensor_map.prognostic_var_names, hist
+        )
+        wet_without_hist, _ = extract_wet_mask(
+            val.data, tensor_map.prognostic_var_names, 0
+        )
 
         _ = Normalize.init_instance(
-            data_mean=data_mean,
-            data_std=data_std,
+            data_mean=val.means,
+            data_std=val.stds,
             prognostic_var_names=tensor_map.prognostic_var_names,
             boundary_var_names=tensor_map.boundary_var_names,
             wet_mask=wet_without_hist,
         )
         inference_dataset = InferenceDataset(
-            data,
+            val.data,
             tensor_map.prognostic_var_names,
             tensor_map.boundary_var_names,
             wet,

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -238,12 +238,14 @@ def data_init(hist: int):
         )
         data_mean = data.mean() * 0.0
         data_std = data.std() * 0.0 + 1.0
-        data, data_mean, data_std = validate_data(data, data_mean, data_std)
-        wet_without_hist, _ = extract_wet_mask(data, tensor_map.prognostic_var_names, 0)
+        src = DataSource("test", data, data_mean, data_std)
+        val = validate_data(src)
+        wet_without_hist, _ = extract_wet_mask(
+            val.data, tensor_map.prognostic_var_names, 0
+        )
 
         normalize = Normalize.init_instance(
-            data_mean=data_mean,
-            data_std=data_std,
+            val,
             prognostic_var_names=tensor_map.prognostic_var_names,
             boundary_var_names=tensor_map.boundary_var_names,
             wet_mask=wet_without_hist,

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -8,6 +8,7 @@ from scipy.stats import pearsonr
 
 from ocean_emulators.constants import DEPTH_LEVELS, TensorMap
 from ocean_emulators.utils.data import (
+    DataSource,
     Normalize,
     compute_anomalies,
     extract_wet_mask,
@@ -117,7 +118,11 @@ def test_compute_anomalies():
     ds_std = ds.std().compute()
 
     # compute anomalies
-    anomalies, _, _ = compute_anomalies(ds, ds_mean, ds_std, ("thetao_0_anomalies",))
+
+    anom = compute_anomalies(
+        DataSource("test", ds, ds_mean, ds_std), ("thetao_0_anomalies",)
+    )
+    anomalies = anom.data
     anomalies_np = anomalies["thetao_0_anomalies"].to_numpy()
     anomalies_np_flat = anomalies_np[0][0]
 

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -153,6 +153,8 @@ def normalize_input():
         coords={"lat": [0], "lon": [0]},
     )
 
+    # Warning: the 'data' field is not used because this test tries to test
+    # normalization which only needs mean and std. Thus, we set it to `data_mean`.
     test = DataSource("test", data_mean, data_mean, data_std)
 
     # Create test wet mask

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -153,13 +153,14 @@ def normalize_input():
         coords={"lat": [0], "lon": [0]},
     )
 
+    test = DataSource("test", data_mean, data_mean, data_std)
+
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
     # Initialize Normalize instance
     with MultitonScope():
         normalize = Normalize.init_instance(
-            data_mean=data_mean,
-            data_std=data_std,
+            test,
             prognostic_var_names=["var_0", "var_1"],
             boundary_var_names=["var_2"],
             wet_mask=wet_mask,


### PR DESCRIPTION
This makes progress towards #190. Specifically, this PR argues that the three Xarray datasets (data, means, stds) are actually part of the same concern, one that is fundamentally related to normalization. I anticipate that this affordance will make it easier to modify core aspects to the data loader in the future. In particular, the addition of the `DataSource.filter()` method should provide a single entry point to add data compaction support -- see #215 (initially prototyped in #175). In addition, this change should make #208 trivial to implement.

Fixes #218.