### PR TITLE
Fix bug which ignored loader version in tests

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -54,7 +54,13 @@ def make_loader(
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]
     boundary = BOUNDARY_VARS[cfg.experiment.boundary_vars_key]
 
-    container = cfg.data.build(cfg.experiment.resolved_data_root, boundary)
+    data_config = (
+        cfg.data
+        if version is None
+        else cfg.data.model_copy(update={"loader_version": str(version.value)})
+    )
+
+    container = data_config.build(cfg.experiment.resolved_data_root, boundary)
     version = container.loader_version
     src = container.source
     if src.is_compact and version != LoaderVersion.OM4_TORCH:


### PR DESCRIPTION
Our benchmarks showed a surprising jump in one of them after #295:
<img width="1028" height="514" alt="Screenshot 2025-07-10 at 10 26 37 AM" src="https://github.com/user-attachments/assets/3322d95a-817e-4113-be9a-704ed2b3638c" />

Turns out we were always building a torch loader, not an eager loader. Running the benchmarks locally after this change again shows a big performance gap between eager and torch loaders.