### PR TITLE
Speed up CI by caching `uv` dependencies.

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -25,16 +25,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-        # Invalidate the data cache every time the data source changes.
-        # If an exact cache isn't found, fall back to previous cache.
-      - name: Cache test data
-        uses: actions/cache@v3
-        with:
-          path: .data_cache/
-          key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/*.test.yaml') }}
-
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -41,6 +41,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Cache uv dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
       - name: Install dependencies
         run: uv sync --locked --dev --all-extras
 

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+        # Invalidate the data cache every time the data source changes.
+        # If an exact cache isn't found, fall back to previous cache.
+      - name: Cache test data
+        uses: actions/cache@v3
+        with:
+          path: .data_cache/
+          key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/*.test.yaml') }}
+
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v6
         with:
@@ -34,14 +42,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.11"
-
-      - name: Cache uv dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
 
       - name: Install dependencies
         run: uv sync --locked --dev --all-extras

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Cache uv dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-
+
       - name: Install dependencies
         run: uv sync --locked --dev --all-extras
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-        # Invalidate the data cache every time the data source changes.
-        # If an exact cache isn't found, fall back to previous cache.
-      - name: Cache test data
-        uses: actions/cache@v3
-        with:
-          path: .data_cache/
-          key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/*.test.yaml') }}
-
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+        # Invalidate the data cache every time the data source changes.
+        # If an exact cache isn't found, fall back to previous cache.
+      - name: Cache test data
+        uses: actions/cache@v3
+        with:
+          path: .data_cache/
+          key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/*.test.yaml') }}
+
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v6
         with:
@@ -29,14 +37,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.11"
-
-      - name: Cache uv dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
 
       - name: Install dependencies
         run: uv sync --locked --dev --all-extras


### PR DESCRIPTION
Speeding up CI runtimes by turning on `uv`'s Github Action cache.