### PR TITLE
Sky Train: Cloning data faster via setup section instead of file mount

### DIFF
--- a/configs/data/om4_sky_local.yaml
+++ b/configs/data/om4_sky_local.yaml
@@ -12,6 +12,9 @@ data_stds_location:
   type: local
   path: OM4_means.zarr
 
+# More workers than default; needed for faster data_iter time.
+num_workers: 4
+
 static_data_vars:
   - sea_surface_fraction
   - hfgeou

--- a/configs/data/om4_sky_local.yaml
+++ b/configs/data/om4_sky_local.yaml
@@ -12,9 +12,6 @@ data_stds_location:
   type: local
   path: OM4_means.zarr
 
-# More workers than default; needed for faster data_iter time.
-num_workers: 4
-
 static_data_vars:
   - sea_surface_fraction
   - hfgeou

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -110,7 +110,7 @@ class DataConfig(BaseConfig):
         default=None,
     )
     static_data_vars: list[str] | None = None
-    num_workers: int = 2
+    num_workers: int = 4
     hist: int = 1
     loader_version: str = str(LoaderVersion.OM4_TORCH.value)
     normalize_before_mask: bool = True

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -77,6 +77,8 @@ run: |
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
   echo "Starting distributed training, head node: $MASTER_ADDR"
 
+  DATA_DIR=$(realpath ~/data)
+
   # Explicit check for torchrun
   if ! command -v torchrun >/dev/null 2>&1; then
       echo "ERROR: torchrun command not found" >&2
@@ -92,7 +94,7 @@ run: |
     --node_rank=${SKYPILOT_NODE_RANK} \
     -m ocean_emulators.train ${CONFIG} \
     --data=@${DATA_CONFIG} \
-    --experiment.data_root=~/data/ \
+    --experiment.data_root=${DATA_DIR} \
     --experiment.base_output_dir=/outputs/  \
     --experiment.wandb.mode=online \
     --samudra.checkpointing=all

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -62,7 +62,7 @@ workdir: .
 setup: |
   mkdir /data/
 
-  RCLONE_CONF = $(rclone config file)
+  RCLONE_CONF=$(rclone config file | awk '/Configuration file is stored at:/ {getline; print}')
 
   cat << EOF > $RCLONE_CONF
   [oa-general]

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -48,10 +48,7 @@ envs:
   DATA_CONFIG: configs/data/om4_sky_local.yaml
 
 file_mounts:
-# Using manual `rclone` in the setup section until we can pass args to file mounts.
-#  /data:
-#    source: s3://${DATA_BUCKET}/${DATA_ROOT_PATH}
-#    mode: COPY
+  # TODO(alxmrs): Consider adding a data/ copy here once `mount_options` feature exists.
 
   /outputs:
     source: s3://${OUTPUTS_BUCKET}
@@ -60,6 +57,7 @@ file_mounts:
 workdir: .
 
 setup: |
+
   mkdir ~/data/
 
   RCLONE_CONF=$(rclone config file | awk '/Configuration file is stored at:/ {getline; print}')

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -57,18 +57,18 @@ file_mounts:
 workdir: .
 
 setup: |
-  mkdir ./data/
+  mkdir ~/data/
   rclone config create s3-source s3 provider=AWS env_auth=true
 
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ./data/OM4_means.zarr --ignore-existing
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ./data/OM4_stds.zarr --ignore-existing
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ./data/OM4.zarr --transfers=32 --ignore-existing
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ~/data/OM4_means.zarr --ignore-existing
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ~/data/OM4_stds.zarr --ignore-existing
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ~/data/OM4.zarr --transfers=32 --ignore-existing
 
 run: |
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
   echo "Starting distributed training, head node: $MASTER_ADDR"
 
-  DATA_ROOT=$(realpath ./data)
+  DATA_ROOT=$(realpath ~/data)
 
   # Explicit check for torchrun
   if ! command -v torchrun >/dev/null 2>&1; then

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -38,7 +38,6 @@ envs:
   # If you still hit permission issues, consider making a dedicated SkyPilot IAM via these docs:
   # https://docs.skypilot.co/en/latest/cloud-setup/cloud-permissions/aws.html#dedicated-skypilot-iam-user
 
-  # TODO(alxmrs): Drive everything except secrets from the primary config file.
   CONFIG: null
   OUTPUTS_BUCKET: oa-fomo-outputs
   DATA_BUCKET: oa-fomo
@@ -48,7 +47,8 @@ envs:
   DATA_CONFIG: configs/data/om4_sky_local.yaml
 
 file_mounts:
-  # TODO(alxmrs): Consider adding a data/ copy here once `mount_options` feature exists.
+  # TODO(alxmrs): Consider adding a data/ COPY file_mount here once `mount_options` feature exists.
+  # The current method of copying (in the setup section, below) is faster.
 
   /outputs:
     source: s3://${OUTPUTS_BUCKET}
@@ -76,7 +76,7 @@ run: |
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
   echo "Starting distributed training, head node: $MASTER_ADDR"
 
-  DATA_DIR=$(realpath ~/data)
+  DATA_ROOT=$(realpath ~/data)
 
   # Explicit check for torchrun
   if ! command -v torchrun >/dev/null 2>&1; then
