### PR TITLE
Omit the data config path from sky training.

### DIFF
--- a/train.sky.yaml
+++ b/train.sky.yaml
@@ -44,7 +44,6 @@ envs:
   # We assume that data in this directory is named in the same pattern as
   # the $DATA_CONFIG yaml.
   DATA_ROOT_PATH: null # data/om4_onedeg_compact  # NOTE: path cannot end in a slash `/`.
-  DATA_CONFIG: configs/data/om4_sky_local.yaml
 
 file_mounts:
   # TODO(alxmrs): Consider adding a data/ COPY file_mount here once `mount_options` feature exists.
@@ -84,7 +83,6 @@ run: |
     --master_port=8008 \
     --node_rank=${SKYPILOT_NODE_RANK} \
     -m ocean_emulators.train ${CONFIG} \
-    --data=@${DATA_CONFIG} \
     --experiment.data_root=${DATA_ROOT} \
     --experiment.base_output_dir=/outputs/  \
     --experiment.wandb.mode=online \


### PR DESCRIPTION
Now that we prefer to use `data/public.yaml`, there's no need to specify this in the sky training config. The status quo led to an error when deploying training runs (the sky config has since been deleted).