### PR TITLE
Ensure zero bias is white-colored

### DIFF
--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -2507,6 +2507,16 @@ class Viz:
         colormap = cm.cm.balance
         colormap.set_bad(color=(0.7, 0.7, 0.7, 0))
         sst_bias = sst_data - gt_sst_data
+        if vmin is None:
+            vmin = sst_bias.min().compute().item()
+        if vmax is None:
+            vmax = sst_bias.max().compute().item()
+
+        # ensure symmetric colorbar
+        larger = max(abs(vmin), abs(vmax))
+        vmin = -larger
+        vmax = larger
+
         im = ax.pcolormesh(
             sst_bias["x"],
             sst_bias["y"],

--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -2510,7 +2510,7 @@ class Viz:
         colormap.set_bad(color=(0.7, 0.7, 0.7, 0))
         sst_bias = sst_data - gt_sst_data
         if range is None:
-            bias_max = sst_bias.abs().max().compute().item()
+            bias_max = np.abs(sst_bias).max().compute().item()
             range = (-bias_max, bias_max)
 
         im = ax.pcolormesh(

--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -2503,19 +2503,15 @@ class Viz:
             gl.left_labels = False
         return im
 
-    def plot_bias(self, ax, sst_data, gt_sst_data, title, vmin, vmax):
+    def plot_bias(
+        self, ax, sst_data, gt_sst_data, title, range: tuple[float, float] | None
+    ):
         colormap = cm.cm.balance
         colormap.set_bad(color=(0.7, 0.7, 0.7, 0))
         sst_bias = sst_data - gt_sst_data
-        if vmin is None:
-            vmin = sst_bias.min().compute().item()
-        if vmax is None:
-            vmax = sst_bias.max().compute().item()
-
-        # ensure symmetric colorbar
-        larger = max(abs(vmin), abs(vmax))
-        vmin = -larger
-        vmax = larger
+        if range is None:
+            bias_max = sst_bias.abs().max().compute().item()
+            range = (-bias_max, bias_max)
 
         im = ax.pcolormesh(
             sst_bias["x"],
@@ -2524,8 +2520,8 @@ class Viz:
             shading="auto",
             cmap=colormap,
             transform=ccrs.PlateCarree(),
-            vmin=vmin,
-            vmax=vmax,
+            vmin=range[0],
+            vmax=range[1],
         )
         ax.add_feature(cfeature.COASTLINE, edgecolor="black")
         ax.set_title(title, fontsize=14)
@@ -2582,7 +2578,7 @@ class Viz:
         cbar.set_label(r"$\theta_O$ [$\degree C$]", fontsize=14)
 
         # Plot biases for SST
-        im = self.plot_bias(axs[3], pred1_sst, gt_sst, bias_titles[0], -1.0, 1.0)
+        im = self.plot_bias(axs[3], pred1_sst, gt_sst, bias_titles[0], (-1.0, 1.0))
 
         # Add colorbar for bias plots
         cbar = fig.colorbar(
@@ -2655,7 +2651,7 @@ class Viz:
             cbar.set_label(r"$\theta_O$ [$\degree C$]", fontsize=14)
 
             # Plot biases for SST
-            im = self.plot_bias(axs[3], pred1_sst, gt_sst, bias_titles[0], None, None)
+            im = self.plot_bias(axs[3], pred1_sst, gt_sst, bias_titles[0], None)
 
             # Add colorbar for bias plots
             cbar = fig.colorbar(
@@ -2723,7 +2719,7 @@ class Viz:
         cbar.set_label(r"$so$ [$psu$]", fontsize=14)
 
         # Plot biases for SSS
-        im = self.plot_bias(axs[3], pred1_sss, gt_sss, bias_titles[0], -0.5, 0.5)
+        im = self.plot_bias(axs[3], pred1_sss, gt_sss, bias_titles[0], (-0.5, 0.5))
 
         # Add colorbar for bias plots
         cbar = fig.colorbar(


### PR DESCRIPTION
Previously this plot would produce images like this:
<img width="7159" height="3188" alt="SST_map_snapshot_t_597 (2)" src="https://github.com/user-attachments/assets/c70b162a-860c-4073-8180-c32cf8961b5f" />

Where zero bias was quite red-colored. We now ensure the colorbar is centered at zero:

<img width="7159" height="3188" alt="SST_map_snapshot_t_597 (3)" src="https://github.com/user-attachments/assets/a00e9bfa-29ac-48a2-b7ed-e99ed1753262" />

The OHC plots look like they have a similar bug but I can't actually make it happen so I'm guessing it's not actually a problem due to the way the data is processed before plotting. 