### PR TITLE
Try out 6g.2xlarge to see what that does to benchmark results

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
         uses: mihasya/start-aws-gha-runner@fix-worker-lookup
         with:
           aws_image_id: ami-00096836009b16a22 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch
-          aws_instance_type: g6.xlarge
+          aws_instance_type: g6.2xlarge
           aws_home_dir: /home/ubuntu
         env:
           GH_PAT: ${{ secrets.GH_SA_TOKEN }}


### PR DESCRIPTION
@jder can you trigger a manual benchmark run, please? I figure we can manually push to the `gh-pages` branch later to remove it.

Update: oh, I didn't realize I had perms to do this myself. Have kicked it off here https://github.com/suryadheeshjith/Ocean_Emulator/actions/runs/15302652916