### PR TITLE
Added opt-in uvloop backend for more performant async operations.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
   "scipy>=1.15.2",
   "torch~=2.2.1",
   "torchinfo>=1.8",
+  "uvloop>=0.21",
   "wandb>=0.19.8",
   "xarray[io]>=2025.1.2",
   "xarray-einstats[einops]>=0.8",

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -99,6 +99,14 @@ class DataConfig(BaseConfig):
     normalize_before_mask: bool = True
     masked_fill_value: float = 0.0
     concurrent_compute: bool = False
+    # `uvloop` is a drop-in replacement for `asyncio` that provides
+    # Go-level concurrency performance. It hooks up Python's async event loop
+    # with `libuv`, which is Node.js's core event loop library, written in C.
+    # This feature is only worth turning on if you plan to use concurrency when
+    # loading data, i.e. performing IO-bound, async operations. This often happens
+    # with our dependencies -- for example, Zarr v3 uses asyncio to handle IO-bound
+    # operations -- as well as explicitly in SPDL pipelines.
+    use_uvloop: bool = False
 
 
 BlockType = Literal["conv_next_block", "conv_block"]

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -44,6 +44,14 @@ class Eval:
     def __init__(self, cfg: EvalConfig) -> None:
         cfg.prepare_output_dirs()
 
+        # Turn on uvloop as the asyncio backend
+        if cfg.data.use_uvloop:
+            import asyncio
+
+            import uvloop
+
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
         self.device = init_eval_backend(cfg.backend)
 
         # Adjust workers and memory pinning based on device

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -98,6 +98,14 @@ class Trainer:
         cfg.prepare_output_dirs()
         cfg.save_yaml(cfg.experiment.output_dir / "config.yaml")
 
+        # Turn on uvloop as the asyncio backend
+        if cfg.data.use_uvloop:
+            import asyncio
+
+            import uvloop
+
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
         # Backend
         self.device, self.distributed = init_train_backend(cfg.backend)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'linux'",
