### PR TITLE
Avoid chunking lat/lon

### DIFF
--- a/src/ocean_emulators/utils/writer.py
+++ b/src/ocean_emulators/utils/writer.py
@@ -65,7 +65,7 @@ class ZarrWriter:
             coords=coords,
         )
         ds.attrs["model_path"] = str(self.model_path)
-        ds = ds.chunk({"time": 1, "lat": 180, "lon": 360})
+        ds = ds.chunk({"time": 1})
         if os.path.exists(self.pred_path):
             ds.to_zarr(self.pred_path, mode="a", append_dim="time")
         else:


### PR DESCRIPTION
This was causing us to write 4x the number of chunks we need; I'm pretty sure from experiments and xarray docs that omitting the lat/lon vars here will make single large chunks.