### PR TITLE
Add Weighted Gradient-Enhanced MAE Loss Function

### DIFF
--- a/src/ocean_emulators/aggregator/inference/reduced.py
+++ b/src/ocean_emulators/aggregator/inference/reduced.py
@@ -140,9 +140,14 @@ class AreaWeightedReducedMetric:
                 "target and gen must have the same shape, got "
                 f"{target.shape} and {gen.shape}"
             )
+        # Note(mkeutgen):  this prevents a dimension mismatch error
+        target = target.squeeze()
+        gen = gen.squeeze()
+        
         new_value = (
             self._compute_metric(target=target, gen=gen).mean(dim=0).to(self._device)
         )
+        
         if self._total is None:
             self._total = torch.zeros(
                 [self._n_timesteps], dtype=new_value.dtype, device=self._device

--- a/src/ocean_emulators/aggregator/inference/reduced.py
+++ b/src/ocean_emulators/aggregator/inference/reduced.py
@@ -143,11 +143,11 @@ class AreaWeightedReducedMetric:
         # Note(mkeutgen):  this prevents a dimension mismatch error
         target = target.squeeze()
         gen = gen.squeeze()
-        
+
         new_value = (
             self._compute_metric(target=target, gen=gen).mean(dim=0).to(self._device)
         )
-        
+
         if self._total is None:
             self._total = torch.zeros(
                 [self._n_timesteps], dtype=new_value.dtype, device=self._device

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -72,6 +72,68 @@ def decomposed_mse_mae(
     combined = (mse + mae) / 2
     return combined.mean(dim=(0, 2, 3))
 
+def decomposed_mae_gradient_weighted(
+    pred: torch.Tensor, 
+    target: torch.Tensor, 
+    wet: torch.Tensor,
+    gradient_weight: float = 0.1
+) -> torch.Tensor:
+    """
+    MAE loss with WEIGHTED spatial gradient matching penalty.
+    
+    By controlling gradient_weight,
+    we can balance accuracy (MAE term) vs sharpness (gradient term).
+    
+    Loss = MAE(pred, target) + α * gradient_penalty(pred, target)
+    
+    where α = gradient_weight is a tunable hyperparameter.
+    
+    Recommended starting values:
+    - α = 0.05: Very conservative, prioritize accuracy
+    - α = 0.1:  Conservative, good balance 
+    - α = 0.25: Moderate, more sharpness 
+    - α = 0.5:  Aggressive sharpening
+    - α = 1.0:  Equal weighting 
+    
+    Args:
+        pred: Predicted tensor [batch, channels, height, width]
+        target: Target tensor [batch, channels, height, width]
+        wet: Wet mask [batch, channels, height, width]
+        gradient_weight: Scaling factor α for gradient penalty
+    
+    Returns:
+        Loss per channel [channels]
+    """
+    pred = pred * wet
+    target = target * wet
+    
+    # MAE term (main accuracy objective)
+    mae_loss = F.l1_loss(pred, target, reduction="none")
+    mae_per_channel = mae_loss.mean(dim=(0, 2, 3))
+    
+    # Gradient penalty: Match spatial gradients
+    pred_grad_y = pred[:, :, 1:, :] - pred[:, :, :-1, :]
+    pred_grad_x = pred[:, :, :, 1:] - pred[:, :, :, :-1]
+    
+    target_grad_y = target[:, :, 1:, :] - target[:, :, :-1, :]
+    target_grad_x = target[:, :, :, 1:] - target[:, :, :, :-1]
+    
+    grad_loss_y = F.l1_loss(pred_grad_y, target_grad_y, reduction="none")
+    grad_loss_x = F.l1_loss(pred_grad_x, target_grad_x, reduction="none")
+    
+    # Average gradient losses
+    grad_loss = (
+        F.pad(grad_loss_y, (0, 0, 0, 1), value=0).mean(dim=(0, 2, 3)) +
+        F.pad(grad_loss_x, (0, 1, 0, 0), value=0).mean(dim=(0, 2, 3))
+    ) / 2
+    
+    # Weighted combination
+    total_loss = mae_per_channel + gradient_weight * grad_loss
+    
+    return total_loss
+
+
+
 
 class MseDynamic:
     """A loss function that scales each channel to contribute equally to the loss.


### PR DESCRIPTION
**Summary**
Implements decomposed_mae_gradient_weighted() - a configurable loss function that combines standard MAE with spatial gradient penalties to preserve mesoscale ocean features (eddies, fronts) during training.

**Problem**
Pure MAE loss produces smooth predictions that lose sharp oceanographic features. Models achieve good R² scores but generate unrealistic, overly-diffused fields that lack physical structure

**Solution**
Add tunable gradient penalty term:
`Loss = MAE(pred, target) + α × gradient_penalty(pred, target)
`
Where α (gradient_weight) controls the accuracy vs. sharpness tradeoff:

α = 0.1: Conservative balance (recommended starting point)
α = 0.25: More aggressive feature preservation
α = 0.5: Better sharpness

**Implementation Details**

Per-channel loss computation for multi-variable training
Spatial gradients computed via finite differences (∂/∂x, ∂/∂y)
Gradient penalties averaged and weighted before combination

**Benefits**

Preserves mesoscale eddy coherence during autoregressive rollouts
Maintains fronts and boundaries
Tunable via a single hyperparameter
Computationally efficient (simple finite differences)


