### PR TITLE
Enable upgrade lints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
 ]
 
 [tool.ruff]
-lint.select = [ "D", "E", "F", "I", "W" ]
+lint.select = [ "D", "E", "F", "I", "UP", "W" ]
 # F722: https://docs.kidger.site/jaxtyping/faq/#flake8-or-ruff-are-throwing-an-error
 lint.ignore = [
   "D1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ lint.ignore = [
   "E402",
   "F541",
   "F722",
+  "UP038", # This rule is deprecated.
   "W293",
 ]
 lint.per-file-ignores."*/__init__.py" = [ "F401" ]

--- a/src/ocean_emulators/aggregator/inference/main.py
+++ b/src/ocean_emulators/aggregator/inference/main.py
@@ -1,5 +1,3 @@
-from typing import Dict, List, Optional, Union
-
 import torch
 import wandb
 import xarray as xr
@@ -21,7 +19,7 @@ class InferenceEvaluatorAggregator:
     def __init__(
         self,
         n_timesteps: int,
-        metadata: Dict[str, Dict[str, str]],
+        metadata: dict[str, dict[str, str]],
         hist: int,
         area_weights: torch.Tensor,
         wet: torch.Tensor,
@@ -29,7 +27,7 @@ class InferenceEvaluatorAggregator:
         record_step_20: bool = True,
         log_global_mean_time_series: bool = True,
         log_global_mean_norm_time_series: bool = True,
-        time_mean_reference_data: Optional[xr.Dataset] = None,
+        time_mean_reference_data: xr.Dataset | None = None,
     ):
         """
         Args:
@@ -46,10 +44,10 @@ class InferenceEvaluatorAggregator:
                 time series metrics.
             time_mean_reference_data: Reference time means for computing bias stats.
         """
-        self._aggregators: Dict[
+        self._aggregators: dict[
             str, MeanAggregator | OneStepMeanAggregator | TimeMeanEvaluatorAggregator
         ] = {}
-        self._time_dependent_aggregators: Dict[str, TimeMeanEvaluatorAggregator] = {}
+        self._time_dependent_aggregators: dict[str, TimeMeanEvaluatorAggregator] = {}
         self._log_time_series = (
             log_global_mean_time_series or log_global_mean_norm_time_series
         )
@@ -232,7 +230,7 @@ def to_inference_logs(log):
     for val in log.values():
         if isinstance(val, wandb.Table):
             n_rows = max(n_rows, len(val.data))
-    logs: List[Dict[str, Union[float, int]]] = []
+    logs: list[dict[str, float | int]] = []
     for i in range(max(1, n_rows)):  # need at least one for non-series values
         logs.append({})
     for key, val in log.items():

--- a/src/ocean_emulators/aggregator/inference/reduced.py
+++ b/src/ocean_emulators/aggregator/inference/reduced.py
@@ -1,7 +1,7 @@
 import dataclasses
 from collections import defaultdict
 from functools import partial
-from typing import Dict, List, Literal, Optional, Protocol
+from typing import Literal, Protocol
 
 import numpy as np
 import torch
@@ -29,7 +29,7 @@ class _SeriesData:
         return f"{self.metric_name}/{self.var_name}"
 
 
-def get_gen_shape(gen_data: Dict[str, torch.Tensor]):
+def get_gen_shape(gen_data: dict[str, torch.Tensor]):
     for name in gen_data:
         return gen_data[name].shape
 
@@ -119,7 +119,7 @@ class AreaWeightedReducedMetric:
         n_timesteps: int,
     ):
         self._compute_metric = compute_metric
-        self._total: Optional[torch.Tensor] = None
+        self._total: torch.Tensor | None = None
         self._n_batches = torch.zeros(
             n_timesteps, dtype=torch.int32, device=get_device()
         )
@@ -164,9 +164,9 @@ class MeanAggregator:
         target: Literal["norm", "denorm"],
         n_timesteps: int,
         area_weights: torch.Tensor,
-        metadata: Optional[Dict[str, Dict[str, str]]] = None,
+        metadata: dict[str, dict[str, str]] | None = None,
     ):
-        self._variable_metrics: Optional[Dict[str, Dict[str, MeanMetric]]] = None
+        self._variable_metrics: dict[str, dict[str, MeanMetric]] | None = None
         self._shape_x = None
         self._shape_y = None
         self._target = target
@@ -174,11 +174,11 @@ class MeanAggregator:
         self._area_weights = area_weights
 
         if metadata is None:
-            self._metadata: Dict[str, Dict[str, str]] = {}
+            self._metadata: dict[str, dict[str, str]] = {}
         else:
             self._metadata = metadata
 
-    def _get_variable_metrics(self, gen_data: Dict[str, torch.Tensor]):
+    def _get_variable_metrics(self, gen_data: dict[str, torch.Tensor]):
         if self._variable_metrics is None:
             self._variable_metrics = {}
 
@@ -255,10 +255,10 @@ class MeanAggregator:
     @torch.no_grad()
     def record_batch(
         self,
-        target_data: Dict[str, torch.Tensor],
-        gen_data: Dict[str, torch.Tensor],
-        target_data_norm: Dict[str, torch.Tensor],
-        gen_data_norm: Dict[str, torch.Tensor],
+        target_data: dict[str, torch.Tensor],
+        gen_data: dict[str, torch.Tensor],
+        target_data_norm: dict[str, torch.Tensor],
+        gen_data_norm: dict[str, torch.Tensor],
         i_time_start: int = 0,
     ):
         if self._target == "norm":
@@ -273,11 +273,11 @@ class MeanAggregator:
                     i_time_start=i_time_start,
                 )
 
-    def _get_series_data(self, step_slice: Optional[slice] = None) -> List[_SeriesData]:
+    def _get_series_data(self, step_slice: slice | None = None) -> list[_SeriesData]:
         """Converts internally stored variable_metrics to a list."""
         if self._variable_metrics is None:
             raise ValueError("No batches have been recorded.")
