### PR TITLE
Deduplicate start/stop jobs, remove patched version of action

### DIFF
--- a/.github/workflows/aws-runner-start.yml
+++ b/.github/workflows/aws-runner-start.yml
@@ -33,7 +33,6 @@ on:
 
 permissions:
   id-token: write # This is required for interacting with AWS via OIDC
-  contents: read # This is required for actions/checkout
 
 jobs:
   start-aws-runner:

--- a/.github/workflows/aws-runner-start.yml
+++ b/.github/workflows/aws-runner-start.yml
@@ -1,0 +1,60 @@
+name: Start AWS Runner
+
+on:
+  workflow_call:
+    inputs:
+      aws_image_id:
+        description: "AWS AMI ID to use"
+        required: false
+        type: string
+        default: "ami-00096836009b16a22" # Deep Learning OSS Nvidia Driver AMI GPU PyTorch
+      aws_instance_type:
+        description: "AWS instance type"
+        required: false
+        type: string
+        default: "g6.xlarge"
+      aws_home_dir:
+        description: "Home directory on the AWS instance"
+        required: false
+        type: string
+        default: "/home/ubuntu"
+    outputs:
+      mapping:
+        description: "Instance mapping for stopping later"
+        value: ${{ jobs.start-aws-runner.outputs.mapping }}
+      instances:
+        description: "Instance IDs"
+        value: ${{ jobs.start-aws-runner.outputs.instances }}
+    secrets:
+      AWS_ROLE:
+        required: true
+      GH_SA_TOKEN:
+        required: true
+
+permissions:
+  id-token: write # This is required for interacting with AWS via OIDC
+  contents: read # This is required for actions/checkout
+
+jobs:
+  start-aws-runner:
+    runs-on: ubuntu-latest
+    outputs:
+      mapping: ${{ steps.aws-start.outputs.mapping }}
+      instances: ${{ steps.aws-start.outputs.instances }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-session-name: github-actions-session
+          aws-region: us-east-1
+
+      - name: Create cloud runner
+        id: aws-start
+        uses: omsf/start-aws-gha-runner@v1.0.0
+        with:
+          aws_image_id: ${{ inputs.aws_image_id }}
+          aws_instance_type: ${{ inputs.aws_instance_type }}
+          aws_home_dir: ${{ inputs.aws_home_dir }}
+        env:
+          GH_PAT: ${{ secrets.GH_SA_TOKEN }}

--- a/.github/workflows/aws-runner-stop.yml
+++ b/.github/workflows/aws-runner-stop.yml
@@ -15,7 +15,6 @@ on:
 
 permissions:
   id-token: write # This is required for interacting with AWS via OIDC
-  contents: read # This is required for actions/checkout
 
 jobs:
   stop-aws-runner:

--- a/.github/workflows/aws-runner-stop.yml
+++ b/.github/workflows/aws-runner-stop.yml
@@ -1,0 +1,35 @@
+name: Stop AWS Runner
+
+on:
+  workflow_call:
+    inputs:
+      instance_mapping:
+        description: "Instance mapping from the start workflow"
+        required: true
+        type: string
+    secrets:
+      AWS_ROLE:
+        required: true
+      GH_SA_TOKEN:
+        required: true
+
+permissions:
+  id-token: write # This is required for interacting with AWS via OIDC
+  contents: read # This is required for actions/checkout
+
+jobs:
+  stop-aws-runner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          aws-region: us-east-1
+
+      - name: Stop instances
+        uses: omsf/stop-aws-gha-runner@v1.0.0
+        with:
+          instance_mapping: ${{ inputs.instance_mapping }}
+        env:
+          GH_PAT: ${{ secrets.GH_SA_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,31 +12,14 @@ on:
 permissions:
   contents: write # Allow updating content on GitHub pages
   deployments: write # Allow to deploy to GitHub pages
-  id-token: write   # This is required for interacting with AWS via OIDC
+  id-token: write # This is required for interacting with AWS via OIDC
 
 jobs:
   start-aws-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      mapping: ${{ steps.aws-start.outputs.mapping }}
-      instances: ${{ steps.aws-start.outputs.instances }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-session-name: github-actions-session
-          aws-region: us-east-1
-
-      - name: Create cloud runner
-        id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.0.0
-        with:
-          aws_image_id: ami-00096836009b16a22 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch
-          aws_instance_type: g6.xlarge
-          aws_home_dir: /home/ubuntu
-        env:
-          GH_PAT: ${{ secrets.GH_SA_TOKEN }}
+    uses: ./.github/workflows/aws-runner-start.yml
+    secrets:
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
+      GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}
 
   test:
     needs: start-aws-runner
@@ -106,21 +89,13 @@ jobs:
           alert-comment-cc-users: "@alxmrs,@jder"
 
   stop-aws-runner:
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/aws-runner-stop.yml
     needs:
       - start-aws-runner
       - test
     if: ${{ always() }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-          aws-region: us-east-1
-
-      - name: Stop instances
-        uses: omsf/stop-aws-gha-runner@v1.0.0
-        with:
-          instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
-        env:
-          GH_PAT: ${{ secrets.GH_SA_TOKEN }}
+    with:
+      instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
+    secrets:
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
+      GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -14,8 +14,6 @@ permissions:
 jobs:
   start-aws-runner:
     uses: ./.github/workflows/aws-runner-start.yml
-    with:
-      use_fix_worker_lookup: true
     secrets:
       AWS_ROLE: ${{ secrets.AWS_ROLE }}
       GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -9,31 +9,16 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write   # This is required for interacting with AWS via OIDC
-  contents: read    # This is required for actions/checkout
+  id-token: write # This is required for interacting with AWS via OIDC
+  contents: read # This is required for actions/checkout
 jobs:
   start-aws-runner:
-    runs-on: ubuntu-latest
-    outputs:
-      mapping: ${{ steps.aws-start.outputs.mapping }}
-      instances: ${{ steps.aws-start.outputs.instances }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-          role-session-name: github-actions-session
-          aws-region: us-east-1
-
-      - name: Create cloud runner
-        id: aws-start
-        uses: mihasya/start-aws-gha-runner@fix-worker-lookup
-        with:
-          aws_image_id: ami-00096836009b16a22 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch
-          aws_instance_type: g6.xlarge
-          aws_home_dir: /home/ubuntu
-        env:
-          GH_PAT: ${{ secrets.GH_SA_TOKEN }}
+    uses: ./.github/workflows/aws-runner-start.yml
+    with:
+      use_fix_worker_lookup: true
+    secrets:
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
+      GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}
 
   run-tests:
     needs: start-aws-runner
@@ -65,21 +50,13 @@ jobs:
         run: uv run --locked pytest -n 2 -v -m "not manual and cuda"
 
   stop-aws-runner:
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/aws-runner-stop.yml
     needs:
       - start-aws-runner
       - run-tests
     if: ${{ always() }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE }}
-          aws-region: us-east-1
-
-      - name: Stop instances
-        uses: omsf/stop-aws-gha-runner@v1.0.0
-        with:
-          instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
-        env:
-          GH_PAT: ${{ secrets.GH_SA_TOKEN }}
+    with:
+      instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
+    secrets:
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
+      GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}


### PR DESCRIPTION
I resisted doing this because this is more moving pieces and also more code, but this is also at least the third time we've had them drift out of sync (in this case, one was using the mihasya patched version and the other not), so I think it's probably worth it. 