### PR TITLE
FOMO module components agree in dimension.

### DIFF
--- a/configs/train_fomo.test.yaml
+++ b/configs/train_fomo.test.yaml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=schemas/TrainConfig.json
+
+# A config file to test training.
+# Used in automated tests.
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 2
+batch_size: 1
+preemptible: false
+learning_rate: 0.0001
+scheduler: null
+loss: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: [-1]
+data_percent: 1.0
+train_time:
+  start: '1975-08-15'
+  end: '1975-10-25'
+val_time:
+  start: '1975-10-25'
+  end: '1975-11-25'
+inference_times:
+  - start: '1975-11-25'
+    end: '1975-12-25'
+data_stride: [1]
+steps: [1]
+step_transition: []
+backend: auto
+
+experiment:
+  name: test
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: ocean-emulators
+    entity: m2lines
+    group: samudra-train-om4
+  prognostic_vars_key: thermo_dynamic_5
+  boundary_vars_key: tau_hfds
+  data_root: .data_cache/
+data:
+  data_location: data.zarr
+  data_means_location: means.nc
+  data_stds_location: stds.nc
+  scaling_residuals_file: null
+  num_workers: 4
+  hist: 0
+
+
+model:
+  pred_residuals: false
+  last_kernel_size: 3
+  pad: "circular"
+
+  in_embedding: 2
+  out_embedding: 2
+
+  encoder:
+    perceiver_depth: 2
+
+  processor:
+    ch_width: [2, 2]
+    dilation: [1, 2]
+    n_layers: [1, 1]
+
+    core_block:
+      block_type: "conv_next_block"
+      kernel_size: 3
+      activation: "capped_gelu"
+      upscale_factor: 2
+      norm: "batch"
+
+    down_sampling_block: "avg_pool"
+    up_sampling_block: "bilinear_upsample"

--- a/configs/train_fomo.test.yaml
+++ b/configs/train_fomo.test.yaml
@@ -56,8 +56,7 @@ model:
   last_kernel_size: 3
   pad: "circular"
 
-  in_embedding: 2
-  out_embedding: 2
+  embedding_dim: 2
 
   encoder:
     perceiver_depth: 2

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -35,7 +35,7 @@ step_transition: []
 backend: auto
 
 experiment:
-  name: local_om4_samudra
+  name: local_om4_fomo
   rand_seed: 15
   base_output_dir: .LOCAL
   wandb:

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -53,6 +53,9 @@ model:
   last_kernel_size: 3
   pad: "circular"
 
+  encoder:
+    perceiver_depth: 4
+
   processor:
     ch_width: [200, 250, 300, 400]
     dilation: [1, 2, 4, 8]
@@ -62,7 +65,7 @@ model:
       block_type: "conv_next_block"
       kernel_size: 3
       activation: "capped_gelu"
-      upscale_factor: 4
+      upscale_factor: 2
       norm: "batch"
 
     down_sampling_block: "avg_pool"

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -5,7 +5,7 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 70
-batch_size: 4
+batch_size: 2
 learning_rate: 0.0002
 scheduler: {type: cosine}
 loss: mse
@@ -52,12 +52,15 @@ model:
   pred_residuals: false
   last_kernel_size: 3
   pad: "circular"
+  checkpointing: "all"
+  embedding_dim: 64
 
   encoder:
-    perceiver_depth: 4
+    perceiver_depth: 2
+    patch_size: [4, 8]
 
   processor:
-    ch_width: [200, 250, 300, 400]
+    ch_width: [64, 50, 40, 25]
     dilation: [1, 2, 4, 8]
     n_layers: [1, 1, 1, 1]
 
@@ -65,7 +68,7 @@ model:
       block_type: "conv_next_block"
       kernel_size: 3
       activation: "capped_gelu"
-      upscale_factor: 2
+      upscale_factor: 1
       norm: "batch"
 
     down_sampling_block: "avg_pool"

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -60,7 +60,7 @@ model:
     patch_size: [4, 8]
 
   processor:
-    ch_width: [64, 50, 40, 25]
+    ch_width: [80, 120, 200, 270]
     dilation: [1, 2, 4, 8]
     n_layers: [1, 1, 1, 1]
 

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -56,7 +56,7 @@ model:
   embedding_dim: 64
 
   encoder:
