### PR TITLE
Add learnable positional channels

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -217,7 +217,10 @@ class SamudraConfig(BaseConfig):
     last_kernel_size: int = 3
     pad: str = "circular"
     wet: Any | None = None
-    pos_channels: int = 0
+    pos_channels: int = Field(
+        default=0,
+        description="""Number of channels used for a learned positional embedding""",
+    )
 
     # Block configurations
     core_block: BlockConfig = BlockConfig()

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -217,6 +217,7 @@ class SamudraConfig(BaseConfig):
     last_kernel_size: int = 3
     pad: str = "circular"
     wet: Any | None = None
+    pos_channels: int = 0
 
     # Block configurations
     core_block: BlockConfig = BlockConfig()

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -24,8 +24,11 @@ from ocean_emulators.utils.train import pairwise
 
 class Samudra(BaseModel):
     def __init__(self, config: SamudraConfig, hist, wet, area_weights, static_data):
+        ch_width = config.ch_width.copy()
+        if config.pos_channels > 0:
+            ch_width[0] += config.pos_channels
         super().__init__(
-            ch_width=config.ch_width,
+            ch_width=ch_width,
             n_out=config.n_out,
             wet=wet,
             hist=hist,
@@ -35,11 +38,17 @@ class Samudra(BaseModel):
             static_data=static_data,
         )
 
+        if config.pos_channels > 0:
+            self.positional_params = nn.Parameter(
+                torch.zeros(config.pos_channels, *wet.shape[-2:])
+            )
+        else:
+            self.register_parameter("positional_params", None)
+
         # Get activation class
         activation = get_activation_cl(config.core_block.activation)
 
         # Create local copies of config lists that will be reversed
-        ch_width = config.ch_width.copy()
         dilation = config.dilation.copy()
         n_layers = config.n_layers.copy()
 
@@ -148,10 +157,13 @@ class Samudra(BaseModel):
 
         self.layers = nn.ModuleList(layers)
         self.corrector = Correctors(config.corrector, hist, area_weights, static_data)
-        self.num_steps = int(len(config.ch_width) - 1)
+        self.num_steps = int(len(ch_width) - 1)
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
         fts_input = fts.clone().detach()
+        if self.positional_params is not None:
+            pos = self.positional_params.unsqueeze(0).expand(fts.shape[0], -1, -1, -1)
+            fts = torch.cat([fts, pos], dim=1)
         skip_inputs: list[torch.Tensor] = []
         for i in range(self.num_steps):
             skip_inputs.append(torch.zeros_like(fts))

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -40,8 +40,9 @@ class Samudra(BaseModel):
 
         if config.pos_channels > 0:
             self.positional_params = nn.Parameter(
-                torch.zeros(config.pos_channels, *wet.shape[-2:])
+                torch.empty(config.pos_channels, *wet.shape[-2:])
             )
+            nn.init.normal_(self.positional_params, mean=0.0, std=1e-5)
         else:
             self.register_parameter("positional_params", None)
 

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -3,10 +3,10 @@ import torch
 import xarray as xr
 
 from ocean_emulators.config import SamudraConfig
+from ocean_emulators.constants import TensorMap
 from ocean_emulators.models.samudra import Samudra
 from ocean_emulators.utils.data import DataSource, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
-from ocean_emulators.constants import TensorMap
 
 
 def test_positional_parameters_update():
@@ -55,6 +55,10 @@ def test_positional_parameters_update():
 
         assert model.positional_params is not None
         assert model.positional_params.shape == (config.pos_channels, h, w)
+        assert not torch.allclose(
+            model.positional_params.detach(),
+            torch.zeros_like(model.positional_params),
+        )
 
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         x = torch.randn(1, config.ch_width[0], h, w)
@@ -65,4 +69,3 @@ def test_positional_parameters_update():
         before = model.positional_params.detach().clone()
         optimizer.step()
         assert not torch.allclose(model.positional_params.detach(), before)
