### PR TITLE
Updated `add_3d_coordinates` feature to preserve backwards compatibility with previous checkpoints.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -522,7 +522,7 @@ class SamudraConfig(BaseModelConfig):
             in_channels + self.pos_channels + (3 if self.add_3d_coordinates else 0)
         )
         add_3d_coordinates = (
-            Concat3dCoordinates(lat, lon) if self.add_3d_coordinates else nn.Identity()
+            Concat3dCoordinates(lat, lon) if self.add_3d_coordinates else None
         )
         return Samudra(
             in_channels=total_in_channels,

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -19,7 +19,7 @@ class Samudra(BaseModel):
         unet: UNetBackbone,
         corrector: nn.Module | None,
         pos_channels: int,
-        add_3d_coordinates: nn.Module,
+        add_3d_coordinates: nn.Module | None,
         hist: int,
         wet: Grid,
         static_data: xr.Dataset | None,
@@ -53,7 +53,7 @@ class Samudra(BaseModel):
         ]
 
         # This preserves backwards compatibility with previous checkpoints.
-        if not isinstance(add_3d_coordinates, nn.Identity):
+        if add_3d_coordinates is not None:
             layers.insert(0, add_3d_coordinates)
 
         self.layers = nn.ModuleList(layers)

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -46,12 +46,15 @@ class Samudra(BaseModel):
             self.register_parameter("positional_params", None)
 
         layers = [
-            add_3d_coordinates,
             # Add UNet core.
             unet,
             # Samudra "decoder".
             nn.Conv2d(unet.out_channels, out_channels, last_kernel_size),
         ]
+
+        # This preserves backwards compatibility with previous checkpoints.
+        if not isinstance(add_3d_coordinates, nn.Identity):
+            layers.insert(0, add_3d_coordinates)
 
         self.layers = nn.ModuleList(layers)
         self.corrector = corrector


### PR DESCRIPTION
When the `nn.Module` is `nn.Identity`, we now omit adding it to the modules list. This allows for backwards compatibility in the Samudra model. Since we have so few checkpoints in FOMO, I'm not applying this pattern there.