### PR TITLE
Improvements from trying to understand the model

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -335,6 +335,9 @@ class TrainData:
                 self.td_dict[step][1].to(device),
             )
 
+    def __iter__(self):
+        return iter(self.td_dict)
+
 
 class TrainDataset(Dataset):
     """

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -142,7 +142,7 @@ class Eval:
         else:
             raise NotImplementedError
 
-        get_model_summary(model, self.num_in)
+        get_model_summary(model, None, cfg.debug)
 
         self.model = model
         if cfg.ckpt_path is None:

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from typing import assert_never
 
 import numpy as np
@@ -158,7 +157,7 @@ class Samudra(BaseModel):
             skip_inputs.append(torch.zeros_like(fts))
         count = 0
         for layer in self.layers:
-            crop: Sequence | np.ndarray = fts.shape[2:]
+            crop: torch.Size | np.ndarray = fts.shape[2:]
             if isinstance(layer, nn.Conv2d):
                 fts = torch.nn.functional.pad(
                     fts, (self.N_pad, self.N_pad, 0, 0), mode=self.pad

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import assert_never
 
 import numpy as np
@@ -150,14 +151,14 @@ class Samudra(BaseModel):
         self.corrector = Correctors(config.corrector, hist, area_weights, static_data)
         self.num_steps = int(len(config.ch_width) - 1)
 
-    def forward_once(self, fts):
+    def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
         fts_input = fts.clone().detach()
-        temp: list[torch.Tensor] = []
+        skip_inputs: list[torch.Tensor] = []
         for i in range(self.num_steps):
-            temp.append(torch.zeros_like(fts))
+            skip_inputs.append(torch.zeros_like(fts))
         count = 0
         for layer in self.layers:
-            crop = fts.shape[2:]
+            crop: Sequence | np.ndarray = fts.shape[2:]
             if isinstance(layer, nn.Conv2d):
                 fts = torch.nn.functional.pad(
                     fts, (self.N_pad, self.N_pad, 0, 0), mode=self.pad
@@ -166,12 +167,12 @@ class Samudra(BaseModel):
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
             if self.checkpoint_all:
-                fts = torch.utils.checkpoint.checkpoint(layer, fts, use_reentrant=False)
+                fts = torch.utils.checkpoint.checkpoint(layer, fts, use_reentrant=False)  # type: ignore
             else:
                 fts = layer(fts)
             if count < self.num_steps:
                 if isinstance(layer, CoreBlock):
-                    temp[count] = fts
+                    skip_inputs[count] = fts
                     count += 1
             elif count >= self.num_steps:
                 if isinstance(layer, BilinearUpsample) or isinstance(
@@ -179,7 +180,7 @@ class Samudra(BaseModel):
                 ):
                     crop = np.array(fts.shape[2:])
                     shape = np.array(
-                        temp[int(2 * self.num_steps - count - 1)].shape[2:]
+                        skip_inputs[int(2 * self.num_steps - count - 1)].shape[2:]
                     )
                     pads = shape - crop
                     pads = [
@@ -189,7 +190,7 @@ class Samudra(BaseModel):
                         pads[0] - pads[0] // 2,
                     ]
                     fts = nn.functional.pad(fts, pads)
-                    fts += temp[int(2 * self.num_steps - count - 1)]
+                    fts += skip_inputs[int(2 * self.num_steps - count - 1)]
                     count += 1
         fts = self.corrector(fts_input, fts)
         return torch.where(self.wet, fts, 0.0)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -234,8 +234,6 @@ class Trainer:
         else:
             raise NotImplementedError
 
-        get_model_summary(model, self.num_in)
-
         self.model = model
         self.nets_dir = cfg.experiment.nets_dir
         self.network = cfg.experiment.network
@@ -522,6 +520,10 @@ class Trainer:
 
             self.optimizer.zero_grad()
             data.to(self.device)
+
+            if self.num_batches_seen == 0:
+                get_model_summary(self.model, data, self.debug)
+
             TO: TrainBatchOutput = Stepper.train_batch(self.model, data, self.loss_fn)
             TO.loss.backward()
             self._ema(model=self.model)

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -7,6 +7,7 @@ import time
 import traceback
 import warnings
 from collections import defaultdict, deque
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -208,11 +209,13 @@ class MetricLogger:
         )
 
 
-def get_model_summary(model: torch.nn.Module, num_input_channels: int):
+def get_model_summary(model: torch.nn.Module, data: Mapping | None, debug: bool):
     model_parameters = filter(lambda p: p.requires_grad, model.parameters())
     params = sum([np.prod(p.size()) for p in model_parameters])
     logging.info(f"Number of parameters: {params}")
-    logging.info(summary(model))
+    depth = 10 if debug else 2
+    # we pass verbose = 0 because we log the summary ourselves
+    logging.info(summary(model, input_data=[data], depth=depth, verbose=0))
 
 
 def elapsed(func=None, *, level: int = logging.INFO):


### PR DESCRIPTION
* Makes the model summary include grid sizes by delaying calling it until we have data to run a forward pass (this will probably slow down benchmarks but we can ignore)
  * This required making TrainData a typing.Mapping to satisfy the summary function (though this still isn't perfect, it somehow can't figure out how much memory it uses)
* When debug = true, include all the layers not just top ones
* Rename and add type annotations to the core samudra model.