### PR TITLE
Add a scheduler which can run a cosine schedule followed by a flat tail

### DIFF
--- a/configs/slurm_perlmutter_train_cm4.yaml
+++ b/configs/slurm_perlmutter_train_cm4.yaml
@@ -7,7 +7,7 @@ save_freq: 5
 epochs: 120
 batch_size: 3
 learning_rate: 0.0001
-scheduler: true
+scheduler: {type: cosine}
 loss: mse
 finetune: false
 resume_ckpt_path: null

--- a/configs/slurm_perlmutter_train_om4.yaml
+++ b/configs/slurm_perlmutter_train_om4.yaml
@@ -7,7 +7,7 @@ save_freq: 5
 epochs: 70
 batch_size: 4
 learning_rate: 0.0002
-scheduler: true
+scheduler: {type: cosine}
 loss: mse
 finetune: false
 resume_ckpt_path: null

--- a/configs/train_cm4.yaml
+++ b/configs/train_cm4.yaml
@@ -7,7 +7,7 @@ save_freq: 5
 epochs: 120
 batch_size: 3 # 4
 learning_rate: 0.0001
-scheduler: false
+scheduler: null
 loss: mse
 finetune: false
 resume_ckpt_path: null

--- a/configs/train_default.test.yaml
+++ b/configs/train_default.test.yaml
@@ -10,7 +10,7 @@ epochs: 2
 batch_size: 1
 preemptible: false
 learning_rate: 0.0001
-scheduler: false
+scheduler: null
 loss: mse
 finetune: false
 resume_ckpt_path: null

--- a/configs/train_default_2step.test.yaml
+++ b/configs/train_default_2step.test.yaml
@@ -10,7 +10,7 @@ epochs: 1
 batch_size: 1
 preemptible: false
 learning_rate: 0.0001
-scheduler: false
+scheduler: null
 loss: mse
 finetune: false
 resume_ckpt_path: null

--- a/configs/train_om4.yaml
+++ b/configs/train_om4.yaml
@@ -7,7 +7,7 @@ save_freq: 5
 epochs: 70
 batch_size: 4
 learning_rate: 0.0002
-scheduler: true
+scheduler: {type: cosine}
 loss: mse
 finetune: false
 resume_ckpt_path: null

--- a/configs/train_om4_halfdeg.yaml
+++ b/configs/train_om4_halfdeg.yaml
@@ -7,7 +7,7 @@ save_freq: 5
 epochs: 70
 batch_size: 2
 learning_rate: 0.0002
-scheduler: true
+scheduler: { type: cosine }
 loss: mse
 finetune: false
 resume_ckpt_path: null

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -11,6 +11,7 @@ from ocean_emulators.constants import BoundaryVarNames, LoaderVersion
 from ocean_emulators.utils.data import DataContainer, DataSource, validate_data
 from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLocation
 from ocean_emulators.utils.profiler import Profiler
+from ocean_emulators.utils.schedule import Scheduler
 
 
 class WandBConfig(BaseConfig):
@@ -312,7 +313,7 @@ class TrainConfig(TopLevelConfig):
     preemptible: bool = True
     batch_size: int = 2
     learning_rate: float = 2e-4
-    scheduler: bool = False
+    scheduler: Scheduler | None = None
     loss: LossType = "mse"
     finetune: bool = False
     resume_ckpt_path: str | None = None

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -11,7 +11,7 @@ from ocean_emulators.constants import BoundaryVarNames, LoaderVersion
 from ocean_emulators.utils.data import DataContainer, DataSource, validate_data
 from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLocation
 from ocean_emulators.utils.profiler import Profiler
-from ocean_emulators.utils.schedule import Scheduler
+from ocean_emulators.utils.schedule import SchedulerConfig
 
 
 class WandBConfig(BaseConfig):
@@ -313,7 +313,7 @@ class TrainConfig(TopLevelConfig):
     preemptible: bool = True
     batch_size: int = 2
     learning_rate: float = 2e-4
-    scheduler: Scheduler | None = None
+    scheduler: SchedulerConfig | None = None
     loss: LossType = "mse"
     finetune: bool = False
     resume_ckpt_path: str | None = None

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -306,9 +306,7 @@ class Trainer:
         # Scheduler
         self.scheduler = None
         if cfg.scheduler:
-            self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-                self.optimizer, T_max=cfg.epochs
-            )
+            self.scheduler = cfg.scheduler.build(self.optimizer, cfg.epochs)
 
         # Initialize WandB
         self.wandb_logger = WandBLogger.init_instance()

--- a/src/ocean_emulators/utils/schedule.py
+++ b/src/ocean_emulators/utils/schedule.py
@@ -4,7 +4,9 @@ import torch
 from pydantic import BaseModel
 
 
-class CosineScheduler(BaseModel):
+class CosineSchedulerConfig(BaseModel):
+    """Cosine scheduler; see pytorch CosineAnnealingLR."""
+
     type: Literal["cosine"] = "cosine"
 
     def build(
@@ -13,7 +15,9 @@ class CosineScheduler(BaseModel):
         return torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
 
 
-class CosineWithTailScheduler(BaseModel):
+class CosineWithTailSchedulerConfig(BaseModel):
+    """Cosine scheduler which goes to tail_lr for the last tail_epochs."""
+
     type: Literal["cosine_with_tail"] = "cosine_with_tail"
 
     tail_lr: float
@@ -35,4 +39,4 @@ class CosineWithTailScheduler(BaseModel):
         )
 
 
-Scheduler = CosineScheduler | CosineWithTailScheduler
+SchedulerConfig = CosineSchedulerConfig | CosineWithTailSchedulerConfig

