### PR TITLE
Updated `concurrent_compute` logic to create a thread pool only once.

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -597,7 +597,6 @@ class TorchTrainDataset(Dataset):
         self.stride: int = stride
         self.normalize_before_mask: bool = normalize_before_mask
         self.masked_fill_value: float = masked_fill_value
-        self.concurrent_compute: bool = executor is not None
         self._executor = executor
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
@@ -649,8 +648,7 @@ class TorchTrainDataset(Dataset):
             prognostic_selected = self._prognostic_src.data.isel(time=x_index)
             boundary_selected = self._boundary_src.data.isel(time=x_index)
 
-            if self.concurrent_compute:
-                assert self._executor is not None
+            if self._executor is not None:
                 concurrent_compute(
                     prognostic_selected, boundary_selected, executor=self._executor
                 )

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,5 +1,7 @@
 import logging
 import time
+from concurrent.futures import wait
+from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Any
 
 import numpy as np
@@ -585,7 +587,7 @@ class TorchTrainDataset(Dataset):
         normalize_before_mask: bool,
         masked_fill_value: float,
         stride: int = 1,
-        concurrent_compute: bool = False,
+        executor: ThreadPoolExecutor | None = None,
     ):
         super().__init__()
         self.device = get_device()
@@ -595,7 +597,8 @@ class TorchTrainDataset(Dataset):
         self.stride: int = stride
         self.normalize_before_mask: bool = normalize_before_mask
         self.masked_fill_value: float = masked_fill_value
-        self.concurrent_compute: bool = concurrent_compute
+        self.concurrent_compute: bool = executor is not None
+        self._executor = executor
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
         data = src.data
@@ -647,7 +650,9 @@ class TorchTrainDataset(Dataset):
             boundary_selected = self._boundary_src.data.isel(time=x_index)
 
             if self.concurrent_compute:
-                concurrent_compute(prognostic_selected, boundary_selected)
+                concurrent_compute(
+                    prognostic_selected, boundary_selected, executor=self._executor
+                )
 
             if "lev" in prognostic_selected.dims:
                 prognostic_all = torch.from_numpy(
@@ -676,6 +681,10 @@ class TorchTrainDataset(Dataset):
 
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
         return TD
+
+    def __del__(self):
+        self._executor.shutdown(wait=True)
+        super().__del__()
 
     def _get_input_and_label(
         self,
@@ -744,18 +753,14 @@ class TorchTrainDataset(Dataset):
 
 def concurrent_compute(
     *datasets: xr.Dataset,
+    executor: ThreadPoolExecutor | None = None,
 ) -> None:
-    from concurrent.futures import ThreadPoolExecutor, wait
-
     def load_variable_data(var: xr.Variable) -> None:
         var.load()
 
-    with ThreadPoolExecutor(
-        max_workers=None, thread_name_prefix="concurrent_compute"
-    ) as executor:
-        futures = []
-        for ds in datasets:
-            for var in ds.variables.values():
-                futures.append(executor.submit(load_variable_data, var))
+    futures = []
+    for ds in datasets:
+        for var in ds.variables.values():
+            futures.append(executor.submit(load_variable_data, var))
 
-        wait(futures)
+    wait(futures)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -650,6 +650,7 @@ class TorchTrainDataset(Dataset):
             boundary_selected = self._boundary_src.data.isel(time=x_index)
 
             if self.concurrent_compute:
+                assert self._executor is not None
                 concurrent_compute(
                     prognostic_selected, boundary_selected, executor=self._executor
                 )
@@ -681,10 +682,6 @@ class TorchTrainDataset(Dataset):
 
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
         return TD
-
-    def __del__(self):
-        self._executor.shutdown(wait=True)
-        super().__del__()
 
     def _get_input_and_label(
         self,
@@ -753,7 +750,7 @@ class TorchTrainDataset(Dataset):
 
 def concurrent_compute(
     *datasets: xr.Dataset,
-    executor: ThreadPoolExecutor | None = None,
+    executor: ThreadPoolExecutor,
 ) -> None:
     def load_variable_data(var: xr.Variable) -> None:
         var.load()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -11,6 +11,7 @@ import time
 import warnings
 from collections import OrderedDict
 from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from typing import Any, assert_never
 
@@ -167,7 +168,13 @@ class Trainer:
         self.loader_version = LoaderVersion(cfg.data.loader_version)
         self.data_dir = cfg.experiment.data_dir
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
-        self.concurrent_compute = cfg.data.concurrent_compute
+
+        if cfg.data.concurrent_compute:
+            self.executor = ThreadPoolExecutor(
+                max_workers=None, thread_name_prefix="concurrent_compute"
+            )
+        else:
+            self.executor = None
 
         use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
         raw = DataSource.from_config(cfg, use_dask=use_dask)
@@ -737,7 +744,7 @@ class Trainer:
                             normalize_before_mask=self.normalize_before_mask,
                             masked_fill_value=self.normalize_fill_value,
                             stride=stride,
-                            concurrent_compute=self.concurrent_compute,
+                            executor=self.executor,
                         )
                         for stride in self.data_stride
                     ]
@@ -756,7 +763,7 @@ class Trainer:
                             normalize_before_mask=self.normalize_before_mask,
                             masked_fill_value=self.normalize_fill_value,
                             stride=stride,
-                            concurrent_compute=self.concurrent_compute,
+                            executor=self.executor,
                         )
                         for stride in self.data_stride
                     ]
@@ -948,6 +955,8 @@ class Trainer:
             self._ema.restore(parameters=self.model.parameters())
 
     def finish(self):
+        if self.executor is not None:
+            self.executor.shutdown()
         self.wandb_logger.finish()
 
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -169,12 +169,11 @@ class Trainer:
         self.data_dir = cfg.experiment.data_dir
         self.scaling_residuals_file = cfg.data.scaling_residuals_file
 
+        self.executor: ThreadPoolExecutor | None = None
         if cfg.data.concurrent_compute:
             self.executor = ThreadPoolExecutor(
                 max_workers=None, thread_name_prefix="concurrent_compute"
             )
-        else:
-            self.executor = None
 
         use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
         raw = DataSource.from_config(cfg, use_dask=use_dask)


### PR DESCRIPTION
I think that it's a good idea to try to load all the data variables concurrently. However, before this PR, we create and then tear down the executor way too many times (per loop per getitem). This change will allow to to see how effective we can concurrently load Xarray data.