### PR TITLE
CRPS loss draft branch

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -45,18 +45,6 @@ class WandBConfig(BaseConfig):
     notes: str | None = None
 
 
-class CRPSConfig(BaseConfig):
-    """Configuration for CRPS (Continuous Ranked Probability Score) loss."""
-
-    type: Literal["afcrps", "fair", "plain"] = "afcrps"
-    alpha: float = Field(
-        default=0.95,
-        ge=0.0,
-        le=1.0,
-        description="Threshold parameter for almost-fair CRPS (afcrps)",
-    )
-
-
 class JulianDate:
     """Represents a Julian date as a cftime.datetime at noon on the relevant day.
 
@@ -694,15 +682,11 @@ class TrainConfig(TopLevelConfig):
     ensemble_size_train: int = Field(
         default=1,
         ge=1,
-        description="Number of ensemble members to generate per sample during training",
+        description="Number of ensemble members to generate per sample during training. If > 1, uses CRPS loss.",
     )
     seed_per_member: bool = Field(
         default=False,
         description="Whether to fix the random seed per ensemble member across rollout steps",
-    )
-    crps: CRPSConfig | None = Field(
-        default=None,
-        description="CRPS loss configuration. If None, uses standard loss specified in 'loss' field",
     )
 
     # Profiling parameters

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -45,6 +45,18 @@ class WandBConfig(BaseConfig):
     notes: str | None = None
 
 
+class CRPSConfig(BaseConfig):
+    """Configuration for CRPS (Continuous Ranked Probability Score) loss."""
+
+    type: Literal["afcrps", "fair", "plain"] = "afcrps"
+    alpha: float = Field(
+        default=0.95,
+        ge=0.0,
+        le=1.0,
+        description="Threshold parameter for almost-fair CRPS (afcrps)",
+    )
+
+
 class JulianDate:
     """Represents a Julian date as a cftime.datetime at noon on the relevant day.
 
@@ -492,6 +504,22 @@ class SamudraConfig(BaseModelConfig):
         description="""Number of channels used for a learned positional embedding""",
     )
 
+    # Noise conditioning for ensemble generation
+    noise_mode: Literal["film", "concat"] | None = Field(
+        default=None,
+        description="How to condition on noise: 'film' for FiLM modulation, 'concat' for channel concatenation, None for deterministic",
+    )
+    noise_channels: int = Field(
+        default=4,
+        ge=1,
+        description="Number of noise channels to use for conditioning",
+    )
+    film_cond_dim: int = Field(
+        default=128,
+        ge=1,
+        description="Dimension of the conditioning vector for FiLM layers",
+    )
+
     def build(
         self,
         in_channels: int,
@@ -650,6 +678,21 @@ class TrainConfig(TopLevelConfig):
     ema_decay: float = 0.999
     faster_decay_at_start: bool = True
     backend: TrainBackendConfig = "auto"
+
+    # Ensemble training parameters
+    ensemble_size_train: int = Field(
+        default=1,
+        ge=1,
+        description="Number of ensemble members to generate per sample during training",
+    )
+    seed_per_member: bool = Field(
+        default=False,
+        description="Whether to fix the random seed per ensemble member across rollout steps",
+    )
+    crps: CRPSConfig | None = Field(
+        default=None,
+        description="CRPS loss configuration. If None, uses standard loss specified in 'loss' field",
+    )
 
     # Profiling parameters
     profiler: ProfilerConfig = ProfilerConfig()

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -483,6 +483,22 @@ class BaseModelConfig(BaseConfig, abc.ABC):
         description="""Interval for detaching gradients in autoregressive training. `0` means no detaching.""",
     )
 
