### PR TITLE
Fix EMA weights restoration

### DIFF
--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -889,7 +889,12 @@ class Trainer:
             new_state_dict = OrderedDict()
             for k, v in state_dict.items():
                 name = k.removeprefix("module.")
-                new_state_dict[name] = v
+                if isinstance(v, dict):
+                    new_state_dict[name] = {
+                        key.removeprefix("module."): val for key, val in v.items()
+                    }
+                else:
+                    new_state_dict[name] = v
             return new_state_dict
 
         # Load model state

--- a/src/ocean_emulators/utils/ema.py
+++ b/src/ocean_emulators/utils/ema.py
@@ -169,6 +169,7 @@ class EMATracker:
             "num_updates": self.num_updates,
             "faster_decay_at_start": self._faster_decay_at_start,
             "module_name_to_ema_name": self._module_name_to_ema_name,
+            "ema_params": {k: v.cpu() for k, v in self._ema_params.items()},
         }
 
     @classmethod
@@ -187,4 +188,7 @@ class EMATracker:
         ema = cls(model, float(state["decay"]), state["faster_decay_at_start"])
         ema.num_updates = state["num_updates"]
         ema._module_name_to_ema_name = state["module_name_to_ema_name"]
+        if "ema_params" in state:
+            device = next(model.parameters()).device
+            ema._ema_params = {k: v.to(device) for k, v in state["ema_params"].items()}
         return ema

--- a/tests/test_ema.py
+++ b/tests/test_ema.py
@@ -1,0 +1,79 @@
+import torch
+import pytest
+
+from ocean_emulators.utils.ema import EMATracker
+
+
+class SimpleModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(2, 2, bias=False)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def test_restore_state_with_weights():
+    model = SimpleModel()
+    ema = EMATracker(model, decay=0.5, faster_decay_at_start=False)
+    # update EMA with some model updates
+    for _ in range(3):
+        model.linear.weight.data.add_(1.0)
+        ema(model)
+
+    state = ema.get_state()
+    new_model = SimpleModel()
+    restored = EMATracker.from_state(state, new_model)
+
+    for key in ema._ema_params:
+        assert torch.allclose(ema._ema_params[key], restored._ema_params[key])
+
+
+def test_restore_state_without_weights_fails():
+    model = SimpleModel()
+    ema = EMATracker(model, decay=0.5, faster_decay_at_start=False)
+    for _ in range(3):
+        model.linear.weight.data.add_(1.0)
+        ema(model)
+
+    state = ema.get_state()
+    state.pop("ema_params")
+
+    new_model = SimpleModel()
+    restored = EMATracker.from_state(state, new_model)
+
+    mismatched = False
+    for key in ema._ema_params:
+        if not torch.allclose(ema._ema_params[key], restored._ema_params[key]):
+            mismatched = True
+            break
+
+    assert mismatched
+
+
+def test_remove_module_prefix_nested():
+    from collections import OrderedDict
+
+    def remove_module_prefix(state_dict):
+        new_state_dict = OrderedDict()
+        for k, v in state_dict.items():
+            name = k.removeprefix("module.")
+            if isinstance(v, dict):
+                new_state_dict[name] = {
+                    key.removeprefix("module."): val for key, val in v.items()
+                }
+            else:
+                new_state_dict[name] = v
+        return new_state_dict
+
+    state = OrderedDict(
+        {
+            "module.weight": torch.tensor(1.0),
+            "module.ema": {"module.weight": torch.tensor(2.0)},
+        }
+    )
+
+    new_state = remove_module_prefix(state)
+    assert "weight" in new_state
+    assert "ema" in new_state
+    assert "weight" in new_state["ema"]


### PR DESCRIPTION
## Summary
- include EMA weights when saving `EMATracker` state
- restore EMA weights on checkpoint load
- strip `module.` prefix inside nested EMA state
- add regression tests for EMA restoration

## Testing
- `uv run -m pytest tests/test_ema.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e4f4d03348320afbac1da2c9d8e28