### PR TITLE
Spatial grad loss

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -659,7 +659,7 @@ class GradientLossConfig(pydantic.BaseModel):
     # at the moment this metric is only used for the non-gradient loss
     # (and would take a bit of refactoring to make it work for the gradient loss too)
     # so we fix it to MAE for now until it's clear we what flexibility is needed here.
-    # TODO: support other metrics for the gradient loss
+    # TODO(#497): support other metrics for the gradient loss
     metric: Literal["mae"] = "mae"
     alpha: float = Field(
         description="Scaling factor for the gradient penalty term (alpha in the gradient-weighted loss).",

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -656,7 +656,11 @@ class DynamicLossConfig(pydantic.BaseModel):
 
 class GradientLossConfig(pydantic.BaseModel):
     type: Literal["gradient"] = "gradient"
-    metric: LossMetric = "mae"
+    # at the moment this metric is only used for the non-gradient loss
+    # (and would take a bit of refactoring to make it work for the gradient loss too)
+    # so we fix it to MAE for now until it's clear we what flexibility is needed here.
+    # TODO: support other metrics for the gradient loss
+    metric: Literal["mae"] = "mae"
     alpha: float = Field(
         description="Scaling factor for the gradient penalty term (alpha in the gradient-weighted loss).",
         default=0.1,

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -86,6 +86,7 @@ from ocean_emulators.utils.loss import (
     decomposed_mse_diff_weighted,
     decomposed_mse_mae,
     decomposed_mse_scaled,
+    decomposed_mae_gradient_weighted,
 )
 from ocean_emulators.utils.train import (
     CheckpointPaths,
@@ -283,6 +284,13 @@ class Trainer:
                     ).to(device=self.device),
                     should_limit=should_limit,
                 )
+            case "mae_gradient_weighted":
+                logger.info(f"Using MAE loss with weighted gradient penalty (α={cfg.gradient_weight})")
+                self.loss_fn = partial(
+                    decomposed_mae_gradient_weighted,
+                    wet=self.wet,
+                    gradient_weight=cfg.gradient_weight
+                )                    
             case _:
                 assert_never(cfg.loss)
 

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -72,6 +72,64 @@ def decomposed_mse_mae(
     combined = (mse + mae) / 2
     return combined.mean(dim=(0, 2, 3))
 
+def decomposed_mae_gradient_weighted(
+    pred: torch.Tensor, 
+    target: torch.Tensor, 
+    wet: torch.Tensor,
+    gradient_weight: float
+) -> torch.Tensor:
+    """MAE loss with WEIGHTED spatial gradient matching penalty.
+    
+    By controlling gradient_weight, we can balance accuracy (MAE term) vs sharpness (gradient term).
+    
+    Loss = MAE(pred, target) + α * gradient_penalty(pred, target).
+    
+    where α = gradient_weight is a tunable hyperparameter.
+    
+    Recommended starting values:
+    - α = 0.05: Very conservative, prioritize accuracy
+    - α = 0.1:  Conservative, good balance 
+    - α = 0.25: Moderate, more sharpness 
+    - α = 0.5:  Aggressive sharpening
+    - α = 1.0:  Equal weighting 
+    
+    Args:
+        pred: Predicted tensor [batch, channels, height, width].
+        target: Target tensor [batch, channels, height, width]
+        wet: Wet mask [batch, channels, height, width]
+        gradient_weight: Scaling factor α for gradient penalty
+    
+    Returns:
+        Loss per channel [channels]
+    """
+    pred = pred * wet
+    target = target * wet
+
+    # MAE term (main accuracy objective)
+    mae_loss = F.l1_loss(pred, target, reduction="none")
+    mae_per_channel = mae_loss.mean(dim=(0, 2, 3))
+
+    # Gradient penalty: Match spatial gradients
+    pred_grad_y = pred[:, :, 1:, :] - pred[:, :, :-1, :]
+    pred_grad_x = pred[:, :, :, 1:] - pred[:, :, :, :-1]
+
+    target_grad_y = target[:, :, 1:, :] - target[:, :, :-1, :]
+    target_grad_x = target[:, :, :, 1:] - target[:, :, :, :-1]
+
+    grad_loss_y = F.l1_loss(pred_grad_y, target_grad_y, reduction="none")
+    grad_loss_x = F.l1_loss(pred_grad_x, target_grad_x, reduction="none")
+
+    # Average gradient losses
+    grad_loss = (
+        F.pad(grad_loss_y, (0, 0, 0, 1), value=0).mean(dim=(0, 2, 3)) +
+        F.pad(grad_loss_x, (0, 1, 0, 0), value=0).mean(dim=(0, 2, 3))
+    ) / 2
+
+    # Weighted combination
+    total_loss = mae_per_channel + gradient_weight * grad_loss
+
+    return total_loss
+
 
 class MseDynamic:
     """A loss function that scales each channel to contribute equally to the loss.


### PR DESCRIPTION
**Summary**
Implements decomposed_mae_gradient_weighted() - a configurable loss function that combines standard MAE with spatial gradient penalties to preserve mesoscale ocean features (eddies, fronts) during training.

**Problem**
Pure MAE loss produces smooth predictions that lose sharp oceanographic features. Models achieve good R² scores but generate unrealistic, overly-diffused fields that lack physical structure

**Solution**
Add tunable gradient penalty term:
Loss = MAE(pred, target) + α × gradient_penalty(pred, target) 
Where α (gradient_weight) controls the accuracy vs. sharpness tradeoff:

α = 0.1: Conservative balance (recommended starting point)
α = 0.25: More aggressive feature preservation
α = 0.5: Better sharpness

**Implementation Details**

Per-channel loss computation for multi-variable training
Spatial gradients computed via finite differences (∂/∂x, ∂/∂y)
Gradient penalties averaged and weighted before combination

**Benefits**

Preserves mesoscale eddy coherence during autoregressive rollouts
Maintains fronts and boundaries
Tunable via a single hyperparameter
Computationally efficient (simple finite differences)