### PR TITLE
Fix `benchmarks.yml`: use ec2-gha, remove FOMO benchmark

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       ec2_instance_type: g6.xlarge
       ec2_image_id: ami-0365bff494b18bf93 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch 2.7 (Ubuntu 22.04) in oa-ci-dev
-      ec2_root_device_size: 200 # AMI's reported VolumeSize (40GB) +20GB; leaves headroom for benchmarking I/O; instance runs out of disk otherwise
+      ec2_root_device_size: 200 # leaves headroom for benchmarking I/O; instance runs out of disk otherwise
     secrets:
       GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
         # Invalidate the data cache every time the data source changes.
         # If an exact cache isn't found, fall back to previous cache.
       - name: Cache test data
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .data_cache/
           key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/*.test.yaml') }}
@@ -44,7 +44,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,15 +15,18 @@ permissions:
   id-token: write # This is required for interacting with AWS via OIDC
 
 jobs:
-  start-aws-runner:
-    uses: ./.github/workflows/aws-runner-start.yml
+  ec2:
+    uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
+    with:
+      ec2_instance_type: g6.xlarge
+      ec2_image_id: ami-0365bff494b18bf93 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch 2.7 (Ubuntu 22.04) in oa-ci-dev
+      ec2_root_device_size: 200 # AMI's reported VolumeSize (40GB) +20GB; leaves headroom for benchmarking I/O; instance runs out of disk otherwise
     secrets:
-      AWS_ROLE: ${{ secrets.AWS_ROLE }}
       GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}
 
   test:
-    needs: start-aws-runner
-    runs-on: ${{ fromJSON(needs.start-aws-runner.outputs.instances) }}
+    needs: ec2
+    runs-on: ${{ needs.ec2.outputs.id }}
 
     steps:
       - name: Check out code
@@ -84,15 +87,3 @@ jobs:
           comment-on-alert: true
           fail-on-alert: false
           alert-comment-cc-users: "@alxmrs,@jder"
-
-  stop-aws-runner:
-    uses: ./.github/workflows/aws-runner-stop.yml
-    needs:
-      - start-aws-runner
-      - test
-    if: ${{ always() }}
-    with:
-      instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
-    secrets:
-      AWS_ROLE: ${{ secrets.AWS_ROLE }}
-      GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
         run: git stash
 
       # gh-pages branch is automatically updated with extracted benchmark data.
-      - name: Store benchmark result
+      - name: Store benchmark result (CPU)
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Python Benchmark with pytest-benchmark
@@ -74,7 +74,7 @@ jobs:
           alert-comment-cc-users: "@alxmrs,@jder"
 
       # gh-pages branch is automatically updated with extracted benchmark data.
-      - name: Store benchmark result
+      - name: Store benchmark result (GPU)
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Python Benchmark with pytest-benchmark (GPU)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ needs.ec2.outputs.id }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
         # Invalidate the data cache every time the data source changes.
         # If an exact cache isn't found, fall back to previous cache.
@@ -42,7 +42,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
         # Invalidate the data cache every time the data source changes.
         # If an exact cache isn't found, fall back to previous cache.
@@ -34,7 +34,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -8,14 +8,12 @@ import torch
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.train import Trainer
 from ocean_emulators.utils.multiton import MultitonScope
-from tests.conftest import DEFAULT_CONFIG, FOMO_CONFIG, TrainPair
+from tests.conftest import DEFAULT_CONFIG, TrainPair
 
 
 @pytest.mark.manual
 @pytest.mark.parametrize(
-    "data_source,config_name",
-    [("mock", DEFAULT_CONFIG), ("mock", FOMO_CONFIG)],
-    indirect=True,
+    "data_source,config_name", [("mock", DEFAULT_CONFIG)], indirect=True
 )
 def test_trainer__mini_benchmark(trainer_pair: TrainPair, caplog, benchmark):
     caplog.set_level(logging.INFO)


### PR DESCRIPTION
- In [#308] I neglected to update `benchmarks.yml` to use ec2-gha, which resulted in an invalid workflow file.
- However, [`benchmarks.yml`] has been broken on `main` since [#384], which added a FOMO model benchmark that uses more memory (and GPU memory)
  - I've not yet found instances that can handle either
  - e.g. [benchmarks#175] uses an [m7i.8xlarge] for CPU benchmarks and a [g6.xlarge] for GPU, and both fail

This PR fixes the former by updating `benchmarks.yml` to use ec2-gha, and works around the latter by restoring the benchmarks configs to the pre-[#384] state.

[benchmarks#172] is a passing run from [`f313865`]

[Open-Athena/Ocean_Emulator#399]: https://github.com/Open-Athena/Ocean_Emulator/pull/399

[benchmarks#172]: https://github.com/Open-Athena/Ocean_Emulator/actions/runs/17985502557/job/51162739635
[benchmarks#175]: https://github.com/Open-Athena/Ocean_Emulator/actions/runs/17986640677/job/51166555978
[m7i.8xlarge]: https://instances.vantage.sh/aws/ec2/m7i.8xlarge
[g6.xlarge]: https://instances.vantage.sh/aws/ec2/g6.xlarge

[`benchmarks.yml`]: https://github.com/Open-Athena/Ocean_Emulator/actions/workflows/benchmarks.yml?query=branch%3Amain

[#308]: https://github.com/Open-Athena/Ocean_Emulator/pull/308
[#384]: https://github.com/Open-Athena/Ocean_Emulator/pull/384
[`f313865`]: https://github.com/Open-Athena/Ocean_Emulator/pull/399/commits/f313865a76db1b401243a4189ae876954b94c4c9

<!-- Synced with https://gist.github.com/81ed211c8bf19f9b97ab1d4c3cdb51bd/1135cb77d4fb2c35bdd774f1330751e4b233f35d via [github-pr.py](https://github.com/ryan-williams/git-helpers/blob/main/github/github-pr.py) -->