-        data: List[_SeriesData] = []
+        data: list[_SeriesData] = []
         for metric in self._variable_metrics:
             sorted_keys = sorted(list(self._variable_metrics[metric].keys()))
             for key in sorted_keys:
@@ -293,7 +293,7 @@ class MeanAggregator:
         return data
 
     @torch.no_grad()
-    def get_logs(self, label: str, step_slice: Optional[slice] = None):
+    def get_logs(self, label: str, step_slice: slice | None = None):
         """
         Returns logs as can be reported to WandB.
 
@@ -302,7 +302,7 @@ class MeanAggregator:
             step_slice: Slice of forecast steps to log.
         """
         logs = {}
-        series_data: Dict[str, np.ndarray] = {
+        series_data: dict[str, np.ndarray] = {
             datum.get_wandb_key(): datum.data
             for datum in self._get_series_data(step_slice)
         }
@@ -312,7 +312,7 @@ class MeanAggregator:
         return logs
 
 
-def data_to_table(data: Dict[str, np.ndarray], init_step: int = 0) -> wandb.Table:
+def data_to_table(data: dict[str, np.ndarray], init_step: int = 0) -> wandb.Table:
     """
     Convert a dictionary of 1-dimensional timeseries data to a wandb Table.
 
@@ -343,7 +343,7 @@ class AreaWeightedSingleTargetReducedMetric:
         n_timesteps: int,
     ):
         self._compute_metric = compute_metric
-        self._total: Optional[torch.Tensor] = None
+        self._total: torch.Tensor | None = None
         self._n_batches = torch.zeros(
             n_timesteps, dtype=torch.int32, device=get_device()
         )
@@ -378,21 +378,21 @@ class SingleTargetMeanAggregator:
         self,
         n_timesteps: int,
         area_weights: torch.Tensor,
-        metadata: Optional[Dict[str, Dict[str, str]]] = None,
+        metadata: dict[str, dict[str, str]] | None = None,
     ):
-        self._variable_metrics: Optional[
-            Dict[str, Dict[str, SingleTargetMeanMetric]]
-        ] = None
+        self._variable_metrics: dict[str, dict[str, SingleTargetMeanMetric]] | None = (
+            None
+        )
         self._shape_x = None
         self._shape_y = None
         self._n_timesteps = n_timesteps
         self._area_weights = area_weights
         if metadata is None:
-            self._metadata: Dict[str, Dict[str, str]] = {}
+            self._metadata: dict[str, dict[str, str]] = {}
         else:
             self._metadata = metadata
 
-    def _get_variable_metrics(self, gen_data: Dict[str, torch.Tensor]):
+    def _get_variable_metrics(self, gen_data: dict[str, torch.Tensor]):
         if self._variable_metrics is None:
             self._variable_metrics = {
                 "weighted_mean_gen": {},
@@ -420,7 +420,7 @@ class SingleTargetMeanAggregator:
     @torch.no_grad()
     def record_batch(
         self,
-        data: Dict[str, torch.Tensor],
+        data: dict[str, torch.Tensor],
         i_time_start: int = 0,
     ):
         variable_metrics = self._get_variable_metrics(data)
@@ -431,11 +431,11 @@ class SingleTargetMeanAggregator:
                     i_time_start=i_time_start,
                 )
 
-    def _get_series_data(self, step_slice: Optional[slice] = None) -> List[_SeriesData]:
+    def _get_series_data(self, step_slice: slice | None = None) -> list[_SeriesData]:
         """Converts internally stored variable_metrics to a list."""
         if self._variable_metrics is None:
             raise ValueError("No batches have been recorded.")
-        data: List[_SeriesData] = []
+        data: list[_SeriesData] = []
         for metric in self._variable_metrics:
             sorted_keys = sorted(list(self._variable_metrics[metric].keys()))
             for key in sorted_keys:
@@ -451,7 +451,7 @@ class SingleTargetMeanAggregator:
         return data
 
     @torch.no_grad()
-    def get_logs(self, label: str, step_slice: Optional[slice] = None) -> Metrics:
+    def get_logs(self, label: str, step_slice: slice | None = None) -> Metrics:
         """
         Returns logs as can be reported to WandB.
 
@@ -460,7 +460,7 @@ class SingleTargetMeanAggregator:
             step_slice: Slice of forecast steps to log.
         """
         logs = {}
-        series_data: Dict[str, np.ndarray] = {
+        series_data: dict[str, np.ndarray] = {
             datum.get_wandb_key(): datum.data
             for datum in self._get_series_data(step_slice)
         }

--- a/src/ocean_emulators/aggregator/inference/time_mean.py
+++ b/src/ocean_emulators/aggregator/inference/time_mean.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Dict, List, Literal, Optional
+from typing import Literal
 
 import matplotlib.pyplot as plt
 import torch
@@ -49,7 +49,7 @@ class _TargetGenPair:
         )
 
 
-def get_gen_shape(gen_data: Dict[str, torch.Tensor]):
+def get_gen_shape(gen_data: dict[str, torch.Tensor]):
     for name in gen_data:
         return gen_data[name].shape
 
@@ -64,8 +64,8 @@ class TimeMeanAggregator:
         self,
         area_weights: torch.Tensor,
         target: Literal["norm", "denorm"] = "denorm",
-        metadata: Optional[Dict[str, Dict[str, str]]] = None,
-        reference_means: Optional[xr.Dataset] = None,
+        metadata: dict[str, dict[str, str]] | None = None,
+        reference_means: xr.Dataset | None = None,
     ):
         """
         Args:
@@ -79,23 +79,23 @@ class TimeMeanAggregator:
         """
         self._target = target
         if metadata is None:
-            self._metadata: Dict[str, Dict[str, str]] = {}
+            self._metadata: dict[str, dict[str, str]] = {}
         else:
             self._metadata = metadata
         # Dictionaries of tensors of shape [n_lat, n_lon] represnting time means
-        self._data: Optional[Dict[str, torch.Tensor]] = None
+        self._data: dict[str, torch.Tensor] | None = None
         self._n_timesteps = 0
-        self._n_samples: Optional[int] = None
+        self._n_samples: int | None = None
         self._reference_means = reference_means
         self._reference_validated = False
         self._area_weights = area_weights
 
     @staticmethod
     def _add_or_initialize_time_mean(
-        maybe_dict: Optional[Dict[str, torch.Tensor]],
-        new_data: Dict[str, torch.Tensor],
+        maybe_dict: dict[str, torch.Tensor] | None,
+        new_data: dict[str, torch.Tensor],
         ignore_initial: bool = False,
-    ) -> Dict[str, torch.Tensor]:
+    ) -> dict[str, torch.Tensor]:
         sample_dim = 0
         time_dim = 1
         if ignore_initial:
@@ -103,7 +103,7 @@ class TimeMeanAggregator:
         else:
             time_slice = slice(0, None)
         if maybe_dict is None:
-            d: Dict[str, torch.Tensor] = {
+            d: dict[str, torch.Tensor] = {
                 name: tensor[:, time_slice].sum(dim=time_dim).sum(dim=sample_dim)
                 for name, tensor in new_data.items()
             }
@@ -116,7 +116,7 @@ class TimeMeanAggregator:
     @torch.no_grad()
     def record_batch(
         self,
-        data: Dict[str, torch.Tensor],
+        data: dict[str, torch.Tensor],
         i_time_start: int = 0,
     ):
         ignore_initial = i_time_start == 0
@@ -137,7 +137,7 @@ class TimeMeanAggregator:
                 self.get_logs(label="")
             self._reference_validated = True
 
-    def get_data(self) -> Dict[str, torch.Tensor]:
+    def get_data(self) -> dict[str, torch.Tensor]:
         if self._n_timesteps == 0 or self._data is None:
             raise ValueError("No data recorded.")
 
@@ -226,9 +226,9 @@ class TimeMeanEvaluatorAggregator:
         self,
         area_weights: torch.Tensor,
         target: Literal["norm", "denorm"] = "denorm",
-        metadata: Optional[Dict[str, Dict[str, str]]] = None,
-        reference_means: Optional[xr.Dataset] = None,
-        channel_mean_names: Optional[List[str]] = None,
+        metadata: dict[str, dict[str, str]] | None = None,
+        reference_means: xr.Dataset | None = None,
+        channel_mean_names: list[str] | None = None,
     ):
         """
         Args:
@@ -244,7 +244,7 @@ class TimeMeanEvaluatorAggregator:
         """
         self._target = target
         if metadata is None:
-            self._metadata: Dict[str, Dict[str, str]] = {}
+            self._metadata: dict[str, dict[str, str]] = {}
         else:
             self._metadata = metadata
         self._area_weights = area_weights
@@ -263,10 +263,10 @@ class TimeMeanEvaluatorAggregator:
     @torch.no_grad()
     def record_batch(
         self,
-        target_data: Dict[str, torch.Tensor],
-        gen_data: Dict[str, torch.Tensor],
-        target_data_norm: Dict[str, torch.Tensor],
-        gen_data_norm: Dict[str, torch.Tensor],
+        target_data: dict[str, torch.Tensor],
+        gen_data: dict[str, torch.Tensor],
+        target_data_norm: dict[str, torch.Tensor],
+        gen_data_norm: dict[str, torch.Tensor],
         i_time_start: int = 0,
     ):
         if self._target == "norm":
@@ -275,7 +275,7 @@ class TimeMeanEvaluatorAggregator:
         self._target_agg.record_batch(target_data, i_time_start)
         self._gen_agg.record_batch(gen_data, i_time_start)
 
-    def _get_target_gen_pairs(self) -> List[_TargetGenPair]:
+    def _get_target_gen_pairs(self) -> list[_TargetGenPair]:
         target_data = self._target_agg.get_data()
         gen_data = self._gen_agg.get_data()
 

--- a/src/ocean_emulators/aggregator/loss.py
+++ b/src/ocean_emulators/aggregator/loss.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import torch
 
 from ocean_emulators.constants import TensorMap
@@ -14,13 +12,13 @@ class LossAggregator(Multiton):
     that are initialized every epoch.
     """
 
-    def _initialize(self, loss_scale: Dict[str, float] = {}):
+    def _initialize(self, loss_scale: dict[str, float] = {}):
         self.tensor_map = TensorMap.get_instance()
         self.loss_scale = loss_scale
 
     def get_depth_loss_dict(
         self, label: str, loss_per_channel: torch.Tensor
-    ) -> Dict[str, torch.Tensor]:
+    ) -> dict[str, torch.Tensor]:
         metrics = {}
         for depth in self.tensor_map.DEPTH_SET:
             metrics[f"{label}/loss/depth/depth_{depth}_loss"] = loss_per_channel[
@@ -30,7 +28,7 @@ class LossAggregator(Multiton):
 
     def get_variable_loss_dict(
         self, label: str, loss_per_channel: torch.Tensor
-    ) -> Dict[str, torch.Tensor]:
+    ) -> dict[str, torch.Tensor]:
         metrics = {}
         for variable in self.tensor_map.VAR_SET:
             metrics[f"{label}/loss/variable/{variable}_loss"] = loss_per_channel[
@@ -40,7 +38,7 @@ class LossAggregator(Multiton):
 
     def get_channel_loss_dict(
         self, label: str, loss_per_channel: torch.Tensor
-    ) -> Dict[str, torch.Tensor]:
+    ) -> dict[str, torch.Tensor]:
         metrics = {}
         for i, channel in enumerate(self.tensor_map.prognostic_var_names):
             metrics[f"{label}/loss/channel/{channel}_loss"] = loss_per_channel[i]

