### PR TITLE
Initializing EMA after wrapping model with DDP

### DIFF
--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -310,6 +310,13 @@ class Trainer:
             cfg.resume_ckpt_path, cfg, finetune=cfg.finetune
         )
 
+        # Modify DDP setup based on device
+        if self.distributed is not None:
+            self.model = nn.parallel.DistributedDataParallel(
+                nn.SyncBatchNorm.convert_sync_batchnorm(self.model),
+                device_ids=[self.distributed.gpu],
+            )
+
         self.num_batches_seen = 0
         if cfg.resume_ckpt_path is not None:
             if cfg.finetune:
@@ -330,13 +337,6 @@ class Trainer:
                 self.model,
                 decay=cfg.ema_decay,
                 faster_decay_at_start=cfg.faster_decay_at_start,
-            )
-
-        # Modify DDP setup based on device
-        if self.distributed is not None:
-            self.model = nn.parallel.DistributedDataParallel(
-                nn.SyncBatchNorm.convert_sync_batchnorm(self.model),
-                device_ids=[self.distributed.gpu],
             )
 
         # Training


### PR DESCRIPTION
I encountered a bug where I hit a key error during the EMATracker call phase where it was unable to find the key for any layer.
```
 File "/home/ubuntu/sky_workdir/src/ocean_emulators/utils/ema.py", line 129, in __call__
    ema_name = self._module_name_to_ema_name[key]
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  KeyError: 'module.layers.0.skip_module.weight'
```

I found that this was caused by wrapping the `DDP` component onto the model -- doing so adds a `module` prefix to the weight names. Thus, the names of the weights don't match the model setup and EMATracker call during training.

In this PR, I make a simple fix, which is to just move the DDP wrapper code above the part where we set up the EMATracker.