### PR TITLE
Remove unused method with a bad bug

### DIFF
--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -219,17 +219,6 @@ class DataSource:
         return norm
 
     @classmethod
-    def from_dataset(cls, dataset: xr.Dataset, *, name: str = "dataset") -> Self:
-        """Create a DataSource from the data, computing means and stds."""
-        # TODO(alxmrs): Support compact data
-        assert "lev" not in dataset.dims, "We currently only support non-compact data"
-
-        means = dataset.mean()
-        stds = dataset.std()
-
-        return cls(name=name, data=dataset, means=means, stds=stds)
-
-    @classmethod
     def from_locations(
         cls,
         data_location: ResolvedLocation,


### PR DESCRIPTION
As per https://openathena.slack.com/archives/C08CYM42DT3/p1764188280159869, we should be masking out land somehow before computing these statistics. But this method is unused (and already kinda unlikely to be what we want in the future) so I figured it makes sense to delete it rather than fix. 