### PR TITLE
Added simple 2d patch embedding module for the FOMO encoder.

### DIFF
--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -45,9 +45,7 @@ class PatchEmbed2d(nn.Module):
         self.embed_dim: int = embed_dim
         self.n_channels = len(input_vars) * (1 + hist)
 
-        self.n_patches = patch_dim = (
-            self.n_channels * self.patch_size[0] * self.patch_size[1]
-        )
+        patch_dim = self.n_channels * self.patch_size[0] * self.patch_size[1]
 
         # While we could perform a patch embedding and linear projection in one step with a convolution, this
         # implementation is much clearer. I don't expect the additional computational cost to be arduous.

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -66,17 +66,12 @@ class PatchEmbed2d(nn.Module):
 
         # Ensure patch_size is appropriate for the data.
         assert H % self.patch_size[0] == 0, f"{H} %  {self.patch_size[0]} != 0."
-        assert (h := (H // self.patch_size[0]) ** 2) and h >= 16, (
-            f"{h=}: A picture is worth 16x16 words!"
-        )
         assert W % self.patch_size[1] == 0, f"{W} %  {self.patch_size[1]} != 0."
-        assert (w := (W // self.patch_size[1]) ** 2) and w >= 16, (
-            f"{w=}: A picture is worth 16x16 words!"
-        )
 
         x = self.patches(x)
         x = self.norm_patches(x)
         x = self.linear(x)
         x = self.norm_embedding(x)  # (batch, patch_dim, embed_dim)
         x = x.transpose(1, 2)  # (batch, embed_dim, patch_dim)
+
         return x

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -12,7 +12,7 @@ from ocean_emulators.constants import Input
 class PatchEmbed2d(nn.Module):
     """A patch embedding for Samudra's flattened data (the channel dim is a cross of variable, level, and time).
 
-    Arguments:
+    Args:
         input_vars (list[str]): list of input variable names. For input, this is typically the target prognostic
           and boundary variable names.
         patch_size (int): the size of the patches to embed. Patches must evenly divide the input grid.

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -1,12 +1,12 @@
 # Sources inspired by the following implementations:
 # - https://github.com/microsoft/aurora/blob/main/aurora/model/patchembed.py
 # - https://github.com/lucidrains/vit-pytorch
-
+import torch
 from einops.layers.torch import Rearrange
 from jaxtyping import Float
 from torch import nn
 
-from ocean_emulators.constants import Array, Input
+from ocean_emulators.constants import Input
 
 
 class PatchEmbed2d(nn.Module):
@@ -56,7 +56,9 @@ class PatchEmbed2d(nn.Module):
         self.linear = nn.Linear(patch_dim, embed_dim)
         self.norm_embedding = norm(embed_dim) if norm is not None else nn.Identity()
 
-    def forward(self, x: Input) -> Float[Array, "*batch {self.embed_dim} patch_dim"]:
+    def forward(
+        self, x: Input
+    ) -> Float[torch.Tensor, "*batch {self.embed_dim} patch_dim"]:
         B, V, H, W = x.shape
 
         # V is a cross product of variable, level (encoded in vars), and time (has history).

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -37,6 +37,9 @@ class PatchEmbed2d(nn.Module):
         if isinstance(patch_size, int):
             self.patch_size: tuple[int, int] = (patch_size, patch_size)
         else:
+            assert isinstance(patch_size, tuple) and len(patch_size) == 2, (
+                "We only ever consider patches for the spatial dimensions (lat and lon)!"
+            )
             self.patch_size = patch_size
 
         self.embed_dim: int = embed_dim

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -27,7 +27,7 @@ class PatchEmbed2d(nn.Module):
               and boundary variable names.
             patch_size (int): the size of the patches to embed. Patches must evenly divide the input grid. Further, the
               grid dimension divided by the patch size must be greater than 16 pixels.
-            embed_dim (int): the dimension of the embedding to use.
+            embed_dim (int): size of the latent dimension.
             hist (int): for the input channels, the number of additional time steps to include. With `hist=0`, it will
               only include the present timestep. With `hist=1`, it will include the present and previous time step.
             norm (type[nn.Module]): the normalization layer to use. This is applied both after creating patches and

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -1,0 +1,81 @@
+# Sources inspired by the following implementations:
+# - https://github.com/microsoft/aurora/blob/main/aurora/model/patchembed.py
+# - https://github.com/lucidrains/vit-pytorch
+
+from einops.layers.torch import Rearrange
+from jaxtyping import Array, Float
+from torch import nn
+
+from ocean_emulators.constants import Input
+
+
+class PatchEmbed2d(nn.Module):
+    """A patch embedding for Samudra's flattened data (the channel dim is a cross of variable, level, and time)."""
+
+    def __init__(
+        self,
+        input_vars: list[str],
+        patch_size: int | tuple[int, int] = 4,
+        embed_dim: int = 1024,
+        hist: int = 1,
+        norm: type[nn.Module] | None = nn.LayerNorm,
+    ) -> None:
+        """Embed TrainData arrays into patches.
+
+        Args:
+            input_vars (list[str]): list of input variable names. For input, this is typically the target prognostic
+              and boundary variable names.
+            patch_size (int): the size of the patches to embed. Patches must evenly divide the input grid. Further, the
+              grid dimension divided by the patch size must be greater than 16 pixels.
+            embed_dim (int): the dimension of the embedding to use.
+            hist (int): for the input channels, the number of additional time steps to include. With `hist=0`, it will
+              only include the present timestep. With `hist=1`, it will include the present and previous time step.
+            norm (type[nn.Module]): the normalization layer to use. This is applied both after creating patches and
+              after performing the linear projection.
+        """
+        super().__init__()
+        if isinstance(patch_size, int):
+            self.patch_size: tuple[int, int] = (patch_size, patch_size)
+        else:
+            self.patch_size = patch_size
+
+        self.embed_dim: int = embed_dim
+        self.n_channels = len(input_vars) * (1 + hist)
+
+        self.n_patches = patch_dim = (
+            self.n_channels * self.patch_size[0] * self.patch_size[1]
+        )
+
+        # While we could perform a patch embedding and linear projection in one step with a convolution, this
+        # implementation is much clearer. I don't expect that the additional computational cost to be that arduous.
+        self.patches = Rearrange(
+            "b v (h ph) (w pw) -> b (h w) (ph pw v)",
+            ph=self.patch_size[0],
+            pw=self.patch_size[1],
+        )
+        self.norm_patches = norm(patch_dim) if norm is not None else nn.Identity()
+        self.linear = nn.Linear(patch_dim, embed_dim)
+        self.norm_embedding = norm(embed_dim) if norm is not None else nn.Identity()
+
+    def forward(self, x: Input) -> Float[Array, "*batch patch_dim {self.embed_dim}"]:
+        B, V, H, W = x.shape
+
+        # V is a cross product of variable, level (encoded in vars), and time (has history).
+        assert V == self.n_channels
+
+        # Ensure patch_size is appropriate for the data.
+        assert H % self.patch_size[0] == 0, f"{H} %  {self.patch_size[0]} != 0."
+        assert (h := (H // self.patch_size[0]) ** 2) and h >= 16, (
+            f"{h=}: A picture is work 16x16 words!"
+        )
+        assert W % self.patch_size[1] == 0, f"{W} %  {self.patch_size[1]} != 0."
+        assert (w := (W // self.patch_size[1]) ** 2) and w >= 16, (
+            f"{w=}: A picture is work 16x16 words!"
+        )
+
+        x = self.patches(x)
+        x = self.norm_patches(x)
+        x = self.linear(x)
+        x = self.norm_embedding(x)
+
+        return x

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -10,7 +10,19 @@ from ocean_emulators.constants import Input
 
 
 class PatchEmbed2d(nn.Module):
-    """A patch embedding for Samudra's flattened data (the channel dim is a cross of variable, level, and time)."""
+    """A patch embedding for Samudra's flattened data (the channel dim is a cross of variable, level, and time).
+
+    Arguments:
+        input_vars (list[str]): list of input variable names. For input, this is typically the target prognostic
+          and boundary variable names.
+        patch_size (int): the size of the patches to embed. Patches must evenly divide the input grid. Further, the
+          grid dimension divided by the patch size must be greater than 16 pixels.
+        embed_dim (int): size of the latent dimension.
+        hist (int): for the input channels, the number of additional time steps to include. With `hist=0`, it will
+          only include the present timestep. With `hist=1`, it will include the present and previous time step.
+        norm (type[nn.Module]): the normalization layer to use. This is applied both after creating patches and
+          after performing the linear projection.
+    """
 
     def __init__(
         self,
@@ -20,19 +32,6 @@ class PatchEmbed2d(nn.Module):
         hist: int = 1,
         norm: type[nn.Module] | None = nn.LayerNorm,
     ) -> None:
-        """Embed TrainData arrays into patches.
-
-        Args:
-            input_vars (list[str]): list of input variable names. For input, this is typically the target prognostic
-              and boundary variable names.
-            patch_size (int): the size of the patches to embed. Patches must evenly divide the input grid. Further, the
-              grid dimension divided by the patch size must be greater than 16 pixels.
-            embed_dim (int): size of the latent dimension.
-            hist (int): for the input channels, the number of additional time steps to include. With `hist=0`, it will
-              only include the present timestep. With `hist=1`, it will include the present and previous time step.
-            norm (type[nn.Module]): the normalization layer to use. This is applied both after creating patches and
-              after performing the linear projection.
-        """
         super().__init__()
         if isinstance(patch_size, int):
             self.patch_size: tuple[int, int] = (patch_size, patch_size)

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -69,11 +69,11 @@ class PatchEmbed2d(nn.Module):
         # Ensure patch_size is appropriate for the data.
         assert H % self.patch_size[0] == 0, f"{H} %  {self.patch_size[0]} != 0."
         assert (h := (H // self.patch_size[0]) ** 2) and h >= 16, (
-            f"{h=}: A picture is work 16x16 words!"
+            f"{h=}: A picture is worth 16x16 words!"
         )
         assert W % self.patch_size[1] == 0, f"{W} %  {self.patch_size[1]} != 0."
         assert (w := (W // self.patch_size[1]) ** 2) and w >= 16, (
-            f"{w=}: A picture is work 16x16 words!"
+            f"{w=}: A picture is worth 16x16 words!"
         )
 
         x = self.patches(x)

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -38,7 +38,7 @@ class PatchEmbed2d(nn.Module):
             self.patch_size: tuple[int, int] = (patch_size, patch_size)
         else:
             assert isinstance(patch_size, tuple) and len(patch_size) == 2, (
-                "We only ever consider patches for the spatial dimensions (lat and lon)!"
+                "Patch sizes must only span spatial dimensions (lat and lon)!"
             )
             self.patch_size = patch_size
 

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -3,10 +3,10 @@
 # - https://github.com/lucidrains/vit-pytorch
 
 from einops.layers.torch import Rearrange
-from jaxtyping import Array, Float
+from jaxtyping import Float
 from torch import nn
 
-from ocean_emulators.constants import Input
+from ocean_emulators.constants import Array, Input
 
 
 class PatchEmbed2d(nn.Module):
@@ -15,8 +15,7 @@ class PatchEmbed2d(nn.Module):
     Arguments:
         input_vars (list[str]): list of input variable names. For input, this is typically the target prognostic
           and boundary variable names.
-        patch_size (int): the size of the patches to embed. Patches must evenly divide the input grid. Further, the
-          grid dimension divided by the patch size must be greater than 16 pixels.
+        patch_size (int): the size of the patches to embed. Patches must evenly divide the input grid.
         embed_dim (int): size of the latent dimension.
         hist (int): for the input channels, the number of additional time steps to include. With `hist=0`, it will
           only include the present timestep. With `hist=1`, it will include the present and previous time step.

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -58,7 +58,7 @@ class PatchEmbed2d(nn.Module):
         self.linear = nn.Linear(patch_dim, embed_dim)
         self.norm_embedding = norm(embed_dim) if norm is not None else nn.Identity()
 
-    def forward(self, x: Input) -> Float[Array, "*batch patch_dim {self.embed_dim}"]:
+    def forward(self, x: Input) -> Float[Array, "*batch {self.embed_dim} patch_dim"]:
         B, V, H, W = x.shape
 
         # V is a cross product of variable, level (encoded in vars), and time (has history).
@@ -77,6 +77,6 @@ class PatchEmbed2d(nn.Module):
         x = self.patches(x)
         x = self.norm_patches(x)
         x = self.linear(x)
-        x = self.norm_embedding(x)
-
+        x = self.norm_embedding(x)  # (batch, patch_dim, embed_dim)
+        x = x.transpose(1, 2)  # (batch, embed_dim, patch_dim)
         return x

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -50,7 +50,7 @@ class PatchEmbed2d(nn.Module):
         )
 
         # While we could perform a patch embedding and linear projection in one step with a convolution, this
-        # implementation is much clearer. I don't expect that the additional computational cost to be that arduous.
+        # implementation is much clearer. I don't expect the additional computational cost to be arduous.
         self.patches = Rearrange(
             "b v (h ph) (w pw) -> b (h w) (ph pw v)",
             ph=self.patch_size[0],

--- a/src/ocean_emulators/models/modules/patchembed.py
+++ b/src/ocean_emulators/models/modules/patchembed.py
@@ -19,17 +19,13 @@ class PatchEmbed2d(nn.Module):
         embed_dim (int): size of the latent dimension.
         hist (int): for the input channels, the number of additional time steps to include. With `hist=0`, it will
           only include the present timestep. With `hist=1`, it will include the present and previous time step.
-        norm (type[nn.Module]): the normalization layer to use. This is applied both after creating patches and
-          after performing the linear projection.
     """
 
     def __init__(
         self,
-        input_vars: list[str],
+        n_channels: int,
         patch_size: int | tuple[int, int] = 4,
         embed_dim: int = 1024,
-        hist: int = 1,
-        norm: type[nn.Module] | None = nn.LayerNorm,
     ) -> None:
         super().__init__()
         if isinstance(patch_size, int):
@@ -40,8 +36,8 @@ class PatchEmbed2d(nn.Module):
             )
             self.patch_size = patch_size
 
+        self.n_channels = n_channels
         self.embed_dim: int = embed_dim
-        self.n_channels = len(input_vars) * (1 + hist)
 
         patch_dim = self.n_channels * self.patch_size[0] * self.patch_size[1]
 
@@ -52,9 +48,9 @@ class PatchEmbed2d(nn.Module):
             ph=self.patch_size[0],
             pw=self.patch_size[1],
         )
-        self.norm_patches = norm(patch_dim) if norm is not None else nn.Identity()
+        self.norm_patches = nn.LayerNorm(patch_dim)
         self.linear = nn.Linear(patch_dim, embed_dim)
-        self.norm_embedding = norm(embed_dim) if norm is not None else nn.Identity()
+        self.norm_embedding = nn.LayerNorm(embed_dim)
 
     def forward(
         self, x: Input

--- a/tests/test_patchembed.py
+++ b/tests/test_patchembed.py
@@ -1,0 +1,121 @@
+import torch
+
+from ocean_emulators.config import TrainConfig
+from ocean_emulators.constants import BOUNDARY_VARS, PROGNOSTIC_VARS
+from ocean_emulators.datasets import TrainData
+from ocean_emulators.models.modules.patchembed import PatchEmbed2d
+
+from .test_datasets import make_loader
+
+
+def test_makes_patches():
+    x = torch.randn(1, 20, 180, 360)
+
+    patch_embed = PatchEmbed2d(
+        input_vars=[f"var_{i}" for i in range(x.shape[1])],
+        patch_size=4,
+        embed_dim=1024,
+        hist=0,
+        norm=None,
+    )
+
+    patches = patch_embed(x)
+
+    assert patches.shape == (1, 4050, 1024)
+
+
+def test_makes_patches__high_res():
+    x = torch.randn(1, 20, 360, 720)
+
+    patch_embed = PatchEmbed2d(
+        input_vars=[f"var_{i}" for i in range(x.shape[1])],
+        patch_size=4,
+        embed_dim=1024,
+        hist=0,
+        norm=None,
+    )
+
+    patches = patch_embed(x)
+
+    assert patches.shape == (1, 16200, 1024)
+
+
+def test_makes_patches__more_variables():
+    x = torch.randn(1, 71, 180, 360)
+
+    patch_embed = PatchEmbed2d(
+        input_vars=[f"var_{i}" for i in range(x.shape[1])],
+        patch_size=4,
+        embed_dim=1024,
+        hist=0,
+        norm=None,
+    )
+
+    patches = patch_embed(x)
+
+    assert patches.shape == (1, 4050, 1024)
+
+
+def test_makes_patches__with_layer_norm():
+    x = torch.randn(1, 20, 180, 360)
+
+    patch_embed = PatchEmbed2d(
+        input_vars=[f"var_{i}" for i in range(x.shape[1])],
+        patch_size=4,
+        embed_dim=1024,
+        hist=0,
+        norm=torch.nn.LayerNorm,
+    )
+
+    patches = patch_embed(x)
+
+    assert patches.shape == (1, 4050, 1024)
+
+
+def test_makes_patches__with_history():
+    x = torch.randn(1, 20, 180, 360)
+
+    patch_embed = PatchEmbed2d(
+        input_vars=[f"var_{i}" for i in range(x.shape[1] // 2)],
+        patch_size=4,
+        embed_dim=1024,
+        hist=1,
+        norm=None,
+    )
+
+    patches = patch_embed(x)
+
+    assert patches.shape == (1, 4050, 1024)
+
+
+def test_patch_embed__on_real_data(train_config: TrainConfig):
+    prognostic_vars = PROGNOSTIC_VARS[train_config.experiment.prognostic_vars_key]
+    boundary_vars = BOUNDARY_VARS[train_config.experiment.boundary_vars_key]
+    input_vars = prognostic_vars + boundary_vars
+
+    patch_embed = PatchEmbed2d(input_vars, hist=train_config.data.hist)
+
+    with make_loader(train_config) as loader:
+        for td in loader:
+            assert isinstance(td, TrainData), (
+                "The loader must return a TrainData! This is for the type checker."
+            )
+            # The forward pass of our base model manages a rollout across steps, where the model
+            # only ever needs to predict one step. There are two possible inputs in this step rollout
+            # system: the initial state, or a "merged" state, where we merge our latest prognostic
+            # prediction with the boundary forcings for that step.
+            # Thus, to ensure our patch encoder works as expected (for the one-step prediction part),
+            # we only need to test that the patch embedding works for either the initial input or the
+            # merged input.
+            initial_input = td.get_initial_input()
+            patches = patch_embed(initial_input)
+            assert patches.shape == (1, 4050, 1024)
+
+            prev_output = td.get_label(
+                max(0, len(td) - 2)
+            )  # Let's assume our predictor does a perfect job.
+            merged_input = td.merge_prognostic_and_boundary(
+                prognostic=prev_output, step=len(td) - 1
+            )
+            patches = patch_embed(merged_input)
+            assert patches.shape == (1, 4050, 1024)

--- a/tests/test_patchembed.py
+++ b/tests/test_patchembed.py
@@ -111,11 +111,11 @@ def test_patch_embed__on_real_data(train_config: TrainConfig):
             patches = patch_embed(initial_input)
             assert patches.shape == (1, 4050, 1024)
 
-            prev_output = td.get_label(
+            prev_prediction = td.get_label(
                 max(0, len(td) - 2)
             )  # Let's assume our predictor does a perfect job.
             merged_input = td.merge_prognostic_and_boundary(
-                prognostic=prev_output, step=len(td) - 1
+                prognostic=prev_prediction, step=len(td) - 1
             )
             patches = patch_embed(merged_input)
             assert patches.shape == (1, 4050, 1024)

--- a/tests/test_patchembed.py
+++ b/tests/test_patchembed.py
@@ -12,11 +12,9 @@ def test_makes_patches():
     x = torch.randn(1, 20, 180, 360)
 
     patch_embed = PatchEmbed2d(
-        input_vars=[f"var_{i}" for i in range(x.shape[1])],
+        n_channels=20,
         patch_size=4,
         embed_dim=1024,
-        hist=0,
-        norm=None,
     )
 
     patches = patch_embed(x)
@@ -28,11 +26,9 @@ def test_makes_patches__high_res():
     x = torch.randn(1, 20, 360, 720)
 
     patch_embed = PatchEmbed2d(
-        input_vars=[f"var_{i}" for i in range(x.shape[1])],
+        n_channels=20,
         patch_size=4,
         embed_dim=1024,
-        hist=0,
-        norm=None,
     )
 
     patches = patch_embed(x)
@@ -44,43 +40,9 @@ def test_makes_patches__more_variables():
     x = torch.randn(1, 71, 180, 360)
 
     patch_embed = PatchEmbed2d(
-        input_vars=[f"var_{i}" for i in range(x.shape[1])],
+        n_channels=71,
         patch_size=4,
         embed_dim=1024,
-        hist=0,
-        norm=None,
-    )
-
-    patches = patch_embed(x)
-
-    assert patches.shape == (1, 1024, 4050)
-
-
-def test_makes_patches__with_layer_norm():
-    x = torch.randn(1, 20, 180, 360)
-
-    patch_embed = PatchEmbed2d(
-        input_vars=[f"var_{i}" for i in range(x.shape[1])],
-        patch_size=4,
-        embed_dim=1024,
-        hist=0,
-        norm=torch.nn.LayerNorm,
-    )
-
-    patches = patch_embed(x)
-
-    assert patches.shape == (1, 1024, 4050)
-
-
-def test_makes_patches__with_history():
-    x = torch.randn(1, 20, 180, 360)
-
-    patch_embed = PatchEmbed2d(
-        input_vars=[f"var_{i}" for i in range(x.shape[1] // 2)],
-        patch_size=4,
-        embed_dim=1024,
-        hist=1,
-        norm=None,
     )
 
     patches = patch_embed(x)
@@ -93,7 +55,9 @@ def test_patch_embed__on_real_data(train_config: TrainConfig):
     boundary_vars = BOUNDARY_VARS[train_config.experiment.boundary_vars_key]
     input_vars = prognostic_vars + boundary_vars
 
-    patch_embed = PatchEmbed2d(input_vars, hist=train_config.data.hist)
+    patch_embed = PatchEmbed2d(
+        n_channels=len(input_vars) * (1 + train_config.data.hist)
+    )
 
     with make_loader(train_config) as loader:
         for td in loader:
@@ -109,7 +73,7 @@ def test_patch_embed__on_real_data(train_config: TrainConfig):
             # merged input.
             initial_input = td.get_initial_input()
             patches = patch_embed(initial_input)
-            assert patches.shape == (1, 1024, 4050)
+            assert patches.shape[:2] == (1, 1024)
 
             prev_prediction = td.get_label(
                 max(0, len(td) - 2)
@@ -118,4 +82,4 @@ def test_patch_embed__on_real_data(train_config: TrainConfig):
                 prognostic=prev_prediction, step=len(td) - 1
             )
             patches = patch_embed(merged_input)
-            assert patches.shape == (1, 1024, 4050)
+            assert patches.shape[:2] == (1, 1024)

--- a/tests/test_patchembed.py
+++ b/tests/test_patchembed.py
@@ -21,7 +21,7 @@ def test_makes_patches():
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 4050, 1024)
+    assert patches.shape == (1, 1024, 4050)
 
 
 def test_makes_patches__high_res():
@@ -37,7 +37,7 @@ def test_makes_patches__high_res():
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 16200, 1024)
+    assert patches.shape == (1, 1024, 16200)
 
 
 def test_makes_patches__more_variables():
@@ -53,7 +53,7 @@ def test_makes_patches__more_variables():
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 4050, 1024)
+    assert patches.shape == (1, 1024, 4050)
 
 
 def test_makes_patches__with_layer_norm():
@@ -69,7 +69,7 @@ def test_makes_patches__with_layer_norm():
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 4050, 1024)
+    assert patches.shape == (1, 1024, 4050)
 
 
 def test_makes_patches__with_history():
@@ -85,7 +85,7 @@ def test_makes_patches__with_history():
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 4050, 1024)
+    assert patches.shape == (1, 1024, 4050)
 
 
 def test_patch_embed__on_real_data(train_config: TrainConfig):
@@ -109,7 +109,7 @@ def test_patch_embed__on_real_data(train_config: TrainConfig):
             # merged input.
             initial_input = td.get_initial_input()
             patches = patch_embed(initial_input)
-            assert patches.shape == (1, 4050, 1024)
+            assert patches.shape == (1, 1024, 4050)
 
             prev_prediction = td.get_label(
                 max(0, len(td) - 2)
@@ -118,4 +118,4 @@ def test_patch_embed__on_real_data(train_config: TrainConfig):
                 prognostic=prev_prediction, step=len(td) - 1
             )
             patches = patch_embed(merged_input)
-            assert patches.shape == (1, 4050, 1024)
+            assert patches.shape == (1, 1024, 4050)


### PR DESCRIPTION
Soon, we will add a Perceiver-based encoder module to the project. Before applying the Perceiver module, the first step we take on is to break up the input into ViT-style patches. This PR introduces a simple patch embedding mechanism in prep for the rest of the encoder.

Fixes #362.