### PR TITLE
Improvements to our encoder

### DIFF
--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -52,16 +52,17 @@ model:
   last_kernel_size: 3
   pad: "circular"
   checkpointing: "all"
-  embedding_dim: 80
+  embedding_dim: 280
 
   encoder:
     perceiver_depth: 5
-    patch_size: [12, 24]
+    patch_size: [12, 12]
     perceiver_latent_dim: 64
+    perceiver_num_latents: 512
 
   processor:
-    ch_width: [100, 200, 300]
-    dilation: [1, 1, 1]
+    ch_width: [380, 480, 520]
+    dilation: [2, 4, 8]
     n_layers: [1, 1, 1]
 
     core_block:

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -29,7 +29,7 @@ inference_times:
   - start: "2004-10-05"
     end: "2005-10-05" # "2014-10-05"
 data_stride: [1]
-steps: [1]
+steps: [4]
 step_transition: []
 
 backend: auto

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -5,8 +5,8 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 70
-batch_size: 1
-learning_rate: 0.0003
+batch_size: 4
+learning_rate: 0.0006
 scheduler: { type: cosine }
 loss: mse_dynamic_no_limit
 finetune: false
@@ -69,7 +69,7 @@ model:
       block_type: "conv_next_block"
       kernel_size: 3
       activation: "capped_gelu"
-      upscale_factor: 1
+      upscale_factor: 2
       norm: "batch"
 
     down_sampling_block: "avg_pool"

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -62,7 +62,7 @@ model:
 
   processor:
     ch_width: [380, 480, 520]
-    dilation: [2, 4, 8]
+    dilation: [1, 1, 1]
     n_layers: [1, 1, 1]
 
     core_block:

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -44,7 +44,7 @@ experiment:
     entity: m2lines
     group: samudra-train-om4
   prognostic_vars_key: thermo_dynamic_all
-  boundary_vars_key: tau_hfds
+  boundary_vars_key: tau_hfds_hfds_anom
 data: !include data/public.yaml
 
 model:

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -7,7 +7,7 @@ save_freq: 5
 epochs: 70
 batch_size: 1
 learning_rate: 0.0002
-scheduler: {type: cosine}
+scheduler: { type: cosine }
 loss: mse
 finetune: false
 resume_ckpt_path: null
@@ -44,9 +44,8 @@ experiment:
     entity: m2lines
     group: samudra-train-om4
   prognostic_vars_key: thermo_dynamic_all
-  boundary_vars_key: tau_hfds_hfds_anom
-data:
-  !include data/public.yaml
+  boundary_vars_key: tau_hfds
+data: !include data/public.yaml
 
 model:
   pred_residuals: false

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -59,10 +59,6 @@ model:
     patch_size: [12, 24]
     perceiver_latent_dim: 64
 
-  decoder:
-    perceiver_depth: 5
-    perceiver_latent_dim: 64
-
   processor:
     ch_width: [100, 200, 300]
     dilation: [1, 1, 1]

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -56,7 +56,7 @@ model:
 
   encoder:
     perceiver_depth: 5
-    patch_size: [6, 12]
+    patch_size: [12, 24]
     perceiver_latent_dim: 64
 
   decoder:

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -61,7 +61,7 @@ model:
     perceiver_num_latents: 256
 
   processor:
-    ch_width: [380, 480, 520]
+    ch_width: [384, 480, 520]
     dilation: [1, 1, 1]
     n_layers: [1, 1, 1]
 

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -5,10 +5,10 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 70
-batch_size: 1
-learning_rate: 0.0002
+batch_size: 2
+learning_rate: 0.0006
 scheduler: { type: cosine }
-loss: mse
+loss: mse_dynamic_no_limit
 finetune: false
 resume_ckpt_path: null
 inference_epochs: []

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -56,7 +56,7 @@ model:
 
   encoder:
     perceiver_depth: 5
-    patch_size: [12, 12]
+    patch_size: [12, 20]
     perceiver_latent_dim: 64
     perceiver_num_latents: 512
 

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -5,8 +5,8 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 70
-batch_size: 2
-learning_rate: 0.0006
+batch_size: 1
+learning_rate: 0.0003
 scheduler: { type: cosine }
 loss: mse_dynamic_no_limit
 finetune: false
@@ -55,10 +55,10 @@ model:
   embedding_dim: 280
 
   encoder:
