### PR TITLE
Fix wandb nested config logging

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -192,3 +192,6 @@ class EvalConfig(TopLevelConfig):
 
     def prepare_output_dirs(self) -> None:
         self.experiment.output_dir.mkdir(parents=True, exist_ok=True)
+
+
+AnyTopLevelConfig = TrainConfig | EvalConfig

--- a/src/ocean_emulators/utils/wandb.py
+++ b/src/ocean_emulators/utils/wandb.py
@@ -1,6 +1,5 @@
 import logging
 from collections.abc import Mapping
-from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -8,6 +7,7 @@ import torch
 import wandb
 from wandb.data_types import WBValue
 
+from ocean_emulators.config import AnyTopLevelConfig
 from ocean_emulators.utils.multiton import Multiton
 
 # Metrics supported by wandb -- probably there are more possible types too
@@ -27,7 +27,12 @@ class WandBLogger(Multiton):
     def enabled(self):
         return self._enabled
 
-    def setup_run(self, checkpoint_path: str | None, cfg: Any, finetune: bool = False):
+    def setup_run(
+        self,
+        checkpoint_path: str | None,
+        cfg: AnyTopLevelConfig,
+        finetune: bool = False,
+    ):
         """Set up a wandb run, either resuming from checkpoint or creating new run.
 
         Args:
@@ -52,30 +57,29 @@ class WandBLogger(Multiton):
         if self._enabled:
             try:
                 self.init(
-                    config=cfg.__dict__,
+                    config=cfg.model_dump(),
                     name=wandb_name,
                     dir=cfg.experiment.output_dir,
                     resume="must",
                     id=wandb_id,
-                    **cfg.experiment.wandb.__dict__,
+                    **cfg.experiment.wandb.model_dump(),
                 )
             except Exception:
                 # If resume fails, start new run
                 self.init(
-                    config=cfg.__dict__,
+                    config=cfg.model_dump(),
                     name=wandb_name,
                     dir=cfg.experiment.output_dir,
-                    **cfg.experiment.wandb.__dict__,
+                    **cfg.experiment.wandb.model_dump(),
                 )
 
         return wandb_id, wandb_name
 
-    def _init_new_run(self, cfg: Any):
+    def _init_new_run(self, cfg: AnyTopLevelConfig):
         """Initialize a new wandb run.
 
         Args:
             cfg: Configuration object
-
         Returns:
             tuple: (None, generated_name) for new run
         """
@@ -87,10 +91,10 @@ class WandBLogger(Multiton):
 
         if self._enabled:
             self.init(
-                config=cfg.__dict__,
+                config=cfg.model_dump(),
                 name=wandb_name,
                 dir=cfg.experiment.output_dir,
-                **cfg.experiment.wandb.__dict__,
+                **cfg.experiment.wandb.model_dump(),
             )
 
             wandb_id = self.run.id if self.run else None


### PR DESCRIPTION
The config system broke the nice logging of nested config structures to wandb. For example, see the "data" key in this run:

https://wandb.ai/m2lines/ocean-emulators/runs/2i57cuzt/overview

<img width="667" alt="Screenshot 2025-04-29 at 11 21 59 AM" src="https://github.com/user-attachments/assets/9fa91699-bb21-4d28-882a-87465efc87ac" />


This PR uses pydantic serialization to correctly output nested keys, for example this run:

https://wandb.ai/m2lines/ocean-emulators/runs/twx4knvp/overview

<img width="572" alt="Screenshot 2025-04-29 at 11 22 19 AM" src="https://github.com/user-attachments/assets/574147ee-02fb-4198-b57f-43e756d3b51e" />

Fixes #228 