+    # Noise conditioning for ensemble generation (shared by Samudra and FOMO)
+    noise_mode: Literal["conditional_norm"] | None = Field(
+        default=None,
+        description="How to condition on noise: 'conditional_norm' uses noise embeddings in conditional layer norms (AIFS approach), None for deterministic",
+    )
+    noise_channels: int = Field(
+        default=4,
+        ge=1,
+        description="Number of noise channels to use for conditioning",
+    )
+    noise_embed_dim: int = Field(
+        default=128,
+        ge=1,
+        description="Dimension of the noise conditioning embeddings",
+    )
+
     @abc.abstractmethod
     def build(
         self,
@@ -504,22 +520,6 @@ class SamudraConfig(BaseModelConfig):
         description="""Number of channels used for a learned positional embedding""",
     )
 
-    # Noise conditioning for ensemble generation
-    noise_mode: Literal["film", "concat"] | None = Field(
-        default=None,
-        description="How to condition on noise: 'film' for FiLM modulation, 'concat' for channel concatenation, None for deterministic",
-    )
-    noise_channels: int = Field(
-        default=4,
-        ge=1,
-        description="Number of noise channels to use for conditioning",
-    )
-    film_cond_dim: int = Field(
-        default=128,
-        ge=1,
-        description="Dimension of the conditioning vector for FiLM layers",
-    )
-
     def build(
         self,
         in_channels: int,
@@ -533,6 +533,15 @@ class SamudraConfig(BaseModelConfig):
         if self.corrector is not None:
             corrector = self.corrector.build(hist, area_weights, static_data)
         total_in_channels = in_channels + self.pos_channels
+
+        # Pass noise parameters if noise conditioning is enabled
+        noise_channels = (
+            self.noise_channels if self.noise_mode == "conditional_norm" else None
+        )
+        noise_embed_dim = (
+            self.noise_embed_dim if self.noise_mode == "conditional_norm" else None
+        )
+
         return Samudra(
             in_channels=total_in_channels,
             out_channels=out_channels,
@@ -550,6 +559,8 @@ class SamudraConfig(BaseModelConfig):
             wet=wet,
             static_data=static_data,
             gradient_detach_interval=self.gradient_detach_interval,
+            noise_channels=noise_channels,
+            noise_embed_dim=noise_embed_dim,
         )
 
 

--- a/src/ocean_emulators/models/modules/__init__.py
+++ b/src/ocean_emulators/models/modules/__init__.py
@@ -12,6 +12,7 @@ from .blocks import (
     ZonallyPeriodicBilinearUpsample,
 )
 from .encoder import PerceiverEncoder
+from .noise_conditioning import ConditionalBatchNorm2d, NoiseMLP
 from .unet_backbone import UNetBackbone
 
 __all__ = [
@@ -28,4 +29,6 @@ __all__ = [
     "PerceiverEncoder",
     "ReLU",
     "UNetBackbone",
+    "NoiseMLP",
+    "ConditionalBatchNorm2d",
 ]

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 import torch.utils.checkpoint
 
 from ocean_emulators.models.modules.activations import CappedGELU
+from ocean_emulators.models.modules.noise_conditioning import ConditionalBatchNorm2d
 
 
 class TransposedConvUpsample(torch.nn.Module):
@@ -191,6 +192,8 @@ class ConvNeXtBlock(CoreBlock):
     This is a modified version of the actual ConvNextblock which is used in the HealPix
     paper. Use of dilations here.
 
+    Supports optional conditional normalization via noise embeddings (cond_dim parameter).
+
     """
 
     def __init__(
@@ -204,10 +207,13 @@ class ConvNeXtBlock(CoreBlock):
         pad="circular",
         upscale_factor: int = 4,
         norm="batch",
+        cond_dim: int | None = None,
         checkpoint_simple: bool = False,
     ):
         super().__init__(in_channels, out_channels, kernel_size, dilation, pad)
         assert n_layers == 1, "Can only use a single layer here!"
+
+        self.use_conditional_norm = cond_dim is not None
 
         # Instantiate 1x1 conv to increase/decrease channel depth if necessary
         if in_channels == out_channels:
@@ -232,7 +238,13 @@ class ConvNeXtBlock(CoreBlock):
         )
         # BatchNorm
         if norm == "batch":
-            convblock.append(torch.nn.BatchNorm2d(in_channels * upscale_factor))
+            if self.use_conditional_norm:
+                assert cond_dim is not None, "cond_dim must be set for conditional norm"
+                convblock.append(
+                    ConditionalBatchNorm2d(in_channels * upscale_factor, cond_dim)
+                )
+            else:
+                convblock.append(torch.nn.BatchNorm2d(in_channels * upscale_factor))
         # Instance Norm
         elif norm == "instance":
             convblock.append(torch.nn.InstanceNorm2d(in_channels * upscale_factor))
@@ -240,8 +252,10 @@ class ConvNeXtBlock(CoreBlock):
             pass
         else:
             raise NotImplementedError
+
         if activation is not None:
             convblock.append(activation())
+
         convblock.append(
             torch.nn.Conv2d(
                 in_channels=int(in_channels * upscale_factor),
@@ -252,7 +266,13 @@ class ConvNeXtBlock(CoreBlock):
         )
         # BatchNorm
         if norm == "batch":
-            convblock.append(torch.nn.BatchNorm2d(in_channels * upscale_factor))
+            if self.use_conditional_norm:
+                assert cond_dim is not None, "cond_dim must be set for conditional norm"
+                convblock.append(
+                    ConditionalBatchNorm2d(in_channels * upscale_factor, cond_dim)
+                )
+            else:
+                convblock.append(torch.nn.BatchNorm2d(in_channels * upscale_factor))
         # Instance Norm
         elif norm == "instance":
             convblock.append(torch.nn.InstanceNorm2d(in_channels * upscale_factor))
@@ -260,8 +280,10 @@ class ConvNeXtBlock(CoreBlock):
             pass
         else:
             raise NotImplementedError
+
         if activation is not None:
             convblock.append(activation())
+
         # Linear postprocessing
         convblock.append(
             torch.nn.Conv2d(
@@ -271,12 +293,42 @@ class ConvNeXtBlock(CoreBlock):
                 padding="same",
             )
         )
-        self.convblock = torch.nn.Sequential(*convblock)
+
+        # Use ModuleList if conditional, Sequential otherwise for backward compatibility
+        if self.use_conditional_norm:
+            self.convblock: nn.ModuleList | nn.Sequential = torch.nn.ModuleList(
+                convblock
+            )
+        else:
+            self.convblock = torch.nn.Sequential(*convblock)
+
         self.checkpoint_simple = checkpoint_simple
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # return self.skip_module(x) + self.convblock(x)
+    def forward(
+        self, x: torch.Tensor, cond: torch.Tensor | None = None
+    ) -> torch.Tensor:
         skip = self.skip_module(x)
+
+        # non conditional path using nn.sequential
+        if not self.use_conditional_norm:
+            for layer in self.convblock:
+                if isinstance(layer, nn.Conv2d) and layer.kernel_size[0] != 1:
+                    x = torch.nn.functional.pad(
+                        x, (self.N_pad, self.N_pad, 0, 0), mode=self.pad
+                    )
+                    x = torch.nn.functional.pad(
+                        x, (0, 0, self.N_pad, self.N_pad), mode="constant"
+                    )
+                if self.checkpoint_simple and not isinstance(layer, nn.Conv2d):
+                    x = torch.utils.checkpoint.checkpoint(layer, x, use_reentrant=False)
+                else:
+                    x = layer(x)
+            return skip + x
+
+        # Conditional path
+        if cond is None:
+            raise ValueError("Conditioning vector required when cond_dim is set")
+
         for layer in self.convblock:
             if isinstance(layer, nn.Conv2d) and layer.kernel_size[0] != 1:
                 x = torch.nn.functional.pad(
@@ -285,10 +337,23 @@ class ConvNeXtBlock(CoreBlock):
                 x = torch.nn.functional.pad(
                     x, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
-            if self.checkpoint_simple and not isinstance(layer, nn.Conv2d):
-                x = torch.utils.checkpoint.checkpoint(layer, x, use_reentrant=False)
+
+            # Apply layer with conditioning for conditional norms
+            if hasattr(layer, "noise_projection"):  # Check if it's a conditional norm
+                # checkpointing for conditional norm layers
+                if self.checkpoint_simple:
+                    x = torch.utils.checkpoint.checkpoint(
+                        layer, x, cond, use_reentrant=False
+                    )
+                else:
+                    x = layer(x, cond)
             else:
-                x = layer(x)
+                # Regular layer (Conv2d, activation)
+                if self.checkpoint_simple and not isinstance(layer, nn.Conv2d):
+                    x = torch.utils.checkpoint.checkpoint(layer, x, use_reentrant=False)
+                else:
+                    x = layer(x)
+
         return skip + x
 
 

--- a/src/ocean_emulators/models/modules/noise_conditioning.py
+++ b/src/ocean_emulators/models/modules/noise_conditioning.py
@@ -1,0 +1,162 @@
+import torch
+import torch.nn as nn
+
+
+class NoiseMLP(nn.Module):
+    """Two-layer perceptron that processes Gaussian noise into conditioning embeddings.
+
+    Processes independent Gaussian noise samples ξ ~ N(0, I_n) where n equals the number
+    of grid points times the number of noise channels, as described in the AIFS paper.
+
+    Architecture: noise → Linear → GELU → Linear → LayerNorm → embeddings
+
+    These embeddings are used in conditional layer normalizations throughout the network.
+
+    Args:
+        noise_channels: Number of input noise channels per grid point
+        hidden_dim: Hidden dimension of the MLP
+        output_dim: Output dimension (conditioning embedding size)
+        noise_shape: Tuple of (height, width) matching the model's processor grid resolution
+    """
+
+    def __init__(
+        self,
+        noise_channels: int,
+        hidden_dim: int,
+        output_dim: int,
+        noise_shape: tuple[int, int],
+    ):
+        super().__init__()
+        self.noise_channels = noise_channels
+        self.noise_shape = noise_shape
+
+        # Input size is noise_channels * num_noise_grid_points
+        input_size = noise_channels * noise_shape[0] * noise_shape[1]
+
+        # Two-layer MLP
+        self.mlp = nn.Sequential(
+            nn.Linear(input_size, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, output_dim),
+        )
+
+        # Layer normalization on the output
+        self.layer_norm = nn.LayerNorm(output_dim)
+
+    def generate_noise(
+        self,
+        batch_size: int,
+        device: torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> torch.Tensor:
+        """Generate independent Gaussian noise samples ξ ~ N(0, I_n).
+
+        For each model instance and forecast step, we generate independent Gaussian noise
+        where n = noise_channels × noise_height × noise_width.
+
+        Args:
+            batch_size: Number of samples in the batch (or ensemble size)
+            device: Device to generate noise on
+            dtype: Data type for the noise tensor
+
+        Returns:
+            Noise tensor of shape (batch_size, noise_channels, height, width)
+        """
+        return torch.randn(
+            batch_size,
+            self.noise_channels,
+            self.noise_shape[0],
+            self.noise_shape[1],
+            device=device,
+            dtype=dtype,
+        )
+
+    def forward(self, noise: torch.Tensor) -> torch.Tensor:
+        """Process noise into conditioning embeddings.
+
+        Args:
+            noise: Tensor of shape (batch, noise_channels, height, width)
+                   where (height, width) must match noise_shape from __init__
+
+        Returns:
+            conditioning: Tensor of shape (batch, output_dim)
+        """
+        batch_size = noise.shape[0]
+
+        # Validate noise shape matches expected
+        expected_shape = (
+            batch_size,
+            self.noise_channels,
+            self.noise_shape[0],
+            self.noise_shape[1],
+        )
+        if noise.shape != expected_shape:
+            raise ValueError(
+                f"Noise shape {noise.shape} doesn't match expected {expected_shape}. "
+                f"NoiseMLP was initialized with noise_shape={self.noise_shape}, but received "
+                f"noise with spatial dims {noise.shape[2:]}."
+            )
+
+        # Flatten spatial dimensions: (B, C, H, W) -> (B, C*H*W)
+        noise_flat = noise.reshape(batch_size, -1)
+
+        # Apply MLP
+        embedding = self.mlp(noise_flat)
+
+        # Apply layer normalization
+        conditioning = self.layer_norm(embedding)
+
+        return conditioning
+
+
+class ConditionalBatchNorm2d(nn.Module):
+    """Conditional Batch Normalization modulated by noise embeddings.
+
+    Replaces standard BatchNorm with conditional normalization where:
+    - The normalized features are scaled by (1 + gamma) and shifted by beta
+    - gamma and beta are learned functions of the noise conditioning embeddings
+
+    Args:
+        num_features: Number of channels
+        cond_dim: Dimension of the noise conditioning embeddings
+    """
+
+    def __init__(self, num_features: int, cond_dim: int):
+        super().__init__()
+        self.num_features = num_features
+
+        # Standard batch normalization (without learnable affine parameters)
+        self.bn = nn.BatchNorm2d(num_features, affine=False)
+
+        # Learned projection from noise embeddings to scale/shift parameters
+        self.noise_projection = nn.Linear(cond_dim, 2 * num_features)
+
+        # Initialize projection to output zeros (initially behaves like regular BN)
+        nn.init.zeros_(self.noise_projection.weight)
+        nn.init.zeros_(self.noise_projection.bias)
+
+    def forward(self, x: torch.Tensor, cond: torch.Tensor) -> torch.Tensor:
+        """Apply conditional batch normalization.
+
+        Args:
+            x: Input tensor of shape (batch, channels, height, width)
+            cond: Noise conditioning embeddings of shape (batch, cond_dim)
+
+        Returns:
+            modulated: Tensor of same shape as x
+        """
+        # Apply standard batch normalization (without affine transform)
+        normalized = self.bn(x)
+
+        # Project noise embeddings to scale and shift parameters
+        params = self.noise_projection(cond)  # (B, 2*C)
+        gamma, beta = torch.chunk(params, 2, dim=1)  # Each (B, C)
+
+        # Reshape to broadcast over spatial dimensions: (B, C) -> (B, C, 1, 1)
+        gamma = gamma.unsqueeze(-1).unsqueeze(-1)
+        beta = beta.unsqueeze(-1).unsqueeze(-1)
+
+        # Apply conditional modulation: out = (1 + gamma) * normalized + beta
+        modulated = (1 + gamma) * normalized + beta
+
+        return modulated

--- a/src/ocean_emulators/models/modules/unet_backbone.py
+++ b/src/ocean_emulators/models/modules/unet_backbone.py
@@ -6,6 +6,7 @@ from torch import nn
 
 from ocean_emulators.models.modules.blocks import (
     BilinearUpsample,
+    ConvNeXtBlock,
     CoreBlock,
     CoreBlockBuilder,
     TransposedConvUpsample,
@@ -146,7 +147,9 @@ class UNetBackbone(nn.Module):
         self.layers = nn.ModuleList(layers)
         self.num_steps = int(len(ch_width) - 1)
 
-    def forward(self, fts: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, fts: torch.Tensor, cond: torch.Tensor | None = None
+    ) -> torch.Tensor:
         skip_inputs: list[torch.Tensor] = []
         for i in range(self.num_steps):
             skip_inputs.append(torch.zeros_like(fts))
@@ -161,11 +164,29 @@ class UNetBackbone(nn.Module):
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
 
+            # Apply layer with conditioning if available and needed
+            # not sure if this is a good idea
             # (Maybe) apply checkpointing
-            if self.checkpoint_all:
-                fts = torch.utils.checkpoint.checkpoint(layer, fts, use_reentrant=False)  # type: ignore
+            if (
+                cond is not None
+                and isinstance(layer, ConvNeXtBlock)
+                and layer.use_conditional_norm
+            ):
+                # ConvNeXt block with conditional norms - pass conditioning
+                if self.checkpoint_all:
+                    fts = torch.utils.checkpoint.checkpoint(
+                        layer, fts, cond, use_reentrant=False
+                    )
+                else:
+                    fts = layer(fts, cond)
             else:
-                fts = layer(fts)
+                # Regular layer or no conditioning available
+                if self.checkpoint_all:
+                    fts = torch.utils.checkpoint.checkpoint(
+                        layer, fts, use_reentrant=False
+                    )  # type: ignore
+                else:
+                    fts = layer(fts)
 
             # UNet residuals logic (skip connections)
             if count < self.num_steps:

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -5,6 +5,7 @@ import xarray as xr
 
 from ocean_emulators.constants import Grid
 from ocean_emulators.models.base import BaseModel
+from ocean_emulators.models.modules.noise_conditioning import NoiseMLP
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
 
 
@@ -23,6 +24,8 @@ class Samudra(BaseModel):
         wet: Grid,
         static_data: xr.Dataset | None,
         gradient_detach_interval: int,
+        noise_channels: int | None = None,
+        noise_embed_dim: int | None = None,
     ):
         super().__init__(
             in_channels=in_channels,
@@ -36,6 +39,9 @@ class Samudra(BaseModel):
             gradient_detach_interval=gradient_detach_interval,
         )
 
+        self.noise_channels = noise_channels
+        self.noise_embed_dim = noise_embed_dim
+
         if pos_channels > 0:
             self.positional_params = nn.Parameter(
                 torch.empty(pos_channels, *wet.shape[-2:])
@@ -43,6 +49,21 @@ class Samudra(BaseModel):
             nn.init.normal_(self.positional_params, mean=0.0, std=1e-5)
         else:
             self.register_parameter("positional_params", None)
+
+        # Initialize noise MLP if noise conditioning is enabled
+        if noise_channels is not None and noise_embed_dim is not None:
+            noise_shape = (
+                wet.shape[-2],
+                wet.shape[-1],
+            )  # Use grid shape for noise by default
+            self.noise_mlp: NoiseMLP | None = NoiseMLP(
+                noise_channels=noise_channels,
+                hidden_dim=noise_embed_dim * 2,  # Hidden dim is 2x output
+                output_dim=noise_embed_dim,
+                noise_shape=noise_shape,  # Noise resolution (can be changed for ablations)
+            )
+        else:
+            self.noise_mlp = None
 
         layers = [
             # Add UNet core.
@@ -56,6 +77,16 @@ class Samudra(BaseModel):
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
         fts_input = fts.clone().detach()
+
+        # Generate and process noise if noise conditioning is enabled
+        cond = None
+        if self.noise_mlp is not None:
+            noise = self.noise_mlp.generate_noise(
+                batch_size=fts.shape[0],
+                device=fts.device,
+                dtype=fts.dtype,
+            )
+            cond = self.noise_mlp(noise)  # (B, noise_embed_dim)
 
         if self.positional_params is not None:
             pos = self.positional_params.unsqueeze(0).expand(fts.shape[0], -1, -1, -1)
@@ -71,10 +102,11 @@ class Samudra(BaseModel):
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
 
-            # TODO(alxmrs): Find a clean way to checkpoint the decoder Conv block.
-
-            # Apply layer
-            fts = layer(fts)
+            # Apply layer with conditioning if it's the UNet
+            if isinstance(layer, UNetBackbone) and cond is not None:
+                fts = layer(fts, cond)
+            else:
+                fts = layer(fts)
 
         if self.corrector is not None:
             fts = self.corrector(fts_input, fts)

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -102,6 +102,7 @@ class Samudra(BaseModel):
                     fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
                 )
 
+            # TODO(alxmrs): Find a clean way to checkpoint the decoder Conv block.
             # Apply layer with conditioning if it's the UNet
             if isinstance(layer, UNetBackbone) and cond is not None:
                 fts = layer(fts, cond)

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -73,6 +73,53 @@ def decomposed_mse_mae(
     return combined.mean(dim=(0, 2, 3))
 
 
+def crps_ensemble(
+    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
+) -> torch.Tensor:
+    """CRPS = E|X - Y| - 0.5 * E|X - X'|
+    where X are ensemble predictions and Y is ground truth.
+
+    Args:
+        pred: Ensemble predictions (ensemble_size, batch, channels, lat, lon)
+        target: Ground truth (batch, channels, lat, lon)
+        wet: Ocean mask
+
+    Returns:
+        CRPS per channel (channels,)
+
+    References:
+        GraphCast implementation - https://github.com/google-deepmind/graphcast/blob/main/gencast_mini_demo.ipynb
+    """
+    if pred.shape[0] < 2:
+        raise ValueError("CRPS requires at least 2 ensemble members (dim 0)")
+
+    # Apply wet mask
+    pred = pred * wet.unsqueeze(0).unsqueeze(0)
+    target = target * wet
+
+    ensemble_size = pred.shape[0]
+
+    # Skill: E|X - Y| = mean over ensemble of |pred - target|
+    mean_abs_err = torch.abs(target.unsqueeze(0) - pred).mean(dim=0)
+
+    # Spread: E|X - X'| = mean over all pairs of |pred_i - pred_j|
+    # Rename ensemble dim for pairwise computation
+    pred_i = pred.unsqueeze(1)  # (ensemble, 1, batch, channels, lat, lon)
+    pred_j = pred.unsqueeze(0)  # (1, ensemble, batch, channels, lat, lon)
+
+    # Fair CRPS: exclude diagonal (i == j) for unbiased estimate
+    # Sum all pairs, then normalize by ensemble_size * (ensemble_size - 1)
+    pairwise_diff = torch.abs(pred_i - pred_j).sum(dim=(0, 1))
+    mean_abs_diff = pairwise_diff / (ensemble_size * (ensemble_size - 1))
+
+    # CRPS = skill - 0.5 * spread
+    crps = mean_abs_err - 0.5 * mean_abs_diff
+
+    # Average over spatial dims and batch, return per-channel
+    num_wet_points = wet.sum()
+    return crps.sum(dim=(0, 2, 3)) / (crps.shape[0] * num_wet_points)
+
+
 class MseDynamic:
     """A loss function that scales each channel to contribute equally to the loss.
 


### PR DESCRIPTION
# Noise-Conditioned Probabilistic Training for Samudra

closes #411 

This PR introduces noise-conditioned probabilistic training for the Samudra model, following the AIFS-style conditioning and CRPS objective.

## Key Changes

### Noise conditioning
Gaussian noise (B, 4, H, W) → NoiseMLP (flatten → Linear → GELU → Linear → LayerNorm) → conditioning embeddings (B, 128) → ConditionalBatchNorm2d modules (learned gamma/beta modulation) in all ConvNeXt blocks throughout the UNet backbone.

### Losses
crps implementation from [graphcast](https://github.com/google-deepmind/graphcast/blob/main/gencast_mini_demo.ipynb)

### Training
Mini-ensemble training (ensemble_size_train) with deterministic per-member seeding and optional ensemble-parallel DDP sharding.

## References
[Notes on CRPS vs MSE](https://drive.google.com/file/d/1tm3I2Q_KcPxKRc8hmmEDsjs8T0qEyaQ8/view?usp=drive_link) - made some notes that convinced me CRPS is superior to MSE for this task.
[AIFS-CRPS](https://arxiv.org/pdf/2412.15832v1) - AIFS-CRPS paper



Updates on CRPS experimentation : 

update 1 : https://docs.google.com/presentation/d/1w0b-_P5mQkNEYxhU7YtKz5N7bS7adNCXQ0L2rD1TinE/edit?usp=sharing

update 2: https://docs.google.com/presentation/d/1mtOHaHaRRN25bkjyU1-Zan2PWEnz5t2T4-o9ulVF4xY/edit?usp=sharing

update 3: https://docs.google.com/presentation/d/1oPB5ymr-KUuODcoNN4Fy7VTzk1-i4Wfn3NgH9fn_m7k/edit?usp=sharing

pr associated with update 3 : https://github.com/Open-Athena/Ocean_Emulator/tree/crps_dump_dynamic 

rollout stability is a major challenge with crps loss
