### PR TITLE
Use passed loader version to decide whether to use dask

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -60,7 +60,7 @@ def make_loader(
     if version is None:
         version = LoaderVersion(cfg.data.loader_version)
 
-    use_dask = version != LoaderVersion.OM4_TORCH.value
+    use_dask = version != LoaderVersion.OM4_TORCH
     raw = DataSource.from_config(cfg, use_dask=use_dask)
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]
     boundary = BOUNDARY_VARS[cfg.experiment.boundary_vars_key]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -52,12 +52,15 @@ def make_loader(
     cfg: TrainConfig,
     time_config: TimeConfig | None = None,
     drop_last: bool = True,
-    version: LoaderVersion = LoaderVersion.OM4_EAGER,
+    version: LoaderVersion | None = None,
 ) -> Generator[DataLoader, None, None]:
     if time_config is None:
         time_config = cfg.train_time
 
-    use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
+    if version is None:
+        version = LoaderVersion(cfg.data.loader_version)
+
+    use_dask = version != LoaderVersion.OM4_TORCH.value
     raw = DataSource.from_config(cfg, use_dask=use_dask)
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]
     boundary = BOUNDARY_VARS[cfg.experiment.boundary_vars_key]


### PR DESCRIPTION
@alxmrs pretty sure this is why our benchmarks did something surprising when we changed the default loader version. Previously the passed `version` was ignored for the purpose of deciding whether to use dask or not. Seems like good additional evidence that we should try and tackle this duplication sometime soon.

This also makes me want to move to a world where we're not using config objects in most tests. It's hard to tell whether this change is sufficient -- if any other code we're calling here transitively uses `cfg.data.loader_version`, then it's probably broken. We could also make a new train config but then if the *caller* is using `cfg.data.loader_version` we have the same problem. We could update all callers to mutate train config rather than passing in verison and time_config separately but I would rather move away from manipulating config rather than towards. (But could be convinced this is still worth doing in the short term.)