### PR TITLE
Remove pointer to patched version of GH Action

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Create cloud runner
         id: aws-start
-        uses: mihasya/start-aws-gha-runner@fix-worker-lookup
+        uses: omsf/start-aws-gha-runner@v1.0.0
         with:
           aws_image_id: ami-00096836009b16a22 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch
           aws_instance_type: g6.xlarge


### PR DESCRIPTION
The `gha_runner` library has pushed a new release with our fix in it.

`start_aws_gha_runner` appears to pull in the latest version of the dependency, so we should no longer need to hardcode a patched version. Whether or not this PR builds successfully will tell us if the fix is being pulled in correctly, as we still have 37 runners registered (>30, the boundary condition for the bug)