### PR TITLE
Masking is same concern as the DataSource.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -157,7 +157,6 @@ class DataConfig(BaseConfig):
         data_root: ResolvedLocation,
         boundary_var_names: BoundaryVarNames,
         prognostic_var_names: PrognosticVarNames,
-        hist: int,
     ) -> DataContainer:
         loader_version = LoaderVersion(self.loader_version)
         use_dask = loader_version != LoaderVersion.OM4_TORCH
@@ -173,7 +172,7 @@ class DataConfig(BaseConfig):
             use_dask=use_dask,
         )
         source = validate_data(source, boundary_var_names, self.static_data_vars)
-        source = source.mask(prognostic_var_names, hist)
+        source = source.mask(prognostic_var_names, self.hist)
 
         if use_dask:
             # If we're already using dask, we don't need a second source
@@ -189,7 +188,7 @@ class DataConfig(BaseConfig):
             source_using_dask = validate_data(
                 source_using_dask, boundary_var_names, self.static_data_vars
             )
-            source_using_dask = source_using_dask.mask(prognostic_var_names, hist)
+            source_using_dask = source_using_dask.mask(prognostic_var_names, self.hist)
 
         static_data = (
             source.data[self.static_data_vars]

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -13,7 +13,14 @@ from torch import nn
 from torch.nn import GELU
 
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
-from ocean_emulators.constants import Grid, Lat, LoaderVersion, Lon, PrognosticVarNames
+from ocean_emulators.constants import (
+    BoundaryVarNames,
+    Grid,
+    Lat,
+    LoaderVersion,
+    Lon,
+    PrognosticVarNames,
+)
 from ocean_emulators.models import FOMO, Samudra
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import (
@@ -149,6 +156,7 @@ class DataConfig(BaseConfig):
         self,
         data_root: ResolvedLocation,
         prognostic_var_names: PrognosticVarNames,
+        boundary_var_names: BoundaryVarNames,
     ) -> DataContainer:
         loader_version = LoaderVersion(self.loader_version)
         use_dask = loader_version != LoaderVersion.OM4_TORCH
@@ -162,6 +170,7 @@ class DataConfig(BaseConfig):
             means_location=means_location,
             stds_location=stds_location,
             prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_var_names,
             static_data_vars=self.static_data_vars,
             use_dask=use_dask,
         )
@@ -176,6 +185,7 @@ class DataConfig(BaseConfig):
                 means_location=means_location,
                 stds_location=stds_location,
                 prognostic_var_names=prognostic_var_names,
