### PR TITLE
Fix performance regression by moving towards a more buildy world with DataContainer

### DIFF
--- a/src/ocean_emulators/aggregator/inference/time_mean.py
+++ b/src/ocean_emulators/aggregator/inference/time_mean.py
@@ -177,7 +177,7 @@ class TimeMeanAggregator:
                 )
                 bias_map = pair.bias().cpu().numpy()
                 vmin_bias, vmax_bias = get_cmap_limits(bias_map, diverging=True)
-                cmap = plt.cm.get_cmap("RdBu_r")
+                cmap = plt.colormaps.get_cmap("RdBu_r")
                 cmap.set_bad(color=(0.7, 0.7, 0.7))
 
                 bias_fig: plt.Figure = plot_imshow(
@@ -300,7 +300,7 @@ class TimeMeanEvaluatorAggregator:
         for pred in preds:
             bias_data = pred.bias().cpu().numpy()
             vmin_bias, vmax_bias = get_cmap_limits(bias_data, diverging=True)
-            cmap = plt.cm.get_cmap("RdBu_r")
+            cmap = plt.colormaps.get_cmap("RdBu_r")
             cmap.set_bad(color=(0.7, 0.7, 0.7))
             bias_fig = plot_imshow(
                 bias_data, vmin=vmin_bias, vmax=vmax_bias, cmap=cmap, nan_padding=False

--- a/src/ocean_emulators/aggregator/plotting.py
+++ b/src/ocean_emulators/aggregator/plotting.py
@@ -61,10 +61,10 @@ def plot_paneled_data(
 ):
     """Plot a list of 2D data arrays in a paneled plot."""
     if diverging:
-        cmap = plt.cm.get_cmap("RdBu_r")
+        cmap = plt.colormaps.get_cmap("RdBu_r")
         cmap.set_bad(color=(0.7, 0.7, 0.7))
     else:
-        cmap = plt.cm.get_cmap("viridis")
+        cmap = plt.colormaps.get_cmap("viridis")
         cmap.set_bad(color="white")
     vmin = np.inf
     vmax = -np.inf

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -7,7 +7,8 @@ import torch
 from pydantic import Field, PlainSerializer, PlainValidator, WithJsonSchema
 
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
-from ocean_emulators.constants import LoaderVersion
+from ocean_emulators.constants import BoundaryVarNames, LoaderVersion
+from ocean_emulators.utils.data import DataContainer, DataSource, validate_data
 from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLocation
 from ocean_emulators.utils.profiler import Profiler
 
@@ -115,6 +116,72 @@ class DataConfig(BaseConfig):
     normalize_before_mask: bool = True
     masked_fill_value: float = 0.0
     concurrent_compute: bool = False
+
+    def build(
+        self,
+        data_root: ResolvedLocation,
+        boundary_var_names: BoundaryVarNames,
+    ) -> DataContainer:
+        loader_version = LoaderVersion(self.loader_version)
+        use_dask = loader_version != LoaderVersion.OM4_TORCH
+
+        data_location = data_root.resolve(self.data_location)
+        means_location = data_root.resolve(self.data_means_location)
+        stds_location = data_root.resolve(self.data_stds_location)
+
+        source = DataSource.from_locations(
+            data_location=data_location,
+            means_location=means_location,
+            stds_location=stds_location,
+            use_dask=use_dask,
+        )
+        source = validate_data(source, boundary_var_names, self.static_data_vars)
+
+        if use_dask:
+            data_using_dask = source
+        else:
+            data_using_dask = DataSource.from_locations(
+                data_location=data_location,
+                means_location=means_location,
+                stds_location=stds_location,
+                use_dask=True,
+            )
+            data_using_dask = validate_data(
+                data_using_dask, boundary_var_names, self.static_data_vars
+            )
+        scaling_residuals_location = (
+            data_root.resolve(self.scaling_residuals_file)
+            if self.scaling_residuals_file is not None
+            else None
+        )
+        scaling_residuals = (
+            scaling_residuals_location.open()
+            if scaling_residuals_location is not None
+            else None
+        )
+        static_data = (
+            source.data[self.static_data_vars]
+            if self.static_data_vars is not None
+            else None
+        )
+
+        supports_fork = all(
+            location is None or location.supports_fork
+            for location in [
+                data_location,
+                means_location,
+                stds_location,
+                scaling_residuals_location,
+            ]
+        )
+        return DataContainer(
+            source,
+            data_using_dask,
+            loader_version,
+            supports_fork,
+            scaling_residuals,
+            static_data,
+        )
 
 
 BlockType = Literal["conv_next_block", "conv_block"]

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -138,27 +138,27 @@ class DataConfig(BaseConfig):
         source = validate_data(source, boundary_var_names, self.static_data_vars)
 
         if use_dask:
-            data_using_dask = source
+            # If we're already using dask, we don't need a second source
+            source_using_dask = source
         else:
-            data_using_dask = DataSource.from_locations(
+            # If we're not using dask for the main source, create a separate one
+            source_using_dask = DataSource.from_locations(
                 data_location=data_location,
                 means_location=means_location,
                 stds_location=stds_location,
                 use_dask=True,
             )
-            data_using_dask = validate_data(
-                data_using_dask, boundary_var_names, self.static_data_vars
+            source_using_dask = validate_data(
+                source_using_dask, boundary_var_names, self.static_data_vars
             )
-        scaling_residuals_location = (
-            data_root.resolve(self.scaling_residuals_file)
-            if self.scaling_residuals_file is not None
-            else None
-        )
-        scaling_residuals = (
-            scaling_residuals_location.open()
-            if scaling_residuals_location is not None
-            else None
-        )
+
+        if self.scaling_residuals_file is not None:
+            scaling_residuals_location = data_root.resolve(self.scaling_residuals_file)
+            scaling_residuals = scaling_residuals_location.open()
+        else:
+            scaling_residuals_location = None
+            scaling_residuals = None
+
         static_data = (
             source.data[self.static_data_vars]
             if self.static_data_vars is not None
@@ -176,7 +176,7 @@ class DataConfig(BaseConfig):
         )
         return DataContainer(
             source,
-            data_using_dask,
+            source_using_dask,
             loader_version,
             supports_fork,
             scaling_residuals,

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -21,12 +21,10 @@ from ocean_emulators.datasets import InferenceDataset
 from ocean_emulators.models.samudra import Samudra
 from ocean_emulators.stepper import Stepper
 from ocean_emulators.utils.data import (
-    DataSource,
     Normalize,
     extract_wet_mask,
     get_inference_steps,
     spherical_area_weights,
-    validate_data,
 )
 from ocean_emulators.utils.device import using_gpu
 from ocean_emulators.utils.distributed import is_main_process, set_seed
@@ -91,20 +89,14 @@ class Eval:
 
         # Dataloaders
         logger.info(f"Loading data")
-        self.data_dir = cfg.experiment.resolved_data_root
-        self.data_location = cfg.data.data_location
-        self.data_means_location = cfg.data.data_means_location
-        self.data_stds_location = cfg.data.data_stds_location
-        self.scaling_residuals_file = cfg.data.scaling_residuals_file
-
-        raw = DataSource.from_config(cfg, use_dask=True)
-        self.src = validate_data(
-            raw, self.boundary_var_names, cfg.data.static_data_vars
+        self.data_container = cfg.data.build(
+            cfg.experiment.resolved_data_root,
+            self.boundary_var_names,
         )
+
+        self.src = self.data_container.source_using_dask
         self.data = self.src.data
-        self.static_data = None
-        if cfg.data.static_data_vars is not None:
-            self.static_data = self.data[cfg.data.static_data_vars]
+        self.static_data = self.data_container.static_data
 
         self.metadata = construct_metadata(self.data)
         self.wet, self.wet_surface = extract_wet_mask(

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -13,6 +13,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
+from multiprocessing.context import BaseContext
 from typing import Any, assert_never
 
 import dask
@@ -36,7 +37,6 @@ from ocean_emulators.constants import (
     PROGNOSTIC_VARS,
     BoundaryVarNames,
     Grid,
-    LoaderVersion,
     PrognosticVarNames,
     TensorMap,
     construct_metadata,
@@ -51,12 +51,10 @@ from ocean_emulators.datasets import (
 from ocean_emulators.models.samudra import Samudra
 from ocean_emulators.stepper import Stepper, TrainBatchOutput, ValBatchOutput
 from ocean_emulators.utils.data import (
-    DataSource,
     Normalize,
     extract_wet_mask,
     get_inference_steps,
     spherical_area_weights,
-    validate_data,
 )
 from ocean_emulators.utils.device import using_gpu
 from ocean_emulators.utils.distributed import (
@@ -108,9 +106,6 @@ class Trainer:
 
         # Distributed mode
         dask.config.set(scheduler="synchronous")
-        self.mp_context = (
-            multiprocessing.get_context("spawn") if cfg.data.num_workers > 0 else None
-        )
 
         # Set seeds
         set_seed(cfg.experiment.rand_seed)
@@ -139,6 +134,20 @@ class Trainer:
         self.N_bound = len(self.boundary_var_names)
         self.N_prog = len(self.prognostic_var_names)
 
+        self.data_container = cfg.data.build(
+            data_root=cfg.experiment.resolved_data_root,
+            boundary_var_names=self.boundary_var_names,
+        )
+
+        self.mp_context: BaseContext | None
+        if cfg.data.num_workers > 0:
+            if self.data_container.supports_fork:
+                self.mp_context = multiprocessing.get_context("fork")
+            else:
+                self.mp_context = multiprocessing.get_context("spawn")
+        else:
+            self.mp_context = None
+
         self.num_in = int((cfg.data.hist + 1) * (self.N_prog + self.N_bound))
         self.num_out = int((cfg.data.hist + 1) * self.N_prog)
 
@@ -164,33 +173,22 @@ class Trainer:
                 f"with validation time range {cfg.val_time}"
             )
 
-        self.loader_version = LoaderVersion(cfg.data.loader_version)
-        self.scaling_residuals_file = (
-            cfg.experiment.resolved_data_root.resolve(cfg.data.scaling_residuals_file)
-            if cfg.data.scaling_residuals_file is not None
-            else None
-        )
         self.executor: ThreadPoolExecutor | None = None
         if cfg.data.concurrent_compute:
             self.executor = ThreadPoolExecutor(
                 max_workers=None, thread_name_prefix="concurrent_compute"
             )
 
-        use_dask = cfg.data.loader_version != LoaderVersion.OM4_TORCH.value
-        raw = DataSource.from_config(cfg, use_dask=use_dask)
-        self.src = validate_data(
-            raw, self.boundary_var_names, cfg.data.static_data_vars
-        )
-        self.data = self.src.data
-        self.static_data = None
-        if cfg.data.static_data_vars is not None:
-            self.static_data = self.data[cfg.data.static_data_vars]
+        self.src = self.data_container.source
+        self.data = self.data_container.source.data
+        self.static_data = self.data_container.static_data
 
         # We use dask for inference since it has memory issues otherwise.
         # TODO(jder): Could rewrite inference dataset like we did for TorchTrainDataset
         # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/208
-        raw = DataSource.from_config(cfg, use_dask=True)
-        self.inference_src = validate_data(raw, self.boundary_var_names)
+        self.inference_src = self.data_container.source_using_dask
+
+        self.loader_version = self.data_container.loader_version
 
         self.metadata = construct_metadata(self.data)
         self.wet, self.wet_surface = extract_wet_mask(
@@ -233,7 +231,7 @@ class Trainer:
                 hist=cfg.data.hist,
                 wet=self.wet,
                 area_weights=self.area_weights,
-                static_data=self.static_data,
+                static_data=self.data_container.static_data,
             ).to(self.device)
         else:
             raise NotImplementedError
@@ -261,15 +259,14 @@ class Trainer:
             )
         elif cfg.loss == "mse_residual_scaled":
             logger.info("Using decomposed mse loss with scaled residuals")
-            assert self.scaling_residuals_file is not None, (
+            assert self.data_container.scaling_residuals is not None, (
                 "With loss of 'mse_residual_scaled' you"
                 " must supply a scaling_residuals_file"
             )
-            scaling_residuals = self.scaling_residuals_file.open()
             scale = torch.from_numpy(
                 (
                     self.src.stds[self.prognostic_var_names]
-                    / scaling_residuals[self.prognostic_var_names]
+                    / self.data_container.scaling_residuals[self.prognostic_var_names]
                 )
                 .compute()
                 .to_array()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -139,14 +139,12 @@ class Trainer:
             boundary_var_names=self.boundary_var_names,
         )
 
-        self.mp_context: BaseContext | None
+        self.mp_context: BaseContext | None = None
         if cfg.data.num_workers > 0:
             if self.data_container.supports_fork:
                 self.mp_context = multiprocessing.get_context("fork")
             else:
                 self.mp_context = multiprocessing.get_context("spawn")
-        else:
-            self.mp_context = None
 
         self.num_in = int((cfg.data.hist + 1) * (self.N_prog + self.N_bound))
         self.num_out = int((cfg.data.hist + 1) * self.N_prog)

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -250,22 +250,14 @@ class DataSource:
         )
 
 
+@dataclasses.dataclass
 class DataContainer:
-    def __init__(
-        self,
-        source: DataSource,
-        source_using_dask: DataSource,
-        loader_version: LoaderVersion,
-        supports_fork: bool,
-        scaling_residuals: xr.Dataset | None = None,
-        static_data: xr.Dataset | None = None,
-    ):
-        self.source = source
-        self.source_using_dask = source_using_dask
-        self.loader_version = loader_version
-        self.scaling_residuals = scaling_residuals
-        self.static_data = static_data
-        self.supports_fork = supports_fork
+    source: DataSource
+    source_using_dask: DataSource
+    loader_version: LoaderVersion
+    supports_fork: bool
+    scaling_residuals: xr.Dataset | None = None
+    static_data: xr.Dataset | None = None
 
 
 def conditional_rearrange(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -516,7 +516,7 @@ def compute_anomalies(
                 data[var] = (
                     data[base_var] - climatology.sel(dayofyear=day_of_year)
                 ).compute()
-                data = data.drop(["dayofyear"])
+                data = data.drop_vars(["dayofyear"])
                 means[var] = data[var].mean().compute()
                 stds[var] = data[var].std().compute()
         return data, means, stds

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -4,14 +4,15 @@ import re
 from collections import defaultdict
 from collections.abc import Callable
 from functools import cached_property
-from typing import Literal, Self
+from typing import TYPE_CHECKING, Literal, Self
 
 import numpy as np
 import torch
 import xarray as xr
 from einops import rearrange
 
-from ocean_emulators.config import EvalConfig, TimeConfig, TrainConfig
+if TYPE_CHECKING:
+    from ocean_emulators.config import TimeConfig
 from ocean_emulators.constants import (
     DEPTH_I_LEVELS,
     DEPTH_LEVELS,
@@ -23,6 +24,7 @@ from ocean_emulators.constants import (
     Grid,
     GridMask,
     Input,
+    LoaderVersion,
     Prognostic,
     PrognosticMask,
     PrognosticVarNames,
@@ -30,6 +32,7 @@ from ocean_emulators.constants import (
     TensorMap,
 )
 from ocean_emulators.derived_variables import add_derived_variables
+from ocean_emulators.utils.location import ResolvedLocation
 from ocean_emulators.utils.multiton import Multiton
 
 logger = logging.getLogger(__name__)
@@ -138,7 +141,7 @@ class DataSource:
         data = func(self.data.copy())
         return dataclasses.replace(self, name=f"{self.name}_{suffix}", data=data)
 
-    def slice(self, time: TimeConfig) -> Self:
+    def slice(self, time: "TimeConfig") -> Self:
         """Slice the data source to only include the specified time slice."""
         data_time_min = self.data.time.min().item()
         data_time_max = self.data.time.max().item()
@@ -226,22 +229,43 @@ class DataSource:
         return cls(name=name, data=dataset, means=means, stds=stds)
 
     @classmethod
-    def from_config(cls, cfg: TrainConfig | EvalConfig, *, use_dask: bool) -> Self:
+    def from_locations(
+        cls,
+        data_location: ResolvedLocation,
+        means_location: ResolvedLocation,
+        stds_location: ResolvedLocation,
+        *,
+        use_dask: bool,
+    ) -> Self:
         chunks: dict[str, int] | None = {} if use_dask else None
-        root = cfg.experiment.resolved_data_root
-
-        data = root.resolve(cfg.data.data_location).open(chunks)
-        means = root.resolve(cfg.data.data_means_location).open(chunks)
-        stds = root.resolve(cfg.data.data_stds_location).open(chunks)
-
-        dask = "with_dask" if use_dask else "without_dask"
+        data = data_location.open(chunks)
+        means = means_location.open(chunks)
+        stds = stds_location.open(chunks)
 
         return cls(
-            name=f"{cfg.experiment.name}-{data}-{dask}",
+            name=f"{data_location}-{use_dask}",
             data=data,
             means=means,
             stds=stds,
         )
+
+
+class DataContainer:
+    def __init__(
+        self,
+        source: DataSource,
+        source_using_dask: DataSource,
+        loader_version: LoaderVersion,
+        supports_fork: bool,
+        scaling_residuals: xr.Dataset | None = None,
+        static_data: xr.Dataset | None = None,
+    ):
+        self.source = source
+        self.source_using_dask = source_using_dask
+        self.loader_version = loader_version
+        self.scaling_residuals = scaling_residuals
+        self.static_data = static_data
+        self.supports_fork = supports_fork
 
 
 def conditional_rearrange(

--- a/src/ocean_emulators/utils/location.py
+++ b/src/ocean_emulators/utils/location.py
@@ -42,6 +42,10 @@ class ResolvedLocation(ABC):
     def resolve(self, location: "Location") -> "ResolvedLocation":
         pass
 
+    @abstractmethod
+    def supports_fork(self) -> bool:
+        pass
+
     def __truediv__(self, other: "Location") -> "ResolvedLocation":
         return self.resolve(other)
 
@@ -88,6 +92,9 @@ class S3Location(ResolvedLocation, BaseModel):
             )
         return location
 
+    def supports_fork(self) -> bool:
+        return False  # s3fs does not support forking
+
     def __str__(self) -> str:
         return self.url()
 
@@ -114,6 +121,9 @@ class LocalLocation(ResolvedLocation, BaseModel):
         if isinstance(location, UnresolvedLocation):
             return LocalLocation(path=self.path / location.path)
         return location
+
+    def supports_fork(self) -> bool:
+        return True
 
     def __str__(self) -> str:
         return str(self.path)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -29,12 +29,7 @@ from ocean_emulators.datasets import (
     TrainData,
     TrainDataset,
 )
-from ocean_emulators.utils.data import (
-    DataSource,
-    Normalize,
-    extract_wet_mask,
-    validate_data,
-)
+from ocean_emulators.utils.data import DataSource, Normalize, extract_wet_mask
 from ocean_emulators.utils.multiton import MultitonScope
 from ocean_emulators.utils.train import collate_train_data
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
@@ -56,21 +51,19 @@ def make_loader(
     if time_config is None:
         time_config = cfg.train_time
 
-    if version is None:
-        version = LoaderVersion(cfg.data.loader_version)
-
-    use_dask = version != LoaderVersion.OM4_TORCH
-    raw = DataSource.from_config(cfg, use_dask=use_dask)
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]
     boundary = BOUNDARY_VARS[cfg.experiment.boundary_vars_key]
-    if raw.is_compact and version != LoaderVersion.OM4_TORCH:
+
+    container = cfg.data.build(cfg.experiment.resolved_data_root, boundary)
+    version = container.loader_version
+    src = container.source
+    if src.is_compact and version != LoaderVersion.OM4_TORCH:
         pytest.skip(f"{version} does not support compact data.")
 
     with MultitonScope():
         TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
         )
-        src = validate_data(raw, boundary)
         wet, wet_surface = extract_wet_mask(src.data, prognostic, cfg.data.hist)
         wet_without_hist, _ = extract_wet_mask(src.data, prognostic, 0)
         normalize_before_mask = cfg.data.normalize_before_mask


### PR DESCRIPTION
Fixes the performance regression from [here](https://github.com/LaureZanna/Ocean_Emulator/commit/32f3043d20bb43b24a1a097004f5c0f34f013075#commitcomment-160869800) by detecting if the data source supports forking or not. 

Doing this required a bit of code movement so I took the opportunity to move us closer towards a world where creating the trainer is `trainer = cfg.build()` by moving a bunch of the stuff in `Trainer.__init__` into `DataConfig.build` and creating a new class which is the result of that method, `DataContainer`. This also reduces some of the duplication between train/eval/tests.

Last commit is some drive-by fixes for warnings that were being printed in tests. 