### PR TITLE
Periodic padding

### DIFF
--- a/skypilot/eval.sky.yaml
+++ b/skypilot/eval.sky.yaml
@@ -36,11 +36,11 @@ envs:
   # Run `sky check aws -v` to verify that AWS storage is properly set up.
   # If you still hit permission issues, consider making a dedicated SkyPilot IAM via these docs:
   # https://docs.skypilot.co/en/latest/cloud-setup/cloud-permissions/aws.html#dedicated-skypilot-iam-user
+  OSN_KEY_ID: null
+  OSN_KEY_SECRET: null
 
   CONFIG: null
   OUTPUTS_BUCKET: oa-fomo-outputs
-  DATA_BUCKET: oa-fomo
-  DATA_ROOT_PATH: null # path to copy from DATA_BUCKET into the local data root eg data/om4_onedeg
   NAME: null # wandb train experiment name (and used for downstream tasks)
   TARGET_CHECKPOINT: null # checkpoint to use, relative to OUTPUTS_BUCKET eg $train_experiment/saved_nets/ckpt.pt
   ARGS: ""
@@ -59,13 +59,13 @@ workdir: .
 setup: |
   set -ex
 
-  rclone config create s3-source s3 provider=AWS env_auth=true
+  rclone config create nyu-osn s3 provider=AWS endpoint=https://nyu1.osn.mghpcc.org/ access_key_id="$OSN_KEY_ID" secret_access_key="$OSN_KEY_SECRET"
 
   mkdir -p ~/data/
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH} ~/data --ignore-existing --transfers=32
+  rclone copy --progress nyu-osn:emulators/jr7309/data/om4_halfdeg/ ~/data --ignore-existing --transfers=32
 
   mkdir -p ~/basins/
-  rclone copy --progress s3-source:${DATA_BUCKET}/basins ~/basins
+  rclone copy --progress nyu-osn:emulators/jr7309/basins ~/basins
 
 #### End of shared setup ####
 

--- a/skypilot/train.sky.yaml
+++ b/skypilot/train.sky.yaml
@@ -39,10 +39,11 @@ envs:
   # If you still hit permission issues, consider making a dedicated SkyPilot IAM via these docs:
   # https://docs.skypilot.co/en/latest/cloud-setup/cloud-permissions/aws.html#dedicated-skypilot-iam-user
 
+  OSN_KEY_ID: null
+  OSN_KEY_SECRET: null
+
   CONFIG: null
   OUTPUTS_BUCKET: oa-fomo-outputs
-  DATA_BUCKET: oa-fomo
-  DATA_ROOT_PATH: null # path to copy from DATA_BUCKET into the local data root eg data/om4_onedeg
   NAME: null # wandb train experiment name (and used for downstream tasks)
   ARGS: ""
 
@@ -60,13 +61,13 @@ workdir: .
 setup: |
   set -ex
 
-  rclone config create s3-source s3 provider=AWS env_auth=true
+  rclone config create nyu-osn s3 provider=AWS endpoint=https://nyu1.osn.mghpcc.org/ access_key_id="$OSN_KEY_ID" secret_access_key="$OSN_KEY_SECRET"
 
   mkdir -p ~/data/
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH} ~/data --ignore-existing --transfers=32
+  rclone copy --progress nyu-osn:emulators/jr7309/data/om4_halfdeg/ ~/data --ignore-existing --transfers=32
 
   mkdir -p ~/basins/
-  rclone copy --progress s3-source:${DATA_BUCKET}/basins ~/basins
+  rclone copy --progress nyu-osn:emulators/jr7309/basins ~/basins
 
 #### End of shared setup ####
 

--- a/skypilot/viz.sky.yaml
+++ b/skypilot/viz.sky.yaml
@@ -38,14 +38,14 @@ envs:
   # Run `sky check aws -v` to verify that AWS storage is properly set up.
   # If you still hit permission issues, consider making a dedicated SkyPilot IAM via these docs:
   # https://docs.skypilot.co/en/latest/cloud-setup/cloud-permissions/aws.html#dedicated-skypilot-iam-user
