### PR TITLE
Essential hparam to tune in the encoder: `latent_dim`.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -292,6 +292,10 @@ class EncoderConfig(BaseConfig):
         description="Either a square patch (int) or a rectangular patch of [height: int, width: int]. It must evenly divide the grid size.",
     )
     perceiver_depth: int = 6
+    perceiver_latent_dim: int = Field(
+        default=128,
+        description="The small, latent dimension of the Perceiver. This is the `N` dimension for the Perceiver's `O(M*N)` complexity",
+    )
 
     def build(self, in_channels: int, out_channels: int) -> PerceiverEncoder:
         if (
@@ -313,6 +317,7 @@ class EncoderConfig(BaseConfig):
             out_channels=out_channels,
             patch_size=patch_size,
             perceiver_depth=self.perceiver_depth,
+            perceiver_latent_dim=self.perceiver_latent_dim,
         )
 
 

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -20,6 +20,8 @@ class PerceiverEncoder(nn.Module):
         patch_size (int | tuple[int, int]): the size of the patches to embed. Patches must evenly divide the input grid.
           If a tuple is supplied, then it represents the (height, width) of the patches to embed.
         perceiver_depth (int): depth of the perceiver module core.
+        perceiver_latent_dim (int): latent dimension of the perceiver module core. The `N` of the Perceiver's `O(M*N)`
+          complexity, where the `M` corresponds to the size of the input data.
     """
 
     # TODO(alxmrs): Implement gradient checkpointing
@@ -29,6 +31,7 @@ class PerceiverEncoder(nn.Module):
         out_channels: int,
         patch_size: int | tuple[int, int],
         perceiver_depth: int,
+        perceiver_latent_dim: int,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
@@ -48,6 +51,7 @@ class PerceiverEncoder(nn.Module):
             depth=perceiver_depth,
             input_axis=2,  # Number of positional dims before token dim
             input_channels=self.in_channels,
+            latent_dim=perceiver_latent_dim,
             num_classes=out_channels,
             weight_tie_layers=True,  # share weights of cross-attn blocks
             self_per_cross_attn=2,  # ratio of self-attn (latent, small) and cross-attn (input, big) blocks

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -7,7 +7,11 @@ def test_makes_patches():
     x = torch.randn(1, 10, 4, 8)
 
     patch_embed = PerceiverEncoder(
-        in_channels=10, out_channels=4, patch_size=4, perceiver_depth=2
+        in_channels=10,
+        out_channels=4,
+        patch_size=4,
+        perceiver_depth=2,
+        perceiver_latent_dim=3,
     )
 
     patches = patch_embed(x)
@@ -19,7 +23,11 @@ def test_makes_rectangular_patches():
     x = torch.randn(1, 10, 4, 8)
 
     patch_embed = PerceiverEncoder(
-        in_channels=10, out_channels=4, patch_size=(4, 2), perceiver_depth=2
+        in_channels=10,
+        out_channels=4,
+        patch_size=(4, 2),
+        perceiver_depth=2,
+        perceiver_latent_dim=3,
     )
 
     patches = patch_embed(x)
@@ -36,7 +44,11 @@ def test_makes_patches__high_res():
     x = torch.randn(1, 10, 8, 16)
 
     patch_embed = PerceiverEncoder(
-        in_channels=10, out_channels=5, patch_size=4, perceiver_depth=2
+        in_channels=10,
+        out_channels=5,
+        patch_size=4,
+        perceiver_depth=2,
+        perceiver_latent_dim=3,
     )
 
     patches = patch_embed(x)
@@ -48,7 +60,11 @@ def test_makes_patches__more_variables():
     x = torch.randn(1, 20, 4, 8)
 
     patch_embed = PerceiverEncoder(
-        in_channels=20, out_channels=5, patch_size=4, perceiver_depth=2
+        in_channels=20,
+        out_channels=5,
+        patch_size=4,
+        perceiver_depth=2,
+        perceiver_latent_dim=3,
     )
 
     patches = patch_embed(x)


### PR DESCRIPTION
I've added the ability to configure the `latent_dim` of the encoder's perceiver. This is essential to decrease (or increase) the memory complexity of the encoder.