### PR TITLE
CUDA Memory profiler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,6 +349,8 @@ like so:
 uvx snakeviz <benchmark_path>.prof
 ```
 
+### Profiling CPU Usage + Memory
+
 We also have a few other profiling tools available in the environment, including:
 
 [py-spy](https://github.com/benfred/py-spy), which captures python + native CPU usage:
@@ -369,3 +371,15 @@ memory usage and GPU (though the latter is a bit deceptive since it is async wrt
 ```shell
 uv run scalene src/ocean_emulators/train.py configs/train_om4.yaml
 ```
+
+### Profiling CUDA Memory
+
+You can turn on profiling of CUDA memory by setting the `profiler.cuda_snapshot_frequency` to a non-None value
+in the config. eg:
+
+```shell
+uv run memray run src/ocean_emulators/train.py --config configs/train_om4.yaml --profiler.cuda_snapshot_frequency 10
+```
+
+This will take a snapshot of the CUDA memory every 10 batches in the output directory. These can be visualized with
+https://docs.pytorch.org/memory_viz -- see https://pytorch.org/blog/understanding-gpu-memory-1/ for more details.

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -4,10 +4,11 @@ from typing import Any, Literal
 
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
 from ocean_emulators.constants import LoaderVersion
+from ocean_emulators.utils.profiler import Profiler
 
 
 class WandBConfig(BaseConfig):
-    mode: str = "disabled"  # online, disabled
+    mode: Literal["online", "disabled"] = "disabled"
     project: str = "3D_ocean_emu_CM4"
     entity: str = "suryadheeshjith"
     group: str | None = None
@@ -123,6 +124,15 @@ class ExperimentConfig(BaseConfig):
                 return Path(self.cluster_data_dir)
 
 
+class ProfilerConfig(BaseConfig):
+    # How often (in batches processed) to take a snapshot of the CUDA memory
+    # (None = no snapshots)
+    cuda_snapshot_frequency: int | None = None
+
+    def build(self, output_dir: Path) -> Profiler:
+        return Profiler(output_dir, self.cuda_snapshot_frequency)
+
+
 # See backend.py for how these are turned into concrete devices
 TrainBackendConfig = Literal["cpu", "cuda", "nccl", "auto"]
 LossType = Literal[
@@ -148,6 +158,9 @@ class TrainConfig(TopLevelConfig):
     ema_decay: float = 0.999
     faster_decay_at_start: bool = True
     backend: TrainBackendConfig = "auto"
+
+    # Profiling parameters
+    profiler: ProfilerConfig = ProfilerConfig()
 
     # Data parameters at root level
     data_percent: float = 1.0

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -2,6 +2,8 @@ from functools import cached_property
 from pathlib import Path
 from typing import Any, Literal
 
+import torch
+
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
 from ocean_emulators.constants import LoaderVersion
 from ocean_emulators.utils.profiler import Profiler
@@ -129,7 +131,12 @@ class ProfilerConfig(BaseConfig):
     # (None = no snapshots)
     cuda_snapshot_frequency: int | None = None
 
-    def build(self, output_dir: Path) -> Profiler:
+    def build(self, output_dir: Path, device: torch.device) -> Profiler:
+        if self.cuda_snapshot_frequency is not None and device.type != "cuda":
+            raise ValueError(
+                "cuda_snapshot_frequency is only supported on CUDA devices, got "
+                f"{device.type}"
+            )
         return Profiler(output_dir, self.cuda_snapshot_frequency)
 
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -353,6 +353,8 @@ class Trainer:
         self.normalize_before_mask: bool = cfg.data.normalize_before_mask
         self.normalize_fill_value: float = cfg.data.masked_fill_value
 
+        self.profiler = cfg.profiler.build(self.output_dir)
+
         assert self.tensor_map is not None
         self.loss_aggregator = LossAggregator.init_instance()
 
@@ -425,6 +427,8 @@ class Trainer:
         self.best_val_loss = 1e8
         self.best_inf_loss = 1e8
         self.wandb_logger.watch(self.model, log="all")
+
+        self.profiler.start()
 
         start_time = time.perf_counter()
         for epoch in range(self.start_epoch, self.epochs + 1):
@@ -552,6 +556,8 @@ class Trainer:
 
             metric_logger.update(loss=loss_value_reduce.item())
             metric_logger.update(lr=lr)
+
+            self.profiler.after_batch(self.num_batches_seen)
 
         if self.scheduler is not None:
             self.scheduler.step()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -353,7 +353,7 @@ class Trainer:
         self.normalize_before_mask: bool = cfg.data.normalize_before_mask
         self.normalize_fill_value: float = cfg.data.masked_fill_value
 
-        self.profiler = cfg.profiler.build(self.output_dir)
+        self.profiler = cfg.profiler.build(self.output_dir, self.device)
 
         assert self.tensor_map is not None
         self.loss_aggregator = LossAggregator.init_instance()

--- a/src/ocean_emulators/utils/profiler.py
+++ b/src/ocean_emulators/utils/profiler.py
@@ -20,5 +20,8 @@ class Profiler:
         if self.cuda_snapshot_frequency is not None:
             if num_batches_seen % self.cuda_snapshot_frequency == 0:
                 torch.cuda.memory._dump_snapshot(
-                    self.output_dir / f"cuda_memory_snapshot_{num_batches_seen}.json"
+                    str(
+                        self.output_dir
+                        / f"cuda_memory_snapshot_{num_batches_seen}.json"
+                    )
                 )

--- a/src/ocean_emulators/utils/profiler.py
+++ b/src/ocean_emulators/utils/profiler.py
@@ -20,5 +20,5 @@ class Profiler:
         if self.cuda_snapshot_frequency is not None:
             if num_batches_seen % self.cuda_snapshot_frequency == 0:
                 torch.cuda.memory._dump_snapshot(
-                    f"{self.output_dir}/cuda_memory_snapshot_{num_batches_seen}.json"
+                    self.output_dir / f"cuda_memory_snapshot_{num_batches_seen}.json"
                 )

--- a/src/ocean_emulators/utils/profiler.py
+++ b/src/ocean_emulators/utils/profiler.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import torch
+
+
+class Profiler:
+    def __init__(
+        self,
+        output_dir: Path,
+        cuda_snapshot_frequency: int | None,
+    ) -> None:
+        self.output_dir = output_dir
+        self.cuda_snapshot_frequency = cuda_snapshot_frequency
+
+    def start(self) -> None:
+        if self.cuda_snapshot_frequency is not None:
+            torch.cuda.memory._record_memory_history()
+
+    def after_batch(self, num_batches_seen: int) -> None:
+        if self.cuda_snapshot_frequency is not None:
+            if num_batches_seen % self.cuda_snapshot_frequency == 0:
+                torch.cuda.memory._dump_snapshot(
+                    f"{self.output_dir}/cuda_memory_snapshot_{num_batches_seen}.json"
+                )


### PR DESCRIPTION
Lets us turn on CUDA memory snapshots via config.

TODO:
- [x] Gate on torch.cuda.is_available(), maybe add a test for profile on while on CPU