+  OSN_KEY_ID: null
+  OSN_KEY_SECRET: null
 
   CONFIG: null
   OUTPUTS_BUCKET: oa-fomo-outputs
-  DATA_BUCKET: oa-fomo
-  DATA_ROOT_PATH: null # path to copy from DATA_BUCKET into the local data root eg data/om4_onedeg
   BASIN_PATH: null # relative to DATA_BUCKET/basins we should use for the basin zarr eg basin_masks_original.zarr
   NAME: null # name used for output directory
-  RUNS: null # run JSON, for example '{"name": "my_run", "location": "/outputs/my_run/predictions.zarr"}'
+  RUNS: null # run JSON, for example '[{"name": "my_run", "location": "/inputs/my_run/predictions.zarr"}]'
   ARGS: ""
 
 #### Shared setup, please ensure this is the same as in all *.sky.yaml files ####
@@ -63,9 +63,13 @@ setup: |
   set -ex
 
   rclone config create s3-source s3 provider=AWS env_auth=true
+  rclone config create nyu-osn s3 provider=AWS endpoint=https://nyu1.osn.mghpcc.org/ access_key_id="$OSN_KEY_ID" secret_access_key="$OSN_KEY_SECRET"
 
   mkdir -p ~/data/
-  rclone copy --progress s3-source:${DATA_BUCKET}/${DATA_ROOT_PATH} ~/data --ignore-existing --transfers=32
+  rclone copy --progress nyu-osn:emulators/jr7309/data/om4_halfdeg/ ~/data --ignore-existing --transfers=32
+
+  mkdir -p ~/basins/
+  rclone copy --progress nyu-osn:emulators/jr7309/basins ~/basins
 
   sudo mkdir -p /inputs
   sudo chown $USER /inputs
@@ -118,9 +122,6 @@ setup: |
       print(f'Copying {s3_source} to {local_dest}')
       subprocess.run(cmd, check=True)
   EOPYTHON
-
-  mkdir -p ~/basins/
-  rclone copy --progress s3-source:${DATA_BUCKET}/basins ~/basins
 
 #### End of shared setup ####
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -28,6 +28,7 @@ from ocean_emulators.models.modules import (
     TransposedConvUpsample,
     UNetBackbone,
 )
+from ocean_emulators.models.modules.blocks import PeriodicBilinearUpsample
 from ocean_emulators.utils.data import DataContainer, DataSource, validate_data
 from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLocation
 from ocean_emulators.utils.profiler import Profiler
@@ -322,7 +323,7 @@ class EncoderConfig(BaseConfig):
 
 
 DownSamplingBlocks = Literal["avg_pool", "max_pool"]
-UpSamplingBlocks = Literal["bilinear_upsample", "transposed_conv"]
+UpSamplingBlocks = Literal["bilinear_upsample", "transposed_conv", "periodic_upsample"]
 Checkpointing = Literal["all", "simple"]
 
 
@@ -354,6 +355,8 @@ class UNetBackboneConfig(BaseConfig):
                     return TransposedConvUpsample(
                         in_channels=in_channels, out_channels=out_channels
                     )
+                case "periodic_upsample":
+                    return PeriodicBilinearUpsample()
                 case _:
                     assert_never(self.up_sampling_block)
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -28,7 +28,7 @@ from ocean_emulators.models.modules import (
     TransposedConvUpsample,
     UNetBackbone,
 )
-from ocean_emulators.models.modules.blocks import PeriodicBilinearUpsample
+from ocean_emulators.models.modules.blocks import ZonallyPeriodicBilinearUpsample
 from ocean_emulators.utils.data import DataContainer, DataSource, validate_data
 from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLocation
 from ocean_emulators.utils.profiler import Profiler
@@ -323,7 +323,9 @@ class EncoderConfig(BaseConfig):
 
 
 DownSamplingBlocks = Literal["avg_pool", "max_pool"]
-UpSamplingBlocks = Literal["bilinear_upsample", "transposed_conv", "periodic_upsample"]
+UpSamplingBlocks = Literal[
+    "bilinear_upsample", "transposed_conv", "zonally_periodic_upsample"
+]
 Checkpointing = Literal["all", "simple"]
 
 