--- a/src/ocean_emulators/aggregator/main.py
+++ b/src/ocean_emulators/aggregator/main.py
@@ -4,8 +4,6 @@ The code in this directory is directly inspired by the ACE project by AI2.
 See the original repository at: https://github.com/ai2cm/ace/tree/39133c18524cda85965486ecdc8cb64aac06f4c3/fme/fme/ace/aggregator
 """
 
-from typing import Dict
-
 import torch
 
 from ocean_emulators.aggregator.inference import InferenceEvaluatorAggregator
@@ -20,7 +18,7 @@ class Aggregator:
 
     @staticmethod
     def get_validation_aggregator(
-        metadata: Dict[str, Dict[str, str]],
+        metadata: dict[str, dict[str, str]],
         hist: int,
         area_weights: torch.Tensor,
         wet: torch.Tensor,
@@ -37,7 +35,7 @@ class Aggregator:
     @staticmethod
     def get_inline_inference_aggregator(
         n_timesteps: int,
-        metadata: Dict[str, Dict[str, str]],
+        metadata: dict[str, dict[str, str]],
         hist: int,
         area_weights: torch.Tensor,
         wet: torch.Tensor,
@@ -58,7 +56,7 @@ class Aggregator:
     @staticmethod
     def get_standalone_inference_aggregator(
         n_timesteps: int,
-        metadata: Dict[str, Dict[str, str]],
+        metadata: dict[str, dict[str, str]],
         hist: int,
         area_weights: torch.Tensor,
         wet: torch.Tensor,

--- a/src/ocean_emulators/aggregator/metrics.py
+++ b/src/ocean_emulators/aggregator/metrics.py
@@ -1,11 +1,9 @@
-from typing import Optional
-
 import torch
 
 
 def weighted_mean(
     tensor: torch.Tensor,
-    weights: Optional[torch.Tensor] = None,
+    weights: torch.Tensor | None = None,
     dim: tuple[int, ...] = (-2, -1),
     keepdim: bool = False,
 ) -> torch.Tensor:
@@ -78,7 +76,7 @@ def gradient_magnitude(
 
 def weighted_mean_gradient_magnitude(
     tensor: torch.Tensor,
-    weights: Optional[torch.Tensor] = None,
+    weights: torch.Tensor | None = None,
     dim: tuple[int, ...] = (-2, -1),
 ) -> torch.Tensor:
     """Compute weighted mean of gradient magnitude across the specified dimensions."""
@@ -88,7 +86,7 @@ def weighted_mean_gradient_magnitude(
 def gradient_magnitude_percent_diff(
     target: torch.Tensor,
     gen: torch.Tensor,
-    weights: Optional[torch.Tensor] = None,
+    weights: torch.Tensor | None = None,
     dim: tuple[int, ...] = (-2, -1),
 ) -> torch.Tensor:
     """Compute the percent difference of the weighted mean gradient magnitude across

