### PR TITLE
Refactoring dynamic loss to compose any loss method, not just MSE.

### DIFF
--- a/configs/fomo_om4/train.yaml
+++ b/configs/fomo_om4/train.yaml
@@ -8,7 +8,9 @@ epochs: 70
 batch_size: 4
 learning_rate: 0.0006
 scheduler: { type: cosine }
-loss: mse_dynamic_no_limit
+loss:
+  metric: mse
+  type: dynamic
 finetune: false
 resume_ckpt_path: null
 inference_epochs: []

--- a/configs/fomo_om4/train.yaml
+++ b/configs/fomo_om4/train.yaml
@@ -9,8 +9,8 @@ batch_size: 4
 learning_rate: 0.0006
 scheduler: { type: cosine }
 loss:
-  metric: mse
   type: dynamic
+  metric: mse
 finetune: false
 resume_ckpt_path: null
 inference_epochs: []

--- a/configs/samudra_om4/train.yaml
+++ b/configs/samudra_om4/train.yaml
@@ -9,8 +9,8 @@ batch_size: 4
 learning_rate: 0.0006
 scheduler: { type: cosine }
 loss:
-  metric: mse
   type: dynamic
+  metric: mse
 finetune: false
 resume_ckpt_path: null
 inference_epochs: []

--- a/configs/samudra_om4/train.yaml
+++ b/configs/samudra_om4/train.yaml
@@ -10,7 +10,7 @@ learning_rate: 0.0006
 scheduler: { type: cosine }
 loss:
   metric: mse
-  limit: false
+  type: dynamic
 finetune: false
 resume_ckpt_path: null
 inference_epochs: []

--- a/configs/samudra_om4/train.yaml
+++ b/configs/samudra_om4/train.yaml
@@ -8,7 +8,9 @@ epochs: 70
 batch_size: 4
 learning_rate: 0.0006
 scheduler: { type: cosine }
-loss: mse_dynamic_no_limit
+loss:
+  metric: mse
+  limit: false
 finetune: false
 resume_ckpt_path: null
 inference_epochs: []

--- a/configs/test/train_default.yaml
+++ b/configs/test/train_default.yaml
@@ -46,7 +46,6 @@ data:
   data_location: data.zarr
   data_means_location: means.nc
   data_stds_location: stds.nc
-  scaling_residuals_file: null
   num_workers: 4
   hist: 0
 

--- a/configs/test/train_default_2step.yaml
+++ b/configs/test/train_default_2step.yaml
@@ -46,7 +46,6 @@ data:
   data_location: data.zarr
   data_means_location: means.nc
   data_stds_location: stds.nc
-  scaling_residuals_file: null
   num_workers: 4
   hist: 0
 

--- a/configs/test/train_fomo.yaml
+++ b/configs/test/train_fomo.yaml
@@ -46,7 +46,6 @@ data:
   data_location: data.zarr
   data_means_location: means.nc
   data_stds_location: stds.nc
-  scaling_residuals_file: null
   num_workers: 4
   hist: 0
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -1,13 +1,21 @@
 import abc
-from functools import cached_property
+from functools import cached_property, partial
 from pathlib import Path
-from typing import Annotated, Literal, Self, assert_never
+from typing import Annotated, Any, Literal, Self, assert_never, get_args
 
 import cftime
+import numpy as np
+import pydantic
 import torch
 import xarray as xr
 from perceiver_pytorch import Perceiver as NaivePerceiver
-from pydantic import Field, PlainSerializer, PlainValidator, WithJsonSchema
+from pydantic import (
+    BeforeValidator,
+    Field,
+    PlainSerializer,
+    PlainValidator,
+    WithJsonSchema,
+)
 from torch import nn
 from torch.nn import GELU
 
@@ -33,6 +41,16 @@ from ocean_emulators.models.modules.augment_input import Concat3dCoordinates
 from ocean_emulators.models.modules.blocks import ZonallyPeriodicBilinearUpsample
 from ocean_emulators.utils.data import DataContainer, DataSource, validate_data
 from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLocation
+from ocean_emulators.utils.loss import (
+    DynamicLoss,
+    LossFn,
+    decomposed_mae,
+    decomposed_mse,
+    decomposed_mse_cos_weighted,
+    decomposed_mse_diff_weighted,
+    decomposed_mse_mae,
+    decomposed_mse_scaled,
+)
 from ocean_emulators.utils.profiler import Profiler
 from ocean_emulators.utils.schedule import SchedulerConfig
 
@@ -648,18 +666,111 @@ class ProfilerConfig(BaseConfig):
 
 # See backend.py for how these are turned into concrete devices
 TrainBackendConfig = Literal["cpu", "cuda", "nccl", "auto"]