-

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -1,0 +1,68 @@
+import numpy as np
+import torch
+import xarray as xr
+
+from ocean_emulators.config import SamudraConfig
+from ocean_emulators.models.samudra import Samudra
+from ocean_emulators.utils.data import DataSource, Normalize
+from ocean_emulators.utils.multiton import MultitonScope
+from ocean_emulators.constants import TensorMap
+
+
+def test_positional_parameters_update():
+    h, w = 4, 5
+    with MultitonScope():
+        TensorMap.init_instance("thetao_1", "hfds")
+        coords = {"lev": [0], "y": np.arange(h), "x": np.arange(w)}
+        zero = np.zeros((1, h, w))
+        data = xr.Dataset(
+            {
+                "thetao": (("lev", "y", "x"), zero),
+                "hfds": (("y", "x"), np.zeros((h, w))),
+            },
+            coords=coords,
+        )
+        ones = xr.Dataset(
+            {
+                "thetao": (("lev", "y", "x"), np.ones((1, h, w))),
+                "hfds": (("y", "x"), np.ones((h, w))),
+            },
+            coords=coords,
+        )
+        src = DataSource(name="dummy", data=data, means=data, stds=ones)
+        Normalize.init_instance(
+            src,
+            TensorMap.get_instance().prognostic_var_names,
+            TensorMap.get_instance().boundary_var_names,
+            torch.ones(h, w),
+            torch.ones(h, w),
+        )
+
+        config = SamudraConfig(
+            ch_width=[2, 2],
+            n_out=1,
+            dilation=[1],
+            n_layers=[1],
+            pos_channels=1,
+        )
+        model = Samudra(
+            config=config,
+            hist=0,
+            wet=torch.ones(1, h, w, dtype=torch.bool),
+            area_weights=torch.ones(h, w),
+            static_data=None,
+        )
+
+        assert model.positional_params is not None
+        assert model.positional_params.shape == (config.pos_channels, h, w)
+
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        x = torch.randn(1, config.ch_width[0], h, w)
+        optimizer.zero_grad()
+        out = model.forward_once(x)
+        loss = out.sum()
+        loss.backward()
+        before = model.positional_params.detach().clone()
+        optimizer.step()
+        assert not torch.allclose(model.positional_params.detach(), before)
+

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -10,8 +10,10 @@ from ocean_emulators.utils.multiton import MultitonScope
 
 
 def test_positional_parameters_update():
+    """Verify that positional parameters can learn something in a tiny example."""
     h, w = 4, 5
     with MultitonScope():
+        # Create some tiny data
         TensorMap.init_instance("thetao_1", "hfds")
         coords = {"lev": [0], "y": np.arange(h), "x": np.arange(w)}
         data = xr.Dataset(
@@ -37,6 +39,7 @@ def test_positional_parameters_update():
             torch.ones(h, w),
         )
 
+        # Create the model itself with learned positional embeddings
         config = SamudraConfig(
             ch_width=[2, 2],
             n_out=1,
@@ -52,6 +55,7 @@ def test_positional_parameters_update():
             static_data=None,
         )
 
+        # Verify we have created the positional embeddings
         assert model.positional_params is not None
         assert model.positional_params.shape == (config.pos_channels, h, w)
         assert not torch.allclose(
@@ -59,6 +63,7 @@ def test_positional_parameters_update():
             torch.zeros_like(model.positional_params),
         )
 
+        # Run a step and confirm they have changed
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
         x = torch.randn(1, config.ch_width[0], h, w)
         optimizer.zero_grad()

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -14,10 +14,9 @@ def test_positional_parameters_update():
     with MultitonScope():
         TensorMap.init_instance("thetao_1", "hfds")
         coords = {"lev": [0], "y": np.arange(h), "x": np.arange(w)}
-        zero = np.zeros((1, h, w))
         data = xr.Dataset(
             {
-                "thetao": (("lev", "y", "x"), zero),
+                "thetao": (("lev", "y", "x"), np.zeros((1, h, w))),
                 "hfds": (("y", "x"), np.zeros((h, w))),
             },
             coords=coords,


### PR DESCRIPTION
## Summary
- allow configuring extra learned positional channels
- incorporate positional parameters into Samudra model forward pass
- add unit test verifying positional parameters update via gradients

## Testing
- `uvx pre-commit run --all-files`
- `uv run pytest -m "not manual and not cuda"` *(fails: FileNotFoundError for remote dataset)*
- `uv run pytest tests/test_positional_channels.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd13368e4832085aed233390cc422