### PR TITLE
Allow us to block ec2-related failures from merging

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
     secrets:
       GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}
 
-  test:
+  benchmark:
     needs: ec2
     runs-on: ${{ needs.ec2.outputs.id }}
 

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       ec2_instance_type: g6.xlarge
       ec2_image_id: ami-0365bff494b18bf93 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch 2.7 (Ubuntu 22.04) in oa-ci-dev
-      ec2_root_device_size: '+1' # AMI's reported VolumeSize (40GB) +1GB; leaves headroom for test I/O; instance runs out of disk otherwise
+      ec2_root_device_size: "+1" # AMI's reported VolumeSize (40GB) +1GB; leaves headroom for test I/O; instance runs out of disk otherwise
     secrets:
       GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}
   run-tests:
@@ -51,3 +51,15 @@ jobs:
 
       - name: Run pytest
         run: uv run --locked pytest -n 2 -v -m "not manual and cuda"
+
+  # This exists beacuse the run-tests job will be skipped if the ec2 job fails,
+  # and that skip will not block merging the PR.
+  report-gpu-test-status:
+    name: All GPU tests passed
+    if: always()
+    needs: [ec2, run-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check job results
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -56,7 +56,7 @@ jobs:
   # and that skip will not block merging the PR.
   report-gpu-test-status:
     if: always()
-    needs: [ec2, run-tests]
+    needs: [ec2, test-gpu]
     runs-on: ubuntu-latest
     steps:
       - name: Check job results

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -21,7 +21,7 @@ jobs:
       ec2_root_device_size: "+1" # AMI's reported VolumeSize (40GB) +1GB; leaves headroom for test I/O; instance runs out of disk otherwise
     secrets:
       GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}
-  run-tests:
+  test-gpu:
     needs: ec2
     runs-on: ${{ needs.ec2.outputs.id }}
     steps:
@@ -55,7 +55,6 @@ jobs:
   # This exists beacuse the run-tests job will be skipped if the ec2 job fails,
   # and that skip will not block merging the PR.
   report-gpu-test-status:
-    name: All GPU tests passed
     if: always()
     needs: [ec2, run-tests]
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  test:
+  test-cpu:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
#420 was merged without GPU tests passing. This was permitted by our branch protection rules because the "run-tests" job in the GPU tests workflow was *skipped* (because one of its dependencies, the ec2 job which spins up a GPU for us) failed. Perhaps surprisingly, this skipped state [counts as success](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks) for the purpose of branch protection rules. 

So this defines a new job which explicitly fails when either the ec2-spin-up or GPU test themselves fail, which we'll add to our branch protection rules.