+                boundary_var_names=boundary_var_names,
                 static_data_vars=self.static_data_vars,
                 use_dask=True,
             )

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -13,14 +13,7 @@ from torch import nn
 from torch.nn import GELU
 
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
-from ocean_emulators.constants import (
-    BoundaryVarNames,
-    Grid,
-    Lat,
-    LoaderVersion,
-    Lon,
-    PrognosticVarNames,
-)
+from ocean_emulators.constants import Grid, Lat, LoaderVersion, Lon, PrognosticVarNames
 from ocean_emulators.models import FOMO, Samudra
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import (
@@ -39,7 +32,7 @@ from ocean_emulators.models.modules import (
 )
 from ocean_emulators.models.modules.augment_input import Concat3dCoordinates
 from ocean_emulators.models.modules.blocks import ZonallyPeriodicBilinearUpsample
-from ocean_emulators.utils.data import DataContainer, DataSource, validate_data
+from ocean_emulators.utils.data import DataContainer, DataSource
 from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLocation
 from ocean_emulators.utils.loss import (
     DynamicLoss,
@@ -155,7 +148,6 @@ class DataConfig(BaseConfig):
     def build(
         self,
         data_root: ResolvedLocation,
-        boundary_var_names: BoundaryVarNames,
         prognostic_var_names: PrognosticVarNames,
     ) -> DataContainer:
         loader_version = LoaderVersion(self.loader_version)
@@ -165,15 +157,13 @@ class DataConfig(BaseConfig):
         means_location = data_root.resolve(self.data_means_location)
         stds_location = data_root.resolve(self.data_stds_location)
 
-        source = (
-            DataSource.from_locations(
-                data_location=data_location,
-                means_location=means_location,
-                stds_location=stds_location,
-                use_dask=use_dask,
-            )
-            .pipe(validate_data, boundary_var_names, self.static_data_vars)
-            .mask(prognostic_var_names, self.hist)
+        source = DataSource.from_locations(
+            data_location=data_location,
+            means_location=means_location,
+            stds_location=stds_location,
+            prognostic_var_names=prognostic_var_names,
+            static_data_vars=self.static_data_vars,
+            use_dask=use_dask,
         )
 
         if use_dask:
@@ -181,15 +171,13 @@ class DataConfig(BaseConfig):
             source_using_dask = source
         else:
             # If we're not using dask for the main source, create a separate one
-            source_using_dask = (
-                DataSource.from_locations(
-                    data_location=data_location,
-                    means_location=means_location,
-                    stds_location=stds_location,
-                    use_dask=True,
-                )
-                .pipe(validate_data, boundary_var_names, self.static_data_vars)
-                .mask(prognostic_var_names, self.hist)
+            source_using_dask = DataSource.from_locations(
+                data_location=data_location,
+                means_location=means_location,
+                stds_location=stds_location,
+                prognostic_var_names=prognostic_var_names,
+                static_data_vars=self.static_data_vars,
+                use_dask=True,
             )
 
         static_data = (

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -13,7 +13,14 @@ from torch import nn
 from torch.nn import GELU
 
 from ocean_emulators.config_base import BaseConfig, TopLevelConfig
-from ocean_emulators.constants import BoundaryVarNames, Grid, Lat, LoaderVersion, Lon
+from ocean_emulators.constants import (
+    BoundaryVarNames,
+    Grid,
+    Lat,
+    LoaderVersion,
+    Lon,
+    PrognosticVarNames,
+)
 from ocean_emulators.models import FOMO, Samudra
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import (
@@ -149,6 +156,8 @@ class DataConfig(BaseConfig):
         self,
         data_root: ResolvedLocation,
         boundary_var_names: BoundaryVarNames,
+        prognostic_var_names: PrognosticVarNames,
+        hist: int,
     ) -> DataContainer:
         loader_version = LoaderVersion(self.loader_version)
         use_dask = loader_version != LoaderVersion.OM4_TORCH
@@ -164,6 +173,7 @@ class DataConfig(BaseConfig):
             use_dask=use_dask,
         )
         source = validate_data(source, boundary_var_names, self.static_data_vars)
+        source = source.mask(prognostic_var_names, hist)
 
         if use_dask:
             # If we're already using dask, we don't need a second source
@@ -179,6 +189,7 @@ class DataConfig(BaseConfig):
             source_using_dask = validate_data(
                 source_using_dask, boundary_var_names, self.static_data_vars
             )
+            source_using_dask = source_using_dask.mask(prognostic_var_names, hist)
 
         static_data = (
             source.data[self.static_data_vars]

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -165,30 +165,32 @@ class DataConfig(BaseConfig):
         means_location = data_root.resolve(self.data_means_location)
         stds_location = data_root.resolve(self.data_stds_location)
 
-        source = DataSource.from_locations(
-            data_location=data_location,
-            means_location=means_location,
-            stds_location=stds_location,
-            use_dask=use_dask,
+        source = (
+            DataSource.from_locations(
+                data_location=data_location,
+                means_location=means_location,
+                stds_location=stds_location,
+                use_dask=use_dask,
+            )
+            .pipe(validate_data, boundary_var_names, self.static_data_vars)
+            .mask(prognostic_var_names, self.hist)
         )
-        source = validate_data(source, boundary_var_names, self.static_data_vars)
-        source = source.mask(prognostic_var_names, self.hist)
 
         if use_dask:
             # If we're already using dask, we don't need a second source
             source_using_dask = source
         else:
             # If we're not using dask for the main source, create a separate one
-            source_using_dask = DataSource.from_locations(
-                data_location=data_location,
-                means_location=means_location,
-                stds_location=stds_location,
-                use_dask=True,
+            source_using_dask = (
+                DataSource.from_locations(
+                    data_location=data_location,
+                    means_location=means_location,
+                    stds_location=stds_location,
+                    use_dask=True,
+                )
+                .pipe(validate_data, boundary_var_names, self.static_data_vars)
+                .mask(prognostic_var_names, self.hist)
             )
-            source_using_dask = validate_data(
-                source_using_dask, boundary_var_names, self.static_data_vars
-            )
-            source_using_dask = source_using_dask.mask(prognostic_var_names, self.hist)
 
         static_data = (
             source.data[self.static_data_vars]

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -15,9 +15,11 @@ from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 from ocean_emulators.constants import (
     BoundaryVarNames,
     Example,
+    GridMask,
     Input,
     LoaderVersion,
     Prognostic,
+    PrognosticMask,
     PrognosticVarNames,
 )
 from ocean_emulators.utils.data import (
@@ -93,8 +95,8 @@ class InferenceDataset(Dataset):
                 f" output at {data.time.values[self.hist + 1]}"
             )
 
-        self.wet: torch.Tensor = src.masks.wet_without_hist_cpu.bool()
-        self.wet_surface: torch.Tensor = src.masks.wet_surface.bool()
+        self.wet: PrognosticMask = src.masks.wet_without_hist_cpu.bool()
+        self.wet_surface: GridMask = src.masks.wet_surface.bool()
         self.size = len(self.rolling_indices)
 
         if using_gpu():
@@ -456,8 +458,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
-        self.wet = src.masks.wet_without_hist_cpu.bool().to(self.device)
-        self.wet_surface = src.masks.wet_surface.bool().to(self.device)
+        self.wet: PrognosticMask = src.masks.wet_without_hist_cpu.bool().to(self.device)
+        self.wet_surface: GridMask = src.masks.wet_surface.bool().to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
             if "lev" in means_or_stds.dims:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -454,8 +454,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
-        self.wet: PrognosticMask = src.masks.prognostic.bool().to(self.device)
-        self.wet_surface: GridMask = src.masks.boundary.bool().to(self.device)
+        self.wet: PrognosticMask = src.masks.prognostic.to(self.device)
+        self.wet_surface: GridMask = src.masks.boundary.to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
             if "lev" in means_or_stds.dims:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -91,8 +91,8 @@ class InferenceDataset(Dataset):
                 f" output at {data.time.values[self.hist + 1]}"
             )
 
-        self.wet: PrognosticMask = src.masks.wet.bool()
-        self.wet_surface: GridMask = src.masks.wet_surface.bool()
+        self.wet: PrognosticMask = src.masks.prognostic.bool()
+        self.wet_surface: GridMask = src.masks.boundary.bool()
         self.size = len(self.rolling_indices)
 
         if using_gpu():
@@ -454,8 +454,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
-        self.wet: PrognosticMask = src.masks.wet.bool().to(self.device)
-        self.wet_surface: GridMask = src.masks.wet_surface.bool().to(self.device)
+        self.wet: PrognosticMask = src.masks.prognostic.bool().to(self.device)
+        self.wet_surface: GridMask = src.masks.boundary.bool().to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
             if "lev" in means_or_stds.dims:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -15,11 +15,9 @@ from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 from ocean_emulators.constants import (
     BoundaryVarNames,
     Example,
-    GridMask,
     Input,
     LoaderVersion,
     Prognostic,
-    PrognosticMask,
     PrognosticVarNames,
 )
 from ocean_emulators.utils.data import DataSource, LoadStats, conditional_rearrange
@@ -49,8 +47,6 @@ class InferenceDataset(Dataset):
         src: DataSource,
         prognostic_var_names,
         boundary_var_names,
-        wet,
-        wet_surface,
         hist,
         normalize_before_mask,
         masked_fill_value,
@@ -93,8 +89,9 @@ class InferenceDataset(Dataset):
                 f" output at {data.time.values[self.hist + 1]}"
             )
 
-        self.wet: torch.Tensor = wet.bool()
-        self.wet_surface: torch.Tensor = wet_surface.bool()
+        assert src.masks is not None
+        self.wet: torch.Tensor = src.masks.wet_without_hist_cpu.bool()
+        self.wet_surface: torch.Tensor = src.masks.wet_surface.bool()
         self.size = len(self.rolling_indices)
 
         if using_gpu():
@@ -415,8 +412,6 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         src: DataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
-        wet: PrognosticMask,
-        wet_surface: GridMask,
         hist: int,
         steps: int,
         normalize_before_mask: bool,
@@ -458,8 +453,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
-        self.wet = wet.bool().to(self.device)
-        self.wet_surface = wet_surface.bool().to(self.device)
+        assert src.masks is not None
+        self.wet = src.masks.wet_without_hist_cpu.bool().to(self.device)
+        self.wet_surface = src.masks.wet_surface.bool().to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
             if "lev" in means_or_stds.dims:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -91,8 +91,8 @@ class InferenceDataset(Dataset):
                 f" output at {data.time.values[self.hist + 1]}"
             )
 
-        self.wet: PrognosticMask = src.masks.prognostic.bool()
-        self.wet_surface: GridMask = src.masks.boundary.bool()
+        self.wet: PrognosticMask = src.masks.prognostic
+        self.wet_surface: GridMask = src.masks.boundary
         self.size = len(self.rolling_indices)
 
         if using_gpu():

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -20,7 +20,11 @@ from ocean_emulators.constants import (
     Prognostic,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import DataSource, LoadStats, conditional_rearrange
+from ocean_emulators.utils.data import (
+    LoadStats,
+    MaskedDataSource,
+    conditional_rearrange,
+)
 from ocean_emulators.utils.device import get_device, using_gpu
 from ocean_emulators.utils.logging import elapsed
 
@@ -44,7 +48,7 @@ class InferenceDataset(Dataset):
     @elapsed
     def __init__(
         self,
-        src: DataSource,
+        src: MaskedDataSource,
         prognostic_var_names,
         boundary_var_names,
         hist,
@@ -89,7 +93,6 @@ class InferenceDataset(Dataset):
                 f" output at {data.time.values[self.hist + 1]}"
             )
 
-        assert src.masks is not None
         self.wet: torch.Tensor = src.masks.wet_without_hist_cpu.bool()
         self.wet_surface: torch.Tensor = src.masks.wet_surface.bool()
         self.size = len(self.rolling_indices)
@@ -409,7 +412,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     @elapsed
     def __init__(
         self,
-        src: DataSource,
+        src: MaskedDataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
         hist: int,
@@ -453,7 +456,6 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
-        assert src.masks is not None
         self.wet = src.masks.wet_without_hist_cpu.bool().to(self.device)
         self.wet_surface = src.masks.wet_surface.bool().to(self.device)
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -22,11 +22,7 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import (
-    LoadStats,
-    MaskedDataSource,
-    conditional_rearrange,
-)
+from ocean_emulators.utils.data import DataSource, LoadStats, conditional_rearrange
 from ocean_emulators.utils.device import get_device, using_gpu
 from ocean_emulators.utils.logging import elapsed
 
@@ -50,7 +46,7 @@ class InferenceDataset(Dataset):
     @elapsed
     def __init__(
         self,
-        src: MaskedDataSource,
+        src: DataSource,
         prognostic_var_names,
         boundary_var_names,
         hist,
@@ -95,7 +91,7 @@ class InferenceDataset(Dataset):
                 f" output at {data.time.values[self.hist + 1]}"
             )
 
-        self.wet: PrognosticMask = src.masks.wet_without_hist_cpu.bool()
+        self.wet: PrognosticMask = src.masks.wet.bool()
         self.wet_surface: GridMask = src.masks.wet_surface.bool()
         self.size = len(self.rolling_indices)
 
@@ -414,7 +410,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     @elapsed
     def __init__(
         self,
-        src: MaskedDataSource,
+        src: DataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
         hist: int,
@@ -458,7 +454,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
-        self.wet: PrognosticMask = src.masks.wet_without_hist_cpu.bool().to(self.device)
+        self.wet: PrognosticMask = src.masks.wet.bool().to(self.device)
         self.wet_surface: GridMask = src.masks.wet_surface.bool().to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -98,9 +98,9 @@ class Eval:
         self.metadata = construct_metadata(self.data)
         self.wet, self.wet_surface = (
             self.src.masks.repeat_prognostic(cfg.data.hist),
-            self.src.masks.wet_surface,
+            self.src.masks.boundary,
         )
-        self.wet_without_hist_cpu = self.src.masks.wet
+        self.wet_without_hist_cpu = self.src.masks.prognostic
         self.area_weights: Grid = spherical_area_weights(self.data)
         self.area_weights = self.area_weights.to(self.device)
 

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -90,6 +90,7 @@ class Eval:
         self.data_container = cfg.data.build(
             cfg.experiment.resolved_data_root,
             self.prognostic_var_names,
+            self.boundary_var_names,
         )
 
         self.src = self.data_container.source_using_dask

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -96,11 +96,7 @@ class Eval:
         self.data = self.src.data
         self.static_data = self.data_container.static_data
         self.metadata = construct_metadata(self.data)
-        self.wet, self.wet_surface = (
-            self.src.masks.repeat_prognostic(cfg.data.hist),
-            self.src.masks.boundary,
-        )
-        self.wet_without_hist_cpu = self.src.masks.prognostic
+        self.wet = self.src.masks.repeat_prognostic(cfg.data.hist)
         self.area_weights: Grid = spherical_area_weights(self.data)
         self.area_weights = self.area_weights.to(self.device)
 
@@ -108,10 +104,7 @@ class Eval:
             self.src,
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
-            wet_mask=self.wet_without_hist_cpu,
-            wet_mask_surface=self.wet_surface,
         )
-        self.wet_without_hist = self.wet_without_hist_cpu.to(self.device)
 
         # Model
         self.model = cfg.model.build(
@@ -178,8 +171,6 @@ class Eval:
             src=sliced_src,
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
-            wet=self.wet_without_hist_cpu,
-            wet_surface=self.wet_surface,
             hist=self.hist,
             normalize_before_mask=self.normalize_before_mask,
             masked_fill_value=self.masked_fill_value,
@@ -212,7 +203,7 @@ class Eval:
             self.metadata,
             self.hist,
             self.area_weights,
-            self.wet_without_hist,
+            self.src.masks.prognostic.to(self.device),
             self.num_out,
             self.prognostic_var_names,
         )

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -91,6 +91,8 @@ class Eval:
         self.data_container = cfg.data.build(
             cfg.experiment.resolved_data_root,
             self.boundary_var_names,
+            self.prognostic_var_names,
+            cfg.data.hist,
         )
 
         self.src = self.data_container.source_using_dask

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -97,7 +97,7 @@ class Eval:
         self.data = self.src.data
         self.static_data = self.data_container.static_data
         self.metadata = construct_metadata(self.data)
-        self.wet = self.src.masks.repeat_prognostic(cfg.data.hist)
+        self.wet = self.src.masks.prognostic_with_hist(cfg.data.hist)
         self.area_weights: Grid = spherical_area_weights(self.data)
         self.area_weights = self.area_weights.to(self.device)
 

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -21,7 +21,6 @@ from ocean_emulators.datasets import InferenceDataset
 from ocean_emulators.stepper import Stepper
 from ocean_emulators.utils.data import (
     Normalize,
-    extract_wet_mask,
     get_inference_steps,
     spherical_area_weights,
 )
@@ -90,21 +89,18 @@ class Eval:
         logger.info(f"Loading data")
         self.data_container = cfg.data.build(
             cfg.experiment.resolved_data_root,
-            self.boundary_var_names,
             self.prognostic_var_names,
         )
 
         self.src = self.data_container.source_using_dask
         self.data = self.src.data
         self.static_data = self.data_container.static_data
-
         self.metadata = construct_metadata(self.data)
-        self.wet, self.wet_surface = extract_wet_mask(
-            self.data, self.prognostic_var_names, cfg.data.hist
+        self.wet, self.wet_surface = (
+            self.src.masks.repeat_prognostic(cfg.data.hist),
+            self.src.masks.wet_surface,
         )
-        self.wet_without_hist_cpu, _ = extract_wet_mask(
-            self.data, self.prognostic_var_names, 0
-        )
+        self.wet_without_hist_cpu = self.src.masks.wet
         self.area_weights: Grid = spherical_area_weights(self.data)
         self.area_weights = self.area_weights.to(self.device)
 

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -92,7 +92,6 @@ class Eval:
             cfg.experiment.resolved_data_root,
             self.boundary_var_names,
             self.prognostic_var_names,
-            cfg.data.hist,
         )
 
         self.src = self.data_container.source_using_dask

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -132,6 +132,7 @@ class Trainer:
         self.data_container = cfg.data.build(
             data_root=cfg.experiment.resolved_data_root,
             prognostic_var_names=self.prognostic_var_names,
+            boundary_var_names=self.boundary_var_names,
         )
 
         self.mp_context: BaseContext | None = None

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -133,7 +133,6 @@ class Trainer:
             data_root=cfg.experiment.resolved_data_root,
             boundary_var_names=self.boundary_var_names,
             prognostic_var_names=self.prognostic_var_names,
-            hist=cfg.data.hist,
         )
 
         self.mp_context: BaseContext | None = None

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -185,7 +185,7 @@ class Trainer:
         self.loader_version = self.data_container.loader_version
 
         self.metadata = construct_metadata(self.data)
-        self.wet = self.src.masks.repeat_prognostic(cfg.data.hist).to(self.device)
+        self.wet = self.src.masks.prognostic_with_hist(cfg.data.hist).to(self.device)
         self.area_weights: Grid = spherical_area_weights(self.data)
 
         self.area_weights = self.area_weights.to(self.device)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -185,7 +185,6 @@ class Trainer:
 
         self.metadata = construct_metadata(self.data)
         self.wet = self.src.masks.repeat_prognostic(cfg.data.hist).to(self.device)
-        self.wet_without_hist = self.src.masks.prognostic.to(self.device)
         self.area_weights: Grid = spherical_area_weights(self.data)
 
         self.area_weights = self.area_weights.to(self.device)
@@ -619,7 +618,7 @@ class Trainer:
             self.metadata,
             self.hist,
             self.area_weights,
-            self.wet_without_hist,
+            self.src.masks.prognostic.to(self.device),
             self.num_out,
         )
         metric_logger = MetricLogger(delimiter="  ")
@@ -653,7 +652,7 @@ class Trainer:
                     self.metadata,
                     self.hist,
                     self.area_weights,
-                    self.wet_without_hist,
+                    self.src.masks.prognostic.to(self.device),
                     self.num_out,
                     self.prognostic_var_names,
                 )

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -185,7 +185,6 @@ class Trainer:
         self.loader_version = self.data_container.loader_version
 
         self.metadata = construct_metadata(self.data)
-        assert self.src.masks is not None
         self.wet = self.src.masks.wet.to(self.device)
         self.wet_without_hist = self.src.masks.wet_without_hist_cpu
         self.area_weights: Grid = spherical_area_weights(self.data)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -186,7 +186,7 @@ class Trainer:
 
         self.metadata = construct_metadata(self.data)
         self.wet = self.src.masks.wet.to(self.device)
-        self.wet_without_hist = self.src.masks.wet_without_hist_cpu
+        self.wet_without_hist = self.src.masks.wet_without_hist_cpu.to(self.device)
         self.area_weights: Grid = spherical_area_weights(self.data)
 
         self.area_weights = self.area_weights.to(self.device)
@@ -620,7 +620,7 @@ class Trainer:
             self.metadata,
             self.hist,
             self.area_weights,
-            self.wet_without_hist.to(self.device),
+            self.wet_without_hist,
             self.num_out,
         )
         metric_logger = MetricLogger(delimiter="  ")
@@ -654,7 +654,7 @@ class Trainer:
                     self.metadata,
                     self.hist,
                     self.area_weights,
-                    self.wet_without_hist.to(self.device),
+                    self.wet_without_hist,
                     self.num_out,
                     self.prognostic_var_names,
                 )

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -136,14 +136,6 @@ class Trainer:
             hist=cfg.data.hist,
         )
 
-        self.src = self.data_container.source
-        self.data = self.data_container.source.data
-        self.static_data = self.data_container.static_data
-
-        assert self.src.masks is not None
-        self.wet = self.src.masks.wet.to(self.device)
-        self.wet_without_hist = self.src.masks.wet_without_hist_cpu
-
         self.mp_context: BaseContext | None = None
         if cfg.data.num_workers > 0:
             if self.data_container.supports_fork:
@@ -182,6 +174,10 @@ class Trainer:
                 max_workers=None, thread_name_prefix="concurrent_compute"
             )
 
