### PR TITLE
Implementing Warmup + Cosine Decay LR schedule from ConvNeXt paper.

### DIFF
--- a/src/ocean_emulators/utils/schedule.py
+++ b/src/ocean_emulators/utils/schedule.py
@@ -63,7 +63,7 @@ class CosineWithWarmupConfig(BaseModel):
         return torch.optim.lr_scheduler.SequentialLR(
             optimizer,
             schedulers=[warmup, cosine],
-            milestones=[epochs - self.warmup_epochs],
+            milestones=[self.warmup_epochs],
         )
 
 

--- a/src/ocean_emulators/utils/schedule.py
+++ b/src/ocean_emulators/utils/schedule.py
@@ -40,7 +40,7 @@ class CosineWithTailSchedulerConfig(BaseModel):
 
 
 class CosineWithWarmupConfig(BaseModel):
-    """Cosine scheduler which goes to head_lr for the first head_epochs."""
+    """Cosine scheduler which goes from warmup_lr to the default lr for the first warmup_epochs."""
 
     type: Literal["cosine_with_warmup"] = "cosine_with_warmup"
 

--- a/src/ocean_emulators/utils/schedule.py
+++ b/src/ocean_emulators/utils/schedule.py
@@ -50,6 +50,9 @@ class CosineWithWarmupConfig(BaseModel):
     def build(
         self, optimizer: torch.optim.Optimizer, epochs: int
     ) -> torch.optim.lr_scheduler.LRScheduler:
+        assert len(optimizer.param_groups) == 1, (
+            "There can only be one parameter group for the optimizer."
+        )
         warmup = torch.optim.lr_scheduler.LinearLR(
             optimizer,
             start_factor=self.warmup_lr / optimizer.param_groups[0]["lr"],
@@ -57,6 +60,9 @@ class CosineWithWarmupConfig(BaseModel):
             total_iters=self.warmup_epochs,
         )
 
+        assert self.warmup_epochs <= epochs, (
+            "'warmup_epochs' is too big; it must be smaller than 'epochs'."
+        )
         cosine = torch.optim.lr_scheduler.CosineAnnealingLR(
             optimizer, T_max=epochs - self.warmup_epochs
         )

--- a/src/ocean_emulators/utils/schedule.py
+++ b/src/ocean_emulators/utils/schedule.py
@@ -39,4 +39,34 @@ class CosineWithTailSchedulerConfig(BaseModel):
         )
 
 
-SchedulerConfig = CosineSchedulerConfig | CosineWithTailSchedulerConfig
+class CosineWithWarmupConfig(BaseModel):
+    """Cosine scheduler which goes to head_lr for the first head_epochs."""
+
+    type: Literal["cosine_with_warmup"] = "cosine_with_warmup"
+
+    warmup_lr: float = 1e-6
+    warmup_epochs: int = 6
+
+    def build(
+        self, optimizer: torch.optim.Optimizer, epochs: int
+    ) -> torch.optim.lr_scheduler.LRScheduler:
+        warmup = torch.optim.lr_scheduler.LinearLR(
+            optimizer,
+            start_factor=self.warmup_lr / optimizer.param_groups[0]["lr"],
+            end_factor=1.0,  # Reaches full LR
+            total_iters=self.warmup_epochs,
+        )
+
+        cosine = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=epochs - self.warmup_epochs
+        )
+        return torch.optim.lr_scheduler.SequentialLR(
+            optimizer,
+            schedulers=[warmup, cosine],
+            milestones=[epochs - self.warmup_epochs],
+        )
+
+
+SchedulerConfig = (
+    CosineSchedulerConfig | CosineWithTailSchedulerConfig | CosineWithWarmupConfig
+)

--- a/src/ocean_emulators/utils/schedule.py
+++ b/src/ocean_emulators/utils/schedule.py
@@ -45,7 +45,7 @@ class CosineWithWarmupConfig(BaseModel):
     type: Literal["cosine_with_warmup"] = "cosine_with_warmup"
 
     warmup_lr: float = 1e-6
-    warmup_epochs: int = 6
+    warmup_epochs: int = 5
 
     def build(
         self, optimizer: torch.optim.Optimizer, epochs: int

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -83,10 +83,7 @@ def test_cosine_with_warmup():
             assert last_lr <= lr, "During warmup, LR should increase"
 
         if i > warmup_epochs:
-            # Monotonically decreasing, with error tolerance for equality.
-            assert last_lr > lr or abs(last_lr - lr) < 1e7, (
-                "During cosine annealing, LR should decrease"
-            )
+            assert last_lr > lr, "During cosine annealing, LR should decrease"
 
         last_lr = lr
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,6 +1,9 @@
 import torch
 
-from ocean_emulators.utils.schedule import CosineWithTailSchedulerConfig
+from ocean_emulators.utils.schedule import (
+    CosineWithTailSchedulerConfig,
+    CosineWithWarmupConfig,
+)
 
 
 def test_cosine_with_tail_holds_constant_lr():
@@ -49,3 +52,40 @@ def test_cosine_with_tail_holds_constant_lr():
     assert all(lr_history[i] > lr_history[i + 1] for i in range(cosine_epochs - 1)), (
         "LRs are not monotonically decreasing"
     )
+
+
+def test_cosine_with_warmup():
+    """Test for linearly increasing "warmup" before cosine annealing learning rate."""
+    warmup_lr = 0.001
+    warmup_epochs = 5
+    target_lr = 0.01
+    total_epochs = 25
+
+    optimizer = torch.optim.SGD([torch.zeros(1)], lr=target_lr)
+    scheduler_config = CosineWithWarmupConfig(
+        warmup_lr=warmup_lr, warmup_epochs=warmup_epochs
+    )
+    scheduler = scheduler_config.build(optimizer, epochs=total_epochs)
+
+    # TODO(alxmrs): Extract function call.
+    lr_history = []
+    # Need to call step after optimizer.step() to avoid warnings
+    # For testing, we'll simulate optimizer steps
+    for epoch in range(total_epochs):
+        lr_history.append(optimizer.param_groups[0]["lr"])
+        optimizer.step()  # Simulate optimizer step
+        scheduler.step()
+
+    assert max(lr_history) == target_lr, "The peak LR should be the target LR"
+    last_lr = -1
+    for i, lr in enumerate(lr_history):
+        if i <= warmup_epochs:
+            assert last_lr <= lr, "During warmup, LR should increase"
+
+        if i > warmup_epochs:
+            # Monotonically decreasing, with error tolerance for equality.
+            assert last_lr > lr or abs(last_lr - lr) < 1e7, (
+                "During cosine annealing, LR should decrease"
+            )
+
+        last_lr = lr

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -89,3 +89,9 @@ def test_cosine_with_warmup():
             )
 
         last_lr = lr
+
+    # Ensure that after warmup, the LR does actually decrease
+    assert (top := lr_history[warmup_epochs + 1]) > (last := lr_history[-1]), (
+        "LR must decrease after warmup"
+    )
+    assert top / 20 > last, "LR must decrease by a significant amount after warmup"


### PR DESCRIPTION
Here is a Warmup implementation. This was added to match the LR schedule of the original ConvNeXt paper. Following the citations, warmup is theorhetical grounded and empirically verified to help the loss curves of networks with _large batch sizes_ -- see this paper: https://arxiv.org/pdf/1706.02677

We have very small batch sizes, though each sample is fairly large (~80 MB). This technique is not likely to lead to a modeling improvement; however, I've queued up a few jobs to test if this improves anything. While this might not make it into the final baseline Samudra config, I could see it being valuable for the next iteration of the model.