### PR TITLE
Handle dynamic loss state in checkpoints

### DIFF
--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -905,6 +905,16 @@ class Trainer:
                 "wandb_id": self.wandb_id,
                 "wandb_name": self.wandb_name,
             }
+            loss_state = None
+            if hasattr(self.loss_fn, "state_dict"):
+                loss_state = self.loss_fn.state_dict()
+            elif hasattr(self.loss_fn, "get_state"):
+                loss_state = self.loss_fn.get_state()
+            if loss_state is not None:
+                checkpoint["loss_fn_state"] = {
+                    k: v.detach().cpu() if torch.is_tensor(v) else v
+                    for k, v in loss_state.items()
+                }
             if self.scheduler:
                 checkpoint["scheduler"] = self.scheduler.state_dict()
 
@@ -937,6 +947,17 @@ class Trainer:
             self.optimizer.load_state_dict(checkpoint["optimizer"])
             if self.scheduler and "scheduler" in checkpoint:
                 self.scheduler.load_state_dict(checkpoint["scheduler"])
+
+            if "loss_fn_state" in checkpoint:
+                loss_state = checkpoint["loss_fn_state"]
+                loss_state = {
+                    k: v.to(self.device) if torch.is_tensor(v) else v
+                    for k, v in loss_state.items()
+                }
+                if hasattr(self.loss_fn, "load_state_dict"):
+                    self.loss_fn.load_state_dict(loss_state)
+                elif hasattr(self.loss_fn, "set_state"):
+                    self.loss_fn.set_state(loss_state)
 
             self.start_epoch = checkpoint["epoch"] + 1
             self.wandb_id = checkpoint.get("wandb_id")

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -905,14 +905,15 @@ class Trainer:
                 "wandb_id": self.wandb_id,
                 "wandb_name": self.wandb_name,
             }
-            loss_state = None
+            loss_state: dict[str, Any] | None = None
             if hasattr(self.loss_fn, "state_dict"):
                 loss_state = self.loss_fn.state_dict()
             elif hasattr(self.loss_fn, "get_state"):
                 loss_state = self.loss_fn.get_state()
-            if loss_state is not None:
+
+            if loss_state:
                 checkpoint["loss_fn_state"] = {
-                    k: v.detach().cpu() if torch.is_tensor(v) else v
+                    k: v.detach().cpu() if isinstance(v, torch.Tensor) else v
                     for k, v in loss_state.items()
                 }
             if self.scheduler:
@@ -949,10 +950,9 @@ class Trainer:
                 self.scheduler.load_state_dict(checkpoint["scheduler"])
 
             if "loss_fn_state" in checkpoint:
-                loss_state = checkpoint["loss_fn_state"]
                 loss_state = {
-                    k: v.to(self.device) if torch.is_tensor(v) else v
-                    for k, v in loss_state.items()
+                    k: v.to(self.device) if isinstance(v, torch.Tensor) else v
+                    for k, v in checkpoint["loss_fn_state"].items()
                 }
                 if hasattr(self.loss_fn, "load_state_dict"):
                     self.loss_fn.load_state_dict(loss_state)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -908,14 +908,9 @@ class Trainer:
             loss_state: dict[str, Any] | None = None
             if hasattr(self.loss_fn, "state_dict"):
                 loss_state = self.loss_fn.state_dict()
-            elif hasattr(self.loss_fn, "get_state"):
-                loss_state = self.loss_fn.get_state()
 
-            if loss_state:
-                checkpoint["loss_fn_state"] = {
-                    k: v.detach().cpu() if isinstance(v, torch.Tensor) else v
-                    for k, v in loss_state.items()
-                }
+            if loss_state is not None:
+                checkpoint["loss_fn_state"] = loss_state
             if self.scheduler:
                 checkpoint["scheduler"] = self.scheduler.state_dict()
 
@@ -949,15 +944,10 @@ class Trainer:
             if self.scheduler and "scheduler" in checkpoint:
                 self.scheduler.load_state_dict(checkpoint["scheduler"])
 
-            if "loss_fn_state" in checkpoint:
-                loss_state = {
-                    k: v.to(self.device) if isinstance(v, torch.Tensor) else v
-                    for k, v in checkpoint["loss_fn_state"].items()
-                }
-                if hasattr(self.loss_fn, "load_state_dict"):
-                    self.loss_fn.load_state_dict(loss_state)
-                elif hasattr(self.loss_fn, "set_state"):
-                    self.loss_fn.set_state(loss_state)
+            if "loss_fn_state" in checkpoint and hasattr(
+                self.loss_fn, "load_state_dict"
+            ):
+                self.loss_fn.load_state_dict(checkpoint["loss_fn_state"])
 
             self.start_epoch = checkpoint["epoch"] + 1
             self.wandb_id = checkpoint.get("wandb_id")

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -123,3 +123,13 @@ class MseDynamic:
 
     def loss_scale_per_channel(self):
         return self.per_channel_scale
+
+    # new methods for saving and loading state
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        """Return state dictionary for checkpointing."""
+        return {"per_channel_scale": self.per_channel_scale.detach().cpu()}
+
+    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
+        """Load state from ``state_dict``."""
+        if "per_channel_scale" in state:
+            self.per_channel_scale = state["per_channel_scale"].to(self.wet.device)


### PR DESCRIPTION
## Summary
- persist dynamic loss function state when saving checkpoints
- reload saved loss state on the correct device when restoring checkpoints

## Testing
- `pytest tests/test_trainer.py::test_checkpoint -q` *(fails: ModuleNotFoundError for jaxtyping)*

------
https://chatgpt.com/codex/tasks/task_e_687e4f1bfd3c8320be53658735f355e4