+        self.src = self.data_container.source
+        self.data = self.data_container.source.data
+        self.static_data = self.data_container.static_data
+
         # We use dask for inference since it has memory issues otherwise.
         # TODO(jder): Could rewrite inference dataset like we did for TorchTrainDataset
         # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/208
@@ -190,6 +186,9 @@ class Trainer:
         self.loader_version = self.data_container.loader_version
 
         self.metadata = construct_metadata(self.data)
+        assert self.src.masks is not None
+        self.wet = self.src.masks.wet.to(self.device)
+        self.wet_without_hist = self.src.masks.wet_without_hist_cpu
         self.area_weights: Grid = spherical_area_weights(self.data)
 
         self.area_weights = self.area_weights.to(self.device)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -185,7 +185,7 @@ class Trainer:
 
         self.metadata = construct_metadata(self.data)
         self.wet = self.src.masks.repeat_prognostic(cfg.data.hist).to(self.device)
-        self.wet_without_hist = self.src.masks.wet.to(self.device)
+        self.wet_without_hist = self.src.masks.prognostic.to(self.device)
         self.area_weights: Grid = spherical_area_weights(self.data)
 
         self.area_weights = self.area_weights.to(self.device)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -131,7 +131,6 @@ class Trainer:
 
         self.data_container = cfg.data.build(
             data_root=cfg.experiment.resolved_data_root,
-            boundary_var_names=self.boundary_var_names,
             prognostic_var_names=self.prognostic_var_names,
         )
 
@@ -185,8 +184,8 @@ class Trainer:
         self.loader_version = self.data_container.loader_version
 
         self.metadata = construct_metadata(self.data)
-        self.wet = self.src.masks.wet.to(self.device)
-        self.wet_without_hist = self.src.masks.wet_without_hist_cpu.to(self.device)
+        self.wet = self.src.masks.repeat_prognostic(cfg.data.hist).to(self.device)
+        self.wet_without_hist = self.src.masks.wet.to(self.device)
         self.area_weights: Grid = spherical_area_weights(self.data)
 
         self.area_weights = self.area_weights.to(self.device)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -54,7 +54,6 @@ from ocean_emulators.models.base import BaseModel
 from ocean_emulators.stepper import Stepper, TrainBatchOutput, ValBatchOutput
 from ocean_emulators.utils.data import (
     Normalize,
-    extract_wet_mask,
     get_inference_steps,
     spherical_area_weights,
 )
@@ -141,13 +140,9 @@ class Trainer:
         self.data = self.data_container.source.data
         self.static_data = self.data_container.static_data
 
-        self.wet, self.wet_surface = extract_wet_mask(
-            self.data, self.prognostic_var_names, cfg.data.hist
-        )
-        self.wet_without_hist_cpu, _ = extract_wet_mask(
-            self.data, self.prognostic_var_names, 0
-        )
-        self.wet = self.wet.to(self.device)
+        assert self.src.masks is not None
+        self.wet = self.src.masks.wet.to(self.device)
+        self.wet_without_hist = self.src.masks.wet_without_hist_cpu
 
         self.mp_context: BaseContext | None = None
         if cfg.data.num_workers > 0:
@@ -203,16 +198,13 @@ class Trainer:
             self.src,
             prognostic_var_names=self.prognostic_var_names,
             boundary_var_names=self.boundary_var_names,
-            wet_mask=self.wet_without_hist_cpu,
-            wet_mask_surface=self.wet_surface,
         )
-        self.wet_without_hist = self.wet_without_hist_cpu.to(self.device)
 
         self.model = cfg.model.build(
             in_channels=self.num_in,
             out_channels=self.num_out,
             hist=cfg.data.hist,
-            wet=self.wet.to(self.device),
+            wet=self.wet,
             area_weights=self.area_weights,
             static_data=self.static_data,
             lat=torch.from_numpy(self.data.lat.values),
@@ -372,8 +364,6 @@ class Trainer:
                 src=sliced_src,
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
-                wet=self.wet_without_hist_cpu,
-                wet_surface=self.wet_surface,
                 hist=self.hist,
                 normalize_before_mask=self.normalize_before_mask,
                 masked_fill_value=self.normalize_fill_value,
@@ -734,8 +724,6 @@ class Trainer:
                 src=self.src.slice(self.train_time),
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
-                wet=self.wet_without_hist_cpu,
-                wet_surface=self.wet_surface,
                 hist=self.hist,
                 steps=cur_step,
                 normalize_before_mask=self.normalize_before_mask,
@@ -751,8 +739,6 @@ class Trainer:
                 src=self.src.slice(self.val_time),
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
-                wet=self.wet_without_hist_cpu,
-                wet_surface=self.wet_surface,
                 hist=self.hist,
                 steps=1,  # current_step set to 1 for validation
                 normalize_before_mask=self.normalize_before_mask,

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -133,7 +133,21 @@ class Trainer:
         self.data_container = cfg.data.build(
             data_root=cfg.experiment.resolved_data_root,
             boundary_var_names=self.boundary_var_names,
+            prognostic_var_names=self.prognostic_var_names,
+            hist=cfg.data.hist,
         )
+
+        self.src = self.data_container.source
+        self.data = self.data_container.source.data
+        self.static_data = self.data_container.static_data
+
+        self.wet, self.wet_surface = extract_wet_mask(
+            self.data, self.prognostic_var_names, cfg.data.hist
+        )
+        self.wet_without_hist_cpu, _ = extract_wet_mask(
+            self.data, self.prognostic_var_names, 0
+        )
+        self.wet = self.wet.to(self.device)
 
         self.mp_context: BaseContext | None = None
         if cfg.data.num_workers > 0:
@@ -173,10 +187,6 @@ class Trainer:
                 max_workers=None, thread_name_prefix="concurrent_compute"
             )
 
-        self.src = self.data_container.source
-        self.data = self.data_container.source.data
-        self.static_data = self.data_container.static_data
-
         # We use dask for inference since it has memory issues otherwise.
         # TODO(jder): Could rewrite inference dataset like we did for TorchTrainDataset
         # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/208
@@ -185,13 +195,6 @@ class Trainer:
         self.loader_version = self.data_container.loader_version
 
         self.metadata = construct_metadata(self.data)
-        self.wet, self.wet_surface = extract_wet_mask(
-            self.data, self.prognostic_var_names, cfg.data.hist
-        )
-        self.wet_without_hist_cpu, _ = extract_wet_mask(
-            self.data, self.prognostic_var_names, 0
-        )
-        self.wet = self.wet.to(self.device)
         self.area_weights: Grid = spherical_area_weights(self.data)
 
         self.area_weights = self.area_weights.to(self.device)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -620,7 +620,7 @@ class Trainer:
             self.metadata,
             self.hist,
             self.area_weights,
-            self.wet_without_hist,
+            self.wet_without_hist.to(self.device),
             self.num_out,
         )
         metric_logger = MetricLogger(delimiter="  ")
@@ -654,7 +654,7 @@ class Trainer:
                     self.metadata,
                     self.hist,
                     self.area_weights,
-                    self.wet_without_hist,
+                    self.wet_without_hist.to(self.device),
                     self.num_out,
                     self.prognostic_var_names,
                 )

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -243,6 +243,7 @@ class DataSource:
         stds_location: ResolvedLocation,
         *,
         prognostic_var_names: PrognosticVarNames,
+        boundary_var_names: BoundaryVarNames,
         static_data_vars: list[str] | None,
         use_dask: bool,
     ) -> Self:
@@ -256,6 +257,7 @@ class DataSource:
             means,
             stds,
             prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_var_names,
             static_data_vars=static_data_vars,
             name=f"{data_location}-{use_dask}",
         )
@@ -268,11 +270,16 @@ class DataSource:
         stds: xr.Dataset,
         *,
         prognostic_var_names: PrognosticVarNames,
+        boundary_var_names: BoundaryVarNames,
         static_data_vars: list[str] | None = None,
         name: str = "DataSource",
     ) -> Self:
         data, means, stds = validate_data(
-            data, means, stds, static_data_vars=static_data_vars
+            data,
+            means,
+            stds,
+            boundary_var_names=boundary_var_names,
+            static_data_vars=static_data_vars,
         )
         masks = extract_wet_mask(data, prognostic_var_names)
 
@@ -591,6 +598,7 @@ def validate_data(
     data: xr.Dataset,
     means: xr.Dataset,
     stds: xr.Dataset,
+    boundary_var_names: BoundaryVarNames,
     static_data_vars: list[str] | None = None,
 ) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]:
     """Validate the data such that we have the correct format for training."""