-    perceiver_depth: 2
+    perceiver_depth: 3
     patch_size: [4, 8]
 
   processor:

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -45,7 +45,8 @@ experiment:
     group: samudra-train-om4
   prognostic_vars_key: thermo_dynamic_all
   boundary_vars_key: tau_hfds_hfds_anom
-data: !include data/om4_ohc.yaml
+data:
+  !include data/public.yaml
 
 model:
   pred_residuals: false

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -342,9 +342,7 @@ class UNetBackboneConfig(BaseConfig):
 
         # This replicates the default behavior of Samudra.
         if out_channels is None:
-            out_channels = (
-                self.ch_width[1] if len(self.ch_width) > 1 else self.ch_width[0]
-            )
+            out_channels = self.ch_width[0]
 
         def create_upsampling_block(in_channels: int, out_channels: int):
             match self.up_sampling_block:

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -479,7 +479,7 @@ class FOMOConfig(BaseModelConfig):
                 self.pad,
                 self.checkpointing,
             ),
-            # decoder = self.decoder.build(self.embedding_out_dim, out_channels)  # will be something like this
+            # decoder = self.decoder.build(self.out_embedding, out_channels)  # will be something like this
             hist=hist,
             wet=wet,
             static_data=static_data,

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -342,7 +342,9 @@ class UNetBackboneConfig(BaseConfig):
 
         # This replicates the default behavior of Samudra.
         if out_channels is None:
-            out_channels = self.ch_width[1]
+            out_channels = (
+                self.ch_width[1] if len(self.ch_width) > 1 else self.ch_width[0]
+            )
 
         def create_upsampling_block(in_channels: int, out_channels: int):
             match self.up_sampling_block:

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -332,17 +332,12 @@ class UNetBackboneConfig(BaseConfig):
     def build(
         self,
         in_channels: int,
-        out_channels: int | None,
         pad: str,
         checkpointing: Checkpointing | None,
     ) -> UNetBackbone:
         assert len(self.ch_width) == len(self.dilation) == len(self.n_layers), (
             "`ch_width`, `dilation`, and `n_layers` must have the same length."
         )
-
-        # This replicates the default behavior of Samudra.
-        if out_channels is None:
-            out_channels = self.ch_width[0]
 
         def create_upsampling_block(in_channels: int, out_channels: int):
             match self.up_sampling_block:
@@ -367,7 +362,6 @@ class UNetBackboneConfig(BaseConfig):
 
         return UNetBackbone(
             in_channels=in_channels,
-            out_channels=out_channels,
             ch_width=self.ch_width,
             dilation=self.dilation,
             n_layers=self.n_layers,
@@ -436,7 +430,6 @@ class SamudraConfig(BaseModelConfig):
             pad=self.pad,
             unet=self.unet.build(
                 in_channels=total_in_channels,
-                out_channels=None,  # `out_channels` is set from the unet config (via `ch_width[1]`).
                 pad=self.pad,
                 checkpointing=self.checkpointing,
             ),
@@ -452,8 +445,7 @@ class FOMOConfig(BaseModelConfig):
     encoder: EncoderConfig = EncoderConfig()
     processor: UNetBackboneConfig = UNetBackboneConfig()
     # decoder will go here.
-    in_embedding: int = 512
-    out_embedding: int = 256
+    embedding_dim: int = 128
 
     def build(
         self,
@@ -470,14 +462,13 @@ class FOMOConfig(BaseModelConfig):
             pred_residuals=self.pred_residuals,
             last_kernel_size=self.last_kernel_size,
             pad=self.pad,
-            encoder=self.encoder.build(in_channels, self.in_embedding),
+            encoder=self.encoder.build(in_channels, self.embedding_dim),
             processor=self.processor.build(
-                self.in_embedding,
-                self.out_embedding,
+                self.embedding_dim,
                 self.pad,
                 self.checkpointing,
             ),
-            # decoder = self.decoder.build(self.out_embedding, out_channels)  # will be something like this
+            # decoder = self.decoder.build(processor.out_channels, out_channels)  # will be something like this
             hist=hist,
             wet=wet,
             static_data=static_data,

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -291,10 +291,9 @@ class EncoderConfig(BaseConfig):
         default=4,
         description="Either a square patch (int) or a rectangular patch of [height: int, width: int]. It must evenly divide the grid size.",
     )
-    embed_dim: int = 512
     perceiver_depth: int = 6
 
-    def build(self, in_channels: int) -> PerceiverEncoder:
+    def build(self, in_channels: int, out_channels: int) -> PerceiverEncoder:
         if (
             isinstance(self.patch_size, list)
             and len(self.patch_size) == 2
@@ -311,8 +310,8 @@ class EncoderConfig(BaseConfig):
 
         return PerceiverEncoder(
             in_channels=in_channels,
+            out_channels=out_channels,
             patch_size=patch_size,
-            embed_dim=self.embed_dim,
             perceiver_depth=self.perceiver_depth,
         )
 
@@ -333,12 +332,17 @@ class UNetBackboneConfig(BaseConfig):
     def build(
         self,
         in_channels: int,
+        out_channels: int | None,
         pad: str,
         checkpointing: Checkpointing | None,
     ) -> UNetBackbone:
         assert len(self.ch_width) == len(self.dilation) == len(self.n_layers), (
             "`ch_width`, `dilation`, and `n_layers` must have the same length."
         )
+
+        # This replicates the default behavior of Samudra.
+        if out_channels is None:
+            out_channels = self.ch_width[1]
 
         def create_upsampling_block(in_channels: int, out_channels: int):
             match self.up_sampling_block:
@@ -353,8 +357,6 @@ class UNetBackboneConfig(BaseConfig):
                 case _:
                     assert_never(self.up_sampling_block)
 
-        ch_width = [in_channels] + self.ch_width.copy()
-
         match self.down_sampling_block:
             case "avg_pool":
                 downsampling_block: nn.Module = AvgPool()
@@ -364,7 +366,9 @@ class UNetBackboneConfig(BaseConfig):
                 assert_never(self.down_sampling_block)
 
         return UNetBackbone(
-            ch_width=ch_width,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            ch_width=self.ch_width,
             dilation=self.dilation,
             n_layers=self.n_layers,
             pad=pad,
@@ -432,6 +436,7 @@ class SamudraConfig(BaseModelConfig):
             pad=self.pad,
             unet=self.unet.build(
                 in_channels=total_in_channels,
+                out_channels=None,  # `out_channels` is set from the unet config (via `ch_width[1]`).
                 pad=self.pad,
                 checkpointing=self.checkpointing,
             ),
@@ -447,6 +452,8 @@ class FOMOConfig(BaseModelConfig):
     encoder: EncoderConfig = EncoderConfig()
     processor: UNetBackboneConfig = UNetBackboneConfig()
     # decoder will go here.
+    in_embedding: int = 512
+    out_embedding: int = 256
 
     def build(
         self,
@@ -457,16 +464,20 @@ class FOMOConfig(BaseModelConfig):
         area_weights: Grid,
         static_data: xr.Dataset | None,
     ) -> FOMO:
-        # Maybe consider adding area_weight
         return FOMO(
             in_channels=in_channels,
             out_channels=in_channels,
             pred_residuals=self.pred_residuals,
             last_kernel_size=self.last_kernel_size,
             pad=self.pad,
-            # TODO(alxmrs): Do the encoder and processor need to take in both in_channels and out_channels?
-            encoder=self.encoder.build(in_channels),
-            processor=self.processor.build(in_channels, self.pad, self.checkpointing),
+            encoder=self.encoder.build(in_channels, self.in_embedding),
+            processor=self.processor.build(
+                self.in_embedding,
+                self.out_embedding,
+                self.pad,
+                self.checkpointing,
+            ),
+            # decoder = self.decoder.build(self.embedding_out_dim, out_channels)  # will be something like this
             hist=hist,
             wet=wet,
             static_data=static_data,

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -9,7 +9,10 @@ from ocean_emulators.models.modules.unet_backbone import UNetBackbone
 
 
 class FOMO(BaseModel):
-    """FOMO: A Foundation Model for the Oceans + Observations."""
+    """FOMO: A Foundation Model for the Oceans + Observations.
+
+    Currently, this model is used only as a physical ocean emulator.
+    """
 
     def __init__(
         self,

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -9,7 +9,7 @@ from ocean_emulators.models.modules.unet_backbone import UNetBackbone
 
 
 class FOMO(BaseModel):
-    """A placeholder FOMO model. It currently combines an encoder and processor."""
+    """FOMO: A Foundation Model for the Oceans + Observations."""
 
     def __init__(
         self,
@@ -34,14 +34,15 @@ class FOMO(BaseModel):
             pad=pad,
             static_data=static_data,
         )
-        # TODO(alxmrs): Properly wire up the encoder with the processor.
-        self.layers = [encoder, processor]
-        self.layers.append(
-            # Placeholder decoder -- ignoring global padding for now.
+        # Placeholder decoder is a non-globe aware Conv2d.
+        layers = [
+            encoder,
+            processor,
             nn.Conv2d(processor.out_channels, out_channels, last_kernel_size),
-        )
+        ]
+        self.layers = nn.ModuleList(layers)
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
         for layer in self.layers:
             fts = layer(fts)
-        return fts
+        return torch.where(self.wet, fts, 0.0)

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -16,9 +16,9 @@ class PerceiverEncoder(nn.Module):
 
     Args:
         in_channels (int): the number of input channels (roughly:  time x variable x (surface + depths)).
+        out_channels (int): size of the latent dimension (aka, the embedding dimension).
         patch_size (int | tuple[int, int]): the size of the patches to embed. Patches must evenly divide the input grid.
           If a tuple is supplied, then it represents the (height, width) of the patches to embed.
-        embed_dim (int): size of the latent dimension.
         perceiver_depth (int): depth of the perceiver module core.
     """
 
@@ -26,8 +26,8 @@ class PerceiverEncoder(nn.Module):
     def __init__(
         self,
         in_channels: int,
+        out_channels: int,
         patch_size: int | tuple[int, int],
-        embed_dim: int,
         perceiver_depth: int,
     ) -> None:
         super().__init__()
@@ -39,7 +39,7 @@ class PerceiverEncoder(nn.Module):
                 "Patch sizes must only span spatial dimensions (lat and lon)!"
             )
             self.patch_size = patch_size
-        self.embed_dim: int = embed_dim
+        self.out_channels: int = out_channels  # aka, `embed_dim`.
 
         self.norm_patches = nn.LayerNorm(self.in_channels)
         self.perceiver = Perceiver(
@@ -47,10 +47,10 @@ class PerceiverEncoder(nn.Module):
             max_freq=1.0,
             depth=perceiver_depth,
             input_axis=2,  # Number of positional dims before token dim
-            input_channels=self.in_channels,  # input_dim
-            num_classes=embed_dim,  # output_dim
+            input_channels=self.in_channels,
+            num_classes=out_channels,
         )
-        self.norm_embedding = nn.LayerNorm(embed_dim)
+        self.norm_embedding = nn.LayerNorm(out_channels)
 
     def forward(self, x: Input) -> Float[torch.Tensor, "batch h w {self.embed_dim}"]:
         _, V, H, W = x.shape

--- a/src/ocean_emulators/models/modules/unet_backbone.py
+++ b/src/ocean_emulators/models/modules/unet_backbone.py
@@ -43,6 +43,8 @@ class UNetBackbone(nn.Module):
 
     def __init__(
         self,
+        in_channels: int,
+        out_channels: int,
         ch_width: list[int],
         dilation: list[int],
         n_layers: list[int],
@@ -55,12 +57,12 @@ class UNetBackbone(nn.Module):
         super().__init__()
 
         # Create local copies of config lists that will be reversed
-        ch_width = ch_width.copy()
+        ch_width = [in_channels] + ch_width.copy()
         dilation = dilation.copy()
         n_layers = n_layers.copy()
         self.pad = pad
-        self.in_channels = ch_width[0]
-        self.out_channels = ch_width[1]
+        self.in_channels = in_channels
+        self.out_channels = out_channels
 
         match checkpointing:
             case "all":
@@ -130,7 +132,7 @@ class UNetBackbone(nn.Module):
         layers.append(
             create_block(
                 in_channels=b,
-                out_channels=b,
+                out_channels=self.out_channels,
                 dilation=dilation[i],
                 n_layers=n_layers[i],
                 pad=pad,

--- a/src/ocean_emulators/models/modules/unet_backbone.py
+++ b/src/ocean_emulators/models/modules/unet_backbone.py
@@ -44,7 +44,6 @@ class UNetBackbone(nn.Module):
     def __init__(
         self,
         in_channels: int,
-        out_channels: int,
         ch_width: list[int],
         dilation: list[int],
         n_layers: list[int],
@@ -55,14 +54,14 @@ class UNetBackbone(nn.Module):
         checkpointing: "Checkpointing | None",
     ):
         super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = ch_width[0]
 
         # Create local copies of config lists that will be reversed
         ch_width = [in_channels] + ch_width.copy()
         dilation = dilation.copy()
         n_layers = n_layers.copy()
         self.pad = pad
-        self.in_channels = in_channels
-        self.out_channels = out_channels
 
         match checkpointing:
             case "all":
@@ -132,7 +131,7 @@ class UNetBackbone(nn.Module):
         layers.append(
             create_block(
                 in_channels=b,
-                out_channels=self.out_channels,
+                out_channels=b,  # this is the same as self.out_channels
                 dilation=dilation[i],
                 n_layers=n_layers[i],
                 pad=pad,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,8 @@ from ocean_emulators.utils.multiton import MultitonScope
 
 REMOTE_DATA = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
 DEFAULT_CONFIG = "train_default.test.yaml"
-ALL_CONFIGS = [DEFAULT_CONFIG, "train_default_2step.test.yaml"]
+FOMO_CONFIG = "train_fomo.test.yaml"
+ALL_CONFIGS = [DEFAULT_CONFIG, "train_default_2step.test.yaml", FOMO_CONFIG]
 
 TrainPair = tuple[TrainConfig, Trainer]
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -7,10 +7,7 @@ def test_makes_patches():
     x = torch.randn(1, 10, 4, 8)
 
     patch_embed = PerceiverEncoder(
-        in_channels=10,
-        patch_size=4,
-        embed_dim=4,
-        perceiver_depth=2,
+        in_channels=10, out_channels=4, patch_size=4, perceiver_depth=2
     )
 
     patches = patch_embed(x)
@@ -22,10 +19,7 @@ def test_makes_rectangular_patches():
     x = torch.randn(1, 10, 4, 8)
 
     patch_embed = PerceiverEncoder(
-        in_channels=10,
-        patch_size=(4, 2),
-        embed_dim=4,
-        perceiver_depth=2,
+        in_channels=10, out_channels=4, patch_size=(4, 2), perceiver_depth=2
     )
 
     patches = patch_embed(x)
@@ -37,10 +31,7 @@ def test_makes_patches__high_res():
     x = torch.randn(1, 10, 8, 16)
 
     patch_embed = PerceiverEncoder(
-        in_channels=10,
-        patch_size=4,
-        embed_dim=4,
-        perceiver_depth=2,
+        in_channels=10, out_channels=4, patch_size=4, perceiver_depth=2
     )
 
     patches = patch_embed(x)
@@ -52,10 +43,7 @@ def test_makes_patches__more_variables():
     x = torch.randn(1, 20, 4, 8)
 
     patch_embed = PerceiverEncoder(
-        in_channels=20,
-        patch_size=4,
-        embed_dim=4,
-        perceiver_depth=2,
+        in_channels=20, out_channels=4, patch_size=4, perceiver_depth=2
     )
 
     patches = patch_embed(x)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -8,12 +8,14 @@ import torch
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.train import Trainer
 from ocean_emulators.utils.multiton import MultitonScope
-from tests.conftest import DEFAULT_CONFIG, TrainPair
+from tests.conftest import DEFAULT_CONFIG, FOMO_CONFIG, TrainPair
 
 
 @pytest.mark.manual
 @pytest.mark.parametrize(
-    "data_source,config_name", [("mock", DEFAULT_CONFIG)], indirect=True
+    "data_source,config_name",
+    [("mock", DEFAULT_CONFIG), ("mock", FOMO_CONFIG)],
+    indirect=True,
 )
 def test_trainer__mini_benchmark(trainer_pair: TrainPair, caplog, benchmark):
     caplog.set_level(logging.INFO)


### PR DESCRIPTION
I'm following an `in_channel`/`out_channel` pattern for all Modules now.
I've modified the config system to `build()` with these two values as
inputs. The FOMO model now accepts a tunable `embedding_dim` parameter, 
which define the size of the latent channels of the processor.

The trainer test now includes testing a FOMO config.