-    perceiver_depth: 5
+    perceiver_depth: 3
     patch_size: [12, 20]
     perceiver_latent_dim: 64
-    perceiver_num_latents: 512
+    perceiver_num_latents: 256
 
   processor:
     ch_width: [380, 480, 520]

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -29,7 +29,7 @@ inference_times:
   - start: "2004-10-05"
     end: "2005-10-05" # "2014-10-05"
 data_stride: [1]
-steps: [4]
+steps: [1]
 step_transition: []
 
 backend: auto
@@ -55,8 +55,12 @@ model:
   embedding_dim: 80
 
   encoder:
-    perceiver_depth: 2
-    patch_size: [12, 24]
+    perceiver_depth: 5
+    patch_size: [6, 12]
+    perceiver_latent_dim: 64
+
+  decoder:
+    perceiver_depth: 5
     perceiver_latent_dim: 64
 
   processor:

--- a/configs/train_om4_fomo.yaml
+++ b/configs/train_om4_fomo.yaml
@@ -61,7 +61,7 @@ model:
     perceiver_num_latents: 256
 
   processor:
-    ch_width: [384, 480, 520]
+    ch_width: [380, 480, 520]
     dilation: [1, 1, 1]
     n_layers: [1, 1, 1]
 

--- a/skypilot/train.sky.yaml
+++ b/skypilot/train.sky.yaml
@@ -25,7 +25,7 @@ resources:
   # Optional; if left out, automatically pick the cheapest cloud.
   cloud: lambda
   # 8x NVIDIA A100-80GB GPU
-  accelerator: A100-80GB:8
+  accelerators: A100-80GB:8
   disk_tier: best
 
 # NOTE: Remember to pass environment variables with `--env` or `--env-file`

--- a/skypilot/train.sky.yaml
+++ b/skypilot/train.sky.yaml
@@ -25,7 +25,7 @@ resources:
   # Optional; if left out, automatically pick the cheapest cloud.
   cloud: lambda
   # 8x NVIDIA A100-80GB GPU
-  accelerators: H100-80GB:8
+  accelerators: H100:8
   disk_tier: best
 
 # NOTE: Remember to pass environment variables with `--env` or `--env-file`

--- a/skypilot/train.sky.yaml
+++ b/skypilot/train.sky.yaml
@@ -25,7 +25,7 @@ resources:
   # Optional; if left out, automatically pick the cheapest cloud.
   cloud: lambda
   # 8x NVIDIA A100-80GB GPU
-  accelerators: A100-80GB:8
+  accelerators: H100-80GB:8
   disk_tier: best
 
 # NOTE: Remember to pass environment variables with `--env` or `--env-file`

--- a/skypilot/train.sky.yaml
+++ b/skypilot/train.sky.yaml
@@ -25,7 +25,7 @@ resources:
   # Optional; if left out, automatically pick the cheapest cloud.
   cloud: lambda
   # 8x NVIDIA A100-80GB GPU
-  accelerators: H100:8
+  accelerator: A100-80GB:8
   disk_tier: best
 
 # NOTE: Remember to pass environment variables with `--env` or `--env-file`

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -287,6 +287,23 @@ class CorrectorConfig(BaseConfig):
         )
 
 
+def _validate_patch_size(candidate: int | list[int]) -> int | tuple[int, int]:
+    if (
+        isinstance(candidate, list)
+        and len(candidate) == 2
+        and isinstance(candidate[0], int)
+        and isinstance(candidate[1], int)
+    ):
+        patch_size: int | tuple[int, int] = candidate[0], candidate[1]
+    elif isinstance(candidate, int):
+        patch_size = candidate
+    else:
+        raise ValueError(
+            "`patch_size` must be either a scalar integer or a two-tuple of integers (height: int, width: int)."
+        )
+    return patch_size
+
+
 class EncoderConfig(BaseConfig):
     patch_size: int | list[int] = Field(
         default=4,
@@ -297,28 +314,24 @@ class EncoderConfig(BaseConfig):
         default=128,
         description="The small, latent dimension of the Perceiver. This is the `N` dimension for the Perceiver's `O(M*N)` complexity",
     )
+    perceiver_num_latents: int = Field(
+        default=512,
+        description="The number of latent vectors in the Perceiver. This is the `M` dimension for the Perceiver's `O(M*N)` complexity",
+    )
 
