### PR TITLE
Log data wait time and data load times separately

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Any
 
 import numpy as np
@@ -22,7 +23,7 @@ from ocean_emulators.constants import (
 )
 from ocean_emulators.utils.data import DataSource
 from ocean_emulators.utils.device import get_device, using_gpu
-from ocean_emulators.utils.logging import elapsed
+from ocean_emulators.utils.logging import LoadStats, elapsed
 
 logger = logging.getLogger(__name__)
 
@@ -268,6 +269,7 @@ class InferenceDatasets(Dataset):
 class TrainData:
     def __init__(self, num_prognostic_channels: int):
         self.td_dict: dict[int, Example] = {}
+        self.load_stats: LoadStats | None = None
         self.num_prognostic_channels = num_prognostic_channels
         self.steps = 0
 
@@ -391,6 +393,7 @@ class TrainDataset(Dataset):
 
     @elapsed(level=logging.DEBUG)
     def __getitem__(self, idx: int):
+        start_time = time.perf_counter()
         TD = TrainData(self.num_prognostic_channels)
         prev_rolling_idx = None
         for step in range(self.steps):
@@ -409,6 +412,8 @@ class TrainDataset(Dataset):
                 input_=data_combined,
                 label=label,
             )
+
+        TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
         return TD
 
@@ -599,6 +604,7 @@ class TorchTrainDataset(Dataset):
 
     @elapsed(level=logging.DEBUG)
     def __getitem__(self, idx: int):
+        start_time = time.perf_counter()
         TD = TrainData(self.num_prognostic_channels)
         x_indexes = [self._get_x_index(idx, step) for step in range(self.steps)]
         x_index = xr.concat(x_indexes, dim="step")
@@ -625,6 +631,7 @@ class TorchTrainDataset(Dataset):
                 label=label[i],
             )
 
