### PR TITLE
Activation Checkpointing

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -126,9 +126,11 @@ class SamudraConfig(BaseConfig):
 
     checkpointing: Checkpointing | None = Field(
         default=None,
-        description="Checkpointing strategy for the model; "
-        "'blocks' for recomputing each CoreBlock, "
-        "'simple' for recomputing only cheap layers like scales and nonlinearities",
+        description="""Strategy for storing activations for the model for use in
+        the backward pass. If not set, the model will store all activations in memory
+        (fast but lots of memory). If set to 'blocks', the model will recompute each
+        CoreBlock in the backward pass. If set to 'simple', the model will recompute
+        only cheap layers like scales and nonlinearities.""",
     )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -105,7 +105,7 @@ class CorrectorConfig(BaseConfig):
 
 DownSamplingBlocks = Literal["avg_pool", "max_pool"]
 UpSamplingBlocks = Literal["bilinear_upsample", "transposed_conv"]
-Checkpointing = Literal["blocks", "simple"]
+Checkpointing = Literal["all", "simple"]
 
 
 class SamudraConfig(BaseConfig):
@@ -128,9 +128,10 @@ class SamudraConfig(BaseConfig):
         default=None,
         description="""Strategy for storing activations for the model for use in
         the backward pass. If not set, the model will store all activations in memory
-        (fast but lots of memory). If set to 'blocks', the model will recompute each
-        CoreBlock in the backward pass. If set to 'simple', the model will recompute
-        only cheap layers like scales and nonlinearities.""",
+        (fast but lots of memory). If set to 'all', the model will recompute each
+        top-level layer (CoreBlocks, scaling layers, etc.) in the backward pass.
+        If set to 'simple', the model will recompute only cheap layers like scales
+        and nonlinearities.""",
     )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -4,9 +4,7 @@ from typing import Annotated, Any, Literal
 
 import cftime
 import torch
-from pydantic import PlainSerializer, PlainValidator, WithJsonSchema
-
-from pydantic import Field
+from pydantic import Field, PlainSerializer, PlainValidator, WithJsonSchema
 
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
 from ocean_emulators.constants import LoaderVersion

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -2,6 +2,8 @@ from functools import cached_property
 from pathlib import Path
 from typing import Any, Literal
 
+from pydantic import Field
+
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
 from ocean_emulators.constants import LoaderVersion
 
@@ -76,7 +78,12 @@ class SamudraConfig(BaseConfig):
     down_sampling_block: DownSamplingBlocks = "avg_pool"
     up_sampling_block: UpSamplingBlocks = "bilinear_upsample"
 
-    checkpointing: Checkpointing | None = None
+    checkpointing: Checkpointing | None = Field(
+        default=None,
+        description="Checkpointing strategy for the model; "
+        "'blocks' for recomputing each CoreBlock, "
+        "'simple' for recomputing only cheap layers like scales and nonlinearities",
+    )
 
 
 class DistributedConfig(BaseConfig):

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -57,6 +57,7 @@ class CorrectorConfig(BaseConfig):
 
 DownSamplingBlocks = Literal["avg_pool", "max_pool"]
 UpSamplingBlocks = Literal["bilinear_upsample", "transposed_conv"]
+Checkpointing = Literal["blocks", "simple"]
 
 
 class SamudraConfig(BaseConfig):
@@ -74,6 +75,8 @@ class SamudraConfig(BaseConfig):
     corrector: CorrectorConfig = CorrectorConfig()
     down_sampling_block: DownSamplingBlocks = "avg_pool"
     up_sampling_block: UpSamplingBlocks = "bilinear_upsample"
+
+    checkpointing: Checkpointing | None = None
 
 
 class DistributedConfig(BaseConfig):

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -123,6 +123,8 @@ class ConvBlock(CoreBlock):
                 fts = torch.nn.functional.pad(
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
+                # conv2d layers are expensive so we save their activations,
+                # other (simple) layers are cheap, so we don't save their activations.
             if self.checkpoint_simple and not isinstance(layer, nn.Conv2d):
                 fts = torch.utils.checkpoint.checkpoint(layer, fts, use_reentrant=False)
             else:

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 import torch
 import torch.nn as nn
+import torch.utils.checkpoint
 
 from ocean_emulators.models.modules.activations import CappedGELU
 
@@ -145,6 +146,7 @@ class ConvNeXtBlock(CoreBlock):
         pad="circular",
         upscale_factor: int = 4,
         norm="batch",
+        checkpoint_simple: bool = False,
     ):
         super().__init__(in_channels, out_channels, kernel_size, dilation, pad)
         assert n_layers == 1, "Can only use a single layer here!"
@@ -212,6 +214,7 @@ class ConvNeXtBlock(CoreBlock):
             )
         )
         self.convblock = torch.nn.Sequential(*convblock)
+        self.checkpoint_simple = checkpoint_simple
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # return self.skip_module(x) + self.convblock(x)
@@ -224,5 +227,8 @@ class ConvNeXtBlock(CoreBlock):
                 x = torch.nn.functional.pad(
                     x, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
-            x = layer(x)
+            if self.checkpoint_simple and not isinstance(layer, nn.Conv2d):
+                x = torch.utils.checkpoint.checkpoint(layer, x, use_reentrant=False)
+            else:
+                x = layer(x)
         return skip + x

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -92,6 +92,7 @@ class ConvBlock(CoreBlock):
         n_layers: int = 1,
         activation: Callable[[], torch.nn.Module] = CappedGELU,
         pad="circular",
+        checkpoint_simple: bool = False,
     ):
         super().__init__(in_channels, out_channels, kernel_size, dilation, pad)
 
@@ -111,7 +112,7 @@ class ConvBlock(CoreBlock):
             layers.append(activation())
 
         self.layers = nn.ModuleList(layers)
-        # self.layers = nn.ModuleList(layer)
+        self.checkpoint_simple = checkpoint_simple
 
     def forward(self, fts: torch.Tensor) -> torch.Tensor:
         for layer in self.layers:
@@ -122,7 +123,10 @@ class ConvBlock(CoreBlock):
                 fts = torch.nn.functional.pad(
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
-            fts = layer(fts)
+            if self.checkpoint_simple and not isinstance(layer, nn.Conv2d):
+                fts = torch.utils.checkpoint.checkpoint(layer, fts, use_reentrant=False)
+            else:
+                fts = layer(fts)
         return fts
 
 

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -1,7 +1,11 @@
+from typing import assert_never
+
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.utils.checkpoint
 
+from ocean_emulators.config import SamudraConfig
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.corrector import Correctors
 from ocean_emulators.models.modules.blocks import (
@@ -19,7 +23,7 @@ from ocean_emulators.utils.train import pairwise
 
 
 class Samudra(BaseModel):
-    def __init__(self, config, hist, wet, area_weights, static_data):
+    def __init__(self, config: SamudraConfig, hist, wet, area_weights, static_data):
         super().__init__(
             ch_width=config.ch_width,
             n_out=config.n_out,
@@ -39,6 +43,19 @@ class Samudra(BaseModel):
         dilation = config.dilation.copy()
         n_layers = config.n_layers.copy()
 
+        match config.checkpointing:
+            case "blocks":
+                self.checkpoint_blocks = True
+                checkpoint_simple = False
+            case "simple":
+                self.checkpoint_blocks = False
+                checkpoint_simple = True
+            case None:
+                self.checkpoint_blocks = False
+                checkpoint_simple = False
+            case _:
+                assert_never(config.checkpointing)
+
         # going down
         layers = []
         for i, (a, b) in enumerate(pairwise(ch_width)):
@@ -55,6 +72,7 @@ class Samudra(BaseModel):
                     pad=config.pad,
                     upscale_factor=config.core_block.upscale_factor,
                     norm=config.core_block.norm,
+                    checkpoint_simple=checkpoint_simple,
                 )
             )
             # Down sampling block
@@ -73,6 +91,7 @@ class Samudra(BaseModel):
                 pad=config.pad,
                 upscale_factor=config.core_block.upscale_factor,
                 norm=config.core_block.norm,
+                checkpoint_simple=checkpoint_simple,
             )
         )
 
@@ -100,6 +119,7 @@ class Samudra(BaseModel):
                     pad=config.pad,
                     upscale_factor=config.core_block.upscale_factor,
                     norm=config.core_block.norm,
+                    checkpoint_simple=checkpoint_simple,
                 )
             )
             layers.append(
@@ -119,6 +139,7 @@ class Samudra(BaseModel):
                 pad=config.pad,
                 upscale_factor=config.core_block.upscale_factor,
                 norm=config.core_block.norm,
+                checkpoint_simple=checkpoint_simple,
             )
         )
 
@@ -144,7 +165,10 @@ class Samudra(BaseModel):
                 fts = torch.nn.functional.pad(
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
-            fts = layer(fts)
+            if self.checkpoint_blocks:
+                fts = torch.utils.checkpoint.checkpoint(layer, fts, use_reentrant=False)
+            else:
+                fts = layer(fts)
             if count < self.num_steps:
                 if isinstance(layer, CoreBlock):
                     temp[count] = fts

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -44,14 +44,14 @@ class Samudra(BaseModel):
         n_layers = config.n_layers.copy()
 
         match config.checkpointing:
-            case "blocks":
-                self.checkpoint_blocks = True
+            case "all":
+                self.checkpoint_all = True
                 checkpoint_simple = False
             case "simple":
-                self.checkpoint_blocks = False
+                self.checkpoint_all = False
                 checkpoint_simple = True
             case None:
-                self.checkpoint_blocks = False
+                self.checkpoint_all = False
                 checkpoint_simple = False
             case _:
                 assert_never(config.checkpointing)
@@ -165,7 +165,7 @@ class Samudra(BaseModel):
                 fts = torch.nn.functional.pad(
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
-            if self.checkpoint_blocks:
+            if self.checkpoint_all:
                 fts = torch.utils.checkpoint.checkpoint(layer, fts, use_reentrant=False)
             else:
                 fts = layer(fts)


### PR DESCRIPTION
I am looking into fitting the high res models on our GPUs, so I tried a couple options for activation checkpointing: checkpoint each ConvNeXtBlock and other top-level layers ("all") or checkpointing just simple scalings/nonlinearities ("simple"). 

Results are here: https://wandb.ai/m2lines/ocean-emulators/reports/Checkpointing-2025-05-16--VmlldzoxMjgwOTIyOA

tl;dr: "all" saves about 67% of GPU memory usage (!) but at a performance cost of about 10%. "simple" saves about 20% of GPU memory but has practically no performance degradation. There are probably strategies in between those two we could look at, too. (Perhaps also some wins to be had by using the extra space to pre-load future steps worth of data or similar.)