-    def build(self, in_channels: int, out_channels: int) -> PerceiverEncoder:
-        if (
-            isinstance(self.patch_size, list)
-            and len(self.patch_size) == 2
-            and isinstance(self.patch_size[0], int)
-            and isinstance(self.patch_size[1], int)
-        ):
-            patch_size: int | tuple[int, int] = self.patch_size[0], self.patch_size[1]
-        elif isinstance(self.patch_size, int):
-            patch_size = self.patch_size
-        else:
-            raise ValueError(
-                "`patch_size` must be either a scalar integer or a two-tuple of integers (height: int, width: int)."
-            )
-
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+    ) -> PerceiverEncoder:
+        patch_size = _validate_patch_size(self.patch_size)
         return PerceiverEncoder(
             in_channels=in_channels,
             out_channels=out_channels,
             patch_size=patch_size,
             perceiver_depth=self.perceiver_depth,
             perceiver_latent_dim=self.perceiver_latent_dim,
+            perceiver_num_latents=self.perceiver_num_latents,
         )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -487,6 +487,7 @@ class FOMOConfig(BaseModelConfig):
             hist=hist,
             wet=wet,
             static_data=static_data,
+            checkpointing=self.checkpointing,
         )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -287,23 +287,6 @@ class CorrectorConfig(BaseConfig):
         )
 
 
-def _validate_patch_size(candidate: int | list[int]) -> int | tuple[int, int]:
-    if (
-        isinstance(candidate, list)
-        and len(candidate) == 2
-        and isinstance(candidate[0], int)
-        and isinstance(candidate[1], int)
-    ):
-        patch_size: int | tuple[int, int] = candidate[0], candidate[1]
-    elif isinstance(candidate, int):
-        patch_size = candidate
-    else:
-        raise ValueError(
-            "`patch_size` must be either a scalar integer or a two-tuple of integers (height: int, width: int)."
-        )
-    return patch_size
-
-
 class EncoderConfig(BaseConfig):
     patch_size: int | list[int] = Field(
         default=4,
@@ -319,12 +302,21 @@ class EncoderConfig(BaseConfig):
         description="The number of latent vectors in the Perceiver. This is the `M` dimension for the Perceiver's `O(M*N)` complexity",
     )
 
-    def build(
-        self,
-        in_channels: int,
-        out_channels: int,
-    ) -> PerceiverEncoder:
-        patch_size = _validate_patch_size(self.patch_size)
+    def build(self, in_channels: int, out_channels: int) -> PerceiverEncoder:
+        if (
+            isinstance(self.patch_size, list)
+            and len(self.patch_size) == 2
+            and isinstance(self.patch_size[0], int)
+            and isinstance(self.patch_size[1], int)
+        ):
+            patch_size: int | tuple[int, int] = self.patch_size[0], self.patch_size[1]
+        elif isinstance(self.patch_size, int):
+            patch_size = self.patch_size
+        else:
+            raise ValueError(
+                "`patch_size` must be either a scalar integer or a two-tuple of integers (height: int, width: int)."
+            )
+
         return PerceiverEncoder(
             in_channels=in_channels,
             out_channels=out_channels,

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -12,9 +12,6 @@ from ocean_emulators.constants import Grid
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import PerceiverEncoder
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    apply_activation_checkpointing,
-)
 
 
 class FOMO(BaseModel):
@@ -80,7 +77,7 @@ class FOMO(BaseModel):
         apply_activation_checkpointing(
             self,
             check_fn=lambda m: m.__class__.__name__
-            in ["LayerNorm", "FeedForward", "Linear"],
+            in ["LayerNorm", "FeedForward", "Linear", "Perceiver"],
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -2,14 +2,14 @@ import torch
 import xarray as xr
 from einops import rearrange
 from torch import nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
+)
 
 from ocean_emulators.constants import Grid
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import PerceiverEncoder
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    apply_activation_checkpointing,
-)
 
 
 class FOMO(BaseModel):
