### PR TITLE
The default chunks of `clone_data` should be time=1.

### DIFF
--- a/scripts/clone_data.py
+++ b/scripts/clone_data.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         default=None,
         help="end index for data.isel() along time dimension.",
     )
-    parser.add_argument("--write_time_chunks", type=int, default=10)
+    parser.add_argument("--write_time_chunks", type=int, default=1)
     parser.add_argument("--compact_variables", action="store_true")
     parser.add_argument("--local_cluster", action="store_true")
 


### PR DESCRIPTION
I just verified this and it looks like in the OSN pod, chunks are `time=1`, but by default, we write `time=10` chunks. I want to remedy this so we don't make any accidents when automating are testing setup.