-LossType = Literal[
+LossMetric = Literal[
     "mse",
+    "mae",
     "mse_diff_weighted",
     "mse_cos_weighted",
     "mse_residual_scaled",
     "mse_mae",
-    "mse_dynamic",
-    "mse_dynamic_no_limit",
-    "mae_dynamic",
-    "mae_dynamic_no_limit",
 ]
-LossExtensionType = Literal["off", "dynamic_no_limit", "dynamic"]
+LossType = Literal["standard", "dynamic"]
+
+
+class LossConfig(pydantic.BaseModel):
+    metric: LossMetric = "mse"
+    type: LossType = "standard"
+    limit: bool = Field(
+        description="For dynamic loss, should we limit the range of weighted loss by the variance. Default: off.",
+        default=False,
+    )
+
+    def build(
+        self,
+        hist: int,
+        wet: Grid,
+        y_coord: xr.DataArray,
+        stds: xr.Dataset,
+        scaling_residuals: xr.Dataset | None,
+        device: torch.device,
+    ) -> LossFn:
+        match self.metric:
+            case "mse":
+                loss_fn: LossFn = partial(decomposed_mse, wet=wet)
+            case "mae":
+                loss_fn = partial(decomposed_mae, wet=wet)
+            case "mse_mae":
+                loss_fn = partial(decomposed_mse_mae, wet=wet)
+            case "mse_diff_weighted":
+                assert hist == 1  # TEMP
+                loss_fn = partial(decomposed_mse_diff_weighted, wet=wet)
+            case "mse_cos_weighted":
+                area_weights = np.sqrt(np.cos(np.deg2rad(y_coord))).to_numpy()
+                area_weights = torch.from_numpy(area_weights).to(device=device)
+                loss_fn = partial(
+                    decomposed_mse_cos_weighted, wet=wet, cos=area_weights
+                )
+            case "mse_residual_scaled":
+                assert scaling_residuals is not None, (
+                    "With loss of 'mse_residual_scaled' you must supply a scaling_residuals_file"
+                )
+                scale = torch.from_numpy(
+                    (stds / scaling_residuals).compute().to_array().to_numpy()
+                ).to(device=device)
+                scale = torch.concat([scale] * (hist + 1), dim=0)
+                loss_fn = partial(decomposed_mse_scaled, wet=wet, scaling=scale)
+            case _:
+                assert_never(self.metric)
+
+        match self.type:
+            case "standard":
+                pass
+            case "dynamic":
+                loss_fn = DynamicLoss(
+                    stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
+                    device=device,
+                    should_limit=self.limit,
+                    loss_fn=loss_fn,
+                )
+            case _:
+                assert_never(self.type)
+
+        return loss_fn
+
+
+def parse_loss(candidate: Any) -> Any:
+    """Parse loss configuration, accepting only metric-only strings.
+
+    Args:
+        candidate: Either a metric string (e.g., "mse"), a dict, or a LossConfig
+
+    Returns:
+        LossConfig object or dict to be validated by Pydantic
+
+    Raises:
+        ValueError: If candidate is a string but not a valid LossMetric
+    """
+    if isinstance(candidate, str):
+        if candidate in get_args(LossMetric):
+            return LossConfig(metric=candidate, type="standard", limit=False)  # type: ignore[arg-type]
+        # String that's not a valid metric - reject it
+        valid_metrics = ", ".join(f"'{m}'" for m in get_args(LossMetric))
+        raise ValueError(
+            f"Invalid loss string: '{candidate}'. "
+            f"Valid metric-only losses are: {valid_metrics}. "
+            f"For dynamic losses or custom limits, use the full LossConfig format:\n"
+            f"  loss:\n"
+            f"    metric: mse\n"
+            f"    type: dynamic\n"
+            f"    limit: false"
+        )
+    return candidate
+
+
+Loss = Annotated[
+    Annotated[LossConfig, WithJsonSchema({"type": "string"})],
+    BeforeValidator(parse_loss),
+]
 
 
 class TrainConfig(TopLevelConfig):
@@ -672,8 +783,7 @@ class TrainConfig(TopLevelConfig):
     batch_size: int = 2
     learning_rate: float = 2e-4
     scheduler: SchedulerConfig | None = None
-    loss: LossType = "mse"
-    loss_extension: LossExtensionType = "off"
+    loss: Loss = LossConfig()
     finetune: bool = False
     resume_ckpt_path: str | None = None
     debug: bool = False

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -1,7 +1,7 @@
 import abc
 from functools import cached_property, partial
 from pathlib import Path
-from typing import Annotated, Any, Literal, Self, assert_never, get_args
+from typing import Annotated, Literal, Self, assert_never
 
 import cftime
 import numpy as np
@@ -9,13 +9,7 @@ import pydantic
 import torch
 import xarray as xr
 from perceiver_pytorch import Perceiver as NaivePerceiver
-from pydantic import (
-    BeforeValidator,
-    Field,
-    PlainSerializer,
-    PlainValidator,
-    WithJsonSchema,
-)
+from pydantic import Field, PlainSerializer, PlainValidator, WithJsonSchema
 from torch import nn
 from torch.nn import GELU
 
@@ -49,7 +43,6 @@ from ocean_emulators.utils.loss import (
     decomposed_mse_cos_weighted,
     decomposed_mse_diff_weighted,
     decomposed_mse_mae,
-    decomposed_mse_scaled,
 )
 from ocean_emulators.utils.profiler import Profiler
 from ocean_emulators.utils.schedule import SchedulerConfig
@@ -666,111 +659,69 @@ class ProfilerConfig(BaseConfig):
 
 # See backend.py for how these are turned into concrete devices
 TrainBackendConfig = Literal["cpu", "cuda", "nccl", "auto"]
+
 LossMetric = Literal[
     "mse",
     "mae",
     "mse_mae",
     "mse_diff_weighted",
     "mse_cos_weighted",
-    "mse_residual_scaled",
 ]
-LossType = Literal["standard", "dynamic"]
 
 
-class LossConfig(pydantic.BaseModel):
+class DynamicLossConfig(pydantic.BaseModel):
+    type: Literal["dynamic"] = "dynamic"
     metric: LossMetric = "mse"
-    type: LossType = "standard"
     limit: bool = Field(
         description="For dynamic loss, should we limit the range of weighted loss by the variance. Default: off.",
         default=False,
     )
 
-    def build(
-        self,
-        hist: int,
-        wet: Grid,
-        y_coord: xr.DataArray,
-        stds: xr.Dataset,
-        scaling_residuals: xr.Dataset | None,
-        device: torch.device,
-    ) -> LossFn:
-        match self.metric:
-            case "mse":
-                loss_fn: LossFn = partial(decomposed_mse, wet=wet)
-            case "mae":
-                loss_fn = partial(decomposed_mae, wet=wet)
-            case "mse_mae":
-                loss_fn = partial(decomposed_mse_mae, wet=wet)
-            case "mse_diff_weighted":
-                assert hist == 1  # TEMP
-                loss_fn = partial(decomposed_mse_diff_weighted, wet=wet)
-            case "mse_cos_weighted":
-                area_weights = np.sqrt(np.cos(np.deg2rad(y_coord))).to_numpy()
-                area_weights = torch.from_numpy(area_weights).to(device=device)
-                loss_fn = partial(
-                    decomposed_mse_cos_weighted, wet=wet, cos=area_weights
-                )
-            case "mse_residual_scaled":
-                assert scaling_residuals is not None, (
-                    "With loss of 'mse_residual_scaled' you must supply a scaling_residuals_file"
-                )
-                scale = torch.from_numpy(
-                    (stds / scaling_residuals).compute().to_array().to_numpy()
-                ).to(device=device)
-                scale = torch.concat([scale] * (hist + 1), dim=0)
-                loss_fn = partial(decomposed_mse_scaled, wet=wet, scaling=scale)
-            case _:
-                assert_never(self.metric)
 
-        match self.type:
-            case "standard":
-                pass
-            case "dynamic":
-                loss_fn = DynamicLoss(
-                    loss_fn=loss_fn,
-                    stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
-                    should_limit=self.limit,
-                    device=device,
-                )
-            case _:
-                assert_never(self.type)
-
-        return loss_fn
+Loss = LossMetric | DynamicLossConfig
 
 
-def parse_loss(candidate: Any) -> Any:
-    """Parse loss configuration, accepting only metric-only strings.
+def build_loss_fn(
+    loss_cfg: Loss,
+    hist: int,
+    wet: Grid,
+    y_coord: xr.DataArray,
+    stds: xr.Dataset,
+    device: torch.device,
+) -> LossFn:
+    if isinstance(loss_cfg, str):
+        metric = loss_cfg
+    elif hasattr(loss_cfg, "metric"):
+        metric = loss_cfg.metric
+    else:
+        raise ValueError(f"Could not parse property `metric` from {loss_cfg=}.")
 
-    Args:
-        candidate: Either a metric string (e.g., "mse"), a dict, or a LossConfig
+    match metric:
+        case "mse":
+            loss_fn: LossFn = partial(decomposed_mse, wet=wet)
+        case "mae":
+            loss_fn = partial(decomposed_mae, wet=wet)
+        case "mse_mae":
+            loss_fn = partial(decomposed_mse_mae, wet=wet)
+        case "mse_diff_weighted":
+            assert hist == 1  # TEMP
+            loss_fn = partial(decomposed_mse_diff_weighted, wet=wet)
+        case "mse_cos_weighted":
+            area_weights = np.sqrt(np.cos(np.deg2rad(y_coord))).to_numpy()
+            area_weights = torch.from_numpy(area_weights).to(device=device)
+            loss_fn = partial(decomposed_mse_cos_weighted, wet=wet, cos=area_weights)
+        case _:
+            assert_never(metric)
 
-    Returns:
-        LossConfig object or dict to be validated by Pydantic
-
-    Raises:
-        ValueError: If candidate is a string but not a valid LossMetric
-    """
-    if isinstance(candidate, str):
-        if candidate in get_args(LossMetric):
-            return LossConfig(metric=candidate, type="standard", limit=False)  # type: ignore[arg-type]
-        # String that's not a valid metric - reject it
-        valid_metrics = ", ".join(f"'{m}'" for m in get_args(LossMetric))
-        raise ValueError(
-            f"Invalid loss string: '{candidate}'. "
-            f"Valid metric-only losses are: {valid_metrics}. "
-            f"For dynamic losses or custom limits, use the full LossConfig format:\n"
-            f"  loss:\n"
-            f"    metric: mse\n"
-            f"    type: dynamic\n"
-            f"    limit: false"
+    if isinstance(loss_cfg, DynamicLossConfig):
+        loss_fn = DynamicLoss(
+            loss_fn=loss_fn,
+            stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
+            should_limit=loss_cfg.limit,
+            device=device,
         )
-    return candidate
 
-
-Loss = Annotated[
-    Annotated[LossConfig, WithJsonSchema({"type": "string"})],
-    BeforeValidator(parse_loss),
-]
+    return loss_fn
 
 
 class TrainConfig(TopLevelConfig):
@@ -783,7 +734,7 @@ class TrainConfig(TopLevelConfig):
     batch_size: int = 2
     learning_rate: float = 2e-4
     scheduler: SchedulerConfig | None = None
-    loss: Loss = LossConfig()
+    loss: Loss = "mse"
     finetune: bool = False
     resume_ckpt_path: str | None = None
     debug: bool = False

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -656,7 +656,10 @@ LossType = Literal[
     "mse_mae",
     "mse_dynamic",
     "mse_dynamic_no_limit",
+    "mae_dynamic",
+    "mae_dynamic_no_limit",
 ]
+LossExtensionType = Literal["off", "dynamic_no_limit", "dynamic"]
 
 
 class TrainConfig(TopLevelConfig):
@@ -670,6 +673,7 @@ class TrainConfig(TopLevelConfig):
     learning_rate: float = 2e-4
     scheduler: SchedulerConfig | None = None
     loss: LossType = "mse"
+    loss_extension: LossExtensionType = "off"
     finetune: bool = False
     resume_ckpt_path: str | None = None
     debug: bool = False

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -727,10 +727,10 @@ class LossConfig(pydantic.BaseModel):
                 pass
             case "dynamic":
                 loss_fn = DynamicLoss(
-                    stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
-                    device=device,
-                    should_limit=self.limit,
                     loss_fn=loss_fn,
+                    stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
+                    should_limit=self.limit,
+                    device=device,
                 )
             case _:
                 assert_never(self.type)

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -136,10 +136,6 @@ class DataConfig(BaseConfig):
     data_stds_location: Location = Field(
         description="Location of the data standard deviations; " + LOCATION_DOCS
     )
-    scaling_residuals_file: Location | None = Field(
-        description="Location of the scaling residuals file; " + LOCATION_DOCS,
-        default=None,
-    )
     static_data_vars: list[str] | None = None
     num_workers: int = 4
     hist: int = 1
@@ -183,13 +179,6 @@ class DataConfig(BaseConfig):
                 source_using_dask, boundary_var_names, self.static_data_vars
             )
 
-        if self.scaling_residuals_file is not None:
-            scaling_residuals_location = data_root.resolve(self.scaling_residuals_file)
-            scaling_residuals = scaling_residuals_location.open()
-        else:
-            scaling_residuals_location = None
-            scaling_residuals = None
-
         static_data = (
             source.data[self.static_data_vars]
             if self.static_data_vars is not None
@@ -202,7 +191,6 @@ class DataConfig(BaseConfig):
                 data_location,
                 means_location,
                 stds_location,
-                scaling_residuals_location,
             ]
         )
         return DataContainer(
@@ -210,7 +198,6 @@ class DataConfig(BaseConfig):
             source_using_dask,
             loader_version,
             supports_fork,
-            scaling_residuals,
             static_data,
         )
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -683,7 +683,6 @@ Loss = LossMetric | DynamicLossConfig
 
 def build_loss_fn(
     loss_cfg: Loss,
-    hist: int,
     wet: Grid,
     y_coord: xr.DataArray,
     stds: xr.Dataset,
@@ -704,7 +703,6 @@ def build_loss_fn(
         case "mse_mae":
             loss_fn = partial(decomposed_mse_mae, wet=wet)
         case "mse_diff_weighted":
-            assert hist == 1  # TEMP
             loss_fn = partial(decomposed_mse_diff_weighted, wet=wet)
         case "mse_cos_weighted":
             area_weights = np.sqrt(np.cos(np.deg2rad(y_coord))).to_numpy()

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -669,10 +669,10 @@ TrainBackendConfig = Literal["cpu", "cuda", "nccl", "auto"]
 LossMetric = Literal[
     "mse",
     "mae",
+    "mse_mae",
     "mse_diff_weighted",
     "mse_cos_weighted",
     "mse_residual_scaled",
-    "mse_mae",
 ]
 LossType = Literal["standard", "dynamic"]
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -1,10 +1,9 @@
 import abc
-from functools import cached_property, partial
+from functools import cached_property
 from pathlib import Path
 from typing import Annotated, Literal, Self, assert_never
 
 import cftime
-import numpy as np
 import pydantic
 import torch
 import xarray as xr
@@ -38,11 +37,8 @@ from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLoca
 from ocean_emulators.utils.loss import (
     DynamicLoss,
     LossFn,
-    decomposed_mae,
-    decomposed_mse,
-    decomposed_mse_cos_weighted,
-    decomposed_mse_diff_weighted,
-    decomposed_mse_mae,
+    LossMetric,
+    loss_fn_from_metric,
 )
 from ocean_emulators.utils.profiler import Profiler
 from ocean_emulators.utils.schedule import SchedulerConfig
@@ -660,14 +656,6 @@ class ProfilerConfig(BaseConfig):
 # See backend.py for how these are turned into concrete devices
 TrainBackendConfig = Literal["cpu", "cuda", "nccl", "auto"]
 
-LossMetric = Literal[
-    "mse",
-    "mae",
-    "mse_mae",
-    "mse_diff_weighted",
-    "mse_cos_weighted",
-]
-
 
 class DynamicLossConfig(pydantic.BaseModel):
     type: Literal["dynamic"] = "dynamic"
@@ -688,38 +676,23 @@ def build_loss_fn(
     stds: xr.Dataset,
     device: torch.device,
 ) -> LossFn:
-    if isinstance(loss_cfg, str):
-        metric = loss_cfg
-    elif hasattr(loss_cfg, "metric"):
-        metric = loss_cfg.metric
-    else:
-        raise ValueError(f"Could not parse property `metric` from {loss_cfg=}.")
-
-    match metric:
-        case "mse":
-            loss_fn: LossFn = partial(decomposed_mse, wet=wet)
-        case "mae":
-            loss_fn = partial(decomposed_mae, wet=wet)
-        case "mse_mae":
-            loss_fn = partial(decomposed_mse_mae, wet=wet)
-        case "mse_diff_weighted":
-            loss_fn = partial(decomposed_mse_diff_weighted, wet=wet)
-        case "mse_cos_weighted":
-            area_weights = np.sqrt(np.cos(np.deg2rad(y_coord))).to_numpy()
-            area_weights = torch.from_numpy(area_weights).to(device=device)
-            loss_fn = partial(decomposed_mse_cos_weighted, wet=wet, cos=area_weights)
+    match loss_cfg:
+        case str():
+            return loss_fn_from_metric(
+                loss_cfg, wet=wet, y_coord=y_coord, device=device
+            )
+        case DynamicLossConfig(metric=metric, limit=limit):
+            loss_fn = loss_fn_from_metric(
+                metric, wet=wet, y_coord=y_coord, device=device
+            )
+            return DynamicLoss(
+                loss_fn=loss_fn,
+                stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
+                should_limit=limit,
+                device=device,
+            )
         case _:
-            assert_never(metric)
-
-    if isinstance(loss_cfg, DynamicLossConfig):
-        loss_fn = DynamicLoss(
-            loss_fn=loss_fn,
-            stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
-            should_limit=loss_cfg.limit,
-            device=device,
-        )
-
-    return loss_fn
+            assert_never(loss_cfg)
 
 
 class TrainConfig(TopLevelConfig):

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -10,7 +10,6 @@ import tempfile
 import time
 import warnings
 from collections import OrderedDict
-from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.context import BaseContext
 from pathlib import Path
@@ -77,6 +76,7 @@ from ocean_emulators.utils.logging import (
     handle_logging,
     handle_warnings,
 )
+from ocean_emulators.utils.loss import LossFn
 from ocean_emulators.utils.train import (
     CheckpointPaths,
     collate_inference_data,
@@ -224,20 +224,18 @@ class Trainer:
 
         # Loss function
         stds = self.src.stds[self.prognostic_var_names]
+        scaling_residuals = None
         if self.data_container.scaling_residuals is not None:
             scaling_residuals = self.data_container.scaling_residuals[
                 self.prognostic_var_names
             ]
-        else:
-            scaling_residuals = None
-        self.loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
-        self.loss_fn = cfg.loss.build(
+        self.loss_fn: LossFn = cfg.loss.build(
             hist=cfg.data.hist,
             wet=self.wet,
             y_coord=self.data.y,
-            device=self.device,
             stds=stds,
             scaling_residuals=scaling_residuals,
+            device=self.device,
         )
 
         # Optimizer

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -12,13 +12,11 @@ import warnings
 from collections import OrderedDict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
-from functools import partial
 from multiprocessing.context import BaseContext
 from pathlib import Path
-from typing import Any, assert_never
+from typing import Any
 
 import dask
-import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import (
@@ -78,15 +76,6 @@ from ocean_emulators.utils.logging import (
     get_model_summary,
     handle_logging,
     handle_warnings,
-)
-from ocean_emulators.utils.loss import (
-    DynamicLoss,
-    decomposed_mae,
-    decomposed_mse,
-    decomposed_mse_cos_weighted,
-    decomposed_mse_diff_weighted,
-    decomposed_mse_mae,
-    decomposed_mse_scaled,
 )
 from ocean_emulators.utils.train import (
     CheckpointPaths,
@@ -233,76 +222,23 @@ class Trainer:
         self.nets_dir = cfg.experiment.nets_dir
         self.network = self.model.__class__.__name__
 
-        self.loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
         # Loss function
-        match cfg.loss:
-            case "mse":
-                logger.info("Using decomposed mse loss")
-                self.loss_fn = partial(decomposed_mse, wet=self.wet)
-            case "mse_diff_weighted":
-                assert cfg.data.hist == 1  # TEMP
-                logger.info("Using decomposed mse loss with weighted diff")
-                self.loss_fn = partial(decomposed_mse_diff_weighted, wet=self.wet)
-            case "mse_cos_weighted":
-                logger.info("Using decomposed mse loss with weighted cos")
-                area_weights = np.sqrt(np.cos(np.deg2rad(self.data.y))).to_numpy()
-                area_weights = torch.from_numpy(area_weights).to(device=self.device)
-                self.loss_fn = partial(
-                    decomposed_mse_cos_weighted, wet=self.wet, cos=area_weights
-                )
-            case "mse_residual_scaled":
-                logger.info("Using decomposed mse loss with scaled residuals")
-                assert self.data_container.scaling_residuals is not None, (
-                    "With loss of 'mse_residual_scaled' you"
-                    " must supply a scaling_residuals_file"
-                )
-                scale = torch.from_numpy(
-                    (
-                        self.src.stds[self.prognostic_var_names]
-                        / self.data_container.scaling_residuals[
-                            self.prognostic_var_names
-                        ]
-                    )
-                    .compute()
-                    .to_array()
-                    .to_numpy()
-                ).to(device=self.device)
-                scale = torch.concat([scale] * (cfg.data.hist + 1), dim=0)
-                self.loss_fn = partial(
-                    decomposed_mse_scaled, wet=self.wet, scaling=scale
-                )
-            case "mse_mae":
-                logger.info("Using decomposed mse loss with mae")
-                self.loss_fn = partial(decomposed_mse_mae, wet=self.wet)
-            # The following two cases are here for backwards compatability.
-            case "mse_dynamic" | "mse_dynamic_no_limit":
-                should_limit = cfg.loss == "mse_dynamic"
-                cfg.loss_extension = "dynamic" if should_limit else "dynamic_no_limit"
-                self.loss_fn = partial(decomposed_mse, wet=self.wet)
-            case "mae_dynamic" | "mae_dynamic_no_limit":
-                should_limit = cfg.loss == "mae_dynamic"
-                cfg.loss_extension = "dynamic" if should_limit else "dynamic_no_limit"
-                self.loss_fn = partial(decomposed_mae, wet=self.wet)
-            case _:
-                assert_never(cfg.loss)
-
-        # (Maybe) Extend the loss function.
-        match cfg.loss_extension:
-            case "off":
-                pass
-            case "dynamic_no_limit" | "dynamic":
-                should_limit = "no_limit" not in cfg.loss_extension
-                logger.info(f"Using dynamic loss (limit = {should_limit})")
-                self.loss_fn = DynamicLoss(
-                    stds=torch.from_numpy(
-                        self.src.stds[self.prognostic_var_names].to_array().to_numpy()
-                    ).to(device=self.device),
-                    device=self.wet.device,
-                    should_limit=should_limit,
-                    loss_fn=self.loss_fn,
-                )
-            case _:
-                assert_never(cfg.loss_extension)
+        stds = self.src.stds[self.prognostic_var_names]
+        if self.data_container.scaling_residuals is not None:
+            scaling_residuals = self.data_container.scaling_residuals[
+                self.prognostic_var_names
+            ]
+        else:
+            scaling_residuals = None
+        self.loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+        self.loss_fn = cfg.loss.build(
+            hist=cfg.data.hist,
+            wet=self.wet,
+            y_coord=self.data.y,
+            device=self.device,
+            stds=stds,
+            scaling_residuals=scaling_residuals,
+        )
 
         # Optimizer
         self.optimizer = torch.optim.Adam(self.model.parameters(), lr=cfg.learning_rate)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -226,7 +226,7 @@ class Trainer:
         self.loss_fn: LossFn = build_loss_fn(
             cfg.loss,
             wet=self.wet,
-            y_coord=self.data.y,
+            y_coord=self.data.lat,
             stds=self.src.stds[self.prognostic_var_names],
             device=self.device,
         )

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -227,7 +227,7 @@ class Trainer:
             cfg.loss,
             wet=self.wet,
             y_coord=self.data.lat,
-            stds=self.src.stds[self.prognostic_var_names],
+            stds=self.src.filter(self.prognostic_var_names, prefix="prog_stds").stds,
             device=self.device,
         )
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -80,7 +80,8 @@ from ocean_emulators.utils.logging import (
     handle_warnings,
 )
 from ocean_emulators.utils.loss import (
-    MseDynamic,
+    DynamicLoss,
+    decomposed_mae,
     decomposed_mse,
     decomposed_mse_cos_weighted,
     decomposed_mse_diff_weighted,
@@ -273,18 +274,35 @@ class Trainer:
             case "mse_mae":
                 logger.info("Using decomposed mse loss with mae")
                 self.loss_fn = partial(decomposed_mse_mae, wet=self.wet)
+            # The following two cases are here for backwards compatability.
             case "mse_dynamic" | "mse_dynamic_no_limit":
                 should_limit = cfg.loss == "mse_dynamic"
-                logger.info(f"Using dynamic MSE loss (limit = {should_limit})")
-                self.loss_fn = MseDynamic(
-                    wet=self.wet,
+                cfg.loss_extension = "dynamic" if should_limit else "dynamic_no_limit"
+                self.loss_fn = partial(decomposed_mse, wet=self.wet)
+            case "mae_dynamic" | "mae_dynamic_no_limit":
+                should_limit = cfg.loss == "mae_dynamic"
+                cfg.loss_extension = "dynamic" if should_limit else "dynamic_no_limit"
+                self.loss_fn = partial(decomposed_mae, wet=self.wet)
+            case _:
+                assert_never(cfg.loss)
+
+        # (Maybe) Extend the loss function.
+        match cfg.loss_extension:
+            case "off":
+                pass
+            case "dynamic_no_limit" | "dynamic":
+                should_limit = "no_limit" not in cfg.loss_extension
+                logger.info(f"Using dynamic loss (limit = {should_limit})")
+                self.loss_fn = DynamicLoss(
                     stds=torch.from_numpy(
                         self.src.stds[self.prognostic_var_names].to_array().to_numpy()
                     ).to(device=self.device),
+                    device=self.wet.device,
                     should_limit=should_limit,
+                    loss_fn=self.loss_fn,
                 )
             case _:
-                assert_never(cfg.loss)
+                assert_never(cfg.loss_extension)
 
         # Optimizer
         self.optimizer = torch.optim.Adam(self.model.parameters(), lr=cfg.learning_rate)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -34,7 +34,7 @@ from ocean_emulators.aggregator.loss import (
     get_variable_loss_dict,
 )
 from ocean_emulators.backend import init_train_backend
-from ocean_emulators.config import TrainConfig
+from ocean_emulators.config import TrainConfig, build_loss_fn
 from ocean_emulators.constants import (
     BOUNDARY_VARS,
     MAX_TRAIN_MODEL_STEPS_FORWARD,
@@ -223,18 +223,12 @@ class Trainer:
         self.network = self.model.__class__.__name__
 
         # Loss function
-        stds = self.src.stds[self.prognostic_var_names]
-        scaling_residuals = None
-        if self.data_container.scaling_residuals is not None:
-            scaling_residuals = self.data_container.scaling_residuals[
-                self.prognostic_var_names
-            ]
-        self.loss_fn: LossFn = cfg.loss.build(
+        self.loss_fn: LossFn = build_loss_fn(
+            cfg.loss,
             hist=cfg.data.hist,
             wet=self.wet,
             y_coord=self.data.y,
-            stds=stds,
-            scaling_residuals=scaling_residuals,
+            stds=self.src.stds[self.prognostic_var_names],
             device=self.device,
         )
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -225,7 +225,6 @@ class Trainer:
         # Loss function
         self.loss_fn: LossFn = build_loss_fn(
             cfg.loss,
-            hist=cfg.data.hist,
             wet=self.wet,
             y_coord=self.data.y,
             stds=self.src.stds[self.prognostic_var_names],

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -246,7 +246,6 @@ class DataContainer:
     source_using_dask: DataSource
     loader_version: LoaderVersion
     supports_fork: bool
-    scaling_residuals: xr.Dataset | None = None
     static_data: xr.Dataset | None = None
 
 

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -1,10 +1,44 @@
 from collections.abc import Callable
+from functools import partial
+from typing import Literal, assert_never
 
+import numpy as np
 import torch
 import torch.nn.functional as F
+import xarray as xr
 from jaxtyping import Float
 
+from ocean_emulators.constants import Grid
+
 LossFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+LossMetric = Literal[
+    "mse",
+    "mae",
+    "mse_mae",
+    "mse_diff_weighted",
+    "mse_cos_weighted",
+]
+
+
+def loss_fn_from_metric(
+    metric: LossMetric, *, wet: Grid, y_coord: xr.DataArray, device: torch.device
+) -> LossFn:
+    match metric:
+        case "mse":
+            loss_fn: LossFn = partial(decomposed_mse, wet=wet)
+        case "mae":
+            loss_fn = partial(decomposed_mae, wet=wet)
+        case "mse_mae":
+            loss_fn = partial(decomposed_mse_mae, wet=wet)
+        case "mse_diff_weighted":
+            loss_fn = partial(decomposed_mse_diff_weighted, wet=wet)
+        case "mse_cos_weighted":
+            area_weights = np.sqrt(np.cos(np.deg2rad(y_coord))).to_numpy()
+            area_weights = torch.from_numpy(area_weights).to(device=device)
+            loss_fn = partial(decomposed_mse_cos_weighted, wet=wet, cos=area_weights)
+        case _:
+            assert_never(metric)
+    return loss_fn
 
 
 def decomposed_mse(

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -4,8 +4,6 @@ import torch
 import torch.nn.functional as F
 from jaxtyping import Float
 
-from ocean_emulators.utils.distributed import all_reduce_mean, get_world_size
-
 LossFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
@@ -136,6 +134,9 @@ class DynamicLoss:
         target: Float[torch.Tensor, "batch hist*var lat lon"],
     ) -> None:
         """Given the prediction & target for this step, update the per-channel scale."""
+        # Local import is needed to prevent a circular import error.
+        from ocean_emulators.utils.distributed import all_reduce_mean, get_world_size
+
         loss = self.loss_fn(pred, target)
         loss = torch.where(loss == 0, 1e-8, loss)
         new_target_weights_with_history: Float[torch.Tensor, " hist*var"] = 1.0 / loss

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -127,8 +127,8 @@ class DynamicLoss:
     See: https://openathena.slack.com/archives/C08CYM42DT3/p1752275713570969
     """
 
-    """Rolling window size to average over. (~number of steps)"""
     N_WINDOW = 25
+    """Rolling window size to average over. (~number of steps)"""
 
     def __init__(
         self,

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -92,8 +92,8 @@ class DynamicLoss:
     See: https://openathena.slack.com/archives/C08CYM42DT3/p1752275713570969
     """
 
-    N_WINDOW = 25
     """Rolling window size to average over. (~number of steps)"""
+    N_WINDOW = 25
 
     def __init__(
         self,

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -1,18 +1,30 @@
+from collections.abc import Callable
+
 import torch
 import torch.nn.functional as F
 from jaxtyping import Float
 
-from ocean_emulators.constants import Grid
 from ocean_emulators.utils.distributed import all_reduce_mean, get_world_size
+
+LossFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
 def decomposed_mse(
     pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
 ) -> torch.Tensor:
-    """Standard MSE loss computed per channel."""
+    """Standard MSE loss (l2) computed per channel."""
     pred = pred * wet
     target = target * wet
     return F.mse_loss(pred, target, reduction="none").mean(dim=(0, 2, 3))
+
+
+def decomposed_mae(
+    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
+) -> torch.Tensor:
+    """Standard MAE loss (l1) computed per channel."""
+    pred = pred * wet
+    target = target * wet
+    return F.l1_loss(pred, target, reduction="none").mean(dim=(0, 2, 3))
 
 
 def decomposed_mse_diff_weighted(
@@ -73,7 +85,7 @@ def decomposed_mse_mae(
     return combined.mean(dim=(0, 2, 3))
 
 
-class MseDynamic:
+class DynamicLoss:
     """A loss function that scales each channel to contribute equally to the loss.
 
     This uses a rolling estimate of the loss of each channel to scale each
@@ -87,28 +99,30 @@ class MseDynamic:
 
     def __init__(
         self,
-        wet: Grid,
         stds: Float[torch.Tensor, " var"],
         *,
+        device: torch.device,
         should_limit: bool,
+        loss_fn: LossFn,
     ):
-        self._wet: Grid = wet
+        self._device = device
         self._per_channel_scale: Float[torch.Tensor, " var"] = torch.ones(
-            stds.shape[0], device=wet.device
+            stds.shape[0], device=self._device
         )
         if should_limit:
             vars: Float[torch.Tensor, " var"] = stds.pow(2)
             self._limits: Float[torch.Tensor, " var"] | None = 1.0 / vars
         else:
             self._limits = None
+        self.loss_fn = loss_fn
 
     def __call__(
         self,
         pred: Float[torch.Tensor, "batch hist*var lat lon"],
         target: Float[torch.Tensor, "batch hist*var lat lon"],
     ) -> Float[torch.Tensor, " hist*var"]:
-        loss_with_history_channels: Float[torch.Tensor, " hist*var"] = decomposed_mse(
-            pred, target, self._wet
+        loss_with_history_channels: Float[torch.Tensor, " hist*var"] = self.loss_fn(
+            pred, target
         )
         scaled_loss_including_history_dimension: Float[torch.Tensor, "hist var"] = (
             loss_with_history_channels.reshape(self._per_channel_scale.shape[0], -1)
@@ -122,11 +136,9 @@ class MseDynamic:
         target: Float[torch.Tensor, "batch hist*var lat lon"],
     ) -> None:
         """Given the prediction & target for this step, update the per-channel scale."""
-        mse_loss = decomposed_mse(pred, target, self._wet)
-        mse_loss = torch.where(mse_loss == 0, 1e-8, mse_loss)
-        new_target_weights_with_history: Float[torch.Tensor, " hist*var"] = (
-            1.0 / mse_loss
-        )
+        loss = self.loss_fn(pred, target)
+        loss = torch.where(loss == 0, 1e-8, loss)
+        new_target_weights_with_history: Float[torch.Tensor, " hist*var"] = 1.0 / loss
         # Reshape from channels * history to channels
         # by averaging along the `hist` dimension
         new_target_weights: Float[torch.Tensor, " var"] = (
@@ -141,8 +153,8 @@ class MseDynamic:
             all_reduce_mean(new_target_weights)
 
         self._per_channel_scale = (
-            self._per_channel_scale * (MseDynamic.N_WINDOW - 1) + new_target_weights
-        ) / MseDynamic.N_WINDOW
+            self._per_channel_scale * (DynamicLoss.N_WINDOW - 1) + new_target_weights
+        ) / DynamicLoss.N_WINDOW
 
     def loss_scale_per_channel(self) -> Float[torch.Tensor, " var"]:
         return self._per_channel_scale
@@ -155,4 +167,4 @@ class MseDynamic:
     def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
         """Load state from ``state_dict``."""
         if "per_channel_scale" in state:
-            self._per_channel_scale = state["per_channel_scale"].to(self._wet.device)
+            self._per_channel_scale = state["per_channel_scale"].to(self._device)

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -97,11 +97,11 @@ class DynamicLoss:
 
     def __init__(
         self,
+        loss_fn: LossFn,
         stds: Float[torch.Tensor, " var"],
         *,
-        device: torch.device,
         should_limit: bool,
-        loss_fn: LossFn,
+        device: torch.device,
     ):
         self._device = device
         self._per_channel_scale: Float[torch.Tensor, " var"] = torch.ones(

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -25,6 +25,7 @@ def decomposed_mae(
     return F.l1_loss(pred, target, reduction="none").mean(dim=(0, 2, 3))
 
 
+# TODO(alxmrs): This used to assume that hist=1; it may need to be fixed in the future.
 def decomposed_mse_diff_weighted(
     pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
 ) -> torch.Tensor:

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -103,16 +103,16 @@ class DynamicLoss:
         should_limit: bool,
         device: torch.device,
     ):
+        self.loss_fn = loss_fn
         self._device = device
         self._per_channel_scale: Float[torch.Tensor, " var"] = torch.ones(
             stds.shape[0], device=self._device
         )
         if should_limit:
-            vars: Float[torch.Tensor, " var"] = stds.pow(2)
-            self._limits: Float[torch.Tensor, " var"] | None = 1.0 / vars
+            variances: Float[torch.Tensor, " var"] = stds.pow(2)
+            self._limits: Float[torch.Tensor, " var"] | None = 1.0 / variances
         else:
             self._limits = None
-        self.loss_fn = loss_fn
 
     def __call__(
         self,


### PR DESCRIPTION
We now use a builder function to create the loss function. Loss can be defined as a simple metric, or a more sophisticated loss mixed in with a metric, such as dynamic loss. This should allow us to combine MAE with dynamic loss, for example.

My hope with this change is to follow up with experimenting with this idea from the Cambdige/NVIDIA paper: https://ar5iv.labs.arxiv.org/html/2410.07472v1#S4.SS10. 

(TL;DR: I have reason to believe that dynamic MAE will perform better than dynamic MSE). 