@@ -93,7 +93,7 @@ run: |
     --node_rank=${SKYPILOT_NODE_RANK} \
     -m ocean_emulators.train ${CONFIG} \
     --data=@${DATA_CONFIG} \
-    --experiment.data_root=${DATA_DIR} \
+    --experiment.data_root=${DATA_ROOT} \
     --experiment.base_output_dir=/outputs/  \
     --experiment.wandb.mode=online \
     --samudra.checkpointing=all

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -57,26 +57,18 @@ file_mounts:
 workdir: .
 
 setup: |
-  mkdir ~/data/
+  mkdir ./data/
+  rclone config create s3-source s3 provider=AWS env_auth=true
 
-  RCLONE_CONF=$(rclone config file | awk '/Configuration file is stored at:/ {getline; print}')
-
-  cat << EOF > $RCLONE_CONF
-  [s3-source]
-  type = s3
-  provider = AWS
-  env_auth = true
-  EOF
-
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ~/data/OM4_means.zarr --ignore-existing
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ~/data/OM4_stds.zarr --ignore-existing
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ~/data/OM4.zarr --transfers=32 --ignore-existing
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ./data/OM4_means.zarr --ignore-existing
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ./data/OM4_stds.zarr --ignore-existing
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ./data/OM4.zarr --transfers=32 --ignore-existing
 
 run: |
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
   echo "Starting distributed training, head node: $MASTER_ADDR"
 
-  DATA_ROOT=$(realpath ~/data)
+  DATA_ROOT=$(realpath ./data)
 
   # Explicit check for torchrun
   if ! command -v torchrun >/dev/null 2>&1; then

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -57,21 +57,20 @@ file_mounts:
 workdir: .
 
 setup: |
-
   mkdir ~/data/
 
   RCLONE_CONF=$(rclone config file | awk '/Configuration file is stored at:/ {getline; print}')
 
   cat << EOF > $RCLONE_CONF
-  [oa-general]
+  [s3-source]
   type = s3
   provider = AWS
   env_auth = true
   EOF
 
-  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ~/data/OM4_means.zarr
-  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ~/data/OM4_stds.zarr
-  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ~/data/OM4.zarr --transfers=32
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ~/data/OM4_means.zarr
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ~/data/OM4_stds.zarr
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ~/data/OM4.zarr --transfers=32
 
 run: |
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -48,15 +48,32 @@ envs:
   DATA_CONFIG: configs/data/om4_sky_local.yaml
 
 file_mounts:
-  /data:
-    source: s3://${DATA_BUCKET}/${DATA_ROOT_PATH}
-    mode: COPY
+# Using manual `rclone` in the setup section until we can pass args to file mounts.
+#  /data:
+#    source: s3://${DATA_BUCKET}/${DATA_ROOT_PATH}
+#    mode: COPY
 
   /outputs:
     source: s3://${OUTPUTS_BUCKET}
     mode: MOUNT_CACHED
 
 workdir: .
+
+setup: |
+  mkdir /data/
+
+  RCLONE_CONF = $(rclone config file)
+
+  cat << EOF > $RCLONE_CONF
+  [oa-general]
+  type = s3
+  provider = AWS
+  env_auth = true
+  EOF
+
+  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr /data/OM4_means.zarr
+  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr /data/OM4_stds.zarr
+  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr /data/OM4.zarr --transfers=32
 
 run: |
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -60,7 +60,7 @@ file_mounts:
 workdir: .
 
 setup: |
-  mkdir /data/
+  mkdir ~/data/
 
   RCLONE_CONF=$(rclone config file | awk '/Configuration file is stored at:/ {getline; print}')
 
@@ -71,9 +71,9 @@ setup: |
   env_auth = true
   EOF
 
-  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr /data/OM4_means.zarr
-  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr /data/OM4_stds.zarr
-  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr /data/OM4.zarr --transfers=32
+  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ~/data/OM4_means.zarr
+  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ~/data/OM4_stds.zarr
+  rclone copy --progress oa-general:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ~/data/OM4.zarr --transfers=32
 
 run: |
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)
@@ -94,7 +94,7 @@ run: |
     --node_rank=${SKYPILOT_NODE_RANK} \
     -m ocean_emulators.train ${CONFIG} \
     --data=@${DATA_CONFIG} \
-    --experiment.data_root=/data/ \
+    --experiment.data_root=~/data/ \
     --experiment.base_output_dir=/outputs/  \
     --experiment.wandb.mode=online \
     --samudra.checkpointing=all

--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -68,9 +68,9 @@ setup: |
   env_auth = true
   EOF
 
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ~/data/OM4_means.zarr
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ~/data/OM4_stds.zarr
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ~/data/OM4.zarr --transfers=32
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_means.zarr ~/data/OM4_means.zarr --ignore-existing
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4_stds.zarr ~/data/OM4_stds.zarr --ignore-existing
+  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH}/OM4.zarr ~/data/OM4.zarr --transfers=32 --ignore-existing
 
 run: |
   MASTER_ADDR=$(echo "$SKYPILOT_NODE_IPS" | head -n1)


### PR DESCRIPTION
Since `file_mount` options don't let you pass arguments to rclone, this PR opts to manually `rclone` data during the `setup` stage of the job. This allows us to make faster file transfers with the `--transfers` flag.

It also has required that I map the `data/` dir to home and not root. 