+        TD.load_stats = LoadStats(time.perf_counter() - start_time)
         return TD
 
     def _get_input_and_label(

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -13,6 +13,7 @@ from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 from ocean_emulators.constants import (
     Boundary,
     BoundaryVarNames,
+    Example,
     GridMask,
     Input,
     LoaderVersion,
@@ -20,7 +21,7 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import DataSource, LoadStats, TrainData
+from ocean_emulators.utils.data import DataSource, LoadStats
 from ocean_emulators.utils.device import get_device, using_gpu
 from ocean_emulators.utils.logging import elapsed
 
@@ -263,6 +264,47 @@ class InferenceDatasets(Dataset):
 
     def __getitem__(self, idx):
         return (self.datasets[idx], self.lengths[idx])
+
+
+class TrainData:
+    def __init__(self, num_prognostic_channels: int):
+        self.td_dict: dict[int, Example] = {}
+        self.load_stats: LoadStats | None = None
+        self.num_prognostic_channels = num_prognostic_channels
+        self.steps = 0
+
+    def insert(self, input_: Input, label: Prognostic):
+        self.td_dict[self.steps] = (input_, label)
+        self.steps += 1
+
+    def get_initial_input(self) -> Input:
+        return self.td_dict[0][0]
+
+    def get_input(self, step: int) -> Input:
+        return self.td_dict[step][0]
+
+    def get_label(self, step: int) -> Prognostic:
+        return self.td_dict[step][1]
+
+    def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
+        input, _ = self.td_dict[step]
+        merged = input.clone()
+        merged[:, : self.num_prognostic_channels] = prognostic
+        return merged
+
+    def __getitem__(self, step: int) -> Example:
+        """Converts index (step) into (data, label) tuple."""
+        return self.td_dict[step]
+
+    def __len__(self) -> int:
+        return self.steps
+
+    def to(self, device: torch.device) -> None:
+        for step in self.td_dict:
+            self.td_dict[step] = (
+                self.td_dict[step][0].to(device),
+                self.td_dict[step][1].to(device),
+            )
 
 
 class TrainDataset(Dataset):

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -20,9 +20,9 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import DataSource, TrainData
+from ocean_emulators.utils.data import DataSource, LoadStats, TrainData
 from ocean_emulators.utils.device import get_device, using_gpu
-from ocean_emulators.utils.logging import LoadStats, elapsed
+from ocean_emulators.utils.logging import elapsed
 
 logger = logging.getLogger(__name__)
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -13,7 +13,6 @@ from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 from ocean_emulators.constants import (
     Boundary,
     BoundaryVarNames,
-    Example,
     GridMask,
     Input,
     LoaderVersion,
@@ -21,7 +20,7 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import DataSource
+from ocean_emulators.utils.data import DataSource, TrainData
 from ocean_emulators.utils.device import get_device, using_gpu
 from ocean_emulators.utils.logging import LoadStats, elapsed
 
@@ -264,47 +263,6 @@ class InferenceDatasets(Dataset):
 
     def __getitem__(self, idx):
         return (self.datasets[idx], self.lengths[idx])
-
-
-class TrainData:
-    def __init__(self, num_prognostic_channels: int):
-        self.td_dict: dict[int, Example] = {}
-        self.load_stats: LoadStats | None = None
-        self.num_prognostic_channels = num_prognostic_channels
-        self.steps = 0
-
-    def insert(self, input_: Input, label: Prognostic):
-        self.td_dict[self.steps] = (input_, label)
-        self.steps += 1
-
-    def get_initial_input(self) -> Input:
-        return self.td_dict[0][0]
-
-    def get_input(self, step: int) -> Input:
-        return self.td_dict[step][0]
-
-    def get_label(self, step: int) -> Prognostic:
-        return self.td_dict[step][1]
-
-    def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
-        input, _ = self.td_dict[step]
-        merged = input.clone()
-        merged[:, : self.num_prognostic_channels] = prognostic
-        return merged
-
-    def __getitem__(self, step: int) -> Example:
-        """Converts index (step) into (data, label) tuple."""
-        return self.td_dict[step]
-
-    def __len__(self) -> int:
-        return self.steps
-
-    def to(self, device: torch.device) -> None:
-        for step in self.td_dict:
-            self.td_dict[step] = (
-                self.td_dict[step][0].to(device),
-                self.td_dict[step][1].to(device),
-            )
 
 
 class TrainDataset(Dataset):

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -524,7 +524,10 @@ class Trainer:
                         label="train", loss_per_channel=loss_per_channel_reduce
                     ),
                     "train/batch/data_load_time": metric_logger.meters[
-                        "data_time"
+                        "data_load_time"
+                    ].value,
+                    "train/batch/data_wait_time": metric_logger.meters[
+                        "data_wait_time"
                     ].value,
                 }
             if (it_time := metric_logger.meters["iter_time"]).count > 0:

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -348,8 +348,8 @@ class Trainer:
         self.inference_sampler: DistributedSampler | RandomSampler
 
         # Add type annotations for loaders
-        self.train_loader: DataLoader
-        self.val_loader: DataLoader
+        self.train_loader: DataLoader[TrainData]
+        self.val_loader: DataLoader[TrainData]
         self.inference_loader: DataLoader
 
     def init_inference_stores(self):

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -27,7 +27,6 @@ from ocean_emulators.constants import (
     SingleTimeSeriesOutput,
     TensorMap,
 )
-from ocean_emulators.utils.logging import LoadStats
 from ocean_emulators.utils.multiton import Multiton
 
 
@@ -473,6 +472,15 @@ class Normalize(Multiton):
         unnorm = torch.where(self.wet_mask.to(data.device) == 0, fill_value, unnorm)
         unnorm = unnorm.to(data.dtype)
         return unnorm
+
+
+@dataclasses.dataclass
+class LoadStats:
+    load_time_seconds: float
+
+    @classmethod
+    def accumulated(cls, stats: list["LoadStats"]) -> "LoadStats":
+        return cls(sum(s.load_time_seconds for s in stats))
 
 
 class TrainData:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -476,10 +476,12 @@ class Normalize(Multiton):
 
 @dataclasses.dataclass
 class LoadStats:
+    """Captures stats about loading a single TrainData object."""
     load_time_seconds: float
 
     @classmethod
     def accumulated(cls, stats: list["LoadStats"]) -> "LoadStats":
+        """Accumulate the stats across multiple LoadStats objects in a batch."""
         return cls(sum(s.load_time_seconds for s in stats))
 
 

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -17,7 +17,6 @@ from ocean_emulators.constants import (
     BatchTimeSeriesOutput,
     BoundaryVarNames,
     DictSingleChannelVar,
-    Example,
     Grid,
     GridMask,
     Input,
@@ -484,44 +483,3 @@ class LoadStats:
     def accumulated(cls, stats: list["LoadStats"]) -> "LoadStats":
         """Accumulate the stats across multiple LoadStats objects in a batch."""
         return cls(sum(s.load_time_seconds for s in stats))
-
-
-class TrainData:
-    def __init__(self, num_prognostic_channels: int):
-        self.td_dict: dict[int, Example] = {}
-        self.load_stats: LoadStats | None = None
-        self.num_prognostic_channels = num_prognostic_channels
-        self.steps = 0
-
-    def insert(self, input_: Input, label: Prognostic):
-        self.td_dict[self.steps] = (input_, label)
-        self.steps += 1
-
-    def get_initial_input(self) -> Input:
-        return self.td_dict[0][0]
-
-    def get_input(self, step: int) -> Input:
-        return self.td_dict[step][0]
-
-    def get_label(self, step: int) -> Prognostic:
-        return self.td_dict[step][1]
-
-    def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
-        input, _ = self.td_dict[step]
-        merged = input.clone()
-        merged[:, : self.num_prognostic_channels] = prognostic
-        return merged
-
-    def __getitem__(self, step: int) -> Example:
-        """Converts index (step) into (data, label) tuple."""
-        return self.td_dict[step]
-
-    def __len__(self) -> int:
-        return self.steps
-
-    def to(self, device: torch.device) -> None:
-        for step in self.td_dict:
-            self.td_dict[step] = (
-                self.td_dict[step][0].to(device),
-                self.td_dict[step][1].to(device),
-            )

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -477,6 +477,7 @@ class Normalize(Multiton):
 @dataclasses.dataclass
 class LoadStats:
     """Captures stats about loading a single TrainData object."""
+
     load_time_seconds: float
 
     @classmethod

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -17,6 +17,7 @@ from ocean_emulators.constants import (
     BatchTimeSeriesOutput,
     BoundaryVarNames,
     DictSingleChannelVar,
+    Example,
     Grid,
     GridMask,
     Input,
@@ -26,6 +27,7 @@ from ocean_emulators.constants import (
     SingleTimeSeriesOutput,
     TensorMap,
 )
+from ocean_emulators.utils.logging import LoadStats
 from ocean_emulators.utils.multiton import Multiton
 
 
@@ -471,3 +473,44 @@ class Normalize(Multiton):
         unnorm = torch.where(self.wet_mask.to(data.device) == 0, fill_value, unnorm)
         unnorm = unnorm.to(data.dtype)
         return unnorm
+
+
+class TrainData:
+    def __init__(self, num_prognostic_channels: int):
+        self.td_dict: dict[int, Example] = {}
+        self.load_stats: LoadStats | None = None
+        self.num_prognostic_channels = num_prognostic_channels
+        self.steps = 0
+
+    def insert(self, input_: Input, label: Prognostic):
+        self.td_dict[self.steps] = (input_, label)
+        self.steps += 1
+
+    def get_initial_input(self) -> Input:
+        return self.td_dict[0][0]
+
+    def get_input(self, step: int) -> Input:
+        return self.td_dict[step][0]
+
+    def get_label(self, step: int) -> Prognostic:
+        return self.td_dict[step][1]
+
+    def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
+        input, _ = self.td_dict[step]
+        merged = input.clone()
+        merged[:, : self.num_prognostic_channels] = prognostic
+        return merged
+
+    def __getitem__(self, step: int) -> Example:
+        """Converts index (step) into (data, label) tuple."""
+        return self.td_dict[step]
+
+    def __len__(self) -> int:
+        return self.steps
+
+    def to(self, device: torch.device) -> None:
+        for step in self.td_dict:
+            self.td_dict[step] = (
+                self.td_dict[step][0].to(device),
+                self.td_dict[step][1].to(device),
+            )

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -8,22 +8,12 @@ import traceback
 import warnings
 from collections import defaultdict, deque
 from collections.abc import Sequence
-from dataclasses import dataclass
 
 import numpy as np
 import torch
 from torchinfo import summary
 
 from ocean_emulators.utils.data import TrainData
-
-
-@dataclass
-class LoadStats:
-    load_time_seconds: float
-
-    @classmethod
-    def accumulated(cls, stats: list["LoadStats"]) -> "LoadStats":
-        return cls(sum(s.load_time_seconds for s in stats))
 
 
 def handle_logging(cfg):

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -7,10 +7,10 @@ import time
 import traceback
 import warnings
 from collections import defaultdict, deque
-from collections.abc import Sequence
 
 import numpy as np
 import torch
+from torch.utils.data import DataLoader
 from torchinfo import summary
 
 from ocean_emulators.utils.data import TrainData
@@ -146,7 +146,7 @@ class MetricLogger:
     def add_meter(self, name, meter):
         self.meters[name] = meter
 
-    def log_every(self, iterable: Sequence[TrainData], print_freq, header=None):
+    def log_every(self, iterable: DataLoader[TrainData], print_freq, header=None):
         i = 0
         if not header:
             header = ""

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -7,13 +7,15 @@ import time
 import traceback
 import warnings
 from collections import defaultdict, deque
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 from torch.utils.data import DataLoader
 from torchinfo import summary
 
-from ocean_emulators.utils.data import TrainData
+if TYPE_CHECKING:
+    from ocean_emulators.datasets import TrainData
 
 
 def handle_logging(cfg):
@@ -146,7 +148,7 @@ class MetricLogger:
     def add_meter(self, name, meter):
         self.meters[name] = meter
 
-    def log_every(self, data_loader: DataLoader[TrainData], print_freq, header=None):
+    def log_every(self, data_loader: DataLoader["TrainData"], print_freq, header=None):
         i = 0
         if not header:
             header = ""

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -146,7 +146,7 @@ class MetricLogger:
     def add_meter(self, name, meter):
         self.meters[name] = meter
 
-    def log_every(self, iterable: DataLoader[TrainData], print_freq, header=None):
+    def log_every(self, data_loader: DataLoader[TrainData], print_freq, header=None):
         i = 0
         if not header:
             header = ""
@@ -162,7 +162,7 @@ class MetricLogger:
         self.meters["iter_time"] = iter_time
         self.meters["data_wait_time"] = data_wait_time
         self.meters["data_load_time"] = data_load_time
-        space_fmt = ":" + str(len(str(len(iterable)))) + "d"
+        space_fmt = ":" + str(len(str(len(data_loader)))) + "d"
         log_msg_list: list[str] = [
             header,
             "[{0" + space_fmt + "}/{1}]",
@@ -175,14 +175,14 @@ class MetricLogger:
         log_msg = self.delimiter.join(log_msg_list)
         KB = 1024.0
         MB = 1024.0 * 1024.0
-        for obj in iterable:
+        for obj in data_loader:
             data_wait_time.update(time.perf_counter() - end)
             if obj.load_stats is not None:
                 data_load_time.update(obj.load_stats.load_time_seconds)
             yield obj
             iter_time.update(time.perf_counter() - end)
-            if i % print_freq == 0 or i == len(iterable) - 1:
-                eta_seconds = iter_time.global_avg * (len(iterable) - i)
+            if i % print_freq == 0 or i == len(data_loader) - 1:
+                eta_seconds = iter_time.global_avg * (len(data_loader) - i)
                 eta_string = str(datetime.timedelta(seconds=int(eta_seconds)))
                 named_metrics = dict(
                     eta=eta_string,
@@ -192,14 +192,14 @@ class MetricLogger:
                 if torch.cuda.is_available():
                     named_metrics["gpu_memory"] = torch.cuda.max_memory_allocated() / MB
 
-                logging.info(log_msg.format(i, len(iterable), **named_metrics))
+                logging.info(log_msg.format(i, len(data_loader), **named_metrics))
             i += 1
             end = time.perf_counter()
         total_time = time.perf_counter() - start_time
         total_time_str = str(datetime.timedelta(seconds=int(total_time)))
         logging.info(
             f"{header} Total time: {total_time_str} "
-            f"({total_time / len(iterable):.4f} s / it)"
+            f"({total_time / len(data_loader):.4f} s / it)"
         )
 
 

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -7,10 +7,20 @@ import time
 import traceback
 import warnings
 from collections import defaultdict, deque
+from dataclasses import dataclass
 
 import numpy as np
 import torch
 from torchinfo import summary
+
+
+@dataclass
+class LoadStats:
+    load_time_seconds: float
+
+    @classmethod
+    def accumulated(cls, stats: list["LoadStats"]) -> "LoadStats":
+        return cls(sum(s.load_time_seconds for s in stats))
 
 
 def handle_logging(cfg):
@@ -150,17 +160,21 @@ class MetricLogger:
         start_time = time.perf_counter()
         end = time.perf_counter()
         iter_time = SmoothedValue(fmt="{value:.3f}({avg:.3f})", window_size=print_freq)
-        data_time = SmoothedValue(fmt="{value:.3f}({avg:.3f})", window_size=print_freq)
+        data_wait_time = SmoothedValue(
+            fmt="{value:.3f}({avg:.3f})", window_size=print_freq
+        )
+        data_load_time = SmoothedValue(
+            fmt="{value:.3f}({avg:.3f})", window_size=print_freq
+        )
         self.meters["iter_time"] = iter_time
-        self.meters["data_time"] = data_time
+        self.meters["data_wait_time"] = data_wait_time
+        self.meters["data_load_time"] = data_load_time
         space_fmt = ":" + str(len(str(len(iterable)))) + "d"
         log_msg_list: list[str] = [
             header,
             "[{0" + space_fmt + "}/{1}]",
             "eta: {eta}",
             "{meters}",
-            "time: {time}",
-            "data: {data}",
         ]
         log_msg_list.append("max cpu mem: {cpu_memory:.0f}")
         if torch.cuda.is_available():
@@ -169,7 +183,11 @@ class MetricLogger:
         KB = 1024.0
         MB = 1024.0 * 1024.0
         for obj in iterable:
-            data_time.update(time.perf_counter() - end)
+            data_wait_time.update(time.perf_counter() - end)
+            if hasattr(obj, "load_stats"):
+                stats: LoadStats | None = obj.load_stats
+                if stats is not None:
+                    data_load_time.update(stats.load_time_seconds)
             yield obj
             iter_time.update(time.perf_counter() - end)
             if i % print_freq == 0 or i == len(iterable) - 1:
@@ -178,8 +196,6 @@ class MetricLogger:
                 named_metrics = dict(
                     eta=eta_string,
                     meters=str(self),
-                    time=str(iter_time),
-                    data=str(data_time),
                     cpu_memory=resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / KB,
                 )
                 if torch.cuda.is_available():

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -7,11 +7,14 @@ import time
 import traceback
 import warnings
 from collections import defaultdict, deque
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import numpy as np
 import torch
 from torchinfo import summary
+
+from ocean_emulators.utils.data import TrainData
 
 
 @dataclass
@@ -153,7 +156,7 @@ class MetricLogger:
     def add_meter(self, name, meter):
         self.meters[name] = meter
 
-    def log_every(self, iterable, print_freq, header=None):
+    def log_every(self, iterable: Sequence[TrainData], print_freq, header=None):
         i = 0
         if not header:
             header = ""
@@ -184,10 +187,8 @@ class MetricLogger:
         MB = 1024.0 * 1024.0
         for obj in iterable:
             data_wait_time.update(time.perf_counter() - end)
-            if hasattr(obj, "load_stats"):
-                stats: LoadStats | None = obj.load_stats
-                if stats is not None:
-                    data_load_time.update(stats.load_time_seconds)
+            if obj.load_stats is not None:
+                data_load_time.update(obj.load_stats.load_time_seconds)
             yield obj
             iter_time.update(time.perf_counter() - end)
             if i % print_freq == 0 or i == len(iterable) - 1:

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import torch
 from xarray_einstats.einops import rearrange  # noqa: F401
 
-from ocean_emulators.datasets import InferenceDataset, TrainData
-from ocean_emulators.utils.logging import LoadStats
+from ocean_emulators.datasets import InferenceDataset
+from ocean_emulators.utils.data import TrainData, LoadStats
 
 
 def pairwise(iterable):

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -5,8 +5,8 @@ from pathlib import Path
 import torch
 from xarray_einstats.einops import rearrange  # noqa: F401
 
-from ocean_emulators.datasets import InferenceDataset
-from ocean_emulators.utils.data import LoadStats, TrainData
+from ocean_emulators.datasets import InferenceDataset, TrainData
+from ocean_emulators.utils.data import LoadStats
 
 
 def pairwise(iterable):

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -6,6 +6,7 @@ import torch
 from xarray_einstats.einops import rearrange  # noqa: F401
 
 from ocean_emulators.datasets import InferenceDataset, TrainData
+from ocean_emulators.utils.logging import LoadStats
 
 
 def pairwise(iterable):
@@ -20,6 +21,11 @@ def collate_train_data(data: Sequence[TrainData]) -> TrainData:
     steps = len(data[0])
 
     batched_data = TrainData(num_prognostic_channels)
+
+    stats = LoadStats.accumulated(
+        [d.load_stats for d in data if d.load_stats is not None]
+    )
+    batched_data.load_stats = stats
 
     for step in range(steps):
         input = torch.stack([d.get_input(step) for d in data])

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -6,7 +6,7 @@ import torch
 from xarray_einstats.einops import rearrange  # noqa: F401
 
 from ocean_emulators.datasets import InferenceDataset
-from ocean_emulators.utils.data import TrainData, LoadStats
+from ocean_emulators.utils.data import LoadStats, TrainData
 
 
 def pairwise(iterable):


### PR DESCRIPTION
We now log how much time we spend waiting for data (stalling due to getting ahead of the data loaders, which is what we were logging before) and also how much time the relevant data loader spent loading that data, which is not itself important for overall train time since it's in a separate process and async, but is much more sensitive of a measure for figuring out what is happening with load times. 

example wandb run here: https://wandb.ai/m2lines/ocean-emulators/runs/o3gv8d0k

output looks like this now:

```
2025-04-25 15:18:01,323 - INFO - logging - Training Epoch: [1]  [   0/1412]  eta: 7:19:24  lr: 0.000200  iter_time: 18.672(18.672)  data_wait_time: 9.300(9.300)  data_load_time: 8.747(8.747)  loss: 1.4612 (1.4612)  max cpu mem: 1605  max gpu mem: 30424
2025-04-25 15:18:01,970 - INFO - logging - Training Epoch: [1]  [   1/1412]  eta: 3:47:08  lr: 0.000200  iter_time: 0.645(0.645)  data_wait_time: 0.000(0.000)  data_load_time: 8.745(8.745)  loss: 1.4612 (1.4779)  max cpu mem: 1757  max gpu mem: 30424
2025-04-25 15:18:02,617 - INFO - logging - Training Epoch: [1]  [   2/1412]  eta: 2:36:22  lr: 0.000200  iter_time: 0.646(0.646)  data_wait_time: 0.000(0.000)  data_load_time: 8.736(8.736)  loss: 1.4612 (1.3976)  max cpu mem: 1758  max gpu mem: 30424
2025-04-25 15:18:03,265 - INFO - logging - Training Epoch: [1]  [   3/1412]  eta: 2:00:59  lr: 0.000200  iter_time: 0.647(0.647)  data_wait_time: 0.000(0.000)  data_load_time: 8.748(8.748)  loss: 1.2369 (1.3021)  max cpu mem: 1759  max gpu mem: 30424
2025-04-25 15:18:03,961 - INFO - logging - Training Epoch: [1]  [   4/1412]  eta: 1:39:59  lr: 0.000200  iter_time: 0.695(0.695)  data_wait_time: 0.000(0.000)  data_load_time: 8.854(8.854)  loss: 1.2369 (1.2135)  max cpu mem: 1759  max gpu mem: 30424
2025-04-25 15:18:04,612 - INFO - logging - Training Epoch: [1]  [   5/1412]  eta: 1:25:48  lr: 0.000200  iter_time: 0.649(0.649)  data_wait_time: 0.000(0.000)  data_load_time: 8.747(8.747)  loss: 1.0158 (1.1252)  max cpu mem: 1759  max gpu mem: 30424
2025-04-25 15:18:05,263 - INFO - logging - Training Epoch: [1]  [   6/1412]  eta: 1:15:40  lr: 0.000200  iter_time: 0.650(0.650)  data_wait_time: 0.000(0.000)  data_load_time: 8.748(8.748)  loss: 1.0158 (1.0428)  max cpu mem: 1759  max gpu mem: 30424
```