### PR TITLE
Switch to torch loader and reduce default number of workers per GPU

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -78,9 +78,9 @@ class DataConfig(BaseConfig):
     data_stds_path: str = "CM4_5daily_v0.4.0_stds"
     scaling_residuals_file: str | None = None
     static_data_vars: list[str] | None = None
-    num_workers: int = 4
+    num_workers: int = 2
     hist: int = 1
-    loader_version: str = str(LoaderVersion.OM4_EAGER.value)
+    loader_version: str = str(LoaderVersion.OM4_TORCH.value)
     normalize_before_mask: bool = True
     masked_fill_value: float = 0.0
 


### PR DESCRIPTION
I think the torch loader is a good default now, and I found 4 workers by default overloads the 8-GPU systems I've been using, resulting in very long waits at the start of an epoch. 1-worker-per-GPU seems to be too few on my other host, so I was thinking this might be a better default. (Though of course might need tuning.)