@@ -605,7 +613,6 @@ def validate_data(
 
     if is_compact:
         data = with_lat_lon_coords(data)
-        boundary_vars = [str(var) for var, da in data.items() if "lev" not in da.dims]
     else:
         data = (
             data.pipe(flatten_masks)
@@ -617,10 +624,9 @@ def validate_data(
         # This check is to ensure we convert data to the correct format
         means = with_level_index_vars(means)
         stds = with_level_index_vars(stds)
-        boundary_vars = [str(var) for var in data.data_vars.keys() if "_" not in var]
 
     # Check if any anomalies are needed to be computed
-    anomalies_vars = get_anomalies_vars(boundary_vars)
+    anomalies_vars = get_anomalies_vars(boundary_var_names)
     out = (
         compute_anomalies(data, means, stds, anomalies_vars)
         if anomalies_vars

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -122,6 +122,7 @@ class DataSource:
         return dataclasses.replace(self, name=name, data=data, means=means, stds=stds)
 
     def pipe(self, func: Callable[..., Self], *args, **kwargs) -> Self:
+        """Apply `func(self, *args, **kwargs)`, assuming `func` returns `Self`."""
         return func(self, *args, **kwargs)
 
     def map(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -44,6 +44,25 @@ def _var_name_encode_level(var_name: str) -> bool:
     return bool(var_name_encodes_level.search(var_name))
 
 
+def _is_compact(data: xr.Dataset, means: xr.Dataset, stds: xr.Dataset) -> bool:
+    return all(
+        not _var_name_encode_level(str(v))
+        for d in [data, means, stds]
+        for v in d.keys()
+    )
+
+
+@dataclasses.dataclass
+class Masks:
+    """A collection of masks to expose the ocean and mask land."""
+
+    wet: PrognosticMask
+    wet_surface: GridMask
+
+    def repeat_prognostic(self, hist: int):
+        return torch.concat([self.wet] * (hist + 1), dim=0)
+
+
 @dataclasses.dataclass
 class DataSource:
     """Data source for the model."""
@@ -52,15 +71,12 @@ class DataSource:
     data: xr.Dataset
     means: xr.Dataset
     stds: xr.Dataset
+    masks: Masks
 
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""
-        return all(
-            not _var_name_encode_level(str(v))
-            for d in [self.data, self.means, self.stds]
-            for v in d.keys()
-        )
+        return _is_compact(self.data, self.means, self.stds)
 
     def filter(
         self,
@@ -230,6 +246,8 @@ class DataSource:
         means_location: ResolvedLocation,
         stds_location: ResolvedLocation,
         *,
+        prognostic_var_names: PrognosticVarNames,
+        static_data_vars: list[str] | None,
         use_dask: bool,
     ) -> Self:
         chunks: dict[str, int] | None = {} if use_dask else None
@@ -237,52 +255,46 @@ class DataSource:
         means = means_location.open(chunks)
         stds = stds_location.open(chunks)
 
-        return cls(
+        return cls.from_datasets(
+            data,
+            means,
+            stds,
+            prognostic_var_names=prognostic_var_names,
+            static_data_vars=static_data_vars,
             name=f"{data_location}-{use_dask}",
+        )
+
+    @classmethod
+    def from_datasets(
+        cls,
+        data: xr.Dataset,
+        means: xr.Dataset,
+        stds: xr.Dataset,
+        *,
+        prognostic_var_names: PrognosticVarNames,
+        static_data_vars: list[str] | None = None,
+        name: str = "DataSource",
+    ) -> Self:
+        data, means, stds = validate_data(
+            data, means, stds, static_data_vars=static_data_vars
+        )
+        wet, wet_surface = extract_wet_mask(data, prognostic_var_names)
+
+        masks = Masks(wet=wet, wet_surface=wet_surface)
+
+        return cls(
+            name=name,
             data=data,
             means=means,
             stds=stds,
-        )
-
-    def mask(
-        self, prognostic_var_names: PrognosticVarNames, hist: int
-    ) -> "MaskedDataSource":
-        wet, wet_surface = extract_wet_mask(self.data, prognostic_var_names, hist)
-        wet_no_hist, _ = extract_wet_mask(self.data, prognostic_var_names, 0)
-
-        masks = Masks(
-            wet=wet, wet_surface=wet_surface, wet_without_hist_cpu=wet_no_hist
-        )
-
-        return MaskedDataSource(
-            name=f"{self.name}_with_wetmasks",
-            data=self.data,
-            means=self.means,
-            stds=self.stds,
             masks=masks,
         )
 
 
 @dataclasses.dataclass
-class Masks:
-    """A collection of masks to expose the ocean and mask land."""
-
-    wet: PrognosticMask
-    wet_surface: GridMask
-    wet_without_hist_cpu: PrognosticMask
-
-
-@dataclasses.dataclass
-class MaskedDataSource(DataSource):
-    """A `DataSource` with a `masks` field; created via `DataSource.mask`."""
-
-    masks: Masks
-
-
-@dataclasses.dataclass
 class DataContainer:
-    source: MaskedDataSource
-    source_using_dask: MaskedDataSource
+    source: DataSource
+    source_using_dask: DataSource
     loader_version: LoaderVersion
     supports_fork: bool
     static_data: xr.Dataset | None = None
@@ -376,7 +388,7 @@ def conditional_rearrange(
 
 
 def extract_wet_mask(
-    data: xr.Dataset, prognostic_var_names: PrognosticVarNames, hist: int
+    data: xr.Dataset, prognostic_var_names: PrognosticVarNames
 ) -> tuple[PrognosticMask, GridMask]:
     """A mask for where the oceans are. Water is wet."""
     data_ = flatten_masks(data)
@@ -392,7 +404,6 @@ def extract_wet_mask(
 
     wet_inp = torch.from_numpy(wet_mask_np[depth_ind])
     wet_surface = torch.from_numpy(wet_surface_mask_np)
-    wet_inp = torch.concat([wet_inp] * (hist + 1), dim=0)
     return wet_inp.bool(), wet_surface.bool()
 
 
@@ -524,29 +535,28 @@ def get_anomalies_vars(var_names: BoundaryVarNames) -> tuple[str, ...]:
 
 
 def compute_anomalies(
-    data_src: DataSource, anomalies_vars: tuple[str, ...]
-) -> DataSource:
+    data: xr.Dataset,
+    means: xr.Dataset,
+    stds: xr.Dataset,
+    anomalies_vars: tuple[str, ...],
+) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]:
     """Compute anomalies for the given variables."""
-
-    def _anom(data, means, stds):
-        for var in anomalies_vars:
-            base_var = var.replace("_anomalies", "")
-            if var not in data.variables and base_var in data.variables:
-                logger.info(f"Computing anomalies for {base_var}")
-                climatology = (
-                    data[base_var].groupby("time.dayofyear").mean("time").compute()
-                )
-                # Remove the seasonal cycle (climatology) from the detrended data
-                day_of_year = data[base_var]["time"].dt.dayofyear
-                data[var] = (
-                    data[base_var] - climatology.sel(dayofyear=day_of_year)
-                ).compute()
-                data = data.drop_vars(["dayofyear"])
-                means[var] = data[var].mean().compute()
-                stds[var] = data[var].std().compute()
-        return data, means, stds
-
-    return data_src.map(_anom, suffix="anomalies")
+    for var in anomalies_vars:
+        base_var = var.replace("_anomalies", "")
+        if var not in data.variables and base_var in data.variables:
+            logger.info(f"Computing anomalies for {base_var}")
+            climatology = (
+                data[base_var].groupby("time.dayofyear").mean("time").compute()
+            )
+            # Remove the seasonal cycle (climatology) from the detrended data
+            day_of_year = data[base_var]["time"].dt.dayofyear
+            data[var] = (
+                data[base_var] - climatology.sel(dayofyear=day_of_year)
+            ).compute()
+            data = data.drop_vars(["dayofyear"])
+            means[var] = data[var].mean().compute()
+            stds[var] = data[var].std().compute()
+    return data, means, stds
 
 
 def with_level_index_vars(data: xr.Dataset) -> xr.Dataset:
@@ -584,47 +594,44 @@ def with_lat_lon_coords(data: xr.Dataset) -> xr.Dataset:
 
 
 def validate_data(
-    src: DataSource,
-    boundary_vars: BoundaryVarNames,
+    data: xr.Dataset,
+    means: xr.Dataset,
+    stds: xr.Dataset,
     static_data_vars: list[str] | None = None,
-) -> DataSource:
+) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]:
     """Validate the data such that we have the correct format for training."""
+    is_compact = _is_compact(data, means, stds)
     if static_data_vars is not None:
-
-        def _static_data_checks(data):
-            for var in static_data_vars:
-                assert var in data.variables, (
-                    f"Static data variable {var} not found in data"
-                )
-                if "time" in data[var].dims:
-                    data[var] = data[var].isel(time=0)
-
-            return data
-
-        src = src.map_data(_static_data_checks, suffix="static_data_checked")
-
-    if src.is_compact:
-        src_ = src.map_data(with_lat_lon_coords)
-    else:
-
-        def validated(data, means, stds):
-            data = (
-                data.pipe(flatten_masks)
-                .pipe(with_level_index_vars)
-                .pipe(with_lat_lon_coords)
+        for var in static_data_vars:
+            assert var in data.variables, (
+                f"Static data variable {var} not found in data"
             )
+            if "time" in data[var].dims:
+                data[var] = data[var].isel(time=0)
 
-            # Check if data variables are in the right format
-            # This check is to ensure we convert data to the correct format
-            means = with_level_index_vars(means)
-            stds = with_level_index_vars(stds)
-            return data, means, stds
+    if is_compact:
+        data = with_lat_lon_coords(data)
+        boundary_vars = [str(var) for var, da in data.items() if "lev" not in da.dims]
+    else:
+        data = (
+            data.pipe(flatten_masks)
+            .pipe(with_level_index_vars)
+            .pipe(with_lat_lon_coords)
+        )
 
-        src_ = src.map(validated, suffix="validated")
+        # Check if data variables are in the right format
+        # This check is to ensure we convert data to the correct format
+        means = with_level_index_vars(means)
+        stds = with_level_index_vars(stds)
+        boundary_vars = [str(var) for var in data.data_vars.keys() if "_" not in var]
 
     # Check if any anomalies are needed to be computed
     anomalies_vars = get_anomalies_vars(boundary_vars)
-    out = compute_anomalies(src_, anomalies_vars) if anomalies_vars else src_
+    out = (
+        compute_anomalies(data, means, stds, anomalies_vars)
+        if anomalies_vars
+        else (data, means, stds)
+    )
 
     return out
 
@@ -633,7 +640,7 @@ def validate_data(
 class Normalize(Multiton):
     def _initialize(
         self,
-        src: MaskedDataSource,
+        src: DataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
     ) -> None:
@@ -644,7 +651,7 @@ class Normalize(Multiton):
         self.prognostic_std = prognostic_src.stds
         self.boundary_mean = boundary_src.means
         self.boundary_std = boundary_src.stds
-        self.wet_mask = src.masks.wet_without_hist_cpu
+        self.wet_mask = src.masks.wet
         self.wet_mask_surface = src.masks.wet_surface
 
         # Pre-compute numpy arrays for faster access

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -13,6 +13,7 @@ from einops import rearrange
 
 if TYPE_CHECKING:
     from ocean_emulators.config import TimeConfig
+
 from ocean_emulators.constants import (
     DEPTH_I_LEVELS,
     DEPTH_LEVELS,
@@ -51,6 +52,9 @@ class DataSource:
     data: xr.Dataset
     means: xr.Dataset
     stds: xr.Dataset
+    wet: PrognosticMask | None = None
+    wet_surface: GridMask | None = None
+    wet_without_hist_cpu: PrognosticMask | None = None
 
     @cached_property
     def is_compact(self) -> bool:
@@ -237,6 +241,18 @@ class DataSource:
             data=data,
             means=means,
             stds=stds,
+        )
+
+    def mask(self, prognostic_var_names: PrognosticVarNames, hist: int) -> Self:
+        wet, wet_surface = extract_wet_mask(self.data, prognostic_var_names, hist)
+        wet_no_hist, _ = extract_wet_mask(self.data, prognostic_var_names, 0)
+
+        return dataclasses.replace(
+            self,
+            name=f"{self.name}_with_wetmasks",
+            wet=wet,
+            wet_surface=wet_surface,
+            wet_without_hist_cpu=wet_no_hist,
         )
 
 

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -121,6 +121,9 @@ class DataSource:
 
         return dataclasses.replace(self, name=name, data=data, means=means, stds=stds)
 
+    def pipe(self, func: Callable[..., Self], *args, **kwargs) -> Self:
+        return func(self, *args, **kwargs)
+
     def map(
         self,
         func: Callable[

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -47,7 +47,7 @@ def _var_name_encode_level(var_name: str) -> bool:
 @dataclasses.dataclass
 class Masks:
     wet: PrognosticMask
-    wet_surface: PrognosticMask
+    wet_surface: GridMask
     wet_without_hist_cpu: PrognosticMask
 
 

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -129,10 +129,6 @@ class DataSource:
 
         return dataclasses.replace(self, name=name, data=data, means=means, stds=stds)
 
-    def pipe(self, func: Callable[..., Self], *args, **kwargs) -> Self:
-        """Apply `func(self, *args, **kwargs)`, assuming `func` returns `Self`."""
-        return func(self, *args, **kwargs)
-
     def map(
         self,
         func: Callable[

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -56,11 +56,11 @@ def _is_compact(data: xr.Dataset, means: xr.Dataset, stds: xr.Dataset) -> bool:
 class Masks:
     """A collection of masks to expose the ocean and mask land."""
 
-    wet: PrognosticMask
-    wet_surface: GridMask
+    prognostic: PrognosticMask
+    boundary: GridMask
 
     def repeat_prognostic(self, hist: int):
-        return torch.concat([self.wet] * (hist + 1), dim=0)
+        return torch.concat([self.prognostic] * (hist + 1), dim=0)
 
 
 @dataclasses.dataclass
@@ -274,9 +274,7 @@ class DataSource:
         data, means, stds = validate_data(
             data, means, stds, static_data_vars=static_data_vars
         )
-        wet, wet_surface = extract_wet_mask(data, prognostic_var_names)
-
-        masks = Masks(wet=wet, wet_surface=wet_surface)
+        masks = extract_wet_mask(data, prognostic_var_names)
 
         return cls(
             name=name,
@@ -385,7 +383,7 @@ def conditional_rearrange(
 
 def extract_wet_mask(
     data: xr.Dataset, prognostic_var_names: PrognosticVarNames
-) -> tuple[PrognosticMask, GridMask]:
+) -> Masks:
     """A mask for where the oceans are. Water is wet."""
     data_ = flatten_masks(data)
     wet_mask = data_[MASK_VARS]
@@ -400,7 +398,7 @@ def extract_wet_mask(
 
     wet_inp = torch.from_numpy(wet_mask_np[depth_ind])
     wet_surface = torch.from_numpy(wet_surface_mask_np)
-    return wet_inp.bool(), wet_surface.bool()
+    return Masks(wet_inp.bool(), wet_surface.bool())
 
 
 def _parse_lev_from_output_var(prognostic_var_names: PrognosticVarNames) -> list[int]:
@@ -647,8 +645,8 @@ class Normalize(Multiton):
         self.prognostic_std = prognostic_src.stds
         self.boundary_mean = boundary_src.means
         self.boundary_std = boundary_src.stds
-        self.wet_mask = src.masks.wet
-        self.wet_mask_surface = src.masks.wet_surface
+        self.wet_mask = src.masks.prognostic
+        self.wet_mask_surface = src.masks.boundary
 
         # Pre-compute numpy arrays for faster access
         self._prognostic_mean_np = (

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -60,6 +60,10 @@ class Masks:
     prognostic: PrognosticMask
     boundary: GridMask
 
+    def __post_init__(self):
+        self.prognostic = self.prognostic.bool()
+        self.boundary = self.boundary.bool()
+
     def prognostic_with_hist(
         self, hist: int
     ) -> Bool[GridMask, " prognostic_vars*({hist}+1)"]:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -45,6 +45,13 @@ def _var_name_encode_level(var_name: str) -> bool:
 
 
 @dataclasses.dataclass
+class Masks:
+    wet: PrognosticMask
+    wet_surface: PrognosticMask
+    wet_without_hist_cpu: PrognosticMask
+
+
+@dataclasses.dataclass
 class DataSource:
     """Data source for the model."""
 
@@ -52,9 +59,7 @@ class DataSource:
     data: xr.Dataset
     means: xr.Dataset
     stds: xr.Dataset
-    wet: PrognosticMask | None = None
-    wet_surface: GridMask | None = None
-    wet_without_hist_cpu: PrognosticMask | None = None
+    masks: Masks | None = None
 
     @cached_property
     def is_compact(self) -> bool:
@@ -247,12 +252,14 @@ class DataSource:
         wet, wet_surface = extract_wet_mask(self.data, prognostic_var_names, hist)
         wet_no_hist, _ = extract_wet_mask(self.data, prognostic_var_names, 0)
 
+        masks = Masks(
+            wet=wet, wet_surface=wet_surface, wet_without_hist_cpu=wet_no_hist
+        )
+
         return dataclasses.replace(
             self,
             name=f"{self.name}_with_wetmasks",
-            wet=wet,
-            wet_surface=wet_surface,
-            wet_without_hist_cpu=wet_no_hist,
+            masks=masks,
         )
 
 
@@ -613,8 +620,6 @@ class Normalize(Multiton):
         src: DataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
-        wet_mask: torch.Tensor,
-        wet_mask_surface: torch.Tensor,
     ) -> None:
         """Store normalization parameters and pre-compute numpy arrays."""
         prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
@@ -623,8 +628,9 @@ class Normalize(Multiton):
         self.prognostic_std = prognostic_src.stds
         self.boundary_mean = boundary_src.means
         self.boundary_std = boundary_src.stds
-        self.wet_mask = wet_mask
-        self.wet_mask_surface = wet_mask_surface
+        assert src.masks is not None
+        self.wet_mask = src.masks.wet_without_hist_cpu
+        self.wet_mask_surface = src.masks.wet_surface
 
         # Pre-compute numpy arrays for faster access
         self._prognostic_mean_np = (

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 import xarray as xr
 from einops import rearrange
+from jaxtyping import Bool
 
 if TYPE_CHECKING:
     from ocean_emulators.config import TimeConfig
@@ -59,7 +60,9 @@ class Masks:
     prognostic: PrognosticMask
     boundary: GridMask
 
-    def repeat_prognostic(self, hist: int):
+    def prognostic_with_hist(
+        self, hist: int
+    ) -> Bool[GridMask, " prognostic_vars*({hist}+1)"]:
         return torch.concat([self.prognostic] * (hist + 1), dim=0)
 
 

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -59,7 +59,6 @@ class DataSource:
     data: xr.Dataset
     means: xr.Dataset
     stds: xr.Dataset
-    masks: Masks | None = None
 
     @cached_property
     def is_compact(self) -> bool:
@@ -252,7 +251,9 @@ class DataSource:
             stds=stds,
         )
 
-    def mask(self, prognostic_var_names: PrognosticVarNames, hist: int) -> Self:
+    def mask(
+        self, prognostic_var_names: PrognosticVarNames, hist: int
+    ) -> "MaskedDataSource":
         wet, wet_surface = extract_wet_mask(self.data, prognostic_var_names, hist)
         wet_no_hist, _ = extract_wet_mask(self.data, prognostic_var_names, 0)
 
@@ -260,17 +261,24 @@ class DataSource:
             wet=wet, wet_surface=wet_surface, wet_without_hist_cpu=wet_no_hist
         )
 
-        return dataclasses.replace(
-            self,
+        return MaskedDataSource(
             name=f"{self.name}_with_wetmasks",
+            data=self.data,
+            means=self.means,
+            stds=self.stds,
             masks=masks,
         )
 
 
 @dataclasses.dataclass
+class MaskedDataSource(DataSource):
+    masks: Masks
+
+
+@dataclasses.dataclass
 class DataContainer:
-    source: DataSource
-    source_using_dask: DataSource
+    source: MaskedDataSource
+    source_using_dask: MaskedDataSource
     loader_version: LoaderVersion
     supports_fork: bool
     static_data: xr.Dataset | None = None
@@ -621,7 +629,7 @@ def validate_data(
 class Normalize(Multiton):
     def _initialize(
         self,
-        src: DataSource,
+        src: MaskedDataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
     ) -> None:
@@ -632,7 +640,6 @@ class Normalize(Multiton):
         self.prognostic_std = prognostic_src.stds
         self.boundary_mean = boundary_src.means
         self.boundary_std = boundary_src.stds
-        assert src.masks is not None
         self.wet_mask = src.masks.wet_without_hist_cpu
         self.wet_mask_surface = src.masks.wet_surface
 

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -45,13 +45,6 @@ def _var_name_encode_level(var_name: str) -> bool:
 
 
 @dataclasses.dataclass
-class Masks:
-    wet: PrognosticMask
-    wet_surface: GridMask
-    wet_without_hist_cpu: PrognosticMask
-
-
-@dataclasses.dataclass
 class DataSource:
     """Data source for the model."""
 
@@ -271,7 +264,18 @@ class DataSource:
 
 
 @dataclasses.dataclass
+class Masks:
+    """A collection of masks to expose the ocean and mask land."""
+
+    wet: PrognosticMask
+    wet_surface: GridMask
+    wet_without_hist_cpu: PrognosticMask
+
+
+@dataclasses.dataclass
 class MaskedDataSource(DataSource):
+    """A `DataSource` with a `masks` field; created via `DataSource.mask`."""
+
     masks: Masks
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -349,7 +349,7 @@ def _uncached_data_source(name: str) -> DataSource:
 
             return DataSource.from_datasets(
                 ds,
-                ds.means(),
+                ds.mean(),
                 ds.std(),
                 name=name,
                 prognostic_var_names=[str(var) for var in ds if "_" in str(var)],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,6 +353,7 @@ def _uncached_data_source(name: str) -> DataSource:
                 ds.std(),
                 name=name,
                 prognostic_var_names=[str(var) for var in ds if "_" in str(var)],
+                boundary_var_names=[str(var) for var in ds if "_" not in str(var)],
             )
 
         case "remote-om4" | "compact":
@@ -389,6 +390,11 @@ def _uncached_data_source(name: str) -> DataSource:
                 prognostic_var_names=[
                     str(v) for v in data if v not in BOUNDARY_VARS["tau_hfds_hfds_anom"]
                 ],
+                boundary_var_names=[
+                    str(var)
+                    for var in data
+                    if var in BOUNDARY_VARS["tau_hfds_hfds_anom"]
+                ],
             )
         case _:
             raise ValueError(f"Unknown data source: {name}.")
@@ -411,6 +417,9 @@ def _maybe_read_cache(cache_root: pathlib.Path, cache_name: str) -> DataSource |
             stds=stds,
             prognostic_var_names=[
                 str(v) for v in data if v not in BOUNDARY_VARS["tau_hfds_hfds_anom"]
+            ],
+            boundary_var_names=[
+                str(v) for v in data if v in BOUNDARY_VARS["tau_hfds_hfds_anom"]
             ],
         )
     except (FileNotFoundError, PermissionError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from numpy.typing import ArrayLike, NDArray
 
 import ocean_emulators.constants as c
 from ocean_emulators.config import JulianDate, TrainBackendConfig, TrainConfig
+from ocean_emulators.constants import BOUNDARY_VARS
 from ocean_emulators.train import Trainer
 from ocean_emulators.utils.data import DataSource, compact_dataset
 from ocean_emulators.utils.multiton import MultitonScope
@@ -346,7 +347,14 @@ def _uncached_data_source(name: str) -> DataSource:
             }
             ds = xr.Dataset(vars_2d | vars_3d | masks, coords=coords)
 
-            return DataSource(name=name, data=ds, means=ds.mean(), stds=ds.std())
+            return DataSource.from_datasets(
+                ds,
+                ds.means(),
+                ds.std(),
+                name=name,
+                prognostic_var_names=[str(var) for var in ds if "_" in str(var)],
+            )
+
         case "remote-om4" | "compact":
             # The chunk-size should be about the same as the size of the time slice
             # for optimal download time. In local experiments, this time range (which
@@ -373,11 +381,14 @@ def _uncached_data_source(name: str) -> DataSource:
                 means = compact_dataset(means)
                 stds = compact_dataset(stds)
 
-            return DataSource(
-                name=name,
+            return DataSource.from_datasets(
                 data=data,
                 means=means,
                 stds=stds,
+                name=name,
+                prognostic_var_names=[
+                    str(v) for v in data if v not in BOUNDARY_VARS["tau_hfds_hfds_anom"]
+                ],
             )
         case _:
             raise ValueError(f"Unknown data source: {name}.")
@@ -393,7 +404,15 @@ def _maybe_read_cache(cache_root: pathlib.Path, cache_name: str) -> DataSource |
         data = xr.open_zarr(cache / "data.zarr")
         means = xr.open_dataset(cache / "means.nc")
         stds = xr.open_dataset(cache / "stds.nc")
-        return DataSource(name=cache_name, data=data, means=means, stds=stds)
+        return DataSource.from_datasets(
+            name=cache_name,
+            data=data,
+            means=means,
+            stds=stds,
+            prognostic_var_names=[
+                str(v) for v in data if v not in BOUNDARY_VARS["tau_hfds_hfds_anom"]
+            ],
+        )
     except (FileNotFoundError, PermissionError):
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -416,26 +416,22 @@ def _maybe_read_cache(cache_root: pathlib.Path, cache_name: str) -> DataSource |
         means = xr.open_dataset(cache / "means.nc")
         stds = xr.open_dataset(cache / "stds.nc")
 
-        # Determine prognostic and boundary variable names
         boundary_vars = [
             str(v) for v in data.data_vars if v in BOUNDARY_VARS["tau_hfds_hfds_anom"]
         ]
 
         if _is_compact(data, means, stds):
-            # Compact format: expand variables to include level suffixes
             prognostic_var_names: list[str] = []
             for var in data.data_vars:
                 if var in boundary_vars or "mask" in var:
                     continue
                 if "lev" in data[var].dims:
-                    # Expand to all levels using level indices
                     prognostic_var_names.extend(
                         f"{var}_{i}" for i in range(len(data.lev))
                     )
                 else:
                     prognostic_var_names.append(str(var))
         else:
-            # Flat format: use variable names as-is
             prognostic_var_names = [
                 str(v)
                 for v in data.data_vars

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ import ocean_emulators.constants as c
 from ocean_emulators.config import JulianDate, TrainBackendConfig, TrainConfig
 from ocean_emulators.constants import BOUNDARY_VARS
 from ocean_emulators.train import Trainer
-from ocean_emulators.utils.data import DataSource, compact_dataset
+from ocean_emulators.utils.data import DataSource, _is_compact, compact_dataset
 from ocean_emulators.utils.multiton import MultitonScope
 
 REMOTE_DATA = "https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/"
@@ -377,6 +377,9 @@ def _uncached_data_source(name: str) -> DataSource:
                 ).compute()
             )
 
+            # Keep the original flat data for variable name extraction
+            data_for_vars = data
+
             if name == "compact":
                 data = compact_dataset(data)
                 means = compact_dataset(means)
@@ -388,11 +391,13 @@ def _uncached_data_source(name: str) -> DataSource:
                 stds=stds,
                 name=name,
                 prognostic_var_names=[
-                    str(v) for v in data if v not in BOUNDARY_VARS["tau_hfds_hfds_anom"]
+                    str(v)
+                    for v in data_for_vars
+                    if v not in BOUNDARY_VARS["tau_hfds_hfds_anom"]
                 ],
                 boundary_var_names=[
                     str(var)
-                    for var in data
+                    for var in data_for_vars
                     if var in BOUNDARY_VARS["tau_hfds_hfds_anom"]
                 ],
             )
@@ -410,17 +415,40 @@ def _maybe_read_cache(cache_root: pathlib.Path, cache_name: str) -> DataSource |
         data = xr.open_zarr(cache / "data.zarr")
         means = xr.open_dataset(cache / "means.nc")
         stds = xr.open_dataset(cache / "stds.nc")
+
+        # Determine prognostic and boundary variable names
+        boundary_vars = [
+            str(v) for v in data.data_vars if v in BOUNDARY_VARS["tau_hfds_hfds_anom"]
+        ]
+
+        if _is_compact(data, means, stds):
+            # Compact format: expand variables to include level suffixes
+            prognostic_var_names: list[str] = []
+            for var in data.data_vars:
+                if var in boundary_vars or "mask" in var:
+                    continue
+                if "lev" in data[var].dims:
+                    # Expand to all levels using level indices
+                    prognostic_var_names.extend(
+                        f"{var}_{i}" for i in range(len(data.lev))
+                    )
+                else:
+                    prognostic_var_names.append(str(var))
+        else:
+            # Flat format: use variable names as-is
+            prognostic_var_names = [
+                str(v)
+                for v in data.data_vars
+                if v not in boundary_vars and "mask" not in v
+            ]
+
         return DataSource.from_datasets(
             name=cache_name,
             data=data,
             means=means,
             stds=stds,
-            prognostic_var_names=[
-                str(v) for v in data if v not in BOUNDARY_VARS["tau_hfds_hfds_anom"]
-            ],
-            boundary_var_names=[
-                str(v) for v in data if v in BOUNDARY_VARS["tau_hfds_hfds_anom"]
-            ],
+            prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_vars,
         )
     except (FileNotFoundError, PermissionError):
         return None

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -8,7 +8,7 @@ import xarray as xr
 from ocean_emulators.aggregator.metrics import area_weighted_sum
 from ocean_emulators.derived_variables import compute_global_ocean_heat_content
 from ocean_emulators.models.corrector import OceanHeatCorrector, ReLUCorrector
-from ocean_emulators.utils.data import MaskedDataSource, Masks, Normalize
+from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.device import get_device
 from ocean_emulators.utils.multiton import MultitonScope
 
@@ -43,7 +43,7 @@ def corrector_init():
 
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
-    masks = Masks(wet=wet_mask, wet_surface=wet_mask, wet_without_hist_cpu=wet_mask)
+    masks = Masks(wet=wet_mask, wet_surface=wet_mask)
 
     class MockTensorMap:
         def __init__(self):
@@ -63,7 +63,7 @@ def corrector_init():
             self.dz = torch.tensor([1.0, 1.0])
 
     tensor_map = MockTensorMap()
-    test = MaskedDataSource("test", data, data_mean, data_std, masks)
+    test = DataSource("test", data, data_mean, data_std, masks)
     with MultitonScope():
         normalize = Normalize.init_instance(
             test,
@@ -160,8 +160,8 @@ def ocean_heat_init():
     )
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]])
-    masks = Masks(wet=wet_mask, wet_surface=wet_mask, wet_without_hist_cpu=wet_mask)
-    test = MaskedDataSource("test", data, data_mean, data_std, masks)
+    masks = Masks(wet=wet_mask, wet_surface=wet_mask)
+    test = DataSource("test", data, data_mean, data_std, masks)
 
     class MockTensorMap:
         def __init__(self):

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -43,7 +43,7 @@ def corrector_init():
 
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
-    masks = Masks(wet=wet_mask, wet_surface=wet_mask)
+    masks = Masks(prognostic=wet_mask, boundary=wet_mask)
 
     class MockTensorMap:
         def __init__(self):
@@ -160,7 +160,7 @@ def ocean_heat_init():
     )
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]])
-    masks = Masks(wet=wet_mask, wet_surface=wet_mask)
+    masks = Masks(prognostic=wet_mask, boundary=wet_mask)
     test = DataSource("test", data, data_mean, data_std, masks)
 
     class MockTensorMap:

--- a/tests/test_corrector.py
+++ b/tests/test_corrector.py
@@ -8,7 +8,7 @@ import xarray as xr
 from ocean_emulators.aggregator.metrics import area_weighted_sum
 from ocean_emulators.derived_variables import compute_global_ocean_heat_content
 from ocean_emulators.models.corrector import OceanHeatCorrector, ReLUCorrector
-from ocean_emulators.utils.data import DataSource, Normalize
+from ocean_emulators.utils.data import MaskedDataSource, Masks, Normalize
 from ocean_emulators.utils.device import get_device
 from ocean_emulators.utils.multiton import MultitonScope
 
@@ -43,6 +43,7 @@ def corrector_init():
 
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    masks = Masks(wet=wet_mask, wet_surface=wet_mask, wet_without_hist_cpu=wet_mask)
 
     class MockTensorMap:
         def __init__(self):
@@ -62,14 +63,12 @@ def corrector_init():
             self.dz = torch.tensor([1.0, 1.0])
 
     tensor_map = MockTensorMap()
-    test = DataSource("test", data, data_mean, data_std)
+    test = MaskedDataSource("test", data, data_mean, data_std, masks)
     with MultitonScope():
         normalize = Normalize.init_instance(
             test,
             prognostic_var_names=["var_0", "var_1"],
             boundary_var_names=["var_2"],
-            wet_mask=wet_mask,
-            wet_mask_surface=wet_mask,
         )
 
     return normalize, tensor_map, wet_mask
@@ -159,10 +158,10 @@ def ocean_heat_init():
         },
         coords={"lat": [0], "lon": [0]},
     )
-    test = DataSource("test", data, data_mean, data_std)
-
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]])
+    masks = Masks(wet=wet_mask, wet_surface=wet_mask, wet_without_hist_cpu=wet_mask)
+    test = MaskedDataSource("test", data, data_mean, data_std, masks)
 
     class MockTensorMap:
         def __init__(self):