@@ -62,7 +62,7 @@ class FOMO(BaseModel):
         apply_activation_checkpointing(
             self,
             check_fn=lambda m: m.__class__.__name__
-            in ["LayerNorm", "FeedForward", "Linear"],
+            in ["LayerNorm", "FeedForward", "Linear", "Perceiver"],
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -76,8 +76,9 @@ class FOMO(BaseModel):
 
         apply_activation_checkpointing(
             self,
-            # check_fn=lambda m: m.__class__.__name__
-            # in ["LayerNorm", "FeedForward", "Linear", "Perceiver"],
+            check_fn=lambda m: isinstance(
+                m, nn.LayerNorm | FeedForward | nn.Linear | Perceiver
+            ),
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -7,6 +7,9 @@ from ocean_emulators.constants import Grid
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import PerceiverEncoder
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
+)
 
 
 class FOMO(BaseModel):
@@ -54,6 +57,11 @@ class FOMO(BaseModel):
         self.layers = nn.ModuleList(layers)
         self.unpatch = nn.Linear(
             out_channels, out_channels * self.patch_size[0] * self.patch_size[1]
+        )
+
+        apply_activation_checkpointing(
+            self,
+            lambda m: m.__class__.__name__ in ["LayerNorm", "FeedForward", "Linear"],
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -61,7 +61,8 @@ class FOMO(BaseModel):
 
         apply_activation_checkpointing(
             self,
-            lambda m: m.__class__.__name__ in ["LayerNorm", "FeedForward", "Linear"],
+            check_fn=lambda m: m.__class__.__name__
+            in ["LayerNorm", "FeedForward", "Linear"],
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -76,8 +76,8 @@ class FOMO(BaseModel):
 
         apply_activation_checkpointing(
             self,
-            check_fn=lambda m: m.__class__.__name__
-            in ["LayerNorm", "FeedForward", "Linear", "Perceiver"],
+            # check_fn=lambda m: m.__class__.__name__
+            # in ["LayerNorm", "FeedForward", "Linear", "Perceiver"],
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -1,8 +1,8 @@
-from perceiver_pytorch import Perceiver
-from perceiver_pytorch.perceiver_pytorch import FeedForward
 import torch
 import xarray as xr
 from einops import rearrange
+from perceiver_pytorch import Perceiver
+from perceiver_pytorch.perceiver_pytorch import Attention, FeedForward
 from torch import nn
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     apply_activation_checkpointing,
@@ -70,20 +70,8 @@ class FOMO(BaseModel):
                 | nn.Linear
                 | Perceiver
                 | PerceiverEncoder
-                | UNetBackbone,
-            ),
-        )
-
-        apply_activation_checkpointing(
-            self,
-            check_fn=lambda m: isinstance(
-                m,
-                nn.LayerNorm
-                | FeedForward
-                | nn.Linear
-                | Perceiver
-                | PerceiverEncoder
-                | UNetBackbone,
+                | UNetBackbone
+                | Attention,
             ),
         )
 

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import torch
 import xarray as xr
 from einops import rearrange
@@ -12,6 +14,9 @@ from ocean_emulators.constants import Grid
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import PerceiverEncoder
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
+
+if TYPE_CHECKING:
+    from ocean_emulators.config import Checkpointing
 
 
 class FOMO(BaseModel):
@@ -32,6 +37,7 @@ class FOMO(BaseModel):
         hist: int,
         wet: Grid,
         static_data: xr.Dataset | None,
+        checkpointing: "Checkpointing | None",
     ):
         super().__init__(
             in_channels=in_channels,
@@ -61,19 +67,20 @@ class FOMO(BaseModel):
             out_channels, out_channels * self.patch_size[0] * self.patch_size[1]
         )
 
-        apply_activation_checkpointing(
-            self,
-            check_fn=lambda m: isinstance(
-                m,
-                nn.LayerNorm
-                | FeedForward
-                | nn.Linear
-                | Perceiver
-                | PerceiverEncoder
-                | UNetBackbone
-                | Attention,
-            ),
-        )
+        if checkpointing == "all":
+            apply_activation_checkpointing(
+                self,
+                check_fn=lambda m: isinstance(
+                    m,
+                    nn.LayerNorm
+                    | FeedForward
+                    | nn.Linear
+                    | Perceiver
+                    | PerceiverEncoder
+                    | UNetBackbone
+                    | Attention,
+                ),
+            )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
         for layer in self.layers:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -1,3 +1,5 @@
+from perceiver_pytorch import Perceiver
+from perceiver_pytorch.perceiver_pytorch import FeedForward
 import torch
 import xarray as xr
 from einops import rearrange
@@ -61,8 +63,9 @@ class FOMO(BaseModel):
 
         apply_activation_checkpointing(
             self,
-            # check_fn=lambda m: m.__class__.__name__
-            # in ["LayerNorm", "FeedForward", "Linear", "Perceiver"],
+            check_fn=lambda m: isinstance(
+                m, nn.LayerNorm | FeedForward | nn.Linear | Perceiver
+            ),
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -77,7 +77,13 @@ class FOMO(BaseModel):
         apply_activation_checkpointing(
             self,
             check_fn=lambda m: isinstance(
-                m, nn.LayerNorm | FeedForward | nn.Linear | Perceiver
+                m,
+                nn.LayerNorm
+                | FeedForward
+                | nn.Linear
+                | Perceiver
+                | PerceiverEncoder
+                | UNetBackbone,
             ),
         )
 

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -64,7 +64,13 @@ class FOMO(BaseModel):
         apply_activation_checkpointing(
             self,
             check_fn=lambda m: isinstance(
-                m, nn.LayerNorm | FeedForward | nn.Linear | Perceiver
+                m,
+                nn.LayerNorm
+                | FeedForward
+                | nn.Linear
+                | Perceiver
+                | PerceiverEncoder
+                | UNetBackbone,
             ),
         )
 

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -61,8 +61,8 @@ class FOMO(BaseModel):
 
         apply_activation_checkpointing(
             self,
-            check_fn=lambda m: m.__class__.__name__
-            in ["LayerNorm", "FeedForward", "Linear", "Perceiver"],
+            # check_fn=lambda m: m.__class__.__name__
+            # in ["LayerNorm", "FeedForward", "Linear", "Perceiver"],
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -79,7 +79,8 @@ class FOMO(BaseModel):
 
         apply_activation_checkpointing(
             self,
-            lambda m: m.__class__.__name__ in ["LayerNorm", "FeedForward", "Linear"],
+            check_fn=lambda m: m.__class__.__name__
+            in ["LayerNorm", "FeedForward", "Linear"],
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -12,6 +12,9 @@ from ocean_emulators.constants import Grid
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import PerceiverEncoder
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
+)
 
 
 class FOMO(BaseModel):
@@ -72,6 +75,11 @@ class FOMO(BaseModel):
                 | PerceiverEncoder
                 | UNetBackbone,
             ),
+        )
+
+        apply_activation_checkpointing(
+            self,
+            lambda m: m.__class__.__name__ in ["LayerNorm", "FeedForward", "Linear"],
         )
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -83,6 +83,7 @@ class PerceiverEncoder(nn.Module):
             pw=self.patch_size[1],
         )
         x = self.perceiver(x)  # (B_H_W, PH, PW, V) -> (B_H_W, num_latents, latent_dim)