@@ -355,8 +357,8 @@ class UNetBackboneConfig(BaseConfig):
                     return TransposedConvUpsample(
                         in_channels=in_channels, out_channels=out_channels
                     )
-                case "periodic_upsample":
-                    return PeriodicBilinearUpsample()
+                case "zonally_periodic_upsample":
+                    return ZonallyPeriodicBilinearUpsample()
                 case _:
                     assert_never(self.up_sampling_block)
 

--- a/src/ocean_emulators/models/modules/__init__.py
+++ b/src/ocean_emulators/models/modules/__init__.py
@@ -7,6 +7,7 @@ from .blocks import (
     CoreBlock,
     CoreBlockBuilder,
     MaxPool,
+    PeriodicBilinearUpsample,
     TransposedConvUpsample,
     UpsamplingBlockBuilder,
 )
@@ -16,6 +17,7 @@ from .unet_backbone import UNetBackbone
 __all__ = [
     "AvgPool",
     "BilinearUpsample",
+    "PeriodicBilinearUpsample",
     "ConvBlock",
     "ConvNeXtBlock",
     "CoreBlock",

--- a/src/ocean_emulators/models/modules/__init__.py
+++ b/src/ocean_emulators/models/modules/__init__.py
@@ -7,9 +7,9 @@ from .blocks import (
     CoreBlock,
     CoreBlockBuilder,
     MaxPool,
-    PeriodicBilinearUpsample,
     TransposedConvUpsample,
     UpsamplingBlockBuilder,
+    ZonallyPeriodicBilinearUpsample,
 )
 from .encoder import PerceiverEncoder
 from .unet_backbone import UNetBackbone
@@ -17,7 +17,7 @@ from .unet_backbone import UNetBackbone
 __all__ = [
     "AvgPool",
     "BilinearUpsample",
-    "PeriodicBilinearUpsample",
+    "ZonallyPeriodicBilinearUpsample",
     "ConvBlock",
     "ConvNeXtBlock",
     "CoreBlock",

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -46,6 +46,45 @@ class BilinearUpsample(torch.nn.Module):
         return self.upsampler(x)
 
 
+class PeriodicBilinearUpsample(torch.nn.Module):
+    """Bilinear upsampling that enforces periodicity along the x/longitude axis."""
+
+    def __init__(self, upsampling: int | tuple[int, int] = 2):
+        super().__init__()
+        if isinstance(upsampling, tuple):
+            if tuple(upsampling) != (2, 2):
+                raise ValueError("PeriodicBilinearUpsample only supports 2x upsampling")
+            self.scale_h, self.scale_w = upsampling
+        else:
+            if upsampling != 2:
+                raise ValueError("PeriodicBilinearUpsample only supports 2x upsampling")
+            self.scale_h = self.scale_w = upsampling
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # First upsample along latitude/height using standard "bilinear" interpolation.
+        # (This is just linear interpolation but pytorch requires us to use "bilinear" for
+        # 2d data.)
+        up_height = torch.nn.functional.interpolate(
+            x,
+            scale_factor=(self.scale_h, 1),
+            mode="bilinear",
+        )
+
+        # Then upsample along longitude/width using a circular 1D linear interpolation.
+        left = up_height
+        right = torch.roll(up_height, shifts=-1, dims=-1)
+        midpoint = 0.5 * (left + right)
+
+        out = torch.empty(
+            (*up_height.shape[:-1], up_height.shape[-1] * self.scale_w),
+            dtype=up_height.dtype,
+            device=up_height.device,
+        )
+        out[..., ::2] = left
+        out[..., 1::2] = midpoint
+        return out
+
+
 class AvgPool(torch.nn.Module):
     def __init__(
         self,

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -51,18 +51,13 @@ class ZonallyPeriodicBilinearUpsample(torch.nn.Module):
 
     def __init__(self, upsampling: int | tuple[int, int] = 2):
         super().__init__()
-        if isinstance(upsampling, tuple):
-            if tuple(upsampling) != (2, 2):
-                raise ValueError(
+        if isinstance(upsampling, int):
+            upsampling = (upsampling, upsampling)
+        if tuple(upsampling) != (2, 2):
+            raise ValueError(
                     "ZonallyPeriodicBilinearUpsample only supports 2x upsampling"
-                )
-            self.scale_h, self.scale_w = upsampling
-        else:
-            if upsampling != 2:
-                raise ValueError(
-                    "ZonallyPeriodicBilinearUpsample only supports 2x upsampling"
-                )
-            self.scale_h = self.scale_w = upsampling
+            )
+        self.scale_h, self.scale_w = upsampling
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # First upsample along latitude/height using standard "bilinear" interpolation.

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -46,18 +46,22 @@ class BilinearUpsample(torch.nn.Module):
         return self.upsampler(x)
 
 
-class PeriodicBilinearUpsample(torch.nn.Module):
+class ZonallyPeriodicBilinearUpsample(torch.nn.Module):
     """Bilinear upsampling that enforces periodicity along the x/longitude axis."""
 
     def __init__(self, upsampling: int | tuple[int, int] = 2):
         super().__init__()
         if isinstance(upsampling, tuple):
             if tuple(upsampling) != (2, 2):
-                raise ValueError("PeriodicBilinearUpsample only supports 2x upsampling")
+                raise ValueError(
+                    "ZonallyPeriodicBilinearUpsample only supports 2x upsampling"
+                )
             self.scale_h, self.scale_w = upsampling
         else:
             if upsampling != 2:
-                raise ValueError("PeriodicBilinearUpsample only supports 2x upsampling")
+                raise ValueError(
+                    "ZonallyPeriodicBilinearUpsample only supports 2x upsampling"
+                )
             self.scale_h = self.scale_w = upsampling
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/modules/unet_backbone.py
+++ b/src/ocean_emulators/models/modules/unet_backbone.py
@@ -8,6 +8,7 @@ from ocean_emulators.models.modules.blocks import (
     BilinearUpsample,
     CoreBlock,
     CoreBlockBuilder,
+    PeriodicBilinearUpsample,
     TransposedConvUpsample,
     UpsamplingBlockBuilder,
 )
@@ -172,8 +173,10 @@ class UNetBackbone(nn.Module):
                     skip_inputs[count] = fts
                     count += 1
             elif count >= self.num_steps:
-                if isinstance(layer, BilinearUpsample) or isinstance(
-                    layer, TransposedConvUpsample
+                if (
+                    isinstance(layer, BilinearUpsample)
+                    or isinstance(layer, TransposedConvUpsample)
+                    or isinstance(layer, PeriodicBilinearUpsample)
                 ):
                     crop = np.array(fts.shape[2:])
                     shape = np.array(

--- a/src/ocean_emulators/models/modules/unet_backbone.py
+++ b/src/ocean_emulators/models/modules/unet_backbone.py
@@ -8,9 +8,9 @@ from ocean_emulators.models.modules.blocks import (
     BilinearUpsample,
     CoreBlock,
     CoreBlockBuilder,
-    PeriodicBilinearUpsample,
     TransposedConvUpsample,
     UpsamplingBlockBuilder,
+    ZonallyPeriodicBilinearUpsample,
 )
 from ocean_emulators.utils.train import pairwise
 
@@ -176,7 +176,7 @@ class UNetBackbone(nn.Module):
                 if (
                     isinstance(layer, BilinearUpsample)
                     or isinstance(layer, TransposedConvUpsample)
-                    or isinstance(layer, PeriodicBilinearUpsample)
+                    or isinstance(layer, ZonallyPeriodicBilinearUpsample)
                 ):
                     crop = np.array(fts.shape[2:])
                     shape = np.array(

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -5,7 +5,7 @@ import torch
 from ocean_emulators.models.modules.blocks import (
     AvgPool,
     BilinearUpsample,
-    PeriodicBilinearUpsample,
+    ZonallyPeriodicBilinearUpsample,
 )
 
 
@@ -28,12 +28,12 @@ def _pad_like_unet(feature: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
     "upsampler_cls",
     [
         pytest.param(BilinearUpsample, id="bilinear"),
-        pytest.param(PeriodicBilinearUpsample, id="periodic"),
+        pytest.param(ZonallyPeriodicBilinearUpsample, id="zonally_periodic"),
     ],
 )
 @pytest.mark.parametrize("width", [8, 10, 16])
 @pytest.mark.parametrize("num_blocks", [1, 2, 3])
-def test_downscale_then_upscale_rotation_invariance(
+def test_downscale_then_upscale_translation_invariance(
     upsampler_cls: type[torch.nn.Module],
     width: int,
     num_blocks: int,
@@ -44,8 +44,8 @@ def test_downscale_then_upscale_rotation_invariance(
 
     total_downscale = 2**num_blocks
     if width / total_downscale <= 1:
-        # if the final plane would be a width of 1, there's no shfit we can try
-        # below to confirm rotational invariance
+        # if the final plane would be a width of 1, there's no shift we can try
+        # below to confirm translation invariance
         pytest.skip("Width is too small for the given number of blocks")
     divisibility_condition = width % total_downscale == 0
     batch, channels, height = 1, 3, 8
@@ -82,7 +82,7 @@ def test_downscale_then_upscale_rotation_invariance(
     if upsampler_cls == BilinearUpsample:
         if is_close:
             raise ValueError(
-                "We expected outputs to be different after rotation when using bilinear upsamples"
+                "We expected outputs to be different after translation when using bilinear upsamples"
             )
         else:
             pytest.xfail(
@@ -91,14 +91,14 @@ def test_downscale_then_upscale_rotation_invariance(
     elif not divisibility_condition:
         if is_close:
             raise ValueError(
-                "We expected outputs to be different after rotation when size is not divisible by 2**num_downsamples"
+                "We expected outputs to be different after translation when size is not divisible by 2**num_downsamples"
             )
         else:
             pytest.xfail(
-                "outputs were not identical after rotation when size is not divisible by 2**num_downsamples, as expected"
+                "outputs were not identical after translation when size is not divisible by 2**num_downsamples, as expected"
             )
     else:
         assert is_close, (
-            "Downsample/upsample pipeline should be rotation-invariant along longitude; "
+            "Downsample/upsample pipeline should be translation-invariant along longitude; "
             f"max |delta|={delta.abs().max().item():.6e}, delta={delta}"
         )

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -1,0 +1,104 @@
+import numpy as np
+import pytest
+import torch
+
+from ocean_emulators.models.modules.blocks import (
+    AvgPool,
+    BilinearUpsample,
+    PeriodicBilinearUpsample,
+)
+
+
+def _pad_like_unet(feature: torch.Tensor, skip: torch.Tensor) -> torch.Tensor:
+    crop = np.array(feature.shape[2:])
+    target = np.array(skip.shape[2:])
+    pads = target - crop
+    if np.any(pads < 0):
+        raise ValueError("Downsample/upsample feature is larger than skip connection")
+    pads = [
+        int(pads[1] // 2),
+        int(pads[1] - pads[1] // 2),
+        int(pads[0] // 2),
+        int(pads[0] - pads[0] // 2),
+    ]
+    return torch.nn.functional.pad(feature, pads)
+
+
+@pytest.mark.parametrize(
+    "upsampler_cls",
+    [
+        pytest.param(BilinearUpsample, id="bilinear"),
+        pytest.param(PeriodicBilinearUpsample, id="periodic"),
+    ],
+)
+@pytest.mark.parametrize("width", [8, 10, 16])
+@pytest.mark.parametrize("num_blocks", [1, 2, 3])
+def test_downscale_then_upscale_rotation_invariance(
+    upsampler_cls: type[torch.nn.Module],
+    width: int,
+    num_blocks: int,
+):
+    torch.manual_seed(0)
+    downsample = AvgPool()
+    upsample = upsampler_cls()
+
+    total_downscale = 2**num_blocks
+    if width / total_downscale <= 1:
+        # if the final plane would be a width of 1, there's no shfit we can try
+        # below to confirm rotational invariance
+        pytest.skip("Width is too small for the given number of blocks")
+    divisibility_condition = width % total_downscale == 0
+    batch, channels, height = 1, 3, 8
+    base_input = torch.arange(
+        batch * channels * height * width, dtype=torch.float32
+    ).reshape(batch, channels, height, width)
+
+    def run_pipeline(original: torch.Tensor, count) -> torch.Tensor:
+        if count == 0:
+            return original
+        with torch.no_grad():
+            x = downsample(original)
+            x = torch.square(x) + 1  # a nonlinearity
+            x = run_pipeline(x, count - 1)
+            x = upsample(x)
+            padded = _pad_like_unet(x, original)
+            result = padded + original
+            return result
+
+    baseline_output = run_pipeline(base_input, num_blocks)
+    repeat_output = run_pipeline(base_input, num_blocks)
+    assert torch.all(baseline_output == repeat_output), (
+        "Downsample/upsample pipeline should be deterministic for identical inputs"
+    )
+
+    shift = total_downscale  # shift by one column of the most-downscaled version
+    rotated_input = torch.roll(base_input, shifts=shift, dims=-1)
+    rotated_output = run_pipeline(rotated_input, num_blocks)
+    realigned_rotated_output = torch.roll(rotated_output, shifts=-shift, dims=-1)
+
+    delta = baseline_output - realigned_rotated_output
+    is_close = torch.all(baseline_output == realigned_rotated_output)
+
+    if upsampler_cls == BilinearUpsample:
+        if is_close:
+            raise ValueError(
+                "We expected outputs to be different after rotation when using bilinear upsamples"
+            )
+        else:
+            pytest.xfail(
+                "outputs were not identical after using bilinear upsampling, as expected"
+            )
+    elif not divisibility_condition:
+        if is_close:
+            raise ValueError(
+                "We expected outputs to be different after rotation when size is not divisible by 2**num_downsamples"
+            )
+        else:
+            pytest.xfail(
+                "outputs were not identical after rotation when size is not divisible by 2**num_downsamples, as expected"
+            )
+    else:
+        assert is_close, (
+            "Downsample/upsample pipeline should be rotation-invariant along longitude; "
+            f"max |delta|={delta.abs().max().item():.6e}, delta={delta}"
+        )


### PR DESCRIPTION
NB Stacked on #407 (and so #406).

We have had a clear artifact in our outputs at lon=0. I believe there were 2 causes ([thread](https://openathena.slack.com/archives/C09FXFDR2BF/p1758734811767269)):
* On 1 degree data: since there are 4 ConvNext blocks and each has a 2x downsample before them, that gives a final image width of 360/(2^4) which is 22.5. So, the last downsample block (from 45 -> 22) will end up sampling from implicit zero padding in the far-right column (which is lon=359). And on the upscale from 22 -> 45 we pad with zeros. These are both non-periodic.
* In any dataset, the bilinear upsample was non-periodic i.e. `[[1, 2, 3], ...]` gets upsampled to `[[1.0, 1.25, 1.75, 2.25, 2.75, 3.0], ...]` rather than circularly to eg `[[1.0, 1.5, 2.0, 2.5, 3.0, 2.0], …]`. 

This PR resolves the latter and appears to resolve the artifact for us on half-degree data. 
Before (from [om4_samudra_halfdeg_wide_dmse_no_cap](https://wandb.ai/m2lines/ocean-emulators/runs/k5szfus3?nw=nwuseroa_jder)):
<img width="7155" height="3188" alt="SST_map_snapshot_t_0_before" src="https://github.com/user-attachments/assets/24c21518-46ee-4eb0-8284-4e4498e914b1" />

After (from [periodic_test](https://wandb.ai/m2lines/ocean-emulators/runs/6dtu2st0?nw=nwuseroa_jder) and [periodic_eval](https://wandb.ai/m2lines/ocean-emulators/runs/cnmoqz0c?nw=nwuseroa_jder)):
<img width="7155" height="3188" alt="SST_map_snapshot_t_0_after" src="https://github.com/user-attachments/assets/fa2b3236-9510-4c8e-a80c-c7c2831dba6e" />
