### PR TITLE
Decoder now using linear projection to unpatchify.

### DIFF
--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -52,8 +52,6 @@ class FOMO(BaseModel):
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
-        _, _, H, W = fts.shape
-
         for layer in self.layers:
             fts = layer(fts)
 

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -44,7 +44,12 @@ class FOMO(BaseModel):
         layers = [
             encoder,
             processor,
-            nn.Conv2d(processor.out_channels, out_channels, last_kernel_size),
+            nn.Conv2d(
+                processor.out_channels,
+                out_channels,
+                last_kernel_size,
+                padding=last_kernel_size // 2,
+            ),
         ]
         self.layers = nn.ModuleList(layers)
         self.unpatch = nn.Linear(

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -55,22 +55,18 @@ class FOMO(BaseModel):
         for layer in self.layers:
             fts = layer(fts)
 
-        # Get current patch-level dimensions
-        _, _, h_patches, w_patches = fts.shape
-
-        # project latent to output channels × patch area
+        # Unpatchify: project to patch area, then reshape back to original spatial dimensions
+        _, _, h, w = fts.shape
         fts = rearrange(fts, "b l h w -> b h w l")
         fts = self.unpatch(fts)  # (b, h, w, out_channels * ph * pw)
-
-        # Unpatchify: reshape back to original spatial dimensions
         fts = rearrange(
             fts,
             "b h w (c ph pw) -> b c (h ph) (w pw)",
             c=self.out_channels,
             ph=self.patch_size[0],
             pw=self.patch_size[1],
-            h=h_patches,
-            w=w_patches,
+            h=h,
+            w=w,
         )
 
         return torch.where(self.wet, fts, 0.0)

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -56,7 +56,7 @@ class FOMO(BaseModel):
             fts = layer(fts)
 
         # Get current patch-level dimensions
-        _, _out_channels, h_patches, w_patches = fts.shape
+        _, _, h_patches, w_patches = fts.shape
 
         # project latent to output channels × patch area
         fts = rearrange(fts, "b l h w -> b h w l")

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -1,5 +1,6 @@
 import torch
 import xarray as xr
+from einops import rearrange
 from torch import nn
 
 from ocean_emulators.constants import Grid
@@ -37,6 +38,8 @@ class FOMO(BaseModel):
             pad=pad,
             static_data=static_data,
         )
+        self.patch_size = encoder.patch_size
+
         # Placeholder decoder is a non-globe aware Conv2d.
         layers = [
             encoder,
@@ -44,8 +47,32 @@ class FOMO(BaseModel):
             nn.Conv2d(processor.out_channels, out_channels, last_kernel_size),
         ]
         self.layers = nn.ModuleList(layers)
+        self.unpatch = nn.Linear(
+            out_channels, out_channels * self.patch_size[0] * self.patch_size[1]
+        )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
+        _, _, H, W = fts.shape
+
         for layer in self.layers:
             fts = layer(fts)
+
+        # Get current patch-level dimensions
+        _, _out_channels, h_patches, w_patches = fts.shape
+
+        # project latent to output channels × patch area
+        fts = rearrange(fts, "b l h w -> b h w l")
+        fts = self.unpatch(fts)  # (b, h, w, out_channels * ph * pw)
+
+        # Unpatchify: reshape back to original spatial dimensions
+        fts = rearrange(
+            fts,
+            "b h w (c ph pw) -> b c (h ph) (w pw)",
+            c=self.out_channels,
+            ph=self.patch_size[0],
+            pw=self.patch_size[1],
+            h=h_patches,
+            w=w_patches,
+        )
+
         return torch.where(self.wet, fts, 0.0)


### PR DESCRIPTION
This seems to be the standard ViT approach to reverse patches. I've also kept the simple Conv2d because I think it has some benefits (shared weights compared to a nn.Linear; better spatial reasoning; channel mixing is nice).