--- a/src/ocean_emulators/aggregator/validate/main.py
+++ b/src/ocean_emulators/aggregator/validate/main.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import torch
 
 from ocean_emulators.aggregator.loss import LossAggregator
@@ -18,7 +16,7 @@ class ValidateAggregator(TrainAggregator):
 
     def __init__(
         self,
-        metadata: Dict[str, Dict[str, str]],
+        metadata: dict[str, dict[str, str]],
         hist: int,
         area_weights: torch.Tensor,
         wet: torch.Tensor,
@@ -111,7 +109,7 @@ class ValidateAggregator(TrainAggregator):
 
     def _get_loss_scaled_mse_components(
         self,
-        validation_metrics: Dict[str, float],
+        validation_metrics: dict[str, float],
         label: str,
     ):
         """

--- a/src/ocean_emulators/aggregator/validate/map.py
+++ b/src/ocean_emulators/aggregator/validate/map.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import torch
 
 from ocean_emulators.aggregator.plotting import plot_paneled_data
@@ -22,17 +20,17 @@ class MapAggregator(ValidateSubAggregator):
         ),
     }
 
-    def __init__(self, metadata: Dict[str, Dict[str, str]] = {}, hist: int = 0):
+    def __init__(self, metadata: dict[str, dict[str, str]] = {}, hist: int = 0):
         """
         Args:
             metadata: Mapping of variable names their metadata that will
                 used in generating logged image captions.
             hist: Number of history steps to include in the snapshot.
         """
-        self._metadata: Dict[str, Dict[str, str]] = metadata
+        self._metadata: dict[str, dict[str, str]] = metadata
         self._n_batches = 0
-        self._target_data: Dict[str, torch.Tensor] = {}
-        self._gen_data: Dict[str, torch.Tensor] = {}
+        self._target_data: dict[str, torch.Tensor] = {}
+        self._gen_data: dict[str, torch.Tensor] = {}
         self.hist = hist
 
     @torch.no_grad()

--- a/src/ocean_emulators/aggregator/validate/reduced.py
+++ b/src/ocean_emulators/aggregator/validate/reduced.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from functools import partial
-from typing import Callable, Dict, Optional
 
 import numpy as np
 import torch
@@ -57,7 +57,7 @@ class MeanAggregator(ValidateSubAggregator):
 
     def __init__(self, area_weights: torch.Tensor, target_time: int):
         self._n_batches = 0
-        self._variable_metrics: Optional[Dict] = None
+        self._variable_metrics: dict | None = None
         self._target_time = target_time
         self._area_weights = area_weights
 
@@ -107,8 +107,8 @@ class MeanAggregator(ValidateSubAggregator):
         gen_data,
         target_data_norm,
         gen_data_norm,
-        input_data: Dict[str, torch.Tensor] = {},
-        input_data_norm: Dict[str, torch.Tensor] = {},
+        input_data: dict[str, torch.Tensor] = {},
+        input_data_norm: dict[str, torch.Tensor] = {},
         i_time_start: int = 0,
     ):
         variable_metrics = self._get_variable_metrics(gen_data)
@@ -130,13 +130,13 @@ class MeanAggregator(ValidateSubAggregator):
     def _get_data(self):
         if self._variable_metrics is None or self._n_batches == 0:
             raise ValueError("No batches have been recorded.")
-        data: Dict[str, torch.Tensor] = {}
+        data: dict[str, torch.Tensor] = {}
         for metric in self._variable_metrics:
             for key in self._variable_metrics[metric]:
                 data[f"{metric}/{key}"] = (
                     self._variable_metrics[metric][key].get() / self._n_batches
                 )
-        meaned_data: Dict[str, float] = {}
+        meaned_data: dict[str, float] = {}
         for key in sorted(data.keys()):
             meaned_data[key] = float(all_reduce_mean(data[key].detach()).cpu().numpy())
         return meaned_data

--- a/src/ocean_emulators/aggregator/validate/snapshot.py
+++ b/src/ocean_emulators/aggregator/validate/snapshot.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import torch
 
 from ocean_emulators.aggregator.plotting import plot_paneled_data
@@ -27,14 +25,14 @@ class SnapshotAggregator(ValidateSubAggregator):
         ),
     }
 
-    def __init__(self, metadata: Dict[str, Dict[str, str]] = {}, hist: int = 0):
+    def __init__(self, metadata: dict[str, dict[str, str]] = {}, hist: int = 0):
         """
         Args:
             metadata: Mapping of variable names their metadata that will
                 used in generating logged image captions.
             hist: Number of history steps to include in the snapshot.
         """
-        self._metadata: Dict[str, Dict[str, str]] = metadata
+        self._metadata: dict[str, dict[str, str]] = metadata
         self.hist = hist
 
     @torch.no_grad()

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
-from typing import Any, List, Literal, Optional
+from typing import Any, Literal
 
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
 from ocean_emulators.constants import LoaderVersion
@@ -11,9 +11,9 @@ class WandBConfig(BaseConfig):
     mode: str = "disabled"  # online, disabled
     project: str = "3D_ocean_emu_CM4"
     entity: str = "suryadheeshjith"
-    group: Optional[str] = None
-    tags: Optional[List[str]] = None
-    notes: Optional[str] = None
+    group: str | None = None
+    tags: list[str] | None = None
+    notes: str | None = None
 
 
 class TimeConfig(BaseConfig):
@@ -29,7 +29,7 @@ class DataConfig(BaseConfig):
     data_path: str = "CM4_5daily_v0.4.0"
     data_means_path: str = "CM4_5daily_v0.4.0_means"
     data_stds_path: str = "CM4_5daily_v0.4.0_stds"
-    scaling_residuals_file: Optional[str] = None
+    scaling_residuals_file: str | None = None
     time_delta: int = 5
     num_workers: int = 4
     hist: int = 1
@@ -50,7 +50,7 @@ class BlockConfig(BaseConfig):
 
 
 class CorrectorConfig(BaseConfig):
-    non_negative_corrector_names: Optional[List[str]] = None
+    non_negative_corrector_names: list[str] | None = None
 
 
 DownSamplingBlocks = Literal["avg_pool", "max_pool"]
@@ -58,14 +58,14 @@ UpSamplingBlocks = Literal["bilinear_upsample", "transposed_conv"]
 
 
 class SamudraConfig(BaseConfig):
-    ch_width: List[int] = [157, 200, 250, 300, 400]
+    ch_width: list[int] = [157, 200, 250, 300, 400]
     n_out: int = 77
-    dilation: List[int] = [1, 2, 4, 8]
-    n_layers: List[int] = [1, 1, 1, 1]
+    dilation: list[int] = [1, 2, 4, 8]
+    n_layers: list[int] = [1, 1, 1, 1]
     pred_residuals: bool = False
     last_kernel_size: int = 3
     pad: str = "circular"
-    wet: Optional[Any] = None
+    wet: Any | None = None
 
     # Block configurations
     core_block: BlockConfig = BlockConfig()
@@ -75,11 +75,11 @@ class SamudraConfig(BaseConfig):
 
 
 class DistributedConfig(BaseConfig):
-    dist_url: Optional[str] = None
-    world_size: Optional[int] = None
-    rank: Optional[int] = None
-    gpu: Optional[int] = None
-    dist_backend: Optional[str] = None
+    dist_url: str | None = None
+    world_size: int | None = None
+    rank: int | None = None
+    gpu: int | None = None
+    dist_backend: str | None = None
 
 
 class ExperimentConfig(BaseConfig):
@@ -145,7 +145,7 @@ class TrainConfig(TopLevelConfig):
     scheduler: bool = False
     loss: LossType = "mse"
     finetune: bool = False
-    resume_ckpt_path: Optional[str] = None
+    resume_ckpt_path: str | None = None
     debug: bool = False
     test_using_ema: bool = True
     ema_decay: float = 0.999
@@ -154,13 +154,13 @@ class TrainConfig(TopLevelConfig):
 
     # Data parameters at root level
     data_percent: float = 1.0
-    data_stride: List[int] = [1]
-    steps: List[int] = [4]
-    step_transition: List[int] = []
-    inference_epochs: List[int] = [-1]
+    data_stride: list[int] = [1]
+    steps: list[int] = [4]
+    step_transition: list[int] = []
+    inference_epochs: list[int] = [-1]
     train_time: TimeConfig = TimeConfig(start="151-01-06", end="306-01-01")
     val_time: TimeConfig = TimeConfig(start="306-01-01", end="311-01-01")
-    inference_times: List[TimeConfig] = []
+    inference_times: list[TimeConfig] = []
 
     # Config components
     experiment: ExperimentConfig

--- a/src/ocean_emulators/config_base.py
+++ b/src/ocean_emulators/config_base.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import textwrap
 from pathlib import Path
-from typing import Any, Optional, Self
+from typing import Any, Self
 
 import yaml
 from pydantic import BaseModel, ConfigDict
@@ -27,7 +27,7 @@ def register_include_constructor():
                 "To support includes, you must load a file object, not a string"
             )
         filename = os.path.normpath(os.path.join(os.path.dirname(name), node.value))
-        with open(filename, "r") as f:
+        with open(filename) as f:
             return yaml.safe_load(f)
 
     # This is arguably unsafe, but we don't parse untrusted YAML
@@ -70,7 +70,7 @@ class TopLevelConfig(BaseSettings):
     @classmethod
     def from_yaml_and_cli(
         cls,
-        args_to_parse: Optional[list[str]] = None,
+        args_to_parse: list[str] | None = None,
     ) -> Self:
         """Load config from YAML & CLI with validation."""
         parser = argparse.ArgumentParser(
@@ -128,6 +128,6 @@ class IncludeYamlCliSettingsSource(CliSettingsSource):
         self, field_name: str, field: FieldInfo, value: Any
     ) -> Any:
         if isinstance(value, str) and value.startswith("@"):
-            with open(value[1:], "r") as f:
+            with open(value[1:]) as f:
                 return yaml.safe_load(f)
         return super().decode_complex_value(field_name, field, value)

--- a/src/ocean_emulators/config_schema.py
+++ b/src/ocean_emulators/config_schema.py
@@ -3,7 +3,6 @@ import json
 import re
 import sys
 from pathlib import Path
-from typing import Type
 
 import pydantic
 import yaml
@@ -12,9 +11,9 @@ from ocean_emulators.config import EvalConfig, TrainConfig
 
 
 def get_pydantic_models(
-    model: Type[pydantic.BaseModel],
-    seen: dict[str, Type[pydantic.BaseModel]] | None = None,
-) -> dict[str, Type[pydantic.BaseModel]]:
+    model: type[pydantic.BaseModel],
+    seen: dict[str, type[pydantic.BaseModel]] | None = None,
+) -> dict[str, type[pydantic.BaseModel]]:
     """Recursively find all Pydantic models in a model's fields.
 
     Args:
@@ -43,7 +42,7 @@ def get_pydantic_models(
 
 def generate_schemas(
     output_dir: Path,
-    models: dict[str, Type[pydantic.BaseModel]],
+    models: dict[str, type[pydantic.BaseModel]],
 ) -> None:
     """Generate JSON schemas for all Pydantic models and save them to output_dir.
 
@@ -72,7 +71,7 @@ def generate_schemas(
 
 def validate_config_files(
     config_dir: Path,
-    models: dict[str, Type[pydantic.BaseModel]],
+    models: dict[str, type[pydantic.BaseModel]],
 ) -> bool:
     """Validate YAML configuration files against their Pydantic models.
 
@@ -87,7 +86,7 @@ def validate_config_files(
 
     for yaml_file in yaml_files:
         # Read the YAML file
-        with open(yaml_file, "r") as f:
+        with open(yaml_file) as f:
             yaml_content = f.read()
 
         # Extract the schema path from the YAML file's first line
@@ -106,7 +105,7 @@ def validate_config_files(
 
         # Load and validate the YAML content
         try:
-            with open(yaml_file, "r") as f:
+            with open(yaml_file) as f:
                 config = yaml.safe_load(f)
                 # Validate using Pydantic model
                 models[schema_name].model_validate(config)

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -1,6 +1,6 @@
 import enum
 import logging
-from typing import Dict, TypeAlias, TypeVar
+from typing import TypeAlias, TypeVar
 
 import torch
 import xarray as xr
@@ -32,7 +32,7 @@ GridMask = Bool[Array, "180 360"]
 PrognosticMask = Bool[GridMask, "prognostic_vars"]
 
 SingleChannelVar = Float[torch.Tensor, "batch time lat lon"]
-DictSingleChannelVar = Dict[str, SingleChannelVar]
+DictSingleChannelVar = dict[str, SingleChannelVar]
 SinglePrognostic = Float[Grid, "*batch"]
 SinglePrognosticTimeSeries = Float[Grid, "*batch time"]
 
@@ -178,7 +178,7 @@ DEFAULT_METADATA = {
 }
 
 
-def construct_metadata(data: xr.Dataset) -> Dict[str, Dict[str, str]]:
+def construct_metadata(data: xr.Dataset) -> dict[str, dict[str, str]]:
     metadata = {}
     for var in data.variables:
         try:
@@ -216,8 +216,8 @@ class TensorMap(Multiton):
         DP_3D_IDX maps the depth levels to their indices in the input tensor
         """
         self.prognostic_vars_key = prognostic_vars_key
-        self.VAR_3D_IDX: Dict[str, torch.Tensor] = {}
-        self.DP_3D_IDX: Dict[str, torch.Tensor] = {}
+        self.VAR_3D_IDX: dict[str, torch.Tensor] = {}
+        self.DP_3D_IDX: dict[str, torch.Tensor] = {}
 
         self.VAR_SET_2D = []
         self.VAR_SET_3D = []
@@ -231,7 +231,7 @@ class TensorMap(Multiton):
         # Consistent order of variables
         self.VAR_SET = list(
             dict.fromkeys(
-                ([out.split("_")[0] for out in PROGNOSTIC_VARS[prognostic_vars_key]])
+                [out.split("_")[0] for out in PROGNOSTIC_VARS[prognostic_vars_key]]
             )
         )
         self.DEPTH_SET = DEPTH_I_LEVELS

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -79,11 +79,8 @@ class InferenceDataset(Dataset):
 
         if long_rollout:
             logging.info(
-                "Long rollout will use input at time {0} and produce"
-                " output at {1}".format(
-                    data.time.values[0],
-                    data.time.values[self.hist + 1],
-                )
+                f"Long rollout will use input at time {data.time.values[0]} and produce"
+                f" output at {data.time.values[self.hist + 1]}"
             )
 
         self.wet: torch.Tensor = wet.bool()

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -1,7 +1,6 @@
 # TODO: Need to return step-wise losses for logging
 
 import logging
-from typing import Union
 
 import torch
 
@@ -34,7 +33,7 @@ class BaseModel(torch.nn.Module):
         self,
         train_data: TrainData,
         loss_fn=None,
-    ) -> Union[torch.Tensor, list[torch.Tensor]]:
+    ) -> torch.Tensor | list[torch.Tensor]:
         outputs: list[torch.Tensor] = []
         loss = torch.tensor(torch.nan)
         for step in range(len(train_data)):

--- a/src/ocean_emulators/models/corrector.py
+++ b/src/ocean_emulators/models/corrector.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 import numpy as np
 import torch
 from einops import rearrange
@@ -12,7 +10,7 @@ class Corrector(torch.nn.Module):
     def __init__(self, corrector_config, hist):
         super().__init__()
         self.corrector_config = corrector_config
-        self.non_negative_corrector_names: Optional[List[str]] = (
+        self.non_negative_corrector_names: list[str] | None = (
             corrector_config.non_negative_corrector_names
         )
         self.tensor_map: TensorMap = TensorMap.get_instance()

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 import torch.nn as nn

--- a/src/ocean_emulators/models/modules/factory.py
+++ b/src/ocean_emulators/models/modules/factory.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import torch.nn as nn
 
 from ocean_emulators.models.modules.activations import CappedGELU, ReLU
@@ -51,7 +49,7 @@ def create_upsample(block_type: str, **kwargs) -> nn.Module:
     return UPSAMPLE_REGISTRY[block_type](**kwargs)
 
 
-def get_activation_cl(activation_type: str) -> Type[nn.Module]:
+def get_activation_cl(activation_type: str) -> type[nn.Module]:
     if activation_type not in ACTIVATION_REGISTRY:
         raise ValueError(f"Unknown activation type: {activation_type}")
     return ACTIVATION_REGISTRY[activation_type]

--- a/src/ocean_emulators/stepper.py
+++ b/src/ocean_emulators/stepper.py
@@ -1,6 +1,6 @@
 import logging
+from collections.abc import Callable
 from os import PathLike
-from typing import Callable, Optional
 
 import torch
 
@@ -58,8 +58,8 @@ class Stepper:
         dataset: InferenceDataset,
         inf_aggregator: InferenceEvaluatorAggregator,
         epoch: int,
-        output_dir: Optional[str | PathLike] = None,
-        model_path: Optional[str | PathLike] = None,
+        output_dir: str | PathLike | None = None,
+        model_path: str | PathLike | None = None,
         num_model_steps_forward: int = 200,
         save_zarr: bool = False,
     ) -> None:

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -8,8 +8,9 @@ import logging
 import os
 import time
 import warnings
+from collections.abc import Callable, Sequence
 from functools import partial
-from typing import Any, Callable, Sequence, assert_never
+from typing import Any, assert_never
 
 import dask
 import numpy as np
@@ -465,7 +466,7 @@ class Trainer:
         train_aggregator = Aggregator.get_train_aggregator()
         metric_logger = MetricLogger(delimiter="  ")
         metric_logger.add_meter("lr", SmoothedValue(window_size=1, fmt="{value:.6f}"))
-        header = "Training Epoch: [{}]".format(epoch)
+        header = f"Training Epoch: [{epoch}]"
         # iters = len(self.train_loader)
         for data_iter_step, data in enumerate(
             metric_logger.log_every(self.train_loader, 1, header)
@@ -533,7 +534,7 @@ class Trainer:
             self.num_out,
         )
         metric_logger = MetricLogger(delimiter="  ")
-        header = "One-Step Validation Epoch: [{}]".format(epoch)
+        header = f"One-Step Validation Epoch: [{epoch}]"
 
         with torch.no_grad(), self._test_context():
             for data_iter_step, data in enumerate(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
-from typing import Callable, Literal, Self
+from collections.abc import Callable
+from typing import Literal, Self
 
 import cftime
 import numpy as np

--- a/src/ocean_emulators/utils/distributed.py
+++ b/src/ocean_emulators/utils/distributed.py
@@ -34,7 +34,7 @@ def suppress_prints(is_master):
         force = force or (get_world_size() > 8)
         if is_master or force:
             now = datetime.datetime.now().time()
-            builtin_print("[{}] ".format(now), end="")  # print with time stamp
+            builtin_print(f"[{now}] ", end="")  # print with time stamp
             builtin_print(*args, **kwargs)
 
     builtins.print = print

--- a/src/ocean_emulators/utils/ema.py
+++ b/src/ocean_emulators/utils/ema.py
@@ -27,7 +27,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from typing import Iterable, List
+from collections.abc import Iterable
 
 import torch
 from torch import nn
@@ -79,7 +79,7 @@ class EMATracker:
                 self._module_name_to_ema_name.update({name: ema_name})
                 self._ema_params[ema_name] = p.clone().detach().data
 
-        self._stored_params: List[torch.Tensor] = []
+        self._stored_params: list[torch.Tensor] = []
 
     def __call__(self, model: Samudra | nn.parallel.DistributedDataParallel):
         """

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -121,7 +121,7 @@ class MetricLogger:
                 continue
             if isinstance(v, torch.Tensor):
                 v = v.item()
-            assert isinstance(v, float | int)
+            assert isinstance(v, (float, int))
             self.meters[k].update(v, n=n)
 
     def __getattr__(self, attr):

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -60,7 +60,7 @@ def handle_warnings():
     warnings.showwarning = warning_handler
 
 
-class SmoothedValue(object):
+class SmoothedValue:
     """Track a series of values and provide access to smoothed values over a
     window or the global series average.
     """
@@ -110,7 +110,7 @@ class SmoothedValue(object):
         )
 
 
-class MetricLogger(object):
+class MetricLogger:
     def __init__(self, delimiter="\t"):
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
@@ -121,7 +121,7 @@ class MetricLogger(object):
                 continue
             if isinstance(v, torch.Tensor):
                 v = v.item()
-            assert isinstance(v, (float, int))
+            assert isinstance(v, float | int)
             self.meters[k].update(v, n=n)
 
     def __getattr__(self, attr):
@@ -130,13 +130,13 @@ class MetricLogger(object):
         if attr in self.__dict__:
             return self.__dict__[attr]
         raise AttributeError(
-            "'{}' object has no attribute '{}'".format(type(self).__name__, attr)
+            f"'{type(self).__name__}' object has no attribute '{attr}'"
         )
 
     def __str__(self):
         loss_str = []
         for name, meter in self.meters.items():
-            loss_str.append("{}: {}".format(name, str(meter)))
+            loss_str.append(f"{name}: {str(meter)}")
         return self.delimiter.join(loss_str)
 
     def add_meter(self, name, meter):
@@ -208,9 +208,8 @@ class MetricLogger(object):
         total_time = time.perf_counter() - start_time
         total_time_str = str(datetime.timedelta(seconds=int(total_time)))
         logging.info(
-            "{} Total time: {} ({:.4f} s / it)".format(
-                header, total_time_str, total_time / len(iterable)
-            )
+            f"{header} Total time: {total_time_str} "
+            f"({total_time / len(iterable):.4f} s / it)"
         )
 
 

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -1,6 +1,6 @@
+from collections.abc import Sequence
 from itertools import tee
 from pathlib import Path
-from typing import Sequence, Tuple
 
 import torch
 from xarray_einstats.einops import rearrange  # noqa: F401
@@ -31,7 +31,7 @@ def collate_train_data(data: Sequence[TrainData]) -> TrainData:
 
 def collate_inference_data(
     data: Sequence[InferenceDataset],
-) -> Tuple[InferenceDataset, int]:
+) -> tuple[InferenceDataset, int]:
     # TODO: There is probably a better way to do inference batching
     assert len(data) == 1, "Inference batch size must be 1"
     return data[0][0], data[0][1]

--- a/src/ocean_emulators/utils/wandb.py
+++ b/src/ocean_emulators/utils/wandb.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, Dict, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -13,7 +14,7 @@ from ocean_emulators.utils.multiton import Multiton
 Metrics = Mapping[str, float | torch.Tensor | WBValue]
 
 # Same as above but mutable when you're building something up
-MetricsDict = Dict[str, float | torch.Tensor | WBValue]
+MetricsDict = dict[str, float | torch.Tensor | WBValue]
 
 
 class WandBLogger(Multiton):
@@ -149,8 +150,8 @@ class WandBLogger(Multiton):
         loss_value: float,
         loss_per_channel: torch.Tensor,
         outputs: list,
-        depth_indices: Dict,
-        var_indices: Dict,
+        depth_indices: dict,
+        var_indices: dict,
         depth_set: list,
         var_set: list,
         step: int,

--- a/src/ocean_emulators/utils/writer.py
+++ b/src/ocean_emulators/utils/writer.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Any
 
 import torch
 import xarray as xr
@@ -14,7 +14,7 @@ class ZarrWriter:
     def __init__(
         self,
         output_dir: str | os.PathLike,
-        coords: Dict[str, xr.DataArray],
+        coords: dict[str, xr.DataArray],
         hist: int,
         model_path: str | os.PathLike,
     ):
@@ -55,7 +55,7 @@ class ZarrWriter:
         if self.time_buffer is None:
             raise ValueError("No time buffer to write")
 
-        coords: Dict[str, Any] = {k: v for k, v in self.coords.items()}
+        coords: dict[str, Any] = {k: v for k, v in self.coords.items()}
         coords["time"] = self.time_buffer
         ds = xr.Dataset(
             data_vars={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@ import dataclasses
 import pathlib
 import random
 import time
-from typing import ClassVar, Generator
+from collections.abc import Generator
+from typing import ClassVar, Self
 
 import cftime
 import numpy as np
@@ -10,7 +11,6 @@ import pytest
 import xarray as xr
 from aiohttp import ServerDisconnectedError
 from numpy.typing import ArrayLike, NDArray
-from typing_extensions import Self
 
 import ocean_emulators.constants as c
 from ocean_emulators.config import TrainBackendConfig, TrainConfig
@@ -384,11 +384,9 @@ def data_source(request, pytestconfig) -> DataSource:
             # matches the mock data) is about 30 items.
 
             data = retry_with_backoff(
-                (
-                    lambda: xr.open_zarr(REMOTE_DATA + "OM4", chunks=dict(time=50))
-                    .sel(time=slice("1975-08-05", "1976-03-31"))
-                    .compute()
-                )
+                lambda: xr.open_zarr(REMOTE_DATA + "OM4", chunks=dict(time=50))
+                .sel(time=slice("1975-08-05", "1976-03-31"))
+                .compute()
             )
             means = retry_with_backoff(
                 lambda: xr.open_dataset(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,7 +3,7 @@
 import contextlib
 import datetime
 import os
-from typing import Callable, Generator
+from collections.abc import Callable, Generator
 
 import cftime
 import numpy as np

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -226,7 +226,7 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     pred = model.forward_once(input_tensor)
     assert pred.shape == (1, num_prognostic_channels, 1, 1)
     expected_pred = torch.tensor(
-        [2 * hist + 1 + 2 * i * 10 for i in range((hist + 1))], device=pred.device
+        [2 * hist + 1 + 2 * i * 10 for i in range(hist + 1)], device=pred.device
     )
     assert torch.equal(pred.flatten(), expected_pred)
 
@@ -236,7 +236,7 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     )
     assert merged_input_tensor.shape == (1, num_input_channels, 1, 1)
     expected_merged_input = torch.tensor(
-        [2 * hist + 1 + 2 * i * 10 for i in range((hist + 1))]
+        [2 * hist + 1 + 2 * i * 10 for i in range(hist + 1)]
         + [(merge_step + 1) * (num_prognostic_channels * 2) - 1],
         device=merged_input_tensor.device,
     )


### PR DESCRIPTION
On #210, @alxmrs was leaving comments about using `Union` rather than modern`|`, and there are a variety of related things like dict/list vs Dict/List and so on. I think either we should enforce these upgrade (`UPXXXXX`) lints with ruff (which is this PR) or else not worry about it. I'm honestly fine with either so opening this to have the discussion. 

This also turns on warnings about using `"".format` rather than f-strings, older import paths, inheriting from `object`, using `open(foo, "r")` rather than `open(foo)` and others. Full list is here https://docs.astral.sh/ruff/rules/#pyupgrade-up. 

All these fixes were automated (and therefore should be safe) except for one I will call out below.