### PR TITLE
Work around ema name issues

### DIFF
--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -971,10 +971,10 @@ class Trainer:
         checkpoint = torch.load(checkpoint_path, map_location=torch.device(self.device))
 
         # Remove module prefix from state dict
-        def remove_module_prefix(state_dict):
+        def remove_module_prefix(state_dict, prefix="module."):
             new_state_dict = OrderedDict()
             for k, v in state_dict.items():
-                name = k.removeprefix("module.")
+                name = k.removeprefix(prefix)
                 new_state_dict[name] = v
             return new_state_dict
 
@@ -986,6 +986,10 @@ class Trainer:
         # Load EMA state
         model_ema_state_dict = checkpoint["ema"]
         new_ema_state_dict = remove_module_prefix(model_ema_state_dict)
+        if "ema_params" in new_ema_state_dict:
+            new_ema_state_dict["ema_params"] = remove_module_prefix(
+                new_ema_state_dict["ema_params"], prefix="module"
+            )
         self._ema = EMATracker.from_state(new_ema_state_dict, self.model)
 
         if not finetune:

--- a/src/ocean_emulators/utils/ema.py
+++ b/src/ocean_emulators/utils/ema.py
@@ -63,7 +63,6 @@ class EMATracker:
         if decay < 0.0 or decay > 1.0:
             raise ValueError("Decay must be between 0 and 1")
 
-        self._module_name_to_ema_name = {}
         self.decay = torch.tensor(decay, dtype=torch.float32)
         self.cur_decay = torch.tensor(decay, dtype=torch.float32)
         self._faster_decay_at_start = faster_decay_at_start
@@ -73,12 +72,15 @@ class EMATracker:
 
         for name, p in model.named_parameters():
             if p.requires_grad:
-                # remove as '.'-character is not allowed in buffers
-                ema_name = name.replace(".", "")
-                self._module_name_to_ema_name.update({name: ema_name})
+                ema_name = self._get_ema_name(name)
                 self._ema_params[ema_name] = p.clone().detach().data
 
         self._stored_params: list[torch.Tensor] = []
+
+    def _get_ema_name(self, name: str) -> str:
+        # remove as '.'-character is not allowed in buffers
+        # And make ourselves agnostic to module vs not
+        return name.removeprefix("module.").replace(".", "")
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, EMATracker):
@@ -91,7 +93,6 @@ class EMATracker:
             all_equal(self.decay, other.decay)
             and all_equal(self.num_updates, other.num_updates)
             and self._faster_decay_at_start == other._faster_decay_at_start
-            and self._module_name_to_ema_name == other._module_name_to_ema_name
             and all(
                 all_equal(self._ema_params[k], other._ema_params[k])
                 for k in self._ema_params
@@ -125,8 +126,8 @@ class EMATracker:
             module_parameters = dict(model.named_parameters())
 
             for key in module_parameters:
+                ema_name = self._get_ema_name(key)
                 if module_parameters[key].requires_grad:
-                    ema_name = self._module_name_to_ema_name[key]
                     self._ema_params[ema_name] = self._ema_params[ema_name].type_as(
                         module_parameters[key]
                     )
@@ -135,7 +136,7 @@ class EMATracker:
                         (1.0 - decay)
                         * (self._ema_params[ema_name] - module_parameters[key])
                     )
-                elif key in self._module_name_to_ema_name:
+                elif ema_name in self._ema_params:
                     raise ValueError(
                         f"Expected model parameter {key} to require gradient, "
                         "but it does not"
@@ -148,11 +149,9 @@ class EMATracker:
         m_param = dict(model.named_parameters())
         for key in m_param:
             if m_param[key].requires_grad:
-                m_param[key].data.copy_(
-                    self._ema_params[self._module_name_to_ema_name[key]].data
-                )
+                m_param[key].data.copy_(self._ema_params[self._get_ema_name(key)].data)
             else:
-                assert key not in self._module_name_to_ema_name
+                assert self._get_ema_name(key) not in self._ema_params
 
     def store(self, parameters: Iterable[nn.Parameter]):
         """
@@ -197,7 +196,6 @@ class EMATracker:
             "decay": self.decay,
             "num_updates": self.num_updates,
             "faster_decay_at_start": self._faster_decay_at_start,
-            "module_name_to_ema_name": self._module_name_to_ema_name,
         }
         if include_ema_params:
             state["ema_params"] = self._ema_params
@@ -218,11 +216,13 @@ class EMATracker:
         """
         ema = cls(model, float(state["decay"]), state["faster_decay_at_start"])
         ema.num_updates = state["num_updates"]
-        ema._module_name_to_ema_name = state["module_name_to_ema_name"]
         if ema_params := state.get("ema_params"):
-            assert ema_params.keys() == ema._ema_params.keys(), (
-                "EMA parameters keys do not match. "
-                "This is likely due to a mismatch between the model and checkpoint."
+            unexpected_keys = ema_params.keys() - ema._ema_params.keys()
+            missing_keys = ema._ema_params.keys() - ema_params.keys()
+            assert not unexpected_keys and not missing_keys, (
+                f"EMA parameters keys do not match. "
+                f"This is likely due to a mismatch between the model and checkpoint. "
+                f"Unexpected keys: {unexpected_keys}"
             )
             ema._ema_params = ema_params
         return ema


### PR DESCRIPTION
I would love a more principled strategy here, but this:
* Ensures that checkpoints which include ema params are rewritten on load to not have a "module" prefix on those params
* Ensures that EmaTrackers always store parameters without a "module" prefix.
* Ensures that using an EmaTracker works either with or without a "module." prefix on the requested parameters.

Closes #329 