+        # TODO(alxmrs,jder): Why compute the mean? Is it better to directly project from the num_latents x latent_dim?
         x = x.mean(dim=1)  # (B_H_W, num_latents, latent_dim) -> (B_H_W, latent_dim)
         x = self.project(x)  # (B_H_W, latent_dim) -> (B_H_W, out_channels)
         x = rearrange(

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -81,12 +81,7 @@ class PerceiverEncoder(nn.Module):
             ph=self.patch_size[0],
             pw=self.patch_size[1],
         )
-        # This is applying a layer norm across all our data channels. I am not sure if this will have a positive or
-        # negative effect. It may make it easier for the Perceiver to process data across scales, but it destroys the
-        # physical relationships in the data and aggregates across depth level and history. We should be cautious here.
-        x = self.norm_patches(x)
         x = self.perceiver(x)
-        x = self.norm_embedding(x)
         x = rearrange(
             x,
             "(b h w) l -> b l h w",

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -59,8 +59,9 @@ class PerceiverEncoder(nn.Module):
             num_classes=out_channels,
             weight_tie_layers=False,  # share weights of cross-attn blocks
             self_per_cross_attn=2,  # ratio of self-attn (latent, small) and cross-attn (input, big) blocks
+            final_classifier_head=False,
         )
-        self.norm_embedding = nn.LayerNorm(out_channels)
+        self.project = nn.Linear(perceiver_latent_dim, out_channels)
 
     def forward(self, x: Input) -> Float[torch.Tensor, "batch {self.embed_dim} h w"]:
         _, V, H, W = x.shape
@@ -81,7 +82,9 @@ class PerceiverEncoder(nn.Module):
             ph=self.patch_size[0],
             pw=self.patch_size[1],
         )