@@ -2545,6 +2544,7 @@ dependencies = [
     { name = "scipy" },
     { name = "torch" },
     { name = "torchinfo" },
+    { name = "uvloop" },
     { name = "wandb" },
     { name = "xarray", extra = ["io"] },
     { name = "xarray-einstats", extra = ["einops"] },
@@ -2591,6 +2591,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.15.2" },
     { name = "torch", specifier = "~=2.2.1" },
     { name = "torchinfo", specifier = ">=1.8" },
+    { name = "uvloop", specifier = ">=0.21.0" },
     { name = "wandb", specifier = ">=0.19.8" },
     { name = "xarray", extras = ["io"], specifier = ">=2025.1.2" },
     { name = "xarray-einstats", extras = ["einops"], specifier = ">=0.8" },
@@ -4027,6 +4028,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/c0/854216d09d33c543f12a44b393c402e89a920b1a0a7dc634c42de91b9cf6/uvloop-0.21.0.tar.gz", hash = "sha256:3bf12b0fda68447806a7ad847bfa591613177275d35b6724b1ee573faa3704e3", size = 2492741 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/a7/4cf0334105c1160dd6819f3297f8700fda7fc30ab4f61fbf3e725acbc7cc/uvloop-0.21.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c0f3fa6200b3108919f8bdabb9a7f87f20e7097ea3c543754cabc7d717d95cf8", size = 1447410 },
+    { url = "https://files.pythonhosted.org/packages/8c/7c/1517b0bbc2dbe784b563d6ab54f2ef88c890fdad77232c98ed490aa07132/uvloop-0.21.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0878c2640cf341b269b7e128b1a5fed890adc4455513ca710d77d5e93aa6d6a0", size = 805476 },
+    { url = "https://files.pythonhosted.org/packages/ee/ea/0bfae1aceb82a503f358d8d2fa126ca9dbdb2ba9c7866974faec1cb5875c/uvloop-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9fb766bb57b7388745d8bcc53a359b116b8a04c83a2288069809d2b3466c37e", size = 3960855 },
+    { url = "https://files.pythonhosted.org/packages/8a/ca/0864176a649838b838f36d44bf31c451597ab363b60dc9e09c9630619d41/uvloop-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a375441696e2eda1c43c44ccb66e04d61ceeffcd76e4929e527b7fa401b90fb", size = 3973185 },
+    { url = "https://files.pythonhosted.org/packages/30/bf/08ad29979a936d63787ba47a540de2132169f140d54aa25bc8c3df3e67f4/uvloop-0.21.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:baa0e6291d91649c6ba4ed4b2f982f9fa165b5bbd50a9e203c416a2797bab3c6", size = 3820256 },
+    { url = "https://files.pythonhosted.org/packages/da/e2/5cf6ef37e3daf2f06e651aae5ea108ad30df3cb269102678b61ebf1fdf42/uvloop-0.21.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4509360fcc4c3bd2c70d87573ad472de40c13387f5fda8cb58350a1d7475e58d", size = 3937323 },
+    { url = "https://files.pythonhosted.org/packages/8c/4c/03f93178830dc7ce8b4cdee1d36770d2f5ebb6f3d37d354e061eefc73545/uvloop-0.21.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:359ec2c888397b9e592a889c4d72ba3d6befba8b2bb01743f72fffbde663b59c", size = 1471284 },
+    { url = "https://files.pythonhosted.org/packages/43/3e/92c03f4d05e50f09251bd8b2b2b584a2a7f8fe600008bcc4523337abe676/uvloop-0.21.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f7089d2dc73179ce5ac255bdf37c236a9f914b264825fdaacaded6990a7fb4c2", size = 821349 },
+    { url = "https://files.pythonhosted.org/packages/a6/ef/a02ec5da49909dbbfb1fd205a9a1ac4e88ea92dcae885e7c961847cd51e2/uvloop-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:baa4dcdbd9ae0a372f2167a207cd98c9f9a1ea1188a8a526431eef2f8116cc8d", size = 4580089 },
+    { url = "https://files.pythonhosted.org/packages/06/a7/b4e6a19925c900be9f98bec0a75e6e8f79bb53bdeb891916609ab3958967/uvloop-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86975dca1c773a2c9864f4c52c5a55631038e387b47eaf56210f873887b6c8dc", size = 4693770 },
+    { url = "https://files.pythonhosted.org/packages/ce/0c/f07435a18a4b94ce6bd0677d8319cd3de61f3a9eeb1e5f8ab4e8b5edfcb3/uvloop-0.21.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:461d9ae6660fbbafedd07559c6a2e57cd553b34b0065b6550685f6653a98c1cb", size = 4451321 },
+    { url = "https://files.pythonhosted.org/packages/8f/eb/f7032be105877bcf924709c97b1bf3b90255b4ec251f9340cef912559f28/uvloop-0.21.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:183aef7c8730e54c9a3ee3227464daed66e37ba13040bb3f350bc2ddc040f22f", size = 4659022 },
+    { url = "https://files.pythonhosted.org/packages/3f/8d/2cbef610ca21539f0f36e2b34da49302029e7c9f09acef0b1c3b5839412b/uvloop-0.21.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bfd55dfcc2a512316e65f16e503e9e450cab148ef11df4e4e679b5e8253a5281", size = 1468123 },
+    { url = "https://files.pythonhosted.org/packages/93/0d/b0038d5a469f94ed8f2b2fce2434a18396d8fbfb5da85a0a9781ebbdec14/uvloop-0.21.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787ae31ad8a2856fc4e7c095341cccc7209bd657d0e71ad0dc2ea83c4a6fa8af", size = 819325 },
+    { url = "https://files.pythonhosted.org/packages/50/94/0a687f39e78c4c1e02e3272c6b2ccdb4e0085fda3b8352fecd0410ccf915/uvloop-0.21.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ee4d4ef48036ff6e5cfffb09dd192c7a5027153948d85b8da7ff705065bacc6", size = 4582806 },
+    { url = "https://files.pythonhosted.org/packages/d2/19/f5b78616566ea68edd42aacaf645adbf71fbd83fc52281fba555dc27e3f1/uvloop-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3df876acd7ec037a3d005b3ab85a7e4110422e4d9c1571d4fc89b0fc41b6816", size = 4701068 },
+    { url = "https://files.pythonhosted.org/packages/47/57/66f061ee118f413cd22a656de622925097170b9380b30091b78ea0c6ea75/uvloop-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bd53ecc9a0f3d87ab847503c2e1552b690362e005ab54e8a48ba97da3924c0dc", size = 4454428 },
+    { url = "https://files.pythonhosted.org/packages/63/9a/0962b05b308494e3202d3f794a6e85abe471fe3cafdbcf95c2e8c713aabd/uvloop-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a5c39f217ab3c663dc699c04cbd50c13813e31d917642d459fdcec07555cc553", size = 4660018 },
 ]
 
 [[package]]


### PR DESCRIPTION
In my one-off prototype of loading Zarr with SPDL (see below), I noticed marked improvement in overall throughput by adding these modest three LOC that registered `uvloop` as the project's async backend. While this PR is independent of my SPDL pipeline (it should also improve Zarr performance if/when we switch to Zarr v3), it is an important complement to it (see #289).

<details>

<summary> Without <code>uvloop</code>, the max throughput I got was <strong>2.008 GB/s</strong></summary>

