### PR TITLE
First round of perf improvements 

### DIFF
--- a/src/ocean_emulators/aggregator/train.py
+++ b/src/ocean_emulators/aggregator/train.py
@@ -20,13 +20,11 @@ class TrainAggregator:
 
     @torch.no_grad()
     def record_batch(self, batch: TrainBatchOutput):
-        if torch.isnan(self._loss):
+        if self._n_batches == 0:
             self._loss = batch.loss
-        else:
-            self._loss += batch.loss
-        if torch.isnan(self._loss_per_channel).all():
             self._loss_per_channel = batch.loss_per_channel
         else:
+            self._loss += batch.loss
             self._loss_per_channel += batch.loss_per_channel
         self._n_batches += 1
 

--- a/src/ocean_emulators/aggregator/validate/reduced.py
+++ b/src/ocean_emulators/aggregator/validate/reduced.py
@@ -25,7 +25,7 @@ class AreaWeightedReducedMetric:
         compute_metric: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
     ):
         self._compute_metric = compute_metric
-        self._total = torch.tensor(torch.nan)
+        self._total: torch.Tensor | None = None
         self._device = device
 
     def record(self, target: torch.Tensor, gen: torch.Tensor):
@@ -36,12 +36,13 @@ class AreaWeightedReducedMetric:
             gen: Generated data. Should have shape [batch, time, height, width].
         """
         new_value = self._compute_metric(target, gen).mean(dim=0)
-        if torch.isnan(self._total).all():
+        if self._total is None:
             self._total = torch.zeros_like(new_value, device=self._device)
         self._total += new_value
 
     def get(self) -> torch.Tensor:
         """Returns the metric."""
+        assert self._total is not None
         return self._total
 
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -334,12 +334,8 @@ class TrainData:
     def to(self, device: torch.device) -> None:
         for step in self.td_dict:
             self.td_dict[step] = (
-                self.td_dict[step][0].to(
-                    device, non_blocking=True, memory_format=torch.channels_last
-                ),
-                self.td_dict[step][1].to(
-                    device, non_blocking=True, memory_format=torch.channels_last
-                ),
+                self.td_dict[step][0].to(device, non_blocking=True),
+                self.td_dict[step][1].to(device, non_blocking=True),
             )
 
     def pin_memory(self):

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -334,8 +334,12 @@ class TrainData:
     def to(self, device: torch.device) -> None:
         for step in self.td_dict:
             self.td_dict[step] = (
-                self.td_dict[step][0].to(device),
-                self.td_dict[step][1].to(device),
+                self.td_dict[step][0].to(
+                    device, non_blocking=True, memory_format=torch.channels_last
+                ),
+                self.td_dict[step][1].to(
+                    device, non_blocking=True, memory_format=torch.channels_last
+                ),
             )
 
     def __iter__(self):

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -342,6 +342,14 @@ class TrainData:
                 ),
             )
 
+    def pin_memory(self):
+        for step in self.td_dict:
+            self.td_dict[step] = (
+                self.td_dict[step][0].pin_memory(),
+                self.td_dict[step][1].pin_memory(),
+            )
+        return self
+
     def __iter__(self):
         return iter(self.td_dict)
 

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -63,7 +63,7 @@ class BaseModel(torch.nn.Module):
                 pred = decodings  # Absolute prediction
 
             if loss_fn is not None:
-                if torch.isnan(loss).all():
+                if step == 0:
                     loss = loss_fn(
                         pred,
                         train_data.get_label(step),

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -74,7 +74,6 @@ from ocean_emulators.utils.ema import EMATracker
 from ocean_emulators.utils.logging import (
     MetricLogger,
     SmoothedValue,
-    get_model_summary,
     handle_logging,
     handle_warnings,
 )
@@ -462,10 +461,9 @@ class Trainer:
             start_epoch_train_time = time.perf_counter()
             train_stats = self.train_one_epoch(epoch)
             end_epoch_train_time = time.perf_counter()
+            break
             val_stats = self.validate_one_epoch(epoch)
             end_epoch_val_time = time.perf_counter()
-
-            break
 
             if -1 in self.inference_epochs or epoch in self.inference_epochs:
                 inf_stats = self.inference_one_epoch(epoch)
@@ -527,8 +525,8 @@ class Trainer:
             self.optimizer.zero_grad()
             data.to(self.device)
 
-            if self.num_batches_seen == 0:
-                get_model_summary(self.model, data, self.debug)
+            # if self.num_batches_seen == 0:
+            #     get_model_summary(self.model, data, self.debug)
 
             TO: TrainBatchOutput = Stepper.train_batch(self.model, data, self.loss_fn)
             TO.loss.backward()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -74,6 +74,7 @@ from ocean_emulators.utils.ema import EMATracker
 from ocean_emulators.utils.logging import (
     MetricLogger,
     SmoothedValue,
+    get_model_summary,
     handle_logging,
     handle_warnings,
 )
@@ -461,7 +462,6 @@ class Trainer:
             start_epoch_train_time = time.perf_counter()
             train_stats = self.train_one_epoch(epoch)
             end_epoch_train_time = time.perf_counter()
-            break
             val_stats = self.validate_one_epoch(epoch)
             end_epoch_val_time = time.perf_counter()
 
@@ -525,8 +525,8 @@ class Trainer:
             self.optimizer.zero_grad()
             data.to(self.device)
 
-            # if self.num_batches_seen == 0:
-            #     get_model_summary(self.model, data, self.debug)
+            if self.num_batches_seen == 0:
+                get_model_summary(self.model, data, self.debug)
 
             TO: TrainBatchOutput = Stepper.train_batch(self.model, data, self.loss_fn)
             TO.loss.backward()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -465,6 +465,8 @@ class Trainer:
             val_stats = self.validate_one_epoch(epoch)
             end_epoch_val_time = time.perf_counter()
 
+            break
+
             if -1 in self.inference_epochs or epoch in self.inference_epochs:
                 inf_stats = self.inference_one_epoch(epoch)
                 end_epoch_inf_time = time.perf_counter()


### PR DESCRIPTION
3 small fixes from profiling:

* Request async data transfers from CPU to GPU memory.
* Add the [required](https://docs.pytorch.org/docs/stable/data.html#memory-pinning) `pin_memory` method on our custom data type so those transfers can be a DMA 
* Remove a number of places we waited unnecessarily for GPU results to be ready (to check against NaN) which caused our CPU to wait there for the GPU to catch up. This isn't very helpful yet but is a step towards freeing up the CPU for other things (eg data decompression).