-        x = self.perceiver(x)
+        x = self.perceiver(x)  # (B_H_W, PH, PW, V) -> (B_H_W, num_latents, latent_dim)
+        x = x.mean(dim=1)  # (B_H_W, num_latents, latent_dim) -> (B_H_W, latent_dim)
+        x = self.project(x)  # (B_H_W, latent_dim) -> (B_H_W, out_channels)
         x = rearrange(
             x,
             "(b h w) l -> b l h w",

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -47,7 +47,9 @@ class PerceiverEncoder(nn.Module):
         self.norm_patches = nn.LayerNorm(self.in_channels)
         self.perceiver = Perceiver(
             num_freq_bands=4,
-            max_freq=1.0,
+            max_freq=max(
+                *self.patch_size
+            ),  # This is not actually a "frequency" but a maximum of the width appears to be reasonable from looking at the code
             depth=perceiver_depth,
             input_axis=2,  # Number of positional dims before token dim
             input_channels=self.in_channels,

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -45,7 +45,6 @@ class PerceiverEncoder(nn.Module):
             self.patch_size = patch_size
         self.out_channels: int = out_channels  # aka, `embed_dim`.
 
-        self.norm_patches = nn.LayerNorm(self.in_channels)
         self.perceiver = Perceiver(
             num_freq_bands=4,
             max_freq=max(

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -32,6 +32,7 @@ class PerceiverEncoder(nn.Module):
         patch_size: int | tuple[int, int],
         perceiver_depth: int,
         perceiver_latent_dim: int,
+        perceiver_num_latents: int,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
@@ -54,6 +55,7 @@ class PerceiverEncoder(nn.Module):
             input_axis=2,  # Number of positional dims before token dim
             input_channels=self.in_channels,
             latent_dim=perceiver_latent_dim,
+            num_latents=perceiver_num_latents,
             num_classes=out_channels,
             weight_tie_layers=True,  # share weights of cross-attn blocks
             self_per_cross_attn=2,  # ratio of self-attn (latent, small) and cross-attn (input, big) blocks

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -57,7 +57,7 @@ class PerceiverEncoder(nn.Module):
             latent_dim=perceiver_latent_dim,
             num_latents=perceiver_num_latents,
             num_classes=out_channels,
-            weight_tie_layers=True,  # share weights of cross-attn blocks
+            weight_tie_layers=False,  # share weights of cross-attn blocks
             self_per_cross_attn=2,  # ratio of self-attn (latent, small) and cross-attn (input, big) blocks
         )
         self.norm_embedding = nn.LayerNorm(out_channels)

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -57,7 +57,7 @@ class PerceiverEncoder(nn.Module):
             latent_dim=perceiver_latent_dim,
             num_latents=perceiver_num_latents,
             num_classes=out_channels,
-            weight_tie_layers=False,  # share weights of cross-attn blocks
+            weight_tie_layers=True,  # share weights of cross-attn blocks
             self_per_cross_attn=2,  # ratio of self-attn (latent, small) and cross-attn (input, big) blocks
             final_classifier_head=False,
         )

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -12,6 +12,7 @@ def test_makes_patches():
         patch_size=4,
         perceiver_depth=2,
         perceiver_latent_dim=3,
+        perceiver_num_latents=2,
     )
 
     patches = patch_embed(x)
@@ -28,6 +29,7 @@ def test_makes_rectangular_patches():
         patch_size=(4, 2),
         perceiver_depth=2,
         perceiver_latent_dim=3,
+        perceiver_num_latents=2,
     )
 
     patches = patch_embed(x)
@@ -49,6 +51,7 @@ def test_makes_patches__high_res():
         patch_size=4,
         perceiver_depth=2,
         perceiver_latent_dim=3,
+        perceiver_num_latents=2,
     )
 
     patches = patch_embed(x)
@@ -65,6 +68,7 @@ def test_makes_patches__more_variables():
         patch_size=4,
         perceiver_depth=2,
         perceiver_latent_dim=3,
+        perceiver_num_latents=2,
     )
 
     patches = patch_embed(x)


### PR DESCRIPTION
Pulling in improvements from #417, focusing just on the encoder. These include: 
- Activation checkpointing (nice, clean implementation, @jder!).
- Training config wrangling
- Adding an essential config option for the encoder (`perceiver_num_latents`)
- Turning off the default linear projection scheme so that we can implement our own.