### PR TITLE
Readmes for the various model configs, add checkpointing for v1

### DIFF
--- a/configs/fomo_om4/README.md
+++ b/configs/fomo_om4/README.md
@@ -1,0 +1,5 @@
+# FOMO OM4
+
+These configurations are for the FOMO (encoder-processor-decoder) model,
+trained on OM4 data. The intent is for this to support heterogeneous
+resolutions and modalities.

--- a/configs/samudra_om4/README.md
+++ b/configs/samudra_om4/README.md
@@ -1,0 +1,5 @@
+# Samudra OM4
+
+These configurations are our current best Samudra-style (UNet) model,
+trained on OM4 data. Major changes from the v1 model are that it is
+wider and uses a dynamically-weighted loss.

--- a/configs/samudra_om4/train.yaml
+++ b/configs/samudra_om4/train.yaml
@@ -6,7 +6,7 @@ pin_mem: true
 save_freq: 5
 epochs: 70
 batch_size: 4
-learning_rate: 0.0002
+learning_rate: 0.0006
 scheduler: { type: cosine }
 loss: mse_dynamic_no_limit
 finetune: false

--- a/configs/samudra_om4_v1/README.md
+++ b/configs/samudra_om4_v1/README.md
@@ -1,0 +1,4 @@
+# Samudra OM4 V1
+
+These configurations are our replication of the [original Samudra model](https://arxiv.org/abs/2412.03795)
+trained on OM4 data.

--- a/configs/samudra_om4_v1/model.yaml
+++ b/configs/samudra_om4_v1/model.yaml
@@ -3,6 +3,7 @@
 pred_residuals: false
 last_kernel_size: 3
 pad: "circular"
+checkpointing: "all"
 
 unet:
   ch_width: [200, 250, 300, 400]

--- a/configs/samudra_om4_v1/train.yaml
+++ b/configs/samudra_om4_v1/train.yaml
@@ -5,7 +5,7 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 70
-batch_size: 3
+batch_size: 4
 learning_rate: 0.0006
 scheduler: { type: cosine }
 loss: mse


### PR DESCRIPTION
Hopefully this (a) clarifies what is what and (b) means we can train both samudra models on 1/2- and 1-degree datasets the same way.