### PR TITLE
QoL improvements when working on using higher res training data

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -68,8 +68,6 @@ jobs:
         with:
           path: .data_cache/
           key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/*.test.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-data-
 
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           path: .data_cache/
           key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/*.test.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-data-
 
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v5

--- a/configs/data/om4_internal.yaml
+++ b/configs/data/om4_internal.yaml
@@ -3,3 +3,4 @@
 data_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies
 data_means_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies_means
 data_stds_path: 3D_data_OM4_5daily_v0.2.1_with_hfds_anomalies_stds
+static_data_vars: []

--- a/configs/data/public.yaml
+++ b/configs/data/public.yaml
@@ -3,3 +3,4 @@
 data_path: OM4.zarr
 data_means_path: OM4_means.zarr
 data_stds_path: OM4_stds.zarr
+static_data_vars: []

--- a/configs/eval_cm4.yaml
+++ b/configs/eval_cm4.yaml
@@ -4,8 +4,8 @@ debug: true
 save_zarr: true
 disk_mode: true
 inference_time:
-  start: 311-01-01
-  end: 351-01-01
+  start: 0311-01-01
+  end: 0351-01-01
 num_model_steps_forward: 370
 
 experiment:

--- a/configs/gantry_eval_cm4.yaml
+++ b/configs/gantry_eval_cm4.yaml
@@ -4,8 +4,8 @@ debug: false
 save_zarr: true
 disk_mode: true
 inference_time:
-  start: 311-01-01
-  end: 351-01-01
+  start: 0311-01-01
+  end: 0351-01-01
 ckpt_path: /ckpt.pt
 num_model_steps_forward: 370
 

--- a/configs/train_om4_halfdeg.yaml
+++ b/configs/train_om4_halfdeg.yaml
@@ -5,7 +5,7 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 70
-batch_size: 1
+batch_size: 2
 learning_rate: 0.0002
 scheduler: true
 loss: mse
@@ -23,8 +23,9 @@ inference_times:
   - start: "1967-01-01"
     end: "1967-12-29"
 data_stride: [1]
-steps: [1]
+steps: [4]
 step_transition: []
+preemptible: false
 
 backend: auto
 
@@ -38,7 +39,7 @@ experiment:
     project: ocean-emulators
     entity: m2lines
   network: Samudra
-  prognostic_vars_key: thermo_dynamic_5
+  prognostic_vars_key: thermo_dynamic_all
   boundary_vars_key: tau_hfds_hfds_anom
 data:
   !include data/om4_ohc.yaml

--- a/configs/train_om4_halfdeg.yaml
+++ b/configs/train_om4_halfdeg.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=schemas/TrainConfig.json
+
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 70
+batch_size: 1
+learning_rate: 0.0002
+scheduler: true
+loss: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: [-1]
+data_percent: 1.0
+train_time:
+  start: "1958-01-03"
+  end: "1967-12-29"
+val_time:
+  start: "1967-01-01"
+  end: "1967-12-29"
+inference_times:
+  - start: "1967-01-01"
+    end: "1967-12-29"
+data_stride: [1]
+steps: [1]
+step_transition: []
+
+backend: auto
+
+experiment:
+  name: om4_samudra_halfdeg
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  gantry: false
+  wandb:
+    mode: online
+    project: ocean-emulators
+    entity: m2lines
+  network: Samudra
+  prognostic_vars_key: thermo_dynamic_5
+  boundary_vars_key: tau_hfds_hfds_anom
+data:
+  !include data/om4_ohc.yaml
+
+
+samudra:
+  ch_width: [157, 200, 250, 300, 400]
+  n_out: 77
+  dilation: [1, 2, 4, 8]
+  n_layers: [1, 1, 1, 1]
+  pred_residuals: false
+  last_kernel_size: 3
+  pad: "circular"
+
+  core_block:
+    block_type: "conv_next_block"
+    kernel_size: 3
+    activation: "capped_gelu"
+    upscale_factor: 4
+    norm: "batch"
+
+  down_sampling_block: "avg_pool"
+  up_sampling_block: "bilinear_upsample"
+
+  corrector:
+    non_negative_corrector_names: null
+    ocean_heat_corrector: false

--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -74,8 +74,8 @@ def main(args: argparse.Namespace) -> None:
 
     for name, dest_fmt in [
         ("OM4", "zarr"),
-        ("OM4_means", "netcdf"),
-        ("OM4_stds", "netcdf"),
+        ("OM4_means", "zarr"),
+        ("OM4_stds", "zarr"),
     ]:
         dest = os.path.join(args.dest, name)
         source = DATA_ROOT + name
@@ -92,7 +92,9 @@ def main(args: argparse.Namespace) -> None:
 
         with dask.diagnostics.ProgressBar():
             if dest_fmt.lower() == "zarr":
-                data.chunk(output_chunks).to_zarr(dest + ".zarr")
+                if name == "OM4":
+                    data = data.chunk(output_chunks)
+                data.to_zarr(dest + ".zarr")
             else:
                 data.to_netcdf(dest + ".nc")
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -3,9 +3,8 @@ from pathlib import Path
 from typing import Annotated, Any, Literal
 
 import cftime
-from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
-
 import torch
+from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
 
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
 from ocean_emulators.constants import LoaderVersion

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -1,6 +1,9 @@
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
+
+import cftime
+from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
 
 import torch
 
@@ -18,13 +21,56 @@ class WandBConfig(BaseConfig):
     notes: str | None = None
 
 
+class JulianDate:
+    """Represents a Julian date as a cftime.datetime at noon on the relevant day.
+
+    This is the format the OM4 data uses, so we match that here.
+    TODO(jder): probably worth asserting the date format when opening the data.
+    """
+
+    datetime: cftime.datetime
+
+    def __init__(self, s: str):
+        datetime = cftime.datetime.strptime(s, "%Y-%m-%d", calendar="julian")
+        datetime = datetime.replace(hour=12)
+        self.datetime = datetime
+
+    def __str__(self) -> str:
+        return self.datetime.strftime("%Y-%m-%d")
+
+
+def _julian_date_validator(value: str | JulianDate) -> JulianDate:
+    """Pydantic validator which must handle strings or JulianDate objects."""
+    if isinstance(value, str):
+        return JulianDate(value)
+    else:
+        return value
+
+
+"""Represents a Julian date as a string."""
+DateConfig = Annotated[
+    JulianDate,
+    PlainValidator(_julian_date_validator),
+    PlainSerializer(JulianDate.__str__),
+    WithJsonSchema({"type": "string", "format": "date"}),
+]
+
+
 class TimeConfig(BaseConfig):
-    start: str
-    end: str
+    """Represents a time slice of the data.
+
+    Endpoints are Julian dates (not times) but cftime stores them in datetimes.
+    """
+
+    start: DateConfig
+    end: DateConfig
 
     @property
     def time_slice(self) -> slice:
-        return slice(self.start, self.end)
+        return slice(self.start.datetime, self.end.datetime)
+
+    def __str__(self) -> str:
+        return f"{self.start} to {self.end}"
 
 
 class DataConfig(BaseConfig):
@@ -175,8 +221,12 @@ class TrainConfig(TopLevelConfig):
     steps: list[int] = [4]
     step_transition: list[int] = []
     inference_epochs: list[int] = [-1]
-    train_time: TimeConfig = TimeConfig(start="151-01-06", end="306-01-01")
-    val_time: TimeConfig = TimeConfig(start="306-01-01", end="311-01-01")
+    train_time: TimeConfig = TimeConfig(
+        start=JulianDate("0151-01-06"), end=JulianDate("0306-01-01")
+    )
+    val_time: TimeConfig = TimeConfig(
+        start=JulianDate("0306-01-01"), end=JulianDate("0311-01-01")
+    )
     inference_times: list[TimeConfig] = []
 
     # Config components
@@ -205,7 +255,9 @@ class EvalConfig(TopLevelConfig):
     backend: EvalBackendConfig = "auto"
 
     # Config components
-    inference_time: TimeConfig = TimeConfig(start="311-01-01", end="351-01-01")
+    inference_time: TimeConfig = TimeConfig(
+        start=JulianDate("0311-01-01"), end=JulianDate("0351-01-01")
+    )
     experiment: ExperimentConfig
     data: DataConfig
     samudra: SamudraConfig = SamudraConfig()

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -15,7 +15,7 @@ from ocean_emulators.utils.multiton import Multiton
 # Our Arrays will be either `torch.Tensor`s or `xarray.DataArray`s.
 Array = TypeVar("Array", torch.Tensor, xr.DataArray)
 
-Grid = Float[Array, "180 360"]
+Grid = Float[Array, "lat lon"]
 Prognostic = Float[
     Grid, "*batch prognostic_vars"
 ]  # equivalent to "*batch prognostic_vars lat lon"
@@ -28,7 +28,7 @@ Input: TypeAlias = Float[Grid, "*batch total_vars"]
 
 Example = tuple[Input, Prognostic] | tuple[xr.Dataset, xr.Dataset]
 
-GridMask = Bool[Array, "180 360"]
+GridMask = Bool[Array, "lat lon"]
 PrognosticMask = Bool[GridMask, "prognostic_vars"]
 
 SingleChannelVar = Float[torch.Tensor, "batch time lat lon"]

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -194,12 +194,13 @@ class Eval:
         self.model.load_state_dict(new_state_dict)
 
     def init_inference_store(self):
+        sliced_src = self.src.slice(self.inference_time)
         self.num_time_steps = get_inference_steps(
-            self.inference_time,
+            sliced_src,
             hist=self.hist,
         )
         self.inference_dataset = InferenceDataset(
-            src=self.src.slice(self.inference_time),
+            src=sliced_src,
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
             wet=self.wet_without_hist_cpu,

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -425,6 +425,8 @@ class Trainer:
         )
 
     def run(self) -> None:
+        logger.info(f"Starting training")
+        
         self.best_val_loss = 1e8
         self.best_inf_loss = 1e8
         self.wandb_logger.watch(self.model, log="all")

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -426,7 +426,7 @@ class Trainer:
 
     def run(self) -> None:
         logger.info(f"Starting training")
-        
+
         self.best_val_loss = 1e8
         self.best_inf_loss = 1e8
         self.wandb_logger.watch(self.model, log="all")

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -382,12 +382,13 @@ class Trainer:
         inference_datasets = []
         num_steps_inf_set = []
         for i in range(num_splits):
+            sliced_src = self.inference_src.slice(self.inference_times[i])
             num_time_steps = get_inference_steps(
-                self.inference_times[i],
+                sliced_src,
                 hist=self.hist,
             )
             inference_dataset = InferenceDataset(
-                src=self.inference_src.slice(self.inference_times[i]),
+                src=sliced_src,
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 wet=self.wet_without_hist_cpu,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -133,14 +133,15 @@ class DataSource:
         return norm
 
     @classmethod
-    def from_dataset(cls, dataset: xr.Dataset) -> Self:
+    def from_dataset(cls, dataset: xr.Dataset, *, name: str = "dataset") -> Self:
         """Create a DataSource from the data, computing means and stds."""
+        # TODO(alxmrs): Support compact data
         assert "lev" not in dataset.dims, "We currently only support non-compact data"
 
         means = dataset.mean()
         stds = dataset.std()
 
-        return cls(name="dataset", data=dataset, means=means, stds=stds)
+        return cls(name=name, data=dataset, means=means, stds=stds)
 
     @classmethod
     def from_config(cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool) -> Self:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -3,7 +3,6 @@ import logging
 from collections.abc import Callable
 from typing import Literal, Self
 
-import cftime
 import numpy as np
 import torch
 import xarray as xr
@@ -29,6 +28,8 @@ from ocean_emulators.constants import (
 )
 from ocean_emulators.derived_variables import add_derived_variables
 from ocean_emulators.utils.multiton import Multiton
+
+logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
@@ -82,6 +83,22 @@ class DataSource:
 
     def slice(self, time: TimeConfig) -> Self:
         """Slice the data source to only include the specified time slice."""
+        data_time_min = self.data.time.min().item()
+        data_time_max = self.data.time.max().item()
+        if time.start.datetime > data_time_max or time.end.datetime < data_time_min:
+            raise ValueError(
+                f"Time slice {time} is entirely outside the range of the data "
+                f"{data_time_min.strftime('%Y-%m-%d')} to "
+                f"{data_time_max.strftime('%Y-%m-%d')}"
+            )
+
+        if time.start.datetime < data_time_min or time.end.datetime > data_time_max:
+            logger.warning(
+                f"Time slice {time} is partially outside the range of the data "
+                f"{data_time_min.strftime('%Y-%m-%d')} to "
+                f"{data_time_max.strftime('%Y-%m-%d')}"
+            )
+
         data = self.data.sel(time=time.time_slice)
         return dataclasses.replace(self, name=f"{time=}[{self.name}]", data=data)
 
@@ -116,6 +133,16 @@ class DataSource:
         return norm
 
     @classmethod
+    def from_dataset(cls, dataset: xr.Dataset) -> Self:
+        """Create a DataSource from the data, computing means and stds."""
+        assert "lev" not in dataset.dims, "We currently only support non-compact data"
+
+        means = dataset.map(lambda x: x.mean())
+        stds = dataset.map(lambda x: x.std())
+
+        return cls(name="dataset", data=dataset, means=means, stds=stds)
+
+    @classmethod
     def from_config(cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool) -> Self:
         chunks: dict[str, int] | None = {} if use_dask else None
 
@@ -125,7 +152,7 @@ class DataSource:
             data = xr.open_dataset(
                 root / cfg.data.data_path,
                 engine="netcdf4",
-                chunks={"time": 1, "lat": 180, "lon": 360},
+                chunks={"time": 1},
             )
         else:
             data = xr.open_dataset(
@@ -232,30 +259,22 @@ def spherical_area_weights(data: xr.Dataset) -> Grid:
     return weights
 
 
-def get_inference_steps(time_config: TimeConfig, hist: int = 1):
+def get_inference_steps(data_source: DataSource, hist: int = 1):
     """
     Get the number of inference/rollout steps for the given time configuration.
 
     Args:
-        time_config: Time configuration
+        data_source: The data source sliced to the inference time range
         hist: Number of rollout steps
 
     Returns:
-        num_steps: Number of rollout steps
+        num_steps: Total number of rolled-out inferences which fit into the time range
     """
-    time_delta = TIME_DELTA
-    start_time_str = time_config.start
-    start_year, start_month, start_day = start_time_str.split("-")
-    start_time = cftime.DatetimeNoLeap(
-        int(start_year), int(start_month), int(start_day), 0, 0, 0
-    )
+    start_time = data_source.data.time.min().item()
+    end_time = data_source.data.time.max().item()
 
-    end_time_str = time_config.end
-    end_year, end_month, end_day = end_time_str.split("-")
-    end_time = cftime.DatetimeNoLeap(
-        int(end_year), int(end_month), int(end_day), 0, 0, 0
-    )
-    num_steps = (end_time - start_time).days // time_delta + 1
+    num_steps = (end_time - start_time).days // TIME_DELTA + 1
+
     # Might have extra remaining days, so we remove them
     mod = num_steps % (hist + 1)
     num_steps = num_steps - mod

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -137,8 +137,8 @@ class DataSource:
         """Create a DataSource from the data, computing means and stds."""
         assert "lev" not in dataset.dims, "We currently only support non-compact data"
 
-        means = dataset.map(lambda x: x.mean())
-        stds = dataset.map(lambda x: x.std())
+        means = dataset.mean()
+        stds = dataset.std()
 
         return cls(name="dataset", data=dataset, means=means, stds=stds)
 

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -195,6 +195,9 @@ class MetricLogger:
                     named_metrics["gpu_memory"] = torch.cuda.max_memory_allocated() / MB
 
                 logging.info(log_msg.format(i, len(data_loader), **named_metrics))
+
+                if torch.cuda.is_available():
+                    torch.cuda.reset_peak_memory_stats()
             i += 1
             end = time.perf_counter()
         total_time = time.perf_counter() - start_time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from aiohttp import ServerDisconnectedError
 from numpy.typing import ArrayLike, NDArray
 
 import ocean_emulators.constants as c
-from ocean_emulators.config import TrainBackendConfig, TrainConfig
+from ocean_emulators.config import JulianDate, TrainBackendConfig, TrainConfig
 from ocean_emulators.train import Trainer
 from ocean_emulators.utils.data import DataSource
 from ocean_emulators.utils.multiton import MultitonScope
@@ -133,9 +133,7 @@ class DataSourceDims:
     days_since_start: NDArray[np.uint32] = dataclasses.field(
         default_factory=lambda: np.array([0, 5, 10], dtype=np.uint32)
     )
-    start_day: cftime.datetime = cftime.DatetimeNoLeap.strptime(
-        "1969-08-05", "%Y-%m-%d", "noleap"
-    )
+    start_day: cftime.datetime = JulianDate("1969-08-05").datetime
 
     def __post_init__(self):
         if np.any(self.lat < -90.0) or np.any(self.lat > 90.0):
@@ -349,7 +347,7 @@ def data_source(request, pytestconfig) -> DataSource:
     match request.param:
         case "mock":
             time_range = xr.cftime_range(
-                "1975-08-05", "1975-12-31", freq="5D", calendar="noleap"
+                "1975-08-05", "1975-12-31", freq="5D", calendar="julian"
             )
             dims = DataSourceDims()
             dims.set_time_range(time_range)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -177,7 +177,6 @@ def vector_of(max_vec_size: int, min_vec_size=1):
     start_day=st.dates(
         min_value=datetime.date(1900, 1, 1),  # to quiet cftime warning about year < 0
     ),
-    calendar=st.sampled_from(["noleap", "standard"]),
 )
 @example(
     data_var_index=0,
@@ -185,7 +184,6 @@ def vector_of(max_vec_size: int, min_vec_size=1):
     lng=np.array([0.0, 180.0]),
     days_since_start=np.array([5, 10, 15, 20, 25]),
     start_day=datetime.date(2020, 1, 1),
-    calendar="noleap",
 )
 @example(
     data_var_index=255,
@@ -193,7 +191,6 @@ def vector_of(max_vec_size: int, min_vec_size=1):
     lng=np.array([360.0]),
     days_since_start=np.array([999]),
     start_day=datetime.date(2000, 5, 1),
-    calendar="noleap",
 )
 @example(
     data_var_index=7,
@@ -201,7 +198,6 @@ def vector_of(max_vec_size: int, min_vec_size=1):
     lng=np.array([0.0]),
     days_since_start=np.array([0], dtype=np.uint32),
     start_day=datetime.date(2000, 5, 1),
-    calendar="noleap",
 )
 @example(
     lat=np.array([32.87]),
@@ -209,7 +205,6 @@ def vector_of(max_vec_size: int, min_vec_size=1):
     data_var_index=0,
     days_since_start=np.array([0], dtype=np.uint32),
     start_day=datetime.date(2000, 5, 1),
-    calendar="noleap",
 )
 @example(
     data_var_index=0,
@@ -217,7 +212,6 @@ def vector_of(max_vec_size: int, min_vec_size=1):
     lng=np.array([1.375]),
     days_since_start=np.array([0], dtype=np.uint32),
     start_day=datetime.date(2000, 1, 1),
-    calendar="noleap",
 )
 @settings(deadline=1000)
 def test_test_util__data_source_roundtrip(
@@ -226,12 +220,11 @@ def test_test_util__data_source_roundtrip(
     lng: NDArray[np.floating],
     days_since_start: NDArray[np.uint32],
     start_day: datetime.date,
-    calendar: str,
 ) -> None:
     # We use hour=12 because that's what cftime uses when
     # converting from ordinals (in DataSourceDims)
     start_day_cf = cftime.datetime(
-        start_day.year, start_day.month, start_day.day, hour=12, calendar=calendar
+        start_day.year, start_day.month, start_day.day, hour=12, calendar="julian"
     )
 
     # start

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -93,7 +93,7 @@ def test_compute_anomalies():
     """Test the compute_anomalies function."""
     # Create test dataset with OM4 format variables
     daterange = xr.cftime_range(
-        "2000-08-05", "2010-12-31", freq="5D", calendar="noleap"
+        "2000-08-05", "2010-12-31", freq="5D", calendar="julian"
     )
     N = len(daterange)
 


### PR DESCRIPTION
Small grab-bag of things I ran into while trying to train on higher-res data, I suggest anything you want to discuss I just break out into its own PR and we merge this with the easy stuff.

* added `static_data_vars: []` to various data configs -- this is so it overrides any default value of this when picking a dataset which doesn't have them. In particular, currently `uv run oe.train configs/train_om4.yaml --data=@configs/data/public.yaml` doesn't work because train_om4.yaml has a non-empty list here. After this change, it works. I suggest in general we make it our policy that all the configs/data/*.yamls have the same set of keys defined to avoid this problem (or perhaps the stronger "don't have default values for config in code").
* Rather than letting xarray interpret our date strings by magic with what ends up being `data.sel(time=slice("1975-10-31", "1985-10-31"))`, we instead explicitly parse those strings out of the config into the right cftime types (Julian dates at noon, which seems to be what our data uses). This pulls up the validation of format much earlier, but also lets us write some nice validation that you are selecting a reasonable range of time (and remove some existing parsing code). The mysterious errors that selecting small or empty ranges were a real headache when I was first getting started with this codebase and I think this will be helpful.
* Edit some jaxtyping annotations which assumed a particular grid.
* Support computing mean/stds on a DataSource (not used anywhere right now other than my notebook, but I like the direction of enhancing DataSource for use in data processing)
* Update our data processing script to save zarrs for means/stds which seems a little silly but is what the public data uses right now so it's what our configs say.