### PR TITLE
Use dask for inference

### DIFF
--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -164,6 +164,11 @@ class Trainer:
         self.src = validate_data(raw)
         self.data = self.src.data
 
+        # We use dask for inference since it has memory issues otherwise.
+        # TODO(jder): Could rewrite inference dataset like we did for TorchTrainDataset
+        # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/208
+        self.inference_src = validate_data(DataSource.from_config(cfg, use_dask=True))
+
         self.metadata = construct_metadata(self.data)
         self.wet, self.wet_surface = extract_wet_mask(
             self.data, self.prognostic_var_names, cfg.data.hist
@@ -365,7 +370,7 @@ class Trainer:
                 hist=self.hist,
             )
             inference_dataset = InferenceDataset(
-                src=self.src.slice(self.inference_times[i]),
+                src=self.inference_src.slice(self.inference_times[i]),
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 wet=self.wet_without_hist_cpu,


### PR DESCRIPTION
Fixes memory issues with the torch loader, fixes #208. 

After this, the torch and eager loaders have the same peak memory usage during inference. The issue was that the non-dask version was using about 3x the memory of the dask version and getting OOM killed. This is due to a combination of the InferenceDataset not being written with eager evaluation in mind (eg slicing repeatedly) and due to what look like some pretty bad performance bugs in xarray. (It was allocating a ton of memory to lazily track reorderings of the data rather than eagerly shuffling the arrays -- kinda looks like 6x more than the underlying arrays but I could have misread and don't think it's worth digging into this more now.) (And to add insult to injury, the shuffle in question was the identity transform…)