### PR TITLE
Remove TIME_DELTA constant and compute inference steps from data directly

### DIFF
--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -141,8 +141,7 @@ MASK_VARS = [
 
 RHO_0 = 1035.0  # DENSITY_OF_WATER_CM4 kg/m^3
 CP_SW = 3992.0  # SPECIFIC_HEAT_OF_WATER_CM4 J/kg/K
-SECONDS_PER_5DAY = 5 * 24 * 60 * 60  # 5 day average
-TIME_DELTA = 5  # Time delta in days
+SECONDS_PER_TIME_STEP = 5 * 24 * 60 * 60  # 5 day average
 
 PrognosticVarNames = list[str]
 PROGNOSTIC_VARS: dict[str, PrognosticVarNames] = {

--- a/src/ocean_emulators/models/corrector.py
+++ b/src/ocean_emulators/models/corrector.py
@@ -9,7 +9,7 @@ from torch import Tensor
 
 from ocean_emulators.aggregator.metrics import area_weighted_sum
 from ocean_emulators.constants import (
-    SECONDS_PER_5DAY,
+    SECONDS_PER_TIME_STEP,
     Boundary,
     HistBatched,
     HistChanneled,
@@ -148,7 +148,7 @@ def compute_expected_heat_content_change(
     # Expected change in heat content from surface flux
     dHC_expected = (
         area_weighted_func(surface_heat_flux * sea_surface_fraction_tensor)
-        * SECONDS_PER_5DAY
+        * SECONDS_PER_TIME_STEP
     )  # [J]
 
     # Apply geothermal heat flux
@@ -197,7 +197,7 @@ class OceanHeatCorrector(BaseCorrector):
             self.area_weighted_func(
                 self.hfgeou_tensor * self.sea_surface_fraction_tensor
             )
-            * SECONDS_PER_5DAY
+            * SECONDS_PER_TIME_STEP
         )
 
     def forward(self, fts_input: Input, fts: Prognostic) -> Prognostic:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -17,7 +17,6 @@ from ocean_emulators.constants import (
     DEPTH_I_LEVELS,
     DEPTH_LEVELS,
     MASK_VARS,
-    TIME_DELTA,
     BatchTimeSeriesOutput,
     BoundaryVarNames,
     DictSingleChannelVar,
@@ -431,15 +430,12 @@ def get_inference_steps(data_source: DataSource, hist: int = 1):
 
     Args:
         data_source: The data source sliced to the inference time range
-        hist: Number of rollout steps
+        hist: How many additional history samples we get per step
 
     Returns:
         num_steps: Total number of rolled-out inferences which fit into the time range
     """
-    start_time = data_source.data.time.min().item()
-    end_time = data_source.data.time.max().item()
-
-    num_steps = (end_time - start_time).days // TIME_DELTA + 1
+    num_steps = data_source.data.time.size
 
     # Might have extra remaining days, so we remove them
     mod = num_steps % (hist + 1)


### PR DESCRIPTION
The underlying bug in #468 was that the TIME_DELTA was set to 5 but the actual time between individual steps in @mkeutgen's dataset was 1 day. This lead to a mismatch between the size of the array the inference aggregators were accumulating into and the actual produced data's shape.

This is the only place that constant was still used and it seems like we can compute the steps more directly from the data so this kind of error can't happen again. 

@mkeutgen if you wouldn't mind trying out this change with your data that would be a great sanity check!

Closes #468