### PR TITLE
Tweaks while running half-degree experiments

### DIFF
--- a/configs/data/om4_halfdeg_remote.yaml
+++ b/configs/data/om4_halfdeg_remote.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=../schemas/DataConfig.json
+
+data_path: s3://emulators/sd5313/OM4_highres/om4_halfdeg.zarr
+data_means_path: s3://emulators/sd5313/OM4_highres/om4_halfdeg_means.zarr
+data_stds_path: s3://emulators/sd5313/OM4_highres/om4_halfdeg_stds.zarr
+static_data_vars: []

--- a/configs/data/om4_halfdeg_remote.yaml
+++ b/configs/data/om4_halfdeg_remote.yaml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=../schemas/DataConfig.json
 
+# TODO(jder): the URLs below assume you have FSSPEC_S3_ENDPOINT_URL=https://nyu1.osn.mghpcc.org
+# as well as the appropriate AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY (or other S3 credentials) in your environment.
+# Once we have a clear story for launching this task remotely we should remove this implicit requirement.
+
 data_path: s3://emulators/sd5313/OM4_highres/om4_halfdeg.zarr
 data_means_path: s3://emulators/sd5313/OM4_highres/om4_halfdeg_means.zarr
 data_stds_path: s3://emulators/sd5313/OM4_highres/om4_halfdeg_stds.zarr

--- a/configs/train_om4_halfdeg.yaml
+++ b/configs/train_om4_halfdeg.yaml
@@ -11,17 +11,31 @@ scheduler: true
 loss: mse
 finetune: false
 resume_ckpt_path: null
-inference_epochs: [-1]
+inference_epochs: []
 data_percent: 1.0
 train_time:
-  start: "1958-01-03"
-  end: "1967-12-29"
+  start: "1975-01-03"
+  end: "2013-10-05"
 val_time:
-  start: "1967-01-01"
-  end: "1967-12-29"
+  start: "2013-10-05"
+  end: "2014-10-05"
 inference_times:
-  - start: "1967-01-01"
-    end: "1967-12-29"
+  - start: "1975-01-03"
+    end: "1980-01-03"
+  - start: "1980-01-03"
+    end: "1985-01-03"
+  - start: "1985-01-03"
+    end: "1990-01-03"
+  - start: "1990-01-03"
+    end: "1995-01-03"
+  - start: "1995-01-03"
+    end: "2000-01-03"
+  - start: "2000-01-03"
+    end: "2005-01-03"
+  - start: "2005-01-03"
+    end: "2010-01-03"
+  - start: "2010-01-03"
+    end: "2014-10-05"
 data_stride: [1]
 steps: [4]
 step_transition: []
@@ -42,8 +56,7 @@ experiment:
   prognostic_vars_key: thermo_dynamic_all
   boundary_vars_key: tau_hfds_hfds_anom
 data:
-  !include data/om4_ohc.yaml
-
+  !include data/om4_halfdeg_remote.yaml
 
 samudra:
   ch_width: [157, 200, 250, 300, 400]

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -98,6 +98,7 @@ class DataConfig(BaseConfig):
     loader_version: str = str(LoaderVersion.OM4_TORCH.value)
     normalize_before_mask: bool = True
     masked_fill_value: float = 0.0
+    concurrent_compute: bool = False
 
 
 BlockType = Literal["conv_next_block", "conv_block"]

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -585,6 +585,7 @@ class TorchTrainDataset(Dataset):
         normalize_before_mask: bool,
         masked_fill_value: float,
         stride: int = 1,
+        concurrent_compute: bool = False,
     ):
         super().__init__()
         self.device = get_device()
@@ -594,6 +595,7 @@ class TorchTrainDataset(Dataset):
         self.stride: int = stride
         self.normalize_before_mask: bool = normalize_before_mask
         self.masked_fill_value: float = masked_fill_value
+        self.concurrent_compute: bool = concurrent_compute
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
         data = src.data
@@ -641,11 +643,16 @@ class TorchTrainDataset(Dataset):
 
         for step in range(self.steps):
             x_index = self._get_x_index(idx, step)
+            prognostic_selected = self._prognostic_src.data.isel(time=x_index)
+            boundary_selected = self._boundary_src.data.isel(time=x_index)
 