--- a/src/ocean_emulators/utils/schedule.py
+++ b/src/ocean_emulators/utils/schedule.py
@@ -1,0 +1,38 @@
+from typing import Literal
+
+import torch
+from pydantic import BaseModel
+
+
+class CosineScheduler(BaseModel):
+    type: Literal["cosine"] = "cosine"
+
+    def build(
+        self, optimizer: torch.optim.Optimizer, epochs: int
+    ) -> torch.optim.lr_scheduler.LRScheduler:
+        return torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=epochs)
+
+
+class CosineWithTailScheduler(BaseModel):
+    type: Literal["cosine_with_tail"] = "cosine_with_tail"
+
+    tail_lr: float
+    tail_epochs: int = 10
+
+    def build(
+        self, optimizer: torch.optim.Optimizer, epochs: int
+    ) -> torch.optim.lr_scheduler.LRScheduler:
+        cosine = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=epochs - self.tail_epochs, eta_min=self.tail_lr
+        )
+        tail = torch.optim.lr_scheduler.ConstantLR(
+            optimizer,
+            factor=self.tail_lr / optimizer.param_groups[0]["lr"],
+            total_iters=self.tail_epochs,
+        )
+        return torch.optim.lr_scheduler.SequentialLR(
+            optimizer, schedulers=[cosine, tail], milestones=[epochs - self.tail_epochs]
+        )
+
+
+Scheduler = CosineScheduler | CosineWithTailScheduler

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,43 @@
+import torch
+
+from ocean_emulators.utils.schedule import CosineWithTailScheduler
+
+
+def test_cosine_with_tail_holds_constant_lr():
+    """Test that LR is held constant for tail_epochs after cosine schedule completes.
+
+    The scheduler should:
+    1. Run cosine annealing from initial_lr to tail_lr for (total_epochs - tail_epochs)
+    2. Hold LR constant at tail_lr for the final tail_epochs
+    """
+    initial_lr = 0.01
+    tail_lr = 0.001
+    tail_epochs = 10
+    total_epochs = 50
+
+    optimizer = torch.optim.SGD([torch.zeros(1)], lr=initial_lr)
+
+    scheduler_config = CosineWithTailScheduler(tail_lr=tail_lr, tail_epochs=tail_epochs)
+    scheduler = scheduler_config.build(optimizer, epochs=total_epochs)
+
+    lr_history = []
+    # Need to call step after optimizer.step() to avoid warnings
+    # For testing, we'll simulate optimizer steps
+    for epoch in range(total_epochs):
+        lr_history.append(optimizer.param_groups[0]["lr"])
+        optimizer.step()  # Simulate optimizer step
+        scheduler.step()
+
+    cosine_epochs = total_epochs - tail_epochs
+
+    # Verify the last tail_epochs have constant learning rate
+    tail_lrs = lr_history[cosine_epochs:]
+    assert len(tail_lrs) == tail_epochs, (
+        f"Expected {tail_epochs} tail epochs, got {len(tail_lrs)}"
+    )
+
+    # The last 10 epochs should all have the same LR value
+    for i, lr in enumerate(tail_lrs):
+        assert abs(lr - tail_lr) < 1e-7, (
+            f"LR at tail epoch {i} ({lr}) doesn't match first tail LR ({tail_lr})"
+        )

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,6 +1,6 @@
 import torch
 
-from ocean_emulators.utils.schedule import CosineWithTailScheduler
+from ocean_emulators.utils.schedule import CosineWithTailSchedulerConfig
 
 
 def test_cosine_with_tail_holds_constant_lr():
@@ -17,7 +17,9 @@ def test_cosine_with_tail_holds_constant_lr():
 
     optimizer = torch.optim.SGD([torch.zeros(1)], lr=initial_lr)
 
-    scheduler_config = CosineWithTailScheduler(tail_lr=tail_lr, tail_epochs=tail_epochs)
+    scheduler_config = CosineWithTailSchedulerConfig(
+        tail_lr=tail_lr, tail_epochs=tail_epochs
+    )
     scheduler = scheduler_config.build(optimizer, epochs=total_epochs)
 
     lr_history = []

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -32,14 +32,20 @@ def test_cosine_with_tail_holds_constant_lr():
 
     cosine_epochs = total_epochs - tail_epochs
 
-    # Verify the last tail_epochs have constant learning rate
     tail_lrs = lr_history[cosine_epochs:]
-    assert len(tail_lrs) == tail_epochs, (
-        f"Expected {tail_epochs} tail epochs, got {len(tail_lrs)}"
-    )
-
     # The last 10 epochs should all have the same LR value
     for i, lr in enumerate(tail_lrs):
         assert abs(lr - tail_lr) < 1e-7, (
             f"LR at tail epoch {i} ({lr}) doesn't match first tail LR ({tail_lr})"
         )
+
+    # cosine_epochs should start at initial_lr and end at tail_lr, be monotonically decreasing
+    assert lr_history[0] == initial_lr, (
+        f"LR at start of cosine schedule ({lr_history[0]}) doesn't match initial LR ({initial_lr})"
+    )
+    assert lr_history[-1] == tail_lr, (
+        f"LR at end of cosine schedule ({lr_history[-1]}) doesn't match tail LR ({tail_lr})"
+    )
+    assert all(lr_history[i] > lr_history[i + 1] for i in range(cosine_epochs - 1)), (
+        "LRs are not monotonically decreasing"
+    )


### PR DESCRIPTION
To try extending the behavior seen greatly improving loss at low learning rates from [this run](https://openathena.slack.com/archives/C08CYM42DT3/p1753308638843249?thread_ts=1752275713.570969&cid=C08CYM42DT3).