### PR TITLE
Avoid LocalLocation relative footgun

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -272,7 +272,7 @@ class ExperimentConfig(BaseConfig):
             raise ValueError(
                 "data_root must be set, try --experiment.data_root=path/to/data"
             )
-        default_root = LocalLocation(path=Path("."))
+        default_root = LocalLocation(path=Path.cwd())
         return default_root.resolve(self.data_root)
 
 

--- a/src/ocean_emulators/utils/location.py
+++ b/src/ocean_emulators/utils/location.py
@@ -118,7 +118,7 @@ class LocalLocation(ResolvedLocation, BaseModel):
         if not self.path.is_absolute():
             raise ValueError(
                 "Locations with type: local must be absolute. "
-                "For relative paths,use a string instead of a structured location. "
+                "For relative paths, use a string instead of a structured location. "
                 "i.e. 'my/relative/path' instead of "
                 "{type: 'local', path: 'my/relative/path'}"
             )

--- a/src/ocean_emulators/utils/location.py
+++ b/src/ocean_emulators/utils/location.py
@@ -117,7 +117,7 @@ class LocalLocation(ResolvedLocation, BaseModel):
     def validate_path(self) -> Self:
         if not self.path.is_absolute():
             raise ValueError(
-                "Locations with type: local must be absolute. "
+                "Locations with type: 'local' must be absolute. "
                 "For relative paths, use a string instead of a structured location. "
                 "i.e. 'my/relative/path' instead of "
                 "{type: 'local', path: 'my/relative/path'}"

--- a/src/ocean_emulators/utils/location.py
+++ b/src/ocean_emulators/utils/location.py
@@ -100,7 +100,7 @@ class S3Location(ResolvedLocation, BaseModel):
 
 
 class LocalLocation(ResolvedLocation, BaseModel):
-    """A local filesystem path.
+    """A local absolute filesystem path.
 
     For example:
     ```yaml
@@ -112,6 +112,17 @@ class LocalLocation(ResolvedLocation, BaseModel):
 
     type: Literal["local"] = "local"
     path: Path
+
+    @model_validator(mode="after")
+    def validate_path(self) -> Self:
+        if not self.path.is_absolute():
+            raise ValueError(
+                "Locations with type: local must be absolute. "
+                "For relative paths,use a string instead of a structured location. "
+                "i.e. 'my/relative/path' instead of "
+                "{type: 'local', path: 'my/relative/path'}"
+            )
+        return self
 
     def open(self, chunks: dict[str, int] | None = None) -> xr.Dataset:
         engine = "netcdf4" if self.path.suffix == ".nc" else "zarr"

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -61,6 +61,11 @@ class TestLocalLocation:
         loc = LocalLocation(path=Path("/tmp/data"))
         assert str(loc) == "/tmp/data"
 
+    def test_must_be_absolute(self):
+        """Test LocalLocation must be absolute."""
+        with pytest.raises(ValidationError):
+            LocalLocation(path=Path("relative/path"))
+
     def test_resolve_unresolved_location(self):
         """Test resolving an UnresolvedLocation against a LocalLocation."""
         base = LocalLocation(path=Path("/base/path"))
@@ -78,7 +83,7 @@ class TestLocalLocation:
 
         resolved = base.resolve(other)
 
-        assert resolved is other
+        assert resolved == other
 
     def test_truediv_operator(self):
         """Test the / operator for path joining."""
@@ -198,7 +203,7 @@ class TestS3Location:
 
         resolved = base.resolve(other)
 
-        assert resolved is other
+        assert resolved == other
 
     def test_truediv_operator(self):
         """Test the / operator for path joining."""
@@ -235,7 +240,7 @@ class TestLocationValidation:
 
         unresolved = UnresolvedLocation(path="data/test.zarr")
         model = TestModel(location=unresolved)
-        assert model.location is unresolved
+        assert model.location == unresolved
 
 
 class TestLocationIntegration:


### PR DESCRIPTION
Previously, we permitted you to make *relative* local locations as in:

```yaml
data_location:
  type: local
  path: foo/bar
```

But the rule is that if you give a ResolvedLocation (type: local is a ResolvedLocation) then it's *not* resolved relative to the data_root. So this is actually relative to the cwd rather than data_root. This is just confusing so we are now forbidding relative local locations; instead you want:

```yaml
data_location: "foo/bar"
```

This means we can no longer express "resolved paths which are relative to cwd" but this seems preferable to having this footgun. 