### PR TITLE
Various minor viz doc & config fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,9 +262,9 @@ To run a remote viz job with SkyPilot, please use the following command:
 uv run sky launch skypilot/viz.sky.yaml \
   --env WANDB_API_KEY \
   --env-file <my-vars>.env \
-  --env NAME <my-experiment-name>-viz \
-  --env BASIN_PATH basin_masks_original.zarr \
-  --env RUNS=[{"location": "/inputs/<my-experiment-name>-eval/predictions.zarr"}]
+  --env NAME=<my-experiment-name>-viz \
+  --env BASIN_PATH=basin_masks_original.zarr \
+  --env RUNS='[{"name": "my_experiment", "location": "/inputs/<my-experiment-name>-eval/predictions.zarr"}]'
 
 ```
 

--- a/configs/samudra_om4_v1/viz.yaml
+++ b/configs/samudra_om4_v1/viz.yaml
@@ -7,7 +7,7 @@ groundtruth_location: "OM4.zarr"
 basins_location:
   type: s3
   bucket: "emulators"
-  path: "jr7309/basins/basin_masks_regridded.zarr"
+  path: "jr7309/basins/basin_masks_original.zarr"
   endpoint_url: "https://nyu1.osn.mghpcc.org"
 groundtruth_time_range:
   start: "2014-10-20"

--- a/skypilot/viz.sky.yaml
+++ b/skypilot/viz.sky.yaml
@@ -10,7 +10,7 @@
 # To create or re-use a cluster:
 # ```
 # export WANDB_API_KEY=<my-key>  # Get your key at https://wandb.ai/authorize
-# sky launch -c fomo-cluster viz.sky.yaml --env-file <my-env>.env --env WANDB_API_KEY --env RUNS=[{"location": "/inputs/my_eval_job/predictions.zarr"}, …]
+# sky launch -c fomo-cluster viz.sky.yaml --env-file <my-env>.env --env WANDB_API_KEY --env RUNS='[{"name": "my_eval_job", "location": "/inputs/my_eval_job/predictions.zarr"}, …]'
 # ```
 # Any location starting with /inputs will automatically be copied from the OUTPUTS_BUCKET
 # in order to access previous jobs' outputs.


### PR DESCRIPTION
This is a bit awkward because the viz configs don't really have anything to do with the folder they're in (other than trying to be helpful by having the source eval run name included, though arguably this is confusing more than helpful). And really they vary mostly by what resolution of data you need (and so data path + basin mask path). But I think this is at least improving the situation a bit by fixing typos and defaulting everything to 1-degree data.