While the max throughput is similar, the overall range of througputs without `uvloop` is much lower.

```
$ python tests/test_throughput.py 
✓ Basic tests passed
OM4 dataset info:
  Available variables: ['dz', 'areacello', 'so', 'tauuo', 'ocean_fraction', 'hfds_anomalies', 'lat', 'lev', 'lon', 'tauvo', 'hfds', 'lat_b', 'lon_b', 'thetao', 'time', 'uo', 'vo', 'wetmask', 'zos', 'x', 'y']
  Using variable: uo
  Shape: (19, 2048, 180, 360)
  Dtype: float32
  Chunks: (19, 1, 180, 360)
  Total size: 9.4 GB
  Chunk grid: (1, 2048, 1, 1)

Benchmarking 250 blocks from OM4 dataset...

=== Testing SPDL Pipeline Configurations ===

Configuration 1: Load workers=8, Convert workers=4, Total threads=16, Batch size=4
  Throughput: 0.771 GB/s

Configuration 2: Load workers=12, Convert workers=6, Total threads=20, Batch size=6
  Throughput: 1.906 GB/s

Configuration 3: Load workers=16, Convert workers=8, Total threads=28, Batch size=8
  Throughput: 1.775 GB/s

Configuration 4: Load workers=20, Convert workers=10, Total threads=32, Batch size=10
  Throughput: 2.008 GB/s

Configuration 5: Load workers=24, Convert workers=12, Total threads=40, Batch size=12
  Throughput: 1.623 GB/s

Best SPDL configuration: Load=20, Convert=10, Threads=32, Batch=10
Best SPDL Throughput: 2.008 GB/s

=== Sequential Loading ===
Throughput: 0.41 GB/s (loaded 1.15 GB in 2.80s, 250 batches)

=== XBatcher Loading ===
Throughput: 0.41 GB/s (loaded 9.36 GB in 22.66s, 204 batches)

=== Final Results ===
Best SPDL Pipeline: 2.008 GB/s
Sequential Loading:  0.410 GB/s
Speedup:            4.9x
XBatcher Loading:  0.413 GB/s
Speedup:            4.9x

```

</details>


<details>

<summary>With <code>uvloop</code>, the max throughput I got was <strong>2.496 GB/s</strong></summary>

With `uvloop`, we can get higher throughput with overall less resources (a lower resourced configuration provides the max throughput). Furthermore, with `uvloop` turned on, the _baseline_ throughput performance also increases  (at least, modestly) -- see the `xbatcher` and sequential versions. This demonstrates that `uvloop` improves the Zarr v3 backend.

```
$ python tests/test_throughput.py 
✓ Basic tests passed
OM4 dataset info:
  Available variables: ['dz', 'areacello', 'so', 'tauuo', 'ocean_fraction', 'hfds_anomalies', 'lat', 'lev', 'lon', 'tauvo', 'hfds', 'lat_b', 'lon_b', 'thetao', 'time', 'uo', 'vo', 'wetmask', 'zos', 'x', 'y']
  Using variable: uo
  Shape: (19, 2048, 180, 360)
  Dtype: float32
  Chunks: (19, 1, 180, 360)
  Total size: 9.4 GB
  Chunk grid: (1, 2048, 1, 1)

Benchmarking 250 blocks from OM4 dataset...

=== Testing SPDL Pipeline Configurations ===

Configuration 1: Load workers=8, Convert workers=4, Total threads=16, Batch size=4
  Throughput: 1.721 GB/s

Configuration 2: Load workers=12, Convert workers=6, Total threads=20, Batch size=6
  Throughput: 2.496 GB/s

Configuration 3: Load workers=16, Convert workers=8, Total threads=28, Batch size=8
  Throughput: 2.062 GB/s

Configuration 4: Load workers=20, Convert workers=10, Total threads=32, Batch size=10
  Throughput: 2.124 GB/s

Configuration 5: Load workers=24, Convert workers=12, Total threads=40, Batch size=12
  Throughput: 2.485 GB/s

Best SPDL configuration: Load=12, Convert=6, Threads=20, Batch=6
Best SPDL Throughput: 2.496 GB/s

=== Sequential Loading ===
Throughput: 0.47 GB/s (loaded 1.15 GB in 2.42s, 250 batches)

=== XBatcher Loading ===
Throughput: 0.58 GB/s (loaded 9.36 GB in 16.02s, 204 batches)

=== Final Results ===
Best SPDL Pipeline: 2.496 GB/s
Sequential Loading:  0.474 GB/s
Speedup:            5.3x
XBatcher Loading:  0.584 GB/s
Speedup:            4.3x
```

</details>