### PR TITLE
Making the encoder more compatible with the processor.

### DIFF
--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -49,10 +49,12 @@ class PerceiverEncoder(nn.Module):
             input_axis=2,  # Number of positional dims before token dim
             input_channels=self.in_channels,
             num_classes=out_channels,
+            weight_tie_layers=True,  # share weights of cross-attn blocks
+            self_per_cross_attn=2,  # ratio of self-attn (latent, small) and cross-attn (input, big) blocks
         )
         self.norm_embedding = nn.LayerNorm(out_channels)
 
-    def forward(self, x: Input) -> Float[torch.Tensor, "batch h w {self.embed_dim}"]:
+    def forward(self, x: Input) -> Float[torch.Tensor, "batch {self.embed_dim} h w"]:
         _, V, H, W = x.shape
 
         # V is a cross product of variable, level (encoded in vars), and time (has history).
@@ -76,12 +78,12 @@ class PerceiverEncoder(nn.Module):
         # physical relationships in the data and aggregates across depth level and history. We should be cautious here.
         x = self.norm_patches(x)
         x = self.perceiver(x)
+        x = self.norm_embedding(x)
         x = rearrange(
             x,
-            "(b h w) l -> b h w l",
+            "(b h w) l -> b l h w",
             h=(H // self.patch_size[0]),
             w=(W // self.patch_size[1]),
         )
-        x = self.norm_embedding(x)
 
         return x

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -12,7 +12,7 @@ def test_makes_patches():
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 1, 2, 4)
+    assert patches.shape == (1, 4, 1, 2)
 
 
 def test_makes_rectangular_patches():
@@ -24,28 +24,33 @@ def test_makes_rectangular_patches():
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 1, 4, 4)
+    assert patches.shape == (
+        1,
+        4,
+        1,
+        4,
+    )
 
 
 def test_makes_patches__high_res():
     x = torch.randn(1, 10, 8, 16)
 
     patch_embed = PerceiverEncoder(
-        in_channels=10, out_channels=4, patch_size=4, perceiver_depth=2
+        in_channels=10, out_channels=5, patch_size=4, perceiver_depth=2
     )
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 2, 4, 4)
+    assert patches.shape == (1, 5, 2, 4)
 
 
 def test_makes_patches__more_variables():
     x = torch.randn(1, 20, 4, 8)
 
     patch_embed = PerceiverEncoder(
-        in_channels=20, out_channels=4, patch_size=4, perceiver_depth=2
+        in_channels=20, out_channels=5, patch_size=4, perceiver_depth=2
     )
 
     patches = patch_embed(x)
 
-    assert patches.shape == (1, 1, 2, 4)
+    assert patches.shape == (1, 5, 1, 2)


### PR DESCRIPTION
The UNet expects the channel dimension to be on axis=1, but our encoder assumes it's the last channel. In addition, I've fixed a minor bug where we want to apply layer norm before reshaping instead of after.

Last, I've set a few hparams for the Perceiver that I'm definitely sure we'll want, namely weight sharing!