@@ -187,8 +186,6 @@ def ocean_heat_init():
             test,
             prognostic_var_names=["thetao_0", "thetao_1", "thetao_2"],
             boundary_var_names=["hfds"],
-            wet_mask=wet_mask,
-            wet_mask_surface=wet_mask,
         )
 
     wet_mask = wet_mask.to(get_device())

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -29,7 +29,7 @@ from ocean_emulators.datasets import (
     TrainData,
     TrainDataLoader,
 )
-from ocean_emulators.utils.data import DataSource, MaskedDataSource, Masks, Normalize
+from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 from ocean_emulators.utils.train import collate_raw_train_data
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
@@ -60,9 +60,7 @@ def make_loader(
         else cfg.data.model_copy(update={"loader_version": str(version.value)})
     )
 
-    container = data_config.build(
-        cfg.experiment.resolved_data_root, boundary, prognostic
-    )
+    container = data_config.build(cfg.experiment.resolved_data_root, prognostic)
     version = container.loader_version
     src = container.source
     if src.is_compact and version != LoaderVersion.OM4_TORCH:
@@ -441,9 +439,8 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
     masks = Masks(
         wet=wet,
         wet_surface=wet_surface,
-        wet_without_hist_cpu=wet,
     )
-    test = MaskedDataSource("test", data, data_mean, data_std, masks=masks)
+    test = DataSource("test", data, data_mean, data_std, masks=masks)
 
     # Initialize and yield within the MultitonScope
     with MultitonScope():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -60,7 +60,9 @@ def make_loader(
         else cfg.data.model_copy(update={"loader_version": str(version.value)})
     )
 
