### PR TITLE
Stop complaining about long lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ lint.ignore = [
   "D212",
   "E203",
   "E402",
+  "E501",  # We use ruff-format which will already wrap lines to a reasonable length.
   "F541",
   "F722",
   "UP038", # This rule is deprecated.


### PR DESCRIPTION
This rule seems low-value to me, and we already enforce `ruff format` which will wrap lines when reasonable. If ruff format is OK with the line length I don't think we should be wrapping things by hand. 