### PR TITLE
Add .git to .gitignore for the sake of skypilot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.git
 __pycache__
 .DS_Store
 .ipynb_checkpoints


### PR DESCRIPTION
Without this, it seems that skypilot attempts to upload the whole .git folder. Adding this makes it skip doing so. To me, this is a bug in skypilot; I'll file an issue over there and use this as a workaround for the time being.