### PR TITLE
Move data loader compute pieces to GPU

### DIFF
--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -236,7 +236,6 @@ def construct_metadata(data: xr.Dataset) -> dict[str, dict[str, str]]:
 
 
 class LoaderVersion(enum.Enum):
-    OM4_EAGER = "om4-eager"
     OM4_TORCH = "om4-torch"
 
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -416,7 +416,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         executor: ThreadPoolExecutor | None = None,
     ):
         super().__init__()
-        self.id = self.__class__.__name__ + "_" + str(id(self))
+        self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
 
         self.hist: int = hist

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -635,6 +635,7 @@ def concurrent_compute(
     wait(futures)
 
 
+@final
 class TrainDataLoader:
     """Wrapper around a torch DataLoader that handles GPU post-processing.
 
@@ -653,11 +654,11 @@ class TrainDataLoader:
     def __init__(
         self,
         dataloader: torch.utils.data.DataLoader[RawTrainData],
-        datasets: dict[TorchTrainDataset.Id, TorchTrainDataset],
+        datasets: list[TorchTrainDataset],
         device: torch.device,
     ):
         self._dataloader = dataloader
-        self._datasets = datasets
+        self._datasets = {dataset.id: dataset for dataset in datasets}
         self._device = device
 
     def __iter__(self):

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -2,7 +2,7 @@ import logging
 import time
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import Any
+from typing import TypeAlias, final
 
 import numpy as np
 import torch
@@ -13,7 +13,6 @@ from torch.utils.data import Dataset
 from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 
 from ocean_emulators.constants import (
-    Boundary,
     BoundaryVarNames,
     Example,
     GridMask,
@@ -295,12 +294,38 @@ class InferenceDatasets(Dataset):
         return (self.datasets[idx], self.lengths[idx])
 
 
+class RawTrainData:
+    def __init__(self, dataset_id: "TorchTrainDataset.Id"):
+        self.dataset_id: TorchTrainDataset.Id = dataset_id
+        self.raw_data: list[tuple[torch.Tensor, torch.Tensor]] = []
+        self.load_stats: LoadStats | None = None
+
+    def insert(self, all_prognostic: torch.Tensor, all_boundary: torch.Tensor):
+        self.raw_data.append((all_prognostic, all_boundary))
+
+    def to(self, device: torch.device):
+        self.raw_data = [
+            (
+                all_prognostic.to(device, non_blocking=True),
+                all_boundary.to(device, non_blocking=True),
+            )
+            for all_prognostic, all_boundary in self.raw_data
+        ]
+
+    def pin_memory(self):
+        self.raw_data = [
+            (all_prognostic.pin_memory(), all_boundary.pin_memory())
+            for all_prognostic, all_boundary in self.raw_data
+        ]
+        return self
+
+
 class TrainData:
     def __init__(self, num_prognostic_channels: int):
         self.td_dict: dict[int, Example] = {}
-        self.load_stats: LoadStats | None = None
         self.num_prognostic_channels = num_prognostic_channels
         self.steps = 0
+        self.load_stats: LoadStats | None = None
 
     def insert(self, input_: Input, label: Prognostic):
         self.td_dict[self.steps] = (input_, label)
@@ -350,7 +375,8 @@ class TrainData:
         return iter(self.td_dict)
 
 
-class TrainDataset(Dataset):
+@final
+class TorchTrainDataset(Dataset[RawTrainData]):
     """
     This class is used for training and validation.
 
@@ -370,221 +396,7 @@ class TrainDataset(Dataset):
             step=3->[[9, 10, 11], [12, 13, 14]]
     """
 
-    FLAG = LoaderVersion.OM4_EAGER
-
-    @elapsed
-    def __init__(
-        self,
-        src: DataSource,
-        prognostic_var_names: PrognosticVarNames,
-        boundary_var_names: BoundaryVarNames,
-        wet: PrognosticMask,
-        wet_surface: GridMask,
-        hist: int,
-        steps: int,
-        normalize_before_mask: bool,
-        masked_fill_value: float,
-        stride: int = 1,
-    ):
-        super().__init__()
-        self.device = get_device()
-
-        self.hist: int = hist
-        self.steps: int = steps
-        self.stride: int = stride
-        self.normalize_before_mask: bool = normalize_before_mask
-        self.masked_fill_value: float = masked_fill_value
-        data = src.data
-        self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
-        self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
-
-        self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
-
-        # This class will be used only for training
-        total_steps: int = 2 * self.hist + 2
-
-        # Calculate the number of windows
-        num_windows = data.time.size - (total_steps - 1) * self.stride
-
-        # Create base indices
-        indices = np.arange(num_windows)
-        indices_da = xr.DataArray(indices, dims=["window_dim"])
-
-        # Create window dimension
-        window_dim = xr.DataArray(np.arange(total_steps), dims=["time"])
-
-        # Construct rolling indices
-        self.rolling_indices: Float[xr.DataArray, "window_dim time"] = (
-            indices_da + stride * window_dim
-        )
-
-        self.wet = wet.bool()
-        self.wet_surface = wet_surface.bool()
-
-        self.size: int = (
-            data.time.size
-            - self.steps * (self.hist + 1) * self.stride
-            - self.hist * self.stride
-        )
-
-        if using_gpu():
-            self.wet = self.wet.pin_memory()
-            self.wet_surface = self.wet_surface.pin_memory()
-
-    def __len__(self) -> int:
-        return self.size
-
-    @elapsed(level=logging.DEBUG)
-    def __getitem__(self, idx: int):
-        start_time = time.perf_counter()
-        TD = TrainData(self.num_prognostic_channels)
-        prev_rolling_idx = None
-        for step in range(self.steps):
-            x_index = self._get_x_index(idx, step, prev_rolling_idx)
-
-            data_in: Prognostic = self._get_input(x_index)
-            data_in_boundary: Boundary = self._get_boundary(x_index)
-
-            data_combined: Input = torch.cat(
-                (data_in, data_in_boundary), dim=1
-            ).squeeze()
-
-            label: Prognostic = self._get_label(x_index)
-
-            TD.insert(
-                input_=data_combined,
-                label=label,
-            )
-
-        TD.load_stats = LoadStats(time.perf_counter() - start_time)
-
-        return TD
-
-    def _get_x_index(
-        self, idx: int, step: int, prev_rolling_idx: int | None
-    ) -> xr.Variable:
-        assert isinstance(idx, int)
-        if idx < 0:
-            raise IndexError("Sorry, negative indexing is not supported!")
-        if idx >= len(self):
-            raise IndexError("Index out of range")
-
-        start = idx + step * (self.hist + 1) * self.stride
-        end = start + 1
-        # Create a slice for similar indexing as in InferenceDataset
-        idx_slice = slice(start, end)
-        rolling_idx = self.rolling_indices.isel(window_dim=idx_slice)
-
-        x_index = xr.Variable(["window_dim", "time"], rolling_idx)
-        return x_index
-
-    def _get_input(self, x_index) -> Prognostic:
-        # TODO(jder): nicer typing
-        data_in_src: Any = self._prognostic_src.map_data(
-            lambda ds: ds.isel(time=x_index).isel(time=slice(None, self.hist + 1))
-        )
-        if self.normalize_before_mask:
-            data_in = data_in_src.normalize()
-        else:
-            data_in = data_in_src.data
-
-        data_in = (
-            data_in.to_array()
-            .transpose("window_dim", "time", "variable", "lat", "lon")
-            .to_numpy()
-        )
-        data_in = torch.from_numpy(data_in).float()
-        data_in = torch.where(self.wet, data_in, self.masked_fill_value)
-        if not self.normalize_before_mask:
-            data_in = self._prognostic_src.normalize_with(data_in, variable_axis=2)
-
-        data_in = rearrange(
-            data_in,
-            "window_dim time variable lat lon -> \
-                window_dim (time variable) lat lon",
-        )
-        return data_in
-
-    def _get_boundary(self, x_index) -> Boundary:
-        """
-        This function returns the boundary condition for the current time step.
-
-        With hist > 0, the boundary condition considered is always the last step of
-        the input.
-        """
-        # TODO(jder): nicer typing
-        data_in_boundary_src: Any = self._boundary_src.map_data(
-            lambda ds: ds.isel(time=x_index).isel(time=slice(None, self.hist + 1))
-        )
-        if self.normalize_before_mask:
-            data_in_boundary = data_in_boundary_src.normalize()
-        else:
-            data_in_boundary = data_in_boundary_src.data
-        data_in_boundary = (
-            data_in_boundary.to_array()
-            .transpose("window_dim", "time", "variable", "lat", "lon")
-            .to_numpy()
-        )
-        data_in_boundary = torch.from_numpy(data_in_boundary).float()
-        data_in_boundary = torch.where(
-            self.wet_surface, data_in_boundary, self.masked_fill_value
-        )
-        if not self.normalize_before_mask:
-            data_in_boundary = self._boundary_src.normalize_with(
-                data_in_boundary, variable_axis=2
-            )
-        data_in_boundary = rearrange(
-            data_in_boundary,
-            "window_dim time variable lat lon -> \
-                window_dim (time variable) lat lon",
-        )
-        return data_in_boundary
-
-    def _get_label(self, x_index) -> Prognostic:
-        # TODO(jder): nicer typing
-        label_src: Any = self._prognostic_src.map_data(
-            lambda ds: ds.isel(time=x_index).isel(time=slice(self.hist + 1, None))
-        )
-        if self.normalize_before_mask:
-            label = label_src.normalize()
-        else:
-            label = label_src.data
-        label = (
-            label.to_array()
-            .transpose("window_dim", "time", "variable", "lat", "lon")
-            .to_numpy()
-        )
-        label = torch.from_numpy(label).float()
-        label = torch.where(self.wet, label, self.masked_fill_value)
-        if not self.normalize_before_mask:
-            label = label_src.normalize_with(label, variable_axis=2)
-        label = rearrange(
-            label,
-            "window_dim time variable lat lon ->\
-                window_dim (time variable) lat lon",
-        ).squeeze()
-        return label
-
-
-class TorchTrainDataset(Dataset):
-    """
-    This class is used for training and validation.
-
-    It creates rolling indices to keep track of histories/past states. But different
-    from InferenceDataset, as it creates rolling indices based on stride. By default,
-    the sliding window / stride is 1.
-
-    We make use of TrainData class to store a single sample.
-
-    For example,
-    Hist=0 ; TD: step=0->[0, 1]; step=1->[1, 2]; step=2->[2, 3]; step=3->[3, 4]
-    Hist=1 ; TD: step=0->[[0, 1], [2, 3]]; step=1->[[2, 3], [4, 5]];
-            step=2->[[4, 5], [6, 7]]; step=3->[[6, 7], [8, 9]]
-    Hist=2 ; TD: step=0->[[0, 1, 2], [3, 4, 5]];
-            step=1->[[3, 4, 5], [6, 7, 8]];
-            step=2->[[6, 7, 8], [9, 10, 11]];
-            step=3->[[9, 10, 11], [12, 13, 14]]
-    """
+    Id: TypeAlias = str
 
     FLAG = LoaderVersion.OM4_TORCH
 
@@ -604,6 +416,7 @@ class TorchTrainDataset(Dataset):
         executor: ThreadPoolExecutor | None = None,
     ):
         super().__init__()
+        self.id = self.__class__.__name__ + "_" + str(id(self))
         self.device = get_device()
 
         self.hist: int = hist
@@ -636,8 +449,25 @@ class TorchTrainDataset(Dataset):
             indices_da + stride * window_dim
         )
 
-        self.wet = wet.bool()
-        self.wet_surface = wet_surface.bool()
+        self.wet = wet.bool().to(self.device)
+        self.wet_surface = wet_surface.bool().to(self.device)
+
+        def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
+            if "lev" in means_or_stds.dims:
+                array = conditional_rearrange(
+                    means_or_stds,
+                    "(variable lev)=var",
+                    concat_dim="var",
+                ).rename({"var": "variable"})
+            else:
+                array = means_or_stds.to_dataarray()
+            return torch.from_numpy(array.to_numpy().flatten()).to(self.device)
+
+        self.prognostic_means = flatten_to_device(self._prognostic_src.means)
+        self.prognostic_stds = flatten_to_device(self._prognostic_src.stds)
+
+        self.boundary_means = flatten_to_device(self._boundary_src.means)
+        self.boundary_stds = flatten_to_device(self._boundary_src.stds)
 
         self.size: int = (
             data.time.size
@@ -645,17 +475,13 @@ class TorchTrainDataset(Dataset):
             - self.hist * self.stride
         )
 
-        if using_gpu():
-            self.wet = self.wet.pin_memory()
-            self.wet_surface = self.wet_surface.pin_memory()
-
     def __len__(self) -> int:
         return self.size
 
     @elapsed(level=logging.DEBUG)
     def __getitem__(self, idx: int):
         start_time = time.perf_counter()
-        TD = TrainData(self.num_prognostic_channels)
+        TD = RawTrainData(self.id)
 
         for step in range(self.steps):
             x_index = self._get_x_index(idx, step)
@@ -689,63 +515,97 @@ class TorchTrainDataset(Dataset):
                 .to_numpy()
             )
 
-            input_, label = self._get_input_and_label(prognostic_all, boundary)
-            TD.insert(input_=input_, label=label)
-
+            TD.insert(prognostic_all, boundary)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
+
         return TD
+
+    def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
+        train_data = TrainData(self.num_prognostic_channels)
+        for prognostic_all, boundary_all in raw_train_data.raw_data:
+            input, label = self._get_input_and_label(
+                prognostic_all.to(self.device, non_blocking=True),
+                boundary_all.to(self.device, non_blocking=True),
+            )
+            train_data.insert(input, label)
+        train_data.load_stats = raw_train_data.load_stats
+        return train_data
 
     def _get_input_and_label(
         self,
         # time includes (self.hist + 1) past steps and the (label) future steps
-        prognostic_all: Float[torch.Tensor, "time variable lat lon"],
-        boundary_all: Float[torch.Tensor, "time variable lat lon"],
+        prognostic_all: Float[torch.Tensor, "batch time variable lat lon"],
+        boundary_all: Float[torch.Tensor, "batch time variable lat lon"],
     ) -> tuple[Input, Prognostic]:
         # grab past steps and prep for model
         total_input = self._prep_tensor_steps(
-            prognostic_all[: self.hist + 1, :, :, :],
-            boundary_all[: self.hist + 1, :, :, :],
+            prognostic_all[:, : self.hist + 1, :, :, :],
+            boundary_all[:, : self.hist + 1, :, :, :],
         )
         # grab future steps, repeat as we do for input
-        label = self._prep_tensor_steps(prognostic_all[self.hist + 1 :, :, :, :])
+        label = self._prep_tensor_steps(prognostic_all[:, self.hist + 1 :, :, :, :])
         return total_input, label
 
     def _prep_tensor_steps(
         self,
-        prognostic_steps: Float[torch.Tensor, "time variable lat lon"],
-        boundary_steps: Float[torch.Tensor, "time variable lat lon"] | None = None,
+        prognostic_steps: Float[torch.Tensor, "batch time variable lat lon"],
+        boundary_steps: Float[torch.Tensor, "batch time variable lat lon"]
+        | None = None,
     ) -> Input:
         """Prepare tensor steps by normalizing, masking and flattening dimensions."""
+
+        def normalize(
+            data: Float[torch.Tensor, "batch time var lat lon"],
+            means: Float[torch.Tensor, " var"],
+            stds: Float[torch.Tensor, " var"],
+            fill_nan: bool = True,
+            fill_value: float = 0.0,
+        ) -> Float[torch.Tensor, "batch time var lat lon"]:
+            """Normalize input data treated as torch Tensors."""
+            norm = (data - means.view(1, 1, -1, 1, 1)) / stds.view(1, 1, -1, 1, 1)
+            if fill_nan:
+                norm = norm.nan_to_num(nan=fill_value)
+            norm = norm.to(data.dtype)
+            return norm
 
         # Normalize and mask tensors
         def normalize_and_mask(
             tensor: torch.Tensor,
-            src: DataSource,
+            means: torch.Tensor,
+            stds: torch.Tensor,
             mask: torch.Tensor,
         ) -> torch.Tensor:
             if self.normalize_before_mask:
-                tensor = src.normalize_with(tensor, variable_axis=1).float()
+                tensor = normalize(tensor, means, stds)
             tensor = torch.where(mask, tensor, self.masked_fill_value)
             if not self.normalize_before_mask:
-                tensor = src.normalize_with(tensor, variable_axis=1).float()
+                tensor = normalize(tensor, means, stds)
             return tensor
 
         prognostic_steps = normalize_and_mask(
-            prognostic_steps, self._prognostic_src, self.wet
+            prognostic_steps,
+            self.prognostic_means,
+            self.prognostic_stds,
+            self.wet,
         )
         if boundary_steps is not None:
             boundary_steps = normalize_and_mask(
-                boundary_steps, self._boundary_src, self.wet_surface
+                boundary_steps,
+                self.boundary_means,
+                self.boundary_stds,
+                self.wet_surface,
             )
 
         # Flatten time and variable dimensions
         def flatten_dims(tensor: torch.Tensor) -> torch.Tensor:
-            return rearrange(tensor, "time variable lat lon -> (time variable) lat lon")
+            return rearrange(
+                tensor, "batch time variable lat lon -> batch (time variable) lat lon"
+            )
 
         prognostic_steps = flatten_dims(prognostic_steps)
         if boundary_steps is not None:
             boundary_steps = flatten_dims(boundary_steps)
-            return torch.cat((prognostic_steps, boundary_steps), dim=0)
+            return torch.cat((prognostic_steps, boundary_steps), dim=1)
 
         return prognostic_steps
 
@@ -773,3 +633,65 @@ def concurrent_compute(
             futures.append(executor.submit(load_variable_data, var))
 
     wait(futures)
+
+
+class TrainDataLoader:
+    """Wrapper around a torch DataLoader that handles GPU post-processing.
+
+    This class wraps a DataLoader[RawTrainData] and converts the raw data
+    to TrainData by applying GPU-based normalization and masking. This allows
+    the data loading process to handle I/O while the main process handles
+    GPU operations.
+
+    Since the data samples flow from one process to the other, we want to tie
+    them back to the dataset they came from which knows how to do that second
+    half once they're in the main process which has GPU access set up. To do that,
+    each data sample (which could come from a different dataset) has a dataset ID
+    -- `datasets` maps from those IDs to the original datasets.
+    """
+
+    def __init__(
+        self,
+        dataloader: torch.utils.data.DataLoader[RawTrainData],
+        datasets: dict[TorchTrainDataset.Id, TorchTrainDataset],
+        device: torch.device,
+    ):
+        self._dataloader = dataloader
+        self._datasets = datasets
+        self._device = device
+
+    def __iter__(self):
+        """Iterate over the dataloader, converting RawTrainData to TrainData."""
+        for raw_train_data in self._dataloader:
+            dataset = self._datasets[raw_train_data.dataset_id]
+            train_data = dataset.to_train_data(raw_train_data)
+            yield train_data
+
+    def __len__(self) -> int:
+        return len(self._dataloader)
+
+    def __getitem__(self, index: int) -> TrainData:
+        """Access a single item by index, converting RawTrainData to TrainData.
+
+        Note: This bypasses the DataLoader's sampling/batching and directly accesses
+        the underlying dataset for test purposes.
+        """
+        # Access the underlying dataset directly
+        raw_train_data = self._dataloader.dataset[index]
+        # Apply collate function to add batch dimension (expects a list)
+        collate_fn = self._dataloader.collate_fn
+        if collate_fn is not None:
+            raw_train_data = collate_fn([raw_train_data])
+        # Get the dataset that created this raw data
+        dataset = self._datasets[raw_train_data.dataset_id]
+        # Convert to TrainData
+        train_data = dataset.to_train_data(raw_train_data)
+        return train_data
+
+    @property
+    def dataset(self):
+        return self._dataloader.dataset
+
+    @property
+    def sampler(self):
+        return self._dataloader.sampler

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -731,56 +731,49 @@ class Trainer:
         Args:
             cur_step: Current training step size
         """
-        all_datasets: dict[TorchTrainDataset.Id, TorchTrainDataset] = {}
+        train_datasets = [
+            TorchTrainDataset(
+                src=self.src.slice(self.train_time),
+                prognostic_var_names=self.prognostic_var_names,
+                boundary_var_names=self.boundary_var_names,
+                wet=self.wet_without_hist_cpu,
+                wet_surface=self.wet_surface,
+                hist=self.hist,
+                steps=cur_step,
+                normalize_before_mask=self.normalize_before_mask,
+                masked_fill_value=self.normalize_fill_value,
+                stride=stride,
+                executor=self.executor,
+            )
+            for stride in self.data_stride
+        ]
 
-        def register_dataset(dataset: TorchTrainDataset) -> TorchTrainDataset:
-            assert dataset.id not in all_datasets
-            all_datasets[dataset.id] = dataset
-            return dataset
+        val_datasets = [
+            TorchTrainDataset(
+                src=self.src.slice(self.val_time),
+                prognostic_var_names=self.prognostic_var_names,
+                boundary_var_names=self.boundary_var_names,
+                wet=self.wet_without_hist_cpu,
+                wet_surface=self.wet_surface,
+                hist=self.hist,
+                steps=1,  # current_step set to 1 for validation
+                normalize_before_mask=self.normalize_before_mask,
+                masked_fill_value=self.normalize_fill_value,
+                stride=stride,
+                executor=self.executor,
+            )
+            for stride in self.data_stride
+        ]
 
         # Create datasets
         match self.loader_version:
             case TorchTrainDataset.FLAG:
                 train_data: torch.utils.data.Dataset[RawTrainData] = ConcatDataset(
-                    [
-                        register_dataset(
-                            TorchTrainDataset(
-                                src=self.src.slice(self.train_time),
-                                prognostic_var_names=self.prognostic_var_names,
-                                boundary_var_names=self.boundary_var_names,
-                                wet=self.wet_without_hist_cpu,
-                                wet_surface=self.wet_surface,
-                                hist=self.hist,
-                                steps=cur_step,
-                                normalize_before_mask=self.normalize_before_mask,
-                                masked_fill_value=self.normalize_fill_value,
-                                stride=stride,
-                                executor=self.executor,
-                            )
-                        )
-                        for stride in self.data_stride
-                    ]
+                    train_datasets
                 )
 
                 val_data: torch.utils.data.Dataset[RawTrainData] = ConcatDataset(
-                    [
-                        register_dataset(
-                            TorchTrainDataset(
-                                src=self.src.slice(self.val_time),
-                                prognostic_var_names=self.prognostic_var_names,
-                                boundary_var_names=self.boundary_var_names,
-                                wet=self.wet_without_hist_cpu,
-                                wet_surface=self.wet_surface,
-                                hist=self.hist,
-                                steps=1,  # current_step set to 1 for validation
-                                normalize_before_mask=self.normalize_before_mask,
-                                masked_fill_value=self.normalize_fill_value,
-                                stride=stride,
-                                executor=self.executor,
-                            )
-                        )
-                        for stride in self.data_stride
-                    ]
+                    val_datasets
                 )
 
             case _:
@@ -830,8 +823,10 @@ class Trainer:
         )
 
         # Wrap dataloaders to handle GPU post-processing