-            if "lev" in self._prognostic_src.data.dims:
+            if self.concurrent_compute:
+                concurrent_compute(prognostic_selected, boundary_selected)
+
+            if "lev" in prognostic_selected.dims:
                 prognostic_all = torch.from_numpy(
                     conditional_rearrange(
-                        self._prognostic_src.data.isel(time=x_index),
+                        prognostic_selected,
                         "time (variable lev)=var lat lon",
                         concat_dim="var",
                     )
@@ -654,14 +661,12 @@ class TorchTrainDataset(Dataset):
                 )
             else:
                 prognostic_all = torch.from_numpy(
-                    self._prognostic_src.data.isel(time=x_index)
-                    .to_array()
+                    prognostic_selected.to_array()
                     .transpose("time", "variable", "lat", "lon")
                     .to_numpy()
                 )
             boundary = torch.from_numpy(
-                self._boundary_src.data.isel(time=x_index)
-                .to_array()
+                boundary_selected.to_array()
                 .transpose("time", "variable", "lat", "lon")
                 .to_numpy()
             )
@@ -735,3 +740,22 @@ class TorchTrainDataset(Dataset):
 
         window_index = idx + step * (self.hist + 1) * self.stride
         return self.rolling_indices.isel(window=window_index, drop=True)
+
+
+def concurrent_compute(
+    *datasets: xr.Dataset,
+) -> None:
+    from concurrent.futures import ThreadPoolExecutor, wait
+
+    def load_variable_data(var: xr.Variable) -> None:
+        var.load()
+
+    with ThreadPoolExecutor(
+        max_workers=None, thread_name_prefix="concurrent_compute"
+    ) as executor:
+        futures = []
+        for ds in datasets:
+            for var in ds.variables.values():
+                futures.append(executor.submit(load_variable_data, var))
+
+        wait(futures)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -102,10 +102,8 @@ class Trainer:
 
         # Adjust workers and memory pinning based on device
         if not using_gpu():
-            cfg.data.num_workers = 0  # Disable multi-processing on CPU
             cfg.pin_mem = False
         elif cfg.disk_mode:
-            cfg.data.num_workers = torch.cuda.device_count() * cfg.data.num_workers
             cfg.pin_mem = True
 
         # Distributed mode
@@ -165,12 +163,6 @@ class Trainer:
                 f"Training time range {cfg.train_time} overlaps "
                 f"with validation time range {cfg.val_time}"
             )
-        for i, inf_time in enumerate(cfg.inference_times):
-            if cfg.train_time.overlaps(inf_time):
-                raise ValueError(
-                    f"Training time range {cfg.train_time} overlaps "
-                    f"with inference time range {i}: {inf_time}"
-                )
 
         self.loader_version = LoaderVersion(cfg.data.loader_version)
         self.data_dir = cfg.experiment.data_dir
@@ -586,6 +578,7 @@ class Trainer:
         if self.scheduler is not None:
             self.scheduler.step()
 
+        logger.info(f"Aggregating train logs")
         return train_aggregator.get_logs()
 
     def validate_one_epoch(self, epoch):
@@ -615,6 +608,7 @@ class Trainer:
                 val_aggregator.record_validation_batch(VO)
                 metric_logger.update(loss=VO.loss)
 
+        logger.info(f"Aggregating validation logs")
         return val_aggregator.get_logs(label="val")
 
     def inference_one_epoch(self, epoch):
@@ -647,6 +641,8 @@ class Trainer:
                         num_steps // 2, self.max_train_model_steps_forward
                     ),
                 )
+
+        logger.info(f"Aggregating inference logs")
         logs = inf_aggregator.get_summary_logs()
         return {f"inference/{k}": v for k, v in logs.items()}
 
@@ -851,9 +847,9 @@ class Trainer:
         )
         self.save_checkpoint(epoch, self.ckpt_paths.latest_checkpoint_path)
         if epoch > 0 and epoch % self.save_freq == 0:
-            self.save_checkpoint(
-                epoch, self.ckpt_paths.latest_checkpoint_path_with_epoch(epoch)
-            )
+            path = self.ckpt_paths.latest_checkpoint_path_with_epoch(epoch)
+            logger.info(f"Saving per-epoch checkpoint to {path}")
+            self.save_checkpoint(epoch, path)
 
         with self._ema_context():
             logger.info(

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -4,6 +4,7 @@
 import contextlib
 import datetime
 import logging
+import multiprocessing
 import os
 import tempfile
 import time
@@ -109,6 +110,9 @@ class Trainer:
 
         # Distributed mode
         dask.config.set(scheduler="synchronous")
+        self.mp_context = (
+            multiprocessing.get_context("spawn") if cfg.data.num_workers > 0 else None
+        )
 
         # Set seeds
         set_seed(cfg.experiment.rand_seed)
@@ -171,6 +175,7 @@ class Trainer:
         self.loader_version = LoaderVersion(cfg.data.loader_version)
         self.data_dir = cfg.experiment.data_dir
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
+        self.concurrent_compute = cfg.data.concurrent_compute
 
         use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
         raw = DataSource.from_config(cfg, use_dask=use_dask)
@@ -437,6 +442,7 @@ class Trainer:
             pin_memory=False,
             drop_last=False,
             collate_fn=collate_inference_data,
+            multiprocessing_context=self.mp_context,
         )
 
     def run(self) -> None:
@@ -735,6 +741,7 @@ class Trainer:
                             normalize_before_mask=self.normalize_before_mask,
                             masked_fill_value=self.normalize_fill_value,
                             stride=stride,
+                            concurrent_compute=self.concurrent_compute,
                         )
                         for stride in self.data_stride
                     ]
@@ -753,6 +760,7 @@ class Trainer:
                             normalize_before_mask=self.normalize_before_mask,
                             masked_fill_value=self.normalize_fill_value,
                             stride=stride,
+                            concurrent_compute=self.concurrent_compute,
                         )
                         for stride in self.data_stride
                     ]
@@ -792,6 +800,7 @@ class Trainer:
             pin_memory=self.pin_mem,
             drop_last=True,
             collate_fn=collate_fn,
+            multiprocessing_context=self.mp_context,
         )
 
         self.val_loader = DataLoader(
@@ -802,6 +811,7 @@ class Trainer:
             pin_memory=self.pin_mem,
             drop_last=False,
             collate_fn=collate_fn,
+            multiprocessing_context=self.mp_context,
         )
 
     def save_all_checkpoints(self, epoch: int, v_loss: float, inf_loss: float):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -78,23 +78,11 @@ def test_checkpoint(trainer_pair: TrainPair, caplog):
                 "1975-09-01",
             ],
         ),
-        (
-            "mock",
-            DEFAULT_CONFIG,
-            [
-                "--train_time.start",
-                "1975-08-01",
-                "--train_time.end",
-                "1975-09-01",
-                "--inference_times",
-                '[{"start": "1975-08-15", "end": "1975-09-01"}]',
-            ],
-        ),
     ],
     indirect=True,
 )
 def test_trainer_overlapping_time_ranges_raises_error(train_config, caplog):
-    """Creating a trainer with overlapping train + val/inf times should error."""
+    """Creating a trainer with overlapping train + val times should error."""
 
     with MultitonScope():
         with pytest.raises(ValueError, match="Training time range.*"):


### PR DESCRIPTION
The 3 commits are independent so probably easiest to review that way. (Happy to break into separate PRs but I think they're all pretty uncontroversial.)

* Updates config for the half-degree experiments to load remotely when desired and to avoid doing inference during training.
* Adds a flag to load xarray variables concurrently based on [this suggestion](https://github.com/pydata/xarray/issues/8965#issuecomment-2083787484). This helps a lot locally with small datasizes (3x improvement for me) but with larger batch sizes it seems to not help (maybe GIL contention?).
* Swaps to the the "spawn" multiprocessing type since the s3fs requires this when passing those stores around.
* Adds more logging statements so you can tell what's going on more easily
* Removes some logic we had about tweaking the number of workers based on the number of GPUs in use -- the worker counts are are *already* per GPU so this was using `num_gpus * num_gpus * num_workers` workers in total. Also allows us to use multiple workers for CPU jobs, for testing purposes.