### PR TITLE
Fix UnresolvedLocation JSON schema to permit string

### DIFF
--- a/src/ocean_emulators/utils/location.py
+++ b/src/ocean_emulators/utils/location.py
@@ -4,7 +4,13 @@ from typing import Annotated, Any, Literal, Self
 from urllib.parse import quote, urljoin, urlparse
 
 import xarray as xr
-from pydantic import BaseModel, BeforeValidator, model_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    WithJsonSchema,
+    model_serializer,
+    model_validator,
+)
 
 
 class UnresolvedLocation(BaseModel):
@@ -149,6 +155,8 @@ def string_to_unresolved(data: Any) -> Any:
 
 
 Location = Annotated[
-    UnresolvedLocation | S3Location | LocalLocation,
+    Annotated[UnresolvedLocation, WithJsonSchema({"type": "string"})]
+    | S3Location
+    | LocalLocation,
     BeforeValidator(string_to_unresolved),
 ]


### PR DESCRIPTION
This was previously causing red squigglies in VS Code. It's annoying that this annotation and the two `@model_*` annotations on this class are all required -- I spent some time looking for a more direct way to express "this type serializes to/from a string" in the pydantic docs but everything I tried was broken or more complicated than this.