### PR TITLE
Avoid failing benchmarks when they regress

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -70,7 +70,7 @@ jobs:
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: "200%"
           comment-on-alert: true
-          fail-on-alert: true
+          fail-on-alert: false
           alert-comment-cc-users: "@alxmrs,@jder"
 
       # gh-pages branch is automatically updated with extracted benchmark data.
@@ -85,7 +85,7 @@ jobs:
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: "200%"
           comment-on-alert: true
-          fail-on-alert: true
+          fail-on-alert: false
           alert-comment-cc-users: "@alxmrs,@jder"
 
   stop-aws-runner:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ocean Emulator
 
-[![Pre-commit](https://github.com/suryadheeshjith/Ocean_Emulator/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/suryadheeshjith/Ocean_Emulator/actions/workflows/pre-commit.yml)
-[![Test CPU](https://github.com/suryadheeshjith/Ocean_Emulator/actions/workflows/test.yml/badge.svg)](https://github.com/suryadheeshjith/Ocean_Emulator/actions/workflows/test.yml)
-[![Benchmark CPU](https://github.com/suryadheeshjith/Ocean_Emulator/actions/workflows/benchmarks.yml/badge.svg)](https://github.com/suryadheeshjith/Ocean_Emulator/actions/workflows/benchmarks.yml)
-[Benchmark Results](http://suryadheeshjith.github.io/Ocean_Emulator/dev/bench)
+[![Pre-commit](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/pre-commit.yml)
+[![Test CPU](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/test.yml/badge.svg)](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/test.yml)
+[![Benchmark CPU](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/benchmarks.yml/badge.svg)](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/benchmarks.yml)
+[Benchmark Results](http://LaureZanna.github.io/Ocean_Emulator/dev/bench)


### PR DESCRIPTION
This is a bit weird since I always think something went wrong, but I think regressions are "normal" and not failures. In addition, failing the first "store" task causes the second one to never run, which seems bad.