-        self.train_loader = TrainDataLoader(train_dataloader, all_datasets, self.device)
-        self.val_loader = TrainDataLoader(val_dataloader, all_datasets, self.device)
+        self.train_loader = TrainDataLoader(
+            train_dataloader, train_datasets, self.device
+        )
+        self.val_loader = TrainDataLoader(val_dataloader, val_datasets, self.device)
 
     def save_all_checkpoints(self, epoch: int, v_loss: float, inf_loss: float):
         with self._test_context():

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -10,7 +10,7 @@ import tempfile
 import time
 import warnings
 from collections import OrderedDict
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from multiprocessing.context import BaseContext
@@ -51,9 +51,10 @@ from ocean_emulators.constants import (
 from ocean_emulators.datasets import (
     InferenceDataset,
     InferenceDatasets,
+    RawTrainData,
     TorchTrainDataset,
     TrainData,
-    TrainDataset,
+    TrainDataLoader,
 )
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.stepper import Stepper, TrainBatchOutput, ValBatchOutput
@@ -89,7 +90,7 @@ from ocean_emulators.utils.loss import (
 from ocean_emulators.utils.train import (
     CheckpointPaths,
     collate_inference_data,
-    collate_train_data,
+    collate_raw_train_data,
 )
 from ocean_emulators.utils.wandb import WandBLogger
 
@@ -379,9 +380,9 @@ class Trainer:
         self.inference_sampler: DistributedSampler | RandomSampler
 
         # Add type annotations for loaders
-        self.train_loader: DataLoader[TrainData]
-        self.val_loader: DataLoader[TrainData]
-        self.inference_loader: DataLoader
+        self.train_loader: TrainDataLoader
+        self.val_loader: TrainDataLoader
+        self.inference_loader: DataLoader[TrainData]
 
     def init_inference_stores(self):
         # Determine number of processes based on device
@@ -523,7 +524,6 @@ class Trainer:
                 break
 
             self.optimizer.zero_grad()
-            data.to(self.device)
 
             if self.num_batches_seen == 0:
                 get_model_summary(self.model, data, self.debug)
@@ -648,7 +648,6 @@ class Trainer:
                 if self.debug and (data_iter_step + 1) % 5 == 0:
                     break
 
-                data.to(self.device)
                 VO: ValBatchOutput = Stepper.validate_batch(
                     self.model, data, self.loss_fn
                 )
@@ -732,78 +731,53 @@ class Trainer:
         Args:
             cur_step: Current training step size
         """
+        all_datasets: dict[TorchTrainDataset.Id, TorchTrainDataset] = {}
+
+        def register_dataset(dataset: TorchTrainDataset) -> TorchTrainDataset:
+            assert dataset.id not in all_datasets
+            all_datasets[dataset.id] = dataset
+            return dataset
+
         # Create datasets
         match self.loader_version:
-            case TrainDataset.FLAG:
-                train_data: ConcatDataset = ConcatDataset(
-                    [
-                        TrainDataset(
-                            src=self.src.slice(self.train_time),
-                            prognostic_var_names=self.prognostic_var_names,
-                            boundary_var_names=self.boundary_var_names,
-                            wet=self.wet_without_hist_cpu,
-                            wet_surface=self.wet_surface,
-                            hist=self.hist,
-                            steps=cur_step,
-                            normalize_before_mask=self.normalize_before_mask,
-                            masked_fill_value=self.normalize_fill_value,
-                            stride=stride,
-                        )
-                        for stride in self.data_stride
-                    ]
-                )
-
-                val_data: ConcatDataset = ConcatDataset(
-                    [
-                        TrainDataset(
-                            src=self.src.slice(self.val_time),
-                            prognostic_var_names=self.prognostic_var_names,
-                            boundary_var_names=self.boundary_var_names,
-                            wet=self.wet_without_hist_cpu,
-                            wet_surface=self.wet_surface,
-                            hist=self.hist,
-                            steps=1,  # current_step set to 1 for validation
-                            normalize_before_mask=self.normalize_before_mask,
-                            masked_fill_value=self.normalize_fill_value,
-                            stride=stride,
-                        )
-                        for stride in self.data_stride
-                    ]
-                )
             case TorchTrainDataset.FLAG:
-                train_data = ConcatDataset(
+                train_data: torch.utils.data.Dataset[RawTrainData] = ConcatDataset(
                     [
-                        TorchTrainDataset(
-                            src=self.src.slice(self.train_time),
-                            prognostic_var_names=self.prognostic_var_names,
-                            boundary_var_names=self.boundary_var_names,
-                            wet=self.wet_without_hist_cpu,
-                            wet_surface=self.wet_surface,
-                            hist=self.hist,
-                            steps=cur_step,
-                            normalize_before_mask=self.normalize_before_mask,
-                            masked_fill_value=self.normalize_fill_value,
-                            stride=stride,
-                            executor=self.executor,
+                        register_dataset(
+                            TorchTrainDataset(
+                                src=self.src.slice(self.train_time),
+                                prognostic_var_names=self.prognostic_var_names,
+                                boundary_var_names=self.boundary_var_names,
+                                wet=self.wet_without_hist_cpu,
+                                wet_surface=self.wet_surface,
+                                hist=self.hist,
+                                steps=cur_step,
+                                normalize_before_mask=self.normalize_before_mask,
+                                masked_fill_value=self.normalize_fill_value,
+                                stride=stride,
+                                executor=self.executor,
+                            )
                         )
                         for stride in self.data_stride
                     ]
                 )
 
-                val_data = ConcatDataset(
+                val_data: torch.utils.data.Dataset[RawTrainData] = ConcatDataset(
                     [
-                        TorchTrainDataset(
-                            src=self.src.slice(self.val_time),
-                            prognostic_var_names=self.prognostic_var_names,
-                            boundary_var_names=self.boundary_var_names,
-                            wet=self.wet_without_hist_cpu,
-                            wet_surface=self.wet_surface,
-                            hist=self.hist,
-                            steps=1,  # current_step set to 1 for validation
-                            normalize_before_mask=self.normalize_before_mask,
-                            masked_fill_value=self.normalize_fill_value,
-                            stride=stride,
-                            executor=self.executor,
+                        register_dataset(
+                            TorchTrainDataset(
+                                src=self.src.slice(self.val_time),
+                                prognostic_var_names=self.prognostic_var_names,
+                                boundary_var_names=self.boundary_var_names,
+                                wet=self.wet_without_hist_cpu,
+                                wet_surface=self.wet_surface,
+                                hist=self.hist,
+                                steps=1,  # current_step set to 1 for validation
+                                normalize_before_mask=self.normalize_before_mask,
+                                masked_fill_value=self.normalize_fill_value,
+                                stride=stride,
+                                executor=self.executor,
+                            )
                         )
                         for stride in self.data_stride
                     ]
@@ -820,14 +794,12 @@ class Trainer:
             self.train_sampler = DistributedSampler(train_data, shuffle=True)
             self.val_sampler = DistributedSampler(val_data, shuffle=False)
         else:
-            self.train_sampler = RandomSampler(train_data)
-            self.val_sampler = RandomSampler(val_data)
+            self.train_sampler = RandomSampler(train_data)  # type: ignore
+            self.val_sampler = RandomSampler(val_data)  # type: ignore
 
         match self.loader_version:
-            case TrainDataset.FLAG:
-                collate_fn: Callable[[Sequence[Any]], TrainData] = collate_train_data
             case TorchTrainDataset.FLAG:
-                collate_fn = collate_train_data
+                collate_fn = collate_raw_train_data
             case _:
                 raise NotImplementedError(
                     f"Collate function not defined for loader version "
@@ -835,7 +807,7 @@ class Trainer:
                 )
 
         # Create data loaders
-        self.train_loader = DataLoader(
+        train_dataloader = DataLoader(
             train_data,
             batch_size=self.batch_size,
             sampler=self.train_sampler,
@@ -846,7 +818,7 @@ class Trainer:
             multiprocessing_context=self.mp_context,
         )
 
-        self.val_loader = DataLoader(
+        val_dataloader = DataLoader(
             val_data,
             batch_size=self.batch_size,
             sampler=self.val_sampler,
@@ -856,6 +828,10 @@ class Trainer:
             collate_fn=collate_fn,
             multiprocessing_context=self.mp_context,
         )
+
+        # Wrap dataloaders to handle GPU post-processing
+        self.train_loader = TrainDataLoader(train_dataloader, all_datasets, self.device)
+        self.val_loader = TrainDataLoader(val_dataloader, all_datasets, self.device)
 
     def save_all_checkpoints(self, epoch: int, v_loss: float, inf_loss: float):
         with self._test_context():

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -162,6 +162,7 @@ class DataSource:
         data = self.data.sel(time=time.time_slice)
         return dataclasses.replace(self, name=f"{time=}[{self.name}]", data=data)
 
+    # TODO(jder): delete this once we've de-duplicated InferenceDataset with TorchTrainDataset
     def normalize(self, fill_nan=True, fill_value=0.0) -> xr.Dataset:
         """Normalize input data."""
         norm = (self.data - self.means) / self.stds
@@ -169,6 +170,7 @@ class DataSource:
             norm = norm.fillna(fill_value)
         return norm
 
+    # TODO(jder): delete this once we've de-duplicated InferenceDataset with TorchTrainDataset
     def normalize_with(
         self,
         data: torch.Tensor,

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -7,19 +7,17 @@ import time
 import traceback
 import warnings
 from collections import defaultdict, deque
-from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
-from torch.utils.data import DataLoader
 from torchinfo import summary
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ocean_emulators.datasets import TrainData
+    from ocean_emulators.datasets import TrainDataLoader
 
 
 def handle_logging(debug: bool, output_dir: Path):
@@ -152,7 +150,12 @@ class MetricLogger:
     def add_meter(self, name, meter):
         self.meters[name] = meter
 
-    def log_every(self, data_loader: DataLoader["TrainData"], print_freq, header=None):
+    def log_every(
+        self,
+        data_loader: "TrainDataLoader",
+        print_freq,
+        header=None,
+    ):
         i = 0
         if not header:
             header = ""
@@ -212,7 +215,7 @@ class MetricLogger:
         )
 
 
-def get_model_summary(model: torch.nn.Module, data: Mapping | None, debug: bool):
+def get_model_summary(model: torch.nn.Module, data: Any, debug: bool):
     model_parameters = filter(lambda p: p.requires_grad, model.parameters())
     params = sum([np.prod(p.size()) for p in model_parameters])
     logger.info(f"Number of parameters: {params}")

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import torch
 from xarray_einstats.einops import rearrange  # noqa: F401
 
-from ocean_emulators.datasets import InferenceDataset, TrainData
+from ocean_emulators.datasets import InferenceDataset, RawTrainData
 from ocean_emulators.utils.data import LoadStats
 
 
@@ -16,21 +16,22 @@ def pairwise(iterable):
     return zip(a, b)
 
 
-def collate_train_data(data: Sequence[TrainData]) -> TrainData:
-    num_prognostic_channels = data[0].num_prognostic_channels
-    steps = len(data[0])
+def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
+    batched_data = RawTrainData(data[0].dataset_id)
+    assert all(d.dataset_id == batched_data.dataset_id for d in data), (
+        "we don't support heterogenous batches yet"
+    )
 
-    batched_data = TrainData(num_prognostic_channels)
+    steps = len(data[0].raw_data)
+    for step in range(steps):
+        all_prognostic = torch.stack([d.raw_data[step][0] for d in data])
+        all_boundary = torch.stack([d.raw_data[step][1] for d in data])
+        batched_data.insert(all_prognostic, all_boundary)
 
     stats = LoadStats.accumulated(
         [d.load_stats for d in data if d.load_stats is not None]
     )
     batched_data.load_stats = stats
-
-    for step in range(steps):
-        input = torch.stack([d.get_input(step) for d in data])
-        label = torch.stack([d.get_label(step) for d in data])
-        batched_data.insert(input, label)
 
     return batched_data
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,7 +3,7 @@
 import contextlib
 import dataclasses
 import datetime
-from collections.abc import Callable, Generator
+from collections.abc import Generator
 
 import cftime
 import numpy as np
@@ -27,11 +27,11 @@ from ocean_emulators.datasets import (
     InferenceDataset,
     TorchTrainDataset,
     TrainData,
-    TrainDataset,
+    TrainDataLoader,
 )
 from ocean_emulators.utils.data import DataSource, Normalize, extract_wet_mask
 from ocean_emulators.utils.multiton import MultitonScope
-from ocean_emulators.utils.train import collate_train_data
+from ocean_emulators.utils.train import collate_raw_train_data
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
 
 
@@ -47,7 +47,7 @@ def make_loader(
     time_config: TimeConfig | None = None,
     drop_last: bool = True,
     version: LoaderVersion | None = None,
-) -> Generator[DataLoader, None, None]:
+) -> Generator[DataLoader | TrainDataLoader, None, None]:
     if time_config is None:
         time_config = cfg.train_time
 
@@ -76,55 +76,39 @@ def make_loader(
         masked_fill_value = cfg.data.masked_fill_value
 
         match version:
-            case LoaderVersion.OM4_EAGER:
-                data: ConcatDataset | InferenceDataset = ConcatDataset(
-                    [
-                        TrainDataset(
-                            src=src.slice(time_config),
-                            prognostic_var_names=prognostic,
-                            boundary_var_names=boundary,
-                            wet=wet_without_hist,
-                            wet_surface=wet_surface,
-                            hist=cfg.data.hist,
-                            steps=cfg.steps[0],
-                            normalize_before_mask=normalize_before_mask,
-                            masked_fill_value=masked_fill_value,
-                            stride=stride,
-                        )
-                        for stride in cfg.data_stride
-                    ]
-                )
-                collate_fn: Callable = collate_train_data
             case LoaderVersion.OM4_TORCH:
-                data = ConcatDataset(
-                    [
-                        TorchTrainDataset(
-                            src=src.slice(time_config),
-                            prognostic_var_names=prognostic,
-                            boundary_var_names=boundary,
-                            wet=wet_without_hist,
-                            wet_surface=wet_surface,
-                            hist=cfg.data.hist,
-                            steps=cfg.steps[0],
-                            normalize_before_mask=normalize_before_mask,
-                            masked_fill_value=masked_fill_value,
-                            stride=stride,
-                        )
-                        for stride in cfg.data_stride
-                    ]
+                datasets: dict[str, TorchTrainDataset] = {}
+                dataset_list = []
+                for stride in cfg.data_stride:
+                    dataset = TorchTrainDataset(
+                        src=src.slice(time_config),
+                        prognostic_var_names=prognostic,
+                        boundary_var_names=boundary,
+                        wet=wet_without_hist,
+                        wet_surface=wet_surface,
+                        hist=cfg.data.hist,
+                        steps=cfg.steps[0],
+                        normalize_before_mask=normalize_before_mask,
+                        masked_fill_value=masked_fill_value,
+                        stride=stride,
+                    )
+                    datasets[dataset.id] = dataset
+                    dataset_list.append(dataset)
+
+                data: ConcatDataset = ConcatDataset(dataset_list)
+                collate_fn = collate_raw_train_data
+
+                raw_loader = DataLoader(
+                    data,
+                    batch_size=cfg.batch_size,
+                    drop_last=drop_last,
+                    collate_fn=collate_fn,
                 )
-                collate_fn = collate_train_data
+
+                loader = TrainDataLoader(raw_loader, datasets, torch.device("cpu"))
+                yield loader
             case _:
                 raise ValueError(f"Unknown loader version: {version}")
-
-        loader = DataLoader(
-            data,
-            batch_size=cfg.batch_size,
-            drop_last=drop_last,
-            collate_fn=collate_fn,
-        )
-
-        yield loader
 
 
 def extract_sample_arrays(td: TrainData) -> tuple[np.ndarray, np.ndarray]:
@@ -355,9 +339,6 @@ def test_inference__data_is_not_zero(inference_loader_pair):
             )
 
 
-ORIGINAL_LOADER_VERSION = LoaderVersion.OM4_EAGER
-
-
 def assert_equal_samples(original_samples, new_samples):
     for (x_orig, y_orig), (x_new, y_new) in zip(original_samples, new_samples):
         assert x_orig.dtype == x_new.dtype, "Input data types do not match."
@@ -377,19 +358,6 @@ def assert_equal_samples(original_samples, new_samples):
             f"{len(y_not_equal_index)} values differ: "
             f"{y_orig[y_not_equal_index]} != {y_new[y_not_equal_index]}."
         )
-
-
-@pytest.mark.parametrize(
-    "loader_version", [v for v in LoaderVersion if v != ORIGINAL_LOADER_VERSION]
-)
-@pytest.mark.parametrize("data_source", ["mock"], indirect=True)
-def test_new_loaders__are_equal_to_v1_data_loader(train_config, loader_version):
-    with make_loader(train_config, version=ORIGINAL_LOADER_VERSION) as original_loader:
-        original_samples = [extract_sample_arrays(sample) for sample in original_loader]
-    with make_loader(train_config, version=loader_version) as new_loader:
-        new_samples = [extract_sample_arrays(sample) for sample in new_loader]
-
-    assert_equal_samples(original_samples, new_samples)
 
 
 # Warning: the names/constants used in this test are catered to the implementation
@@ -487,18 +455,6 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
             wet_mask=wet,
             wet_mask_surface=wet_surface,
         )
-        traindataset = TrainDataset(
-            src=test,
-            prognostic_var_names=prognostic_var_names,
-            boundary_var_names=boundary_var_names,
-            wet=wet,
-            wet_surface=wet_surface,
-            hist=1,
-            steps=2,
-            normalize_before_mask=normalize_before_mask,
-            masked_fill_value=masked_fill_value,
-            stride=1,
-        )
         torch_train_dataset = TorchTrainDataset(
             src=test,
             prognostic_var_names=prognostic_var_names,
@@ -522,7 +478,17 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
             masked_fill_value=masked_fill_value,
             long_rollout=True,
         )
-        yield traindataset, torch_train_dataset, inference_dataset
+
+        # Create a TrainDataLoader wrapper
+        datasets = {torch_train_dataset.id: torch_train_dataset}
+        raw_loader = DataLoader(
+            torch_train_dataset,
+            batch_size=1,
+            collate_fn=collate_raw_train_data,
+        )
+        train_loader = TrainDataLoader(raw_loader, datasets, torch.device("cpu"))
+
+        yield train_loader, inference_dataset
 
 
 @pytest.mark.parametrize("normalize_before_mask", [True, False])
@@ -530,16 +496,16 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
 def test_train_dataset_no_input_change(
     tiny_dataset_input, normalize_before_mask, masked_fill_value
 ):
-    traindataset, torch_train_dataset, _ = tiny_dataset_input
-    for dataset in [traindataset, torch_train_dataset]:
-        td = collate_train_data([dataset[0], dataset[1], dataset[2]])
-        pred = torch.randn_like(td.get_label(0)) * 0.1
+    train_loader, _ = tiny_dataset_input
+    td = train_loader[0]
+    pred = torch.randn_like(td.get_label(0)) * 0.1
 
-        inp1 = td.get_input(1).clone()
-        td.merge_prognostic_and_boundary(pred, 1)
+    inp1 = td.get_input(1).clone()
+    td.merge_prognostic_and_boundary(pred, 1)
 
-        td_new = collate_train_data([dataset[0], dataset[1], dataset[2]])
-        assert torch.equal(td_new.get_input(1), inp1)
+    # Get a fresh copy from the loader
+    td_new = train_loader[0]
+    assert torch.equal(td_new.get_input(1), inp1)
 
 
 @pytest.mark.parametrize("normalize_before_mask", [True, False])
@@ -547,30 +513,29 @@ def test_train_dataset_no_input_change(
 def test_train_dataset_normalize_pre_fill(
     tiny_dataset_input, normalize_before_mask, masked_fill_value
 ):
-    traindataset, torch_train_dataset, inference_dataset = tiny_dataset_input
-    for dataset in [traindataset, torch_train_dataset]:
-        td0 = dataset[0]
-        data = masked_fill_value
+    train_loader, inference_dataset = tiny_dataset_input
+    td0 = train_loader[0]
+    data = masked_fill_value
 
-        td0_step0_input = td0.get_input(0)
-        td0_step0_label = td0.get_label(0)
-        inf_step0_input, inf_step0_label = inference_dataset[0]
+    td0_step0_input = td0.get_input(0)
+    td0_step0_label = td0.get_label(0)
+    inf_step0_input, inf_step0_label = inference_dataset[0]
 
-        assert td0_step0_input.shape == (8, 2, 2)
-        assert td0_step0_label.shape == (4, 2, 2)
-        assert inf_step0_input.shape == (1, 8, 2, 2)
-        assert inf_step0_label.shape == (1, 4, 2, 2)
+    assert td0_step0_input.shape == (1, 8, 2, 2)
+    assert td0_step0_label.shape == (1, 4, 2, 2)
+    assert inf_step0_input.shape == (1, 8, 2, 2)
+    assert inf_step0_label.shape == (1, 4, 2, 2)
 
-        # We expect [0,0,0] to be masked
-        if normalize_before_mask:
-            assert td0.get_input(0)[0, 0, 0] == data
-            assert inference_dataset[0][0][0][0, 0, 0] == data
-        else:
-            mean = 0.5
-            std = 1.0
-            data = (data - mean) / std
-            assert td0.get_input(0)[0, 0, 0] == data
-            assert inference_dataset[0][0][0][0, 0, 0] == data
+    # We expect [0,0,0] to be masked
+    if normalize_before_mask:
+        assert td0.get_input(0)[0, 0, 0, 0] == data
+        assert inference_dataset[0][0][0][0, 0, 0] == data
+    else:
+        mean = 0.5
+        std = 1.0
+        data = (data - mean) / std
+        assert td0.get_input(0)[0, 0, 0, 0] == data
+        assert inference_dataset[0][0][0][0, 0, 0] == data
 
 
 @pytest.mark.manual

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -77,10 +77,8 @@ def make_loader(
 
         match version:
             case LoaderVersion.OM4_TORCH:
-                datasets: dict[str, TorchTrainDataset] = {}
-                dataset_list = []
-                for stride in cfg.data_stride:
-                    dataset = TorchTrainDataset(
+                dataset_list = [
+                    TorchTrainDataset(
                         src=src.slice(time_config),
                         prognostic_var_names=prognostic,
                         boundary_var_names=boundary,
@@ -92,8 +90,8 @@ def make_loader(
                         masked_fill_value=masked_fill_value,
                         stride=stride,
                     )
-                    datasets[dataset.id] = dataset
-                    dataset_list.append(dataset)
+                    for stride in cfg.data_stride
+                ]
 
                 data: ConcatDataset = ConcatDataset(dataset_list)
                 collate_fn = collate_raw_train_data
@@ -105,7 +103,7 @@ def make_loader(
                     collate_fn=collate_fn,
                 )
 
-                loader = TrainDataLoader(raw_loader, datasets, torch.device("cpu"))
+                loader = TrainDataLoader(raw_loader, dataset_list, torch.device("cpu"))
                 yield loader
             case _:
                 raise ValueError(f"Unknown loader version: {version}")
@@ -480,13 +478,14 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
         )
 
         # Create a TrainDataLoader wrapper
-        datasets = {torch_train_dataset.id: torch_train_dataset}
         raw_loader = DataLoader(
             torch_train_dataset,
             batch_size=1,
             collate_fn=collate_raw_train_data,
         )
-        train_loader = TrainDataLoader(raw_loader, datasets, torch.device("cpu"))
+        train_loader = TrainDataLoader(
+            raw_loader, [torch_train_dataset], torch.device("cpu")
+        )
 
         yield train_loader, inference_dataset
 


### PR DESCRIPTION
We were spending a ton of CPU time doing normalization, which was causing all kinds of bad knock-on performance effects due to (a) not having CPU time for the main process and (b) data loaders not keeping up with the GPU since they were busy doing math. 

This wraps the torch DataLoader with a new class which knows how to do some post-processing on the GPU before handing off the data. This keeps the I/O and xarray/zarr/etc python overhead in separate processes but lets us do the normalization on the main process on the GPU. Experiments on half-degree data shows this cuts train iteration time significantly.

To avoid having multiple paths here, this also deletes the old "eager" data loader. I'd also like to delete the inference data loader to reduce duplication caused by it but figured it could be a follow-up. 

Closes #412 and #403 