-    container = data_config.build(cfg.experiment.resolved_data_root, boundary)
+    container = data_config.build(
+        cfg.experiment.resolved_data_root, boundary, prognostic, cfg.data.hist
+    )
     version = container.loader_version
     src = container.source
     if src.is_compact and version != LoaderVersion.OM4_TORCH:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -29,7 +29,7 @@ from ocean_emulators.datasets import (
     TrainData,
     TrainDataLoader,
 )
-from ocean_emulators.utils.data import DataSource, Normalize, extract_wet_mask
+from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 from ocean_emulators.utils.train import collate_raw_train_data
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
@@ -72,10 +72,6 @@ def make_loader(
         TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
         )
-        wet, wet_surface = extract_wet_mask(src.data, prognostic, cfg.data.hist)
-        wet_without_hist, _ = extract_wet_mask(src.data, prognostic, 0)
-        normalize_before_mask = cfg.data.normalize_before_mask
-        masked_fill_value = cfg.data.masked_fill_value
 
         match version:
             case LoaderVersion.OM4_TORCH:
@@ -84,12 +80,10 @@ def make_loader(
                         src=src.slice(time_config),
                         prognostic_var_names=prognostic,
                         boundary_var_names=boundary,
-                        wet=wet_without_hist,
-                        wet_surface=wet_surface,
                         hist=cfg.data.hist,
                         steps=cfg.steps[0],
-                        normalize_before_mask=normalize_before_mask,
-                        masked_fill_value=masked_fill_value,
+                        normalize_before_mask=cfg.data.normalize_before_mask,
+                        masked_fill_value=cfg.data.masked_fill_value,
                         stride=stride,
                     )
                     for stride in cfg.data_stride
@@ -440,11 +434,16 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
         coords={"lat": [0], "lon": [0]},
     )
 
-    test = DataSource("test", data, data_mean, data_std)
     wet_surface = torch.ones(2, 2)
     wet_surface[0, 0] = 0.0
     wet_surface[1, 1] = 0.0
     wet = wet_surface.expand(2, 2, 2)
+    masks = Masks(
+        wet=wet,
+        wet_surface=wet_surface,
+        wet_without_hist_cpu=wet,
+    )
+    test = DataSource("test", data, data_mean, data_std, masks=masks)
 
     # Initialize and yield within the MultitonScope
     with MultitonScope():
@@ -452,15 +451,11 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
             test,
             prognostic_var_names=["prognostic1", "prognostic2"],
             boundary_var_names=["boundary1", "boundary2"],
-            wet_mask=wet,
-            wet_mask_surface=wet_surface,
         )
         torch_train_dataset = TorchTrainDataset(
             src=test,
             prognostic_var_names=prognostic_var_names,
             boundary_var_names=boundary_var_names,
-            wet=wet,
-            wet_surface=wet_surface,
             hist=1,
             steps=2,
             normalize_before_mask=normalize_before_mask,
@@ -471,8 +466,6 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
             src=test,
             prognostic_var_names=prognostic_var_names,
             boundary_var_names=boundary_var_names,
-            wet=wet,
-            wet_surface=wet_surface,
             hist=1,
             normalize_before_mask=normalize_before_mask,
             masked_fill_value=masked_fill_value,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -437,8 +437,8 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
     wet_surface[1, 1] = 0.0
     wet = wet_surface.expand(2, 2, 2)
     masks = Masks(
-        wet=wet,
-        wet_surface=wet_surface,
+        prognostic=wet,
+        boundary=wet_surface,
     )
     test = DataSource("test", data, data_mean, data_std, masks=masks)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -60,7 +60,9 @@ def make_loader(
         else cfg.data.model_copy(update={"loader_version": str(version.value)})
     )
 
-    container = data_config.build(cfg.experiment.resolved_data_root, prognostic)
+    container = data_config.build(
+        cfg.experiment.resolved_data_root, boundary, prognostic
+    )
     version = container.loader_version
     src = container.source
     if src.is_compact and version != LoaderVersion.OM4_TORCH:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -29,7 +29,7 @@ from ocean_emulators.datasets import (
     TrainData,
     TrainDataLoader,
 )
-from ocean_emulators.utils.data import DataSource, Masks, Normalize
+from ocean_emulators.utils.data import DataSource, MaskedDataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 from ocean_emulators.utils.train import collate_raw_train_data
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
@@ -443,7 +443,7 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
         wet_surface=wet_surface,
         wet_without_hist_cpu=wet,
     )
-    test = DataSource("test", data, data_mean, data_std, masks=masks)
+    test = MaskedDataSource("test", data, data_mean, data_std, masks=masks)
 
     # Initialize and yield within the MultitonScope
     with MultitonScope():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -61,7 +61,7 @@ def make_loader(
     )
 
     container = data_config.build(
-        cfg.experiment.resolved_data_root, boundary, prognostic
+        cfg.experiment.resolved_data_root, prognostic, boundary
     )
     version = container.loader_version
     src = container.source

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -61,7 +61,7 @@ def make_loader(
     )
 
     container = data_config.build(
-        cfg.experiment.resolved_data_root, boundary, prognostic, cfg.data.hist
+        cfg.experiment.resolved_data_root, boundary, prognostic
     )
     version = container.loader_version
     src = container.source

--- a/tests/test_gradient_detaching.py
+++ b/tests/test_gradient_detaching.py
@@ -6,7 +6,7 @@ import xarray as xr
 from ocean_emulators.config import SamudraConfig, UNetBackboneConfig
 from ocean_emulators.constants import TensorMap
 from ocean_emulators.datasets import TrainData
-from ocean_emulators.utils.data import DataSource, Normalize
+from ocean_emulators.utils.data import MaskedDataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 
 
@@ -43,7 +43,10 @@ def create_samudra_model():
                 },
                 coords=coords,
             )
-            src = DataSource(name="dummy", data=data, means=data, stds=ones)
+            masks = Masks(torch.ones(h, w), torch.ones(h, w), torch.ones(h, w))
+            src = MaskedDataSource(
+                name="dummy", data=data, means=data, stds=ones, masks=masks
+            )
 
             # Initialize TensorMap and Normalize
             TensorMap.init_instance("thetao_1", "hfds")
@@ -51,8 +54,6 @@ def create_samudra_model():
                 src,
                 TensorMap.get_instance().prognostic_var_names,
                 TensorMap.get_instance().boundary_var_names,
-                torch.ones(h, w),
-                torch.ones(h, w),
             )
 
             # Create Samudra model with the specified gradient_detach_interval

--- a/tests/test_gradient_detaching.py
+++ b/tests/test_gradient_detaching.py
@@ -6,7 +6,7 @@ import xarray as xr
 from ocean_emulators.config import SamudraConfig, UNetBackboneConfig
 from ocean_emulators.constants import TensorMap
 from ocean_emulators.datasets import TrainData
-from ocean_emulators.utils.data import MaskedDataSource, Masks, Normalize
+from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 
 
@@ -43,8 +43,8 @@ def create_samudra_model():
                 },
                 coords=coords,
             )
-            masks = Masks(torch.ones(h, w), torch.ones(h, w), torch.ones(h, w))
-            src = MaskedDataSource(
+            masks = Masks(torch.ones(h, w), torch.ones(h, w))
+            src = DataSource(
                 name="dummy", data=data, means=data, stds=ones, masks=masks
             )
 

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -4,7 +4,7 @@ import xarray as xr
 
 from ocean_emulators.config import SamudraConfig, UNetBackboneConfig
 from ocean_emulators.constants import TensorMap
-from ocean_emulators.utils.data import MaskedDataSource, Masks, Normalize
+from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 
 
@@ -29,10 +29,8 @@ def test_positional_parameters_update():
             },
             coords=coords,
         )
-        masks = Masks(torch.ones(h, w), torch.ones(h, w), torch.ones(h, w))
-        src = MaskedDataSource(
-            name="dummy", data=data, means=data, stds=ones, masks=masks
-        )
+        masks = Masks(torch.ones(h, w), torch.ones(h, w))
+        src = DataSource(name="dummy", data=data, means=data, stds=ones, masks=masks)
         Normalize.init_instance(
             src,
             TensorMap.get_instance().prognostic_var_names,

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -4,7 +4,7 @@ import xarray as xr
 
 from ocean_emulators.config import SamudraConfig, UNetBackboneConfig
 from ocean_emulators.constants import TensorMap
-from ocean_emulators.utils.data import DataSource, Normalize
+from ocean_emulators.utils.data import MaskedDataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 
 
@@ -29,7 +29,10 @@ def test_positional_parameters_update():
             },
             coords=coords,
         )
-        src = DataSource(name="dummy", data=data, means=data, stds=ones)
+        masks = Masks(torch.ones(h, w), torch.ones(h, w), torch.ones(h, w))
+        src = MaskedDataSource(
+            name="dummy", data=data, means=data, stds=ones, masks=masks
+        )
         Normalize.init_instance(
             src,
             TensorMap.get_instance().prognostic_var_names,

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -37,8 +37,6 @@ def test_positional_parameters_update():
             src,
             TensorMap.get_instance().prognostic_var_names,
             TensorMap.get_instance().boundary_var_names,
-            torch.ones(h, w),
-            torch.ones(h, w),
         )
 
         # Create the model itself with learned positional embeddings

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -64,6 +64,7 @@ def inf_data_init(hist: int):
             data_std,
             name="test-data",
             prognostic_var_names=tensor_map.prognostic_var_names,
+            boundary_var_names=tensor_map.boundary_var_names,
         )
 
         _ = Normalize.init_instance(

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -6,7 +6,7 @@ import xarray as xr
 from ocean_emulators.constants import DEPTH_LEVELS, TensorMap
 from ocean_emulators.datasets import InferenceDataset
 from ocean_emulators.models.base import BaseModel
-from ocean_emulators.utils.data import DataSource, Normalize, validate_data
+from ocean_emulators.utils.data import DataSource, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 
 
@@ -58,10 +58,9 @@ def inf_data_init(hist: int):
         )
         data_mean: xr.Dataset = data.mean() * 0.0
         data_std: xr.Dataset = data.std() * 0.0 + 1.0
-        val = (
-            DataSource("test-data", data, data_mean, data_std)
-            .pipe(validate_data, tensor_map.boundary_var_names)
-            .mask(tensor_map.prognostic_var_names, hist)
+        prog_vars = [str(v) for v in data.data_vars.keys() if "_" in v]
+        val = DataSource.from_datasets(
+            data, data_mean, data_std, name="test-data", prognostic_var_names=prog_vars
         )
 
         _ = Normalize.init_instance(
@@ -79,7 +78,7 @@ def inf_data_init(hist: int):
             long_rollout=True,
         )
 
-        yield inference_dataset, val.masks.wet
+        yield inference_dataset, val.masks.repeat_prognostic(hist)
 
 
 class MockModel(BaseModel):

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -58,9 +58,12 @@ def inf_data_init(hist: int):
         )
         data_mean: xr.Dataset = data.mean() * 0.0
         data_std: xr.Dataset = data.std() * 0.0 + 1.0
-        prog_vars = [str(v) for v in data.data_vars.keys() if "_" in v]
         val = DataSource.from_datasets(
-            data, data_mean, data_std, name="test-data", prognostic_var_names=prog_vars
+            data,
+            data_mean,
+            data_std,
+            name="test-data",
+            prognostic_var_names=tensor_map.prognostic_var_names,
         )
 
         _ = Normalize.init_instance(

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -73,8 +73,6 @@ def inf_data_init(hist: int):
             val,
             tensor_map.prognostic_var_names,
             tensor_map.boundary_var_names,
-            val.masks.wet_without_hist_cpu,
-            val.masks.wet_surface,
             hist,
             normalize_before_mask=True,
             masked_fill_value=0.0,

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -6,12 +6,7 @@ import xarray as xr
 from ocean_emulators.constants import DEPTH_LEVELS, TensorMap
 from ocean_emulators.datasets import InferenceDataset
 from ocean_emulators.models.base import BaseModel
-from ocean_emulators.utils.data import (
-    DataSource,
-    Normalize,
-    extract_wet_mask,
-    validate_data,
-)
+from ocean_emulators.utils.data import DataSource, Normalize, validate_data
 from ocean_emulators.utils.multiton import MultitonScope
 
 
@@ -63,35 +58,30 @@ def inf_data_init(hist: int):
         )
         data_mean: xr.Dataset = data.mean() * 0.0
         data_std: xr.Dataset = data.std() * 0.0 + 1.0
-        test_data = DataSource("test-data", data, data_mean, data_std)
-        val = validate_data(test_data, tensor_map.boundary_var_names)
-        wet, wet_surface = extract_wet_mask(
-            val.data, tensor_map.prognostic_var_names, hist
-        )
-        wet_without_hist, _ = extract_wet_mask(
-            val.data, tensor_map.prognostic_var_names, 0
+        val = (
+            DataSource("test-data", data, data_mean, data_std)
+            .pipe(validate_data, tensor_map.boundary_var_names)
+            .mask(tensor_map.prognostic_var_names, hist)
         )
 
         _ = Normalize.init_instance(
             val,
             prognostic_var_names=tensor_map.prognostic_var_names,
             boundary_var_names=tensor_map.boundary_var_names,
-            wet_mask=wet_without_hist,
-            wet_mask_surface=wet_surface,
         )
         inference_dataset = InferenceDataset(
             val,
             tensor_map.prognostic_var_names,
             tensor_map.boundary_var_names,
-            wet_without_hist,
-            wet_surface,
+            val.masks.wet_without_hist_cpu,
+            val.masks.wet_surface,
             hist,
             normalize_before_mask=True,
             masked_fill_value=0.0,
             long_rollout=True,
         )
 
-        yield inference_dataset, wet
+        yield inference_dataset, val.masks.wet
 
 
 class MockModel(BaseModel):

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -82,7 +82,7 @@ def inf_data_init(hist: int):
             long_rollout=True,
         )
 
-        yield inference_dataset, val.masks.repeat_prognostic(hist)
+        yield inference_dataset, val.masks.prognostic_with_hist(hist)
 
 
 class MockModel(BaseModel):

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -150,7 +150,7 @@ def normalize_input():
 
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
-    masks = Masks(wet=wet_mask, wet_surface=wet_mask)
+    masks = Masks(prognostic=wet_mask, boundary=wet_mask)
 
     # Warning: the 'data' field is not used because this test tries to test
     # normalization which only needs mean and std. Thus, we set it to `data_mean`.
@@ -249,7 +249,7 @@ def data_init(hist: int):
             prognostic_var_names=tensor_map.prognostic_var_names,
             boundary_var_names=tensor_map.boundary_var_names,
         )
-        yield normalize, val.masks.wet
+        yield normalize, val.masks.prognostic
 
 
 @pytest.mark.parametrize("input_type", ["input", "target"])

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -242,6 +242,7 @@ def data_init(hist: int):
             data_std,
             name="test",
             prognostic_var_names=tensor_map.prognostic_var_names,
+            boundary_var_names=tensor_map.boundary_var_names,
         )
 
         normalize = Normalize.init_instance(

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -9,9 +9,10 @@ from scipy.stats import pearsonr
 from ocean_emulators.constants import DEPTH_LEVELS, TensorMap
 from ocean_emulators.utils.data import (
     DataSource,
+    MaskedDataSource,
+    Masks,
     Normalize,
     compute_anomalies,
-    extract_wet_mask,
     flatten_masks,
     get_aggregator_dicts,
     unflatten_masks,
@@ -153,20 +154,20 @@ def normalize_input():
         coords={"lat": [0], "lon": [0]},
     )
 
-    # Warning: the 'data' field is not used because this test tries to test
-    # normalization which only needs mean and std. Thus, we set it to `data_mean`.
-    test = DataSource("test", data_mean, data_mean, data_std)
-
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+    masks = Masks(wet=wet_mask, wet_surface=wet_mask, wet_without_hist_cpu=wet_mask)
+
+    # Warning: the 'data' field is not used because this test tries to test
+    # normalization which only needs mean and std. Thus, we set it to `data_mean`.
+    test = MaskedDataSource("test", data_mean, data_mean, data_std, masks=masks)
+
     # Initialize Normalize instance
     with MultitonScope():
         normalize = Normalize.init_instance(
             test,
             prognostic_var_names=["var_0", "var_1"],
             boundary_var_names=["var_2"],
-            wet_mask=wet_mask,
-            wet_mask_surface=wet_mask,
         )
         yield normalize, wet_mask
 
@@ -241,20 +242,18 @@ def data_init(hist: int):
         )
         data_mean = data.mean() * 0.0
         data_std = data.std() * 0.0 + 1.0
-        src = DataSource("test", data, data_mean, data_std)
-        val = validate_data(src, tensor_map.boundary_var_names)
-        (wet_without_hist, wet_mask_surface) = extract_wet_mask(
-            val.data, tensor_map.prognostic_var_names, 0
+        val = (
+            DataSource("test", data, data_mean, data_std)
+            .pipe(validate_data, tensor_map.boundary_var_names)
+            .mask(tensor_map.boundary_var_names, 0)
         )
 
         normalize = Normalize.init_instance(
             val,
             prognostic_var_names=tensor_map.prognostic_var_names,
             boundary_var_names=tensor_map.boundary_var_names,
-            wet_mask=wet_without_hist,
-            wet_mask_surface=wet_mask_surface,
         )
-        yield normalize, wet_without_hist
+        yield normalize, val.masks.wet_without_hist_cpu
 
 
 @pytest.mark.parametrize("input_type", ["input", "target"])

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -236,9 +236,12 @@ def data_init(hist: int):
         )
         data_mean = data.mean() * 0.0
         data_std = data.std() * 0.0 + 1.0
-        prog_vars = [str(v) for v in data.data_vars.keys() if "_" in v]
         val = DataSource.from_datasets(
-            data, data_mean, data_std, name="test", prognostic_var_names=prog_vars
+            data,
+            data_mean,
+            data_std,
+            name="test",
+            prognostic_var_names=tensor_map.prognostic_var_names,
         )
 
         normalize = Normalize.init_instance(

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -9,14 +9,12 @@ from scipy.stats import pearsonr
 from ocean_emulators.constants import DEPTH_LEVELS, TensorMap
 from ocean_emulators.utils.data import (
     DataSource,
-    MaskedDataSource,
     Masks,
     Normalize,
     compute_anomalies,
     flatten_masks,
     get_aggregator_dicts,
     unflatten_masks,
-    validate_data,
     with_level_index_vars,
 )
 from ocean_emulators.utils.multiton import MultitonScope
@@ -119,11 +117,7 @@ def test_compute_anomalies():
     ds_std = ds.std().compute()
 
     # compute anomalies
-
-    anom = compute_anomalies(
-        DataSource("test", ds, ds_mean, ds_std), ("thetao_0_anomalies",)
-    )
-    anomalies = anom.data
+    anomalies, _, _ = compute_anomalies(ds, ds_mean, ds_std, ("thetao_0_anomalies",))
     anomalies_np = anomalies["thetao_0_anomalies"].to_numpy()
     anomalies_np_flat = anomalies_np[0][0]
 
@@ -156,11 +150,11 @@ def normalize_input():
 
     # Create test wet mask
     wet_mask = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
-    masks = Masks(wet=wet_mask, wet_surface=wet_mask, wet_without_hist_cpu=wet_mask)
+    masks = Masks(wet=wet_mask, wet_surface=wet_mask)
 
     # Warning: the 'data' field is not used because this test tries to test
     # normalization which only needs mean and std. Thus, we set it to `data_mean`.
-    test = MaskedDataSource("test", data_mean, data_mean, data_std, masks=masks)
+    test = DataSource("test", data_mean, data_mean, data_std, masks=masks)
 
     # Initialize Normalize instance
     with MultitonScope():
@@ -242,10 +236,9 @@ def data_init(hist: int):
         )
         data_mean = data.mean() * 0.0
         data_std = data.std() * 0.0 + 1.0
-        val = (
-            DataSource("test", data, data_mean, data_std)
-            .pipe(validate_data, tensor_map.boundary_var_names)
-            .mask(tensor_map.boundary_var_names, 0)
+        prog_vars = [str(v) for v in data.data_vars.keys() if "_" in v]
+        val = DataSource.from_datasets(
+            data, data_mean, data_std, name="test", prognostic_var_names=prog_vars
         )
 
         normalize = Normalize.init_instance(
@@ -253,7 +246,7 @@ def data_init(hist: int):
             prognostic_var_names=tensor_map.prognostic_var_names,
             boundary_var_names=tensor_map.boundary_var_names,
         )
-        yield normalize, val.masks.wet_without_hist_cpu
+        yield normalize, val.masks.wet
 
 
 @pytest.mark.parametrize("input_type", ["input", "target"])


### PR DESCRIPTION
Introducing a `Masks` dataclass the in `DataSource` which has extracted wet masks. It turns out, near everywhere that `DataSource` is used, we have to separately plumb the surface and default wetmask. Thinking about what it would take to load multiple datasets of different resolutions, it seems that ocean/land masks are actually part of the same concern in as the data source. My hope is that after this PR, we can introduce a separate, but related masking concept -- namely, a dataloader-time "nodata" mask that is only necessary when combining disparate datasets.

Along the way, this refactor also brings in data validation into the creation of the `DataSource`.