### PR TITLE
Multi-scale data loading in two ways: "merged" and "multi" example loading.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -647,28 +647,27 @@ def build_nodata_masks(
     )
     ref_lat, ref_lon = sorted_scales.pop(0)
 
-    all_prognostic_masks = [
-        torch.ones(1, num_prognostic_channels, ref_lat, ref_lon, dtype=torch.bool),
+    prognostic_masks = [
+        torch.ones(num_prognostic_channels, ref_lat, ref_lon, dtype=torch.bool),
     ]
-    all_boundary_masks = [
-        torch.ones(1, num_boundary_channels, ref_lat, ref_lon, dtype=torch.bool),
+    boundary_masks = [
+        torch.ones(num_boundary_channels, ref_lat, ref_lon, dtype=torch.bool),
     ]
 
     for lat, lon in sorted_scales:
-        lat_stride = ref_lat // lat
-        lon_stride = ref_lon // lon
+        lat_stride, lon_stride = ref_lat // lat, ref_lon // lon
 
-        prog_mask = torch.zeros_like(all_prognostic_masks[0], dtype=torch.bool)
-        bound_mask = torch.zeros_like(all_boundary_masks[0], dtype=torch.bool)
+        prog_mask_per_scale = torch.zeros_like(prognostic_masks[0], dtype=torch.bool)
+        bound_mask_per_scale = torch.zeros_like(boundary_masks[0], dtype=torch.bool)
 
-        prog_mask[:, :, ::lat_stride, ::lon_stride] = True
-        bound_mask[:, :, ::lat_stride, ::lon_stride] = True
+        prog_mask_per_scale[:, ::lat_stride, ::lon_stride] = True
+        bound_mask_per_scale[:, ::lat_stride, ::lon_stride] = True
 
-        all_prognostic_masks.append(prog_mask)
-        all_boundary_masks.append(bound_mask)
+        prognostic_masks.append(prog_mask_per_scale)
+        boundary_masks.append(bound_mask_per_scale)
 
-    input_mask = torch.cat(all_prognostic_masks + all_boundary_masks, dim=1)
-    label_mask = torch.cat(all_prognostic_masks, dim=1)
+    input_mask = torch.cat(prognostic_masks + boundary_masks, dim=0)
+    label_mask = torch.cat(prognostic_masks, dim=0)
 
     return input_mask, label_mask
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -16,9 +16,11 @@ from ocean_emulators.config_base import BaseConfig, TopLevelConfig
 from ocean_emulators.constants import (
     BoundaryVarNames,
     Grid,
+    InputMask,
     Lat,
     LoaderVersion,
     Lon,
+    PrognosticMask,
     PrognosticVarNames,
 )
 from ocean_emulators.models import FOMO, Samudra
@@ -635,6 +637,40 @@ class ExperimentConfig(BaseConfig):
             )
         default_root = LocalLocation(path=Path.cwd())
         return default_root.resolve(self.data_root)
+
+
+def build_nodata_masks(
+    sources: list[DataSource], num_prognostic_channels: int, num_boundary_channels: int
+) -> tuple[InputMask, PrognosticMask]:
+    sorted_scales = sorted(
+        [(src.data.lat.size, src.data.lon.size) for src in sources], reverse=True
+    )
+    ref_lat, ref_lon = sorted_scales.pop(0)
+
+    all_prognostic_masks = [
+        torch.ones(1, num_prognostic_channels, ref_lat, ref_lon, dtype=torch.bool),
+    ]
+    all_boundary_masks = [
+        torch.ones(1, num_boundary_channels, ref_lat, ref_lon, dtype=torch.bool),
+    ]
+
+    for lat, lon in sorted_scales:
+        lat_stride = ref_lat // lat
+        lon_stride = ref_lon // lon
+
+        prog_mask = torch.zeros_like(all_prognostic_masks[0], dtype=torch.bool)
+        bound_mask = torch.zeros_like(all_boundary_masks[0], dtype=torch.bool)
+
+        prog_mask[:, :, ::lat_stride, ::lon_stride] = True
+        bound_mask[:, :, ::lat_stride, ::lon_stride] = True
+
+        all_prognostic_masks.append(prog_mask)
+        all_boundary_masks.append(bound_mask)
+
+    input_mask = torch.cat(all_prognostic_masks + all_boundary_masks, dim=1)
+    label_mask = torch.cat(all_prognostic_masks, dim=1)
+
+    return input_mask, label_mask
 
 
 class ProfilerConfig(BaseConfig):

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -32,6 +32,8 @@ Example = tuple[Input, Prognostic]
 
 GridMask = Bool[Tensor, "lat lon"]
 PrognosticMask = Bool[GridMask, "prognostic_vars"]
+InputMask = Bool[GridMask, "total_vars"]
+ExampleMask = tuple[InputMask, PrognosticMask]
 
 SingleChannelVar = Float[Tensor, "batch time lat lon"]
 DictSingleChannelVar = dict[str, SingleChannelVar]

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -234,6 +234,7 @@ def construct_metadata(data: xr.Dataset) -> dict[str, dict[str, str]]:
 
 class LoaderVersion(enum.Enum):
     OM4_TORCH = "om4-torch"
+    OM4_MULTISCALE_TORCH = "om4-multiscale-torch"
 
 
 # TODO(#95): See if this can be removed and replaced.

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -237,6 +237,7 @@ def construct_metadata(data: xr.Dataset) -> dict[str, dict[str, str]]:
 class LoaderVersion(enum.Enum):
     OM4_TORCH = "om4-torch"
     OM4_MULTISCALE_TORCH = "om4-multiscale-torch"
+    OM4_MULTISCALE_MERGE = "om4-multiscale-merge"
 
 
 # TODO(#95): See if this can be removed and replaced.

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -382,10 +382,6 @@ class TrainData:
     def values(self):
         return self.example_by_step
 
-    def example_shape(self) -> tuple[tuple[int], tuple[int]]:
-        input_, prognostic = self.get_initial_input()
-        return input_.shape, prognostic.shape
-
     def __getitem__(self, step: int) -> Example:
         """Converts index (step) into (data, label) tuple."""
         return self.example_by_step[step]

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -412,7 +412,7 @@ class TrainData:
         return self
 
 
-class MultiTrainData(TrainData):
+class MultiscaleTrainData(TrainData):
     """Store multiple scales of `TrainData`.
 
     When performing an autoregressive rollout, where multiple steps of input/label pairs are used in training and
@@ -855,7 +855,7 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             case "merge":
                 return merge(tds)
             case "multi":
-                return MultiTrainData(tds)
+                return MultiscaleTrainData(tds)
             case _:
                 typing.assert_never(self.mode)
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -776,8 +776,8 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             ):
                 lat, lon = dst_input.shape[-3:-1]
                 lat_p, lon_p = src_input.shape[-3:-1]
-                assert (lat / lat_p) % 2 == 0 and (lon / lon_p) % 2 == 0, (
-                    "Multi-scale datasets are not downscaled by factors of 2!"
+                assert lat % lat_p == 0 and lon % lon_p == 0, (
+                    f"The smaller datasets spatial dimensions are not an even factor of the largest multi-scale dataset! {lat=} vs {lat_p=}; {lon=} vs {lon_p=}."
                 )
 
                 lat_stride = lat // lat_p

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,10 +1,11 @@
 import dataclasses
 import logging
 import time
+import typing
 from collections.abc import Callable, Iterator
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import Generic, Protocol, Self, TypeAlias, TypeVar, final
+from typing import Generic, Literal, Protocol, Self, TypeAlias, TypeVar, final
 
 import numpy as np
 import torch
@@ -411,6 +412,55 @@ class TrainData:
         return self
 
 
+class MultiTrainData(TrainData):
+    """Store multiple scales of `TrainData`.
+
+    When performing an autoregressive rollout, where multiple steps of input/label pairs are used in training and
+    inference, this class opts to return the biggest single scale worth of data. For other cases, such as multiscale
+    model training, it will output each scale's input/output pair (i.e., an `Example`).
+    """
+
+    def __init__(self, tds: list[TrainData]):
+        super().__init__(tds[0].num_prognostic_channels)
+        # Ensure that data is organized by scale, from largest to smallest.
+        self.tds = sorted(
+            tds, key=lambda td: td.example_by_step[0][0].shape[:-2], reverse=True
+        )
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(range(len(self)))
+
+    def __len__(self) -> int:
+        return len(self.tds[0])
+
+    def __getitem__(self, step: int):
+        return [td[step] for td in self.tds]
+
+    def append(self, input_: Input, label: Prognostic):
+        raise NotImplementedError(
+            "We need to append one `Example` pair per each scale of data."
+        )
+
+    def append_per_scale(self, examples: list[Example]):
+        for td, eg in zip(self.tds, examples, strict=True):
+            td.append(*eg)
+
+    def get_input(self, step: int) -> Input:
+        return self.tds[0].get_input(step)
+
+    def get_label(self, step: int) -> Prognostic:
+        return self.tds[0].get_label(step)
+
+    def to(self, device: torch.device) -> None:
+        for td in self.tds:
+            td.to(device=device)
+
+    def pin_memory(self):
+        for td in self.tds:
+            td.pin_memory()
+        return self
+
+
 class GpuResolvedDataset(Dataset[DataBoundToDataset]):
     """A `torch.utils.data.Dataset` of bound data used to perform normalization
     and other final processing operations on GPU.
@@ -769,6 +819,9 @@ def merge(tds: list[TrainData]) -> TrainData:
     return TD
 
 
+MultiscaleMode = Literal["merge", "multi"]
+
+
 @final
 class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     Id: TypeAlias = str
@@ -778,9 +831,11 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
         self,
         srcs: list[DataSource],
         make_dataset: Callable[[DataSource], TorchTrainDataset],
+        mode: MultiscaleMode,
     ):
         self.datasets = [make_dataset(src) for src in srcs]
-        self.id = f"{self.__class__.__name__}({str(id(self))}, {', '.join([ds.id for ds in self.datasets])})"
+        self.id: MultiscaleTrainDataset.Id = f"{self.__class__.__name__}({str(id(self))}, {', '.join([ds.id for ds in self.datasets])})"
+        self.mode = mode
 
     @elapsed(level=logging.DEBUG)
     def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
@@ -796,7 +851,13 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             ds.to_train_data(rtd)
             for ds, rtd in zip(self.datasets, raw_train_dataset.datasets)
         ]
-        return merge(tds)
+        match self.mode:
+            case "merge":
+                return merge(tds)
+            case "multi":
+                return MultiTrainData(tds)
+            case _:
+                typing.assert_never(self.mode)
 
 
 @final

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -801,7 +801,7 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
                 combined_input = torch.cat((dst_input, src_input_stride), dim=1)
                 combined_label = torch.cat((dst_label, src_label_stride), dim=1)
                 combined_input_mask = torch.cat(
-                    (torch.ones_like(dst_input), src_label_mask), dim=1
+                    (torch.ones_like(dst_input), src_input_mask), dim=1
                 )
                 combined_label_mask = torch.cat(
                     (torch.ones_like(dst_label), src_label_mask), dim=1

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -732,9 +732,9 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             largest_prog = largest_input[:, : largest_td.num_prognostic_channels]
             largest_bound = largest_input[:, largest_td.num_prognostic_channels :]
 
-            all_prognostics = [largest_prog]
-            all_boundaries = [largest_bound]
-            all_labels = [largest_label]
+            prognostics = [largest_prog]
+            boundaries = [largest_bound]
+            labels = [largest_label]
 
             # Iterate through the remaining `TrainData`s at smaller scales.
             for td in tds_sorted:
@@ -751,34 +751,34 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
                 src_bound = src_input[:, td.num_prognostic_channels :]
 
                 # Create strided tensors at reference resolution
-                prog_strided = torch.zeros(
+                prognostic_per_scale = torch.zeros(
                     (src_prog.shape[0], src_prog.shape[1], ref_lat, ref_lon),
                     dtype=src_prog.dtype,
                     device=src_prog.device,
                 )
-                bound_strided = torch.zeros(
+                boundary_per_scale = torch.zeros(
                     (src_bound.shape[0], src_bound.shape[1], ref_lat, ref_lon),
                     dtype=src_bound.dtype,
                     device=src_bound.device,
                 )
-                label_strided = torch.zeros(
+                label_per_scale = torch.zeros(
                     (src_label.shape[0], src_label.shape[1], ref_lat, ref_lon),
                     dtype=src_label.dtype,
                     device=src_label.device,
                 )
 
-                prog_strided[:, :, ::lat_stride, ::lon_stride] = src_prog
-                bound_strided[:, :, ::lat_stride, ::lon_stride] = src_bound
-                label_strided[:, :, ::lat_stride, ::lon_stride] = src_label
+                prognostic_per_scale[:, :, ::lat_stride, ::lon_stride] = src_prog
+                boundary_per_scale[:, :, ::lat_stride, ::lon_stride] = src_bound
+                label_per_scale[:, :, ::lat_stride, ::lon_stride] = src_label
 
-                all_prognostics.append(prog_strided)
-                all_boundaries.append(bound_strided)
-                all_labels.append(label_strided)
+                prognostics.append(prognostic_per_scale)
+                boundaries.append(boundary_per_scale)
+                labels.append(label_per_scale)
 
             # Concatenate: all prognostics first, then all boundaries
             # This maintains the invariant that input[:, :num_prognostic_channels] are prognostics
-            combined_input = torch.cat(all_prognostics + all_boundaries, dim=1)
-            combined_label = torch.cat(all_labels, dim=1)  # Labels are prognostic-only
+            combined_input = torch.cat(prognostics + boundaries, dim=1)
+            combined_label = torch.cat(labels, dim=1)  # Labels are prognostic-only
 
             TD.append(combined_input, combined_label)
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from collections.abc import Callable
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import TypeAlias, final
@@ -293,7 +294,7 @@ class InferenceDatasets(Dataset):
 
 
 class RawTrainData:
-    def __init__(self, dataset_id: "TorchTrainDataset.Id"):
+    def __init__(self, dataset_id: "TorchTrainDataset.Id | MultiscaleTrainDataset.Id"):
         self.dataset_id: TorchTrainDataset.Id = dataset_id
         self.raw_data: list[tuple[torch.Tensor, torch.Tensor]] = []
         self.load_stats: LoadStats | None = None
@@ -421,7 +422,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         executor: ThreadPoolExecutor | None = None,
     ):
         super().__init__()
-        self.id = f"{self.__class__.__name__}_{str(id(self))}"
+        self.id = f"{self.__class__.__name__}({str(id(self))})"
         self.device = get_device()
 
         self.hist: int = hist
@@ -644,22 +645,28 @@ def concurrent_compute(
 
 
 @final
-class MulitscaleTorchTrainDataset(Dataset[RawTrainData]):
+class MultiscaleTrainDataset(Dataset[RawTrainData]):
+    Id: TypeAlias = str
+    FLAG = LoaderVersion.OM4_MULTISCALE_TORCH
+
     def __init__(
         self,
-        srcs: list[DataSource],
-        prognostic_var_names: PrognosticVarNames,
-        boundary_var_names: BoundaryVarNames,
-        wet: PrognosticMask,
-        wet_surface: GridMask,
-        hist: int,
-        steps: int,
-        normalize_before_mask: bool,
-        masked_fill_value: float,
-        stride: int = 1,
-        executor: ThreadPoolExecutor | None = None,
+        srcs: list[MaskedDataSource],
+        make_dataset: Callable[[MaskedDataSource], TorchTrainDataset],
     ):
-        pass
+        self.datasets = [make_dataset(src) for src in srcs]
+        self.id = f"{self.__class__.__name__}({str(id(self))}, {', '.join([ds.id for ds in self.datasets])})"
+
+    def merge(self, tds: list[RawTrainData]) -> RawTrainData:
+        TD = RawTrainData(self.id)
+        for _step, examples_per_step in enumerate(zip(*(td.raw_data for td in tds))):
+            pass
+        return TD
+
+    @elapsed(level=logging.DEBUG)
+    def __getitem__(self, idx: int) -> RawTrainData:
+        raw_tds = [ds[idx] for ds in self.datasets]
+        return self.merge(raw_tds)
 
 
 @final

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Callable
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import Generic, Protocol, TypeAlias, TypeVar, final
+from typing import Generic, Protocol, Self, TypeAlias, TypeVar, final
 
 import numpy as np
 import torch
@@ -294,9 +294,16 @@ class InferenceDatasets(Dataset):
         return (self.datasets[idx], self.lengths[idx])
 
 
+class HasDatasetId(Protocol):
+    dataset_id: str
+
+
+DataBoundToDataset = TypeVar("DataBoundToDataset", bound=HasDatasetId)
+
+
 class RawTrainData:
     def __init__(self, dataset_id: "TorchTrainDataset.Id | MultiscaleTrainDataset.Id"):
-        self.dataset_id: TorchTrainDataset.Id = dataset_id
+        self.dataset_id = dataset_id
         self.raw_data: list[tuple[torch.Tensor, torch.Tensor]] = []
         self.load_stats: LoadStats | None = None
 
@@ -317,6 +324,23 @@ class RawTrainData:
             (all_prognostic.pin_memory(), all_boundary.pin_memory())
             for all_prognostic, all_boundary in self.raw_data
         ]
+        return self
+
+
+@dataclasses.dataclass
+class RawMultiscaleTrainData:
+    """A collection of `RawTrainData` stores of `Example`s at multiple scales."""
+
+    dataset_id: str
+    datasets: list[RawTrainData]
+
+    def to(self, device: torch.device) -> None:
+        for dataset in self.datasets:
+            dataset.to(device=device)
+
+    def pin_memory(self) -> Self:
+        for dataset in self.datasets:
+            dataset.pin_memory()
         return self
 
 
@@ -382,13 +406,6 @@ class TrainData:
                 self[step][1].pin_memory(),
             )
         return self
-
-
-class HasDatasetId(Protocol):
-    dataset_id: str
-
-
-DataBoundToDataset = TypeVar("DataBoundToDataset", bound=HasDatasetId)
 
 
 class GpuResolvedDataset(Dataset[DataBoundToDataset]):
@@ -666,15 +683,9 @@ def concurrent_compute(
     wait(futures)
 
 
-@dataclasses.dataclass
-class MultiRawTrainData:
-    dataset_id: str
-    datasets: list[RawTrainData]
-
-
 # TODO(alxmrs): Need to fix the collate_fn!
 @final
-class MultiscaleTrainDataset(GpuResolvedDataset[MultiRawTrainData]):
+class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     Id: TypeAlias = str
     FLAG = LoaderVersion.OM4_MULTISCALE_TORCH
 
@@ -687,9 +698,9 @@ class MultiscaleTrainDataset(GpuResolvedDataset[MultiRawTrainData]):
         self.id = f"{self.__class__.__name__}({str(id(self))}, {', '.join([ds.id for ds in self.datasets])})"
 
     @elapsed(level=logging.DEBUG)
-    def __getitem__(self, idx: int) -> MultiRawTrainData:
+    def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
         tds = [ds[idx] for ds in self.datasets]
-        return MultiRawTrainData(dataset_id=self.id, datasets=tds)
+        return RawMultiscaleTrainData(dataset_id=self.id, datasets=tds)
 
     def merge(self, tds: list[TrainData]) -> TrainData:
         TD = TrainData(tds[0].num_prognostic_channels)
@@ -697,7 +708,7 @@ class MultiscaleTrainDataset(GpuResolvedDataset[MultiRawTrainData]):
 
         return TD
 
-    def to_train_data(self, raw_train_dataset: MultiRawTrainData) -> TrainData:
+    def to_train_data(self, raw_train_dataset: RawMultiscaleTrainData) -> TrainData:
         """Converts each RawTrainData into a TrainData, then merges it into a single TrainData."""
         tds = [
             ds.to_train_data(rtd)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,9 +1,10 @@
+import dataclasses
 import logging
 import time
 from collections.abc import Callable
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import TypeAlias, final
+from typing import Generic, Protocol, TypeAlias, TypeVar, final
 
 import numpy as np
 import torch
@@ -383,8 +384,29 @@ class TrainData:
         return self
 
 
+class HasDatasetId(Protocol):
+    dataset_id: str
+
+
+BoundToDataset = TypeVar("BoundToDataset", bound=HasDatasetId)
+
+
+class GpuResolvedDataset(Dataset[BoundToDataset]):
+    """A `torch.utils.data.Dataset` of bound data used to perform normalization
+    and other final processing operations on GPU.
+
+    Args:
+        id (str): The ID of the dataset - must be consistent with each data's `dataset_id`.
+    """
+
+    id: str
+
+    def to_train_data(self, raw_train_data: BoundToDataset) -> TrainData:
+        raise NotImplementedError()
+
+
 @final
-class TorchTrainDataset(Dataset[RawTrainData]):
+class TorchTrainDataset(GpuResolvedDataset[RawTrainData]):
     """
     This class is used for training and validation.
 
@@ -644,8 +666,15 @@ def concurrent_compute(
     wait(futures)
 
 
+@dataclasses.dataclass
+class MultiRawTrainData:
+    dataset_id: str
+    datasets: list[RawTrainData]
+
+
+# TODO(alxmrs): Need to fix the collate_fn!
 @final
-class MultiscaleTrainDataset(Dataset[RawTrainData]):
+class MultiscaleTrainDataset(GpuResolvedDataset[MultiRawTrainData]):
     Id: TypeAlias = str
     FLAG = LoaderVersion.OM4_MULTISCALE_TORCH
 
@@ -657,20 +686,28 @@ class MultiscaleTrainDataset(Dataset[RawTrainData]):
         self.datasets = [make_dataset(src) for src in srcs]
         self.id = f"{self.__class__.__name__}({str(id(self))}, {', '.join([ds.id for ds in self.datasets])})"
 
-    def merge(self, tds: list[RawTrainData]) -> RawTrainData:
-        TD = RawTrainData(self.id)
-        for _step, examples_per_step in enumerate(zip(*(td.raw_data for td in tds))):
-            pass
+    @elapsed(level=logging.DEBUG)
+    def __getitem__(self, idx: int) -> MultiRawTrainData:
+        tds = [ds[idx] for ds in self.datasets]
+        return MultiRawTrainData(dataset_id=self.id, datasets=tds)
+
+    def merge(self, tds: list[TrainData]) -> TrainData:
+        TD = TrainData(tds[0].num_prognostic_channels)
+        # TODO(alxmrs): Merge datasets of different dimensions (with masks).
+
         return TD
 
-    @elapsed(level=logging.DEBUG)
-    def __getitem__(self, idx: int) -> RawTrainData:
-        raw_tds = [ds[idx] for ds in self.datasets]
-        return self.merge(raw_tds)
+    def to_train_data(self, raw_train_dataset: MultiRawTrainData) -> TrainData:
+        """Converts each RawTrainData into a TrainData, then merges it into a single TrainData."""
+        tds = [
+            ds.to_train_data(rtd)
+            for ds, rtd in zip(self.datasets, raw_train_dataset.datasets)
+        ]
+        return self.merge(tds)
 
 
 @final
-class TrainDataLoader:
+class TrainDataLoader(Generic[BoundToDataset]):
     """Wrapper around a torch DataLoader that handles GPU post-processing.
 
     This class wraps a DataLoader[RawTrainData] and converts the raw data
@@ -687,8 +724,8 @@ class TrainDataLoader:
 
     def __init__(
         self,
-        dataloader: torch.utils.data.DataLoader[RawTrainData],
-        datasets: list[TorchTrainDataset],
+        dataloader: torch.utils.data.DataLoader[BoundToDataset],
+        datasets: list[GpuResolvedDataset[BoundToDataset]],
         device: torch.device,
     ):
         self._dataloader = dataloader

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,7 +1,7 @@
 import dataclasses
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
 from typing import Generic, Protocol, Self, TypeAlias, TypeVar, final
@@ -307,7 +307,7 @@ class RawTrainData:
         self.raw_data: list[tuple[torch.Tensor, torch.Tensor]] = []
         self.load_stats: LoadStats | None = None
 
-    def insert(self, all_prognostic: torch.Tensor, all_boundary: torch.Tensor):
+    def append(self, all_prognostic: torch.Tensor, all_boundary: torch.Tensor):
         self.raw_data.append((all_prognostic, all_boundary))
 
     def to(self, device: torch.device):
@@ -333,6 +333,9 @@ class RawMultiscaleTrainData:
 
     dataset_id: str
     datasets: list[RawTrainData]
+
+    def __iter__(self) -> Iterator[RawTrainData]:
+        yield from self.datasets
 
     def to(self, device: torch.device) -> None:
         for dataset in self.datasets:
@@ -563,7 +566,7 @@ class TorchTrainDataset(GpuResolvedDataset[RawTrainData]):
                 .astype(np.float32)
             )
 
-            TD.insert(prognostic_all, boundary)
+            TD.append(prognostic_all, boundary)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
         return TD
@@ -683,7 +686,6 @@ def concurrent_compute(
     wait(futures)
 
 
-# TODO(alxmrs): Need to fix the collate_fn!
 @final
 class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     Id: TypeAlias = str
@@ -701,6 +703,9 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
         tds = [ds[idx] for ds in self.datasets]
         return RawMultiscaleTrainData(dataset_id=self.id, datasets=tds)
+
+    def __len__(self) -> int:
+        return len(self.datasets[0])
 
     def merge(self, tds: list[TrainData]) -> TrainData:
         """Merge multiple TrainData at different spatial resolutions into a single TrainData.

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -388,10 +388,10 @@ class HasDatasetId(Protocol):
     dataset_id: str
 
 
-BoundToDataset = TypeVar("BoundToDataset", bound=HasDatasetId)
+DataBoundToDataset = TypeVar("DataBoundToDataset", bound=HasDatasetId)
 
 
-class GpuResolvedDataset(Dataset[BoundToDataset]):
+class GpuResolvedDataset(Dataset[DataBoundToDataset]):
     """A `torch.utils.data.Dataset` of bound data used to perform normalization
     and other final processing operations on GPU.
 
@@ -401,7 +401,7 @@ class GpuResolvedDataset(Dataset[BoundToDataset]):
 
     id: str
 
-    def to_train_data(self, raw_train_data: BoundToDataset) -> TrainData:
+    def to_train_data(self, raw_train_data: DataBoundToDataset) -> TrainData:
         raise NotImplementedError()
 
 
@@ -680,8 +680,8 @@ class MultiscaleTrainDataset(GpuResolvedDataset[MultiRawTrainData]):
 
     def __init__(
         self,
-        srcs: list[MaskedDataSource],
-        make_dataset: Callable[[MaskedDataSource], TorchTrainDataset],
+        srcs: list[DataSource],
+        make_dataset: Callable[[DataSource], TorchTrainDataset],
     ):
         self.datasets = [make_dataset(src) for src in srcs]
         self.id = f"{self.__class__.__name__}({str(id(self))}, {', '.join([ds.id for ds in self.datasets])})"
@@ -707,7 +707,7 @@ class MultiscaleTrainDataset(GpuResolvedDataset[MultiRawTrainData]):
 
 
 @final
-class TrainDataLoader(Generic[BoundToDataset]):
+class TrainDataLoader(Generic[DataBoundToDataset]):
     """Wrapper around a torch DataLoader that handles GPU post-processing.
 
     This class wraps a DataLoader[RawTrainData] and converts the raw data
@@ -724,8 +724,8 @@ class TrainDataLoader(Generic[BoundToDataset]):
 
     def __init__(
         self,
-        dataloader: torch.utils.data.DataLoader[BoundToDataset],
-        datasets: list[GpuResolvedDataset[BoundToDataset]],
+        dataloader: torch.utils.data.DataLoader[DataBoundToDataset],
+        datasets: list[GpuResolvedDataset[DataBoundToDataset]],
         device: torch.device,
     ):
         self._dataloader = dataloader

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -763,19 +763,19 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             all_boundary_masks = [torch.ones_like(largest_bound, dtype=torch.bool)]
             all_label_masks = [torch.ones_like(largest_label, dtype=torch.bool)]
 
+            # Iterate through the remaining `TrainData`s at smaller scales.
             for td in tds_sorted:
                 src_input, src_label = td[step]
-
-                src_prog = src_input[:, : td.num_prognostic_channels]
-                src_bound = src_input[:, td.num_prognostic_channels :]
 
                 lat, lon = src_input.shape[-2:]
                 assert ref_lat % lat == 0 and ref_lon % lon == 0, (
                     f"Spatial dimensions not evenly divisible: {ref_lat=} vs {lat=}; {ref_lon=} vs {lon=}"
                 )
-
                 lat_stride = ref_lat // lat
                 lon_stride = ref_lon // lon
+
+                src_prog = src_input[:, : td.num_prognostic_channels]
+                src_bound = src_input[:, td.num_prognostic_channels :]
 
                 # Create strided tensors at reference resolution
                 prog_strided = torch.zeros(

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -726,88 +726,102 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
 
     # TODO(alxmrs): I'll probably want to extract this into a new Masking Op class.
     def merge(self, tds: list[TrainData]) -> TrainData:
-        """Merge multiple TrainData objects at different spatial resolutions into a single TrainData.
+        """Merge multiple TrainData at different spatial resolutions into a single TrainData.
 
-        This method combines training data from multiple spatial scales by upsampling lower-resolution
-        data to match the highest resolution dataset. Lower-resolution data is placed at strided
-        intervals in a zero-padded tensor, effectively creating a sparse representation at the target
-        resolution. All datasets are concatenated along the channel dimension with corresponding masks
-        to indicate which spatial locations contain valid data.
+        Lower-resolution data is upsampled to the largest resolution by placing values at
+        strided intervals in zero-padded tensors. Masks track which spatial locations contain
+        valid data from each scale.
 
-        The merging process:
-        1. Identifies the highest resolution dataset (largest spatial dimensions)
-        2. For each lower-resolution dataset:
-           - Computes the stride ratio between resolutions
-           - Creates strided tensors by placing values at regular intervals with zeros elsewhere
-           - Generates binary masks indicating valid data locations
-           - Concatenates both data and masks as additional channels
-        3. Returns a merged TrainData with all scales combined
+        Channel layout: input = [all_scale_prognostics, all_scale_boundaries]
+                       label = [all_scale_prognostics]
 
         Args:
-            tds: List of TrainData objects at different spatial resolutions. Each TrainData
-                should have the same number of steps but may have different spatial dimensions
-                (lat, lon). The spatial dimensions must be evenly divisible (e.g., 360x180 and
-                180x90 where the stride is exactly 2).
+            tds: TrainData objects at different resolutions. Spatial dimensions must be
+                evenly divisible (e.g., 360x180 and 180x90 with stride=2).
 
         Returns:
-            TrainData: A merged dataset at the highest resolution with shape
-                [batch, total_channels, max_lat, max_lon] where total_channels includes
-                the original channels from the highest-resolution dataset plus additional
-                channels from each lower-resolution dataset (both data and mask channels).
-
-        Note:
-            The function assumes that spatial dimensions of lower-resolution datasets evenly
-            divide the dimensions of the highest-resolution dataset (i.e., the stride is an
-            integer value). This is typical for datasets downsampled by factors of 2, 4, etc.
+            TrainData with inputs/labels at the largest resolution, where num_prognostic_channels
+            equals the sum of prognostic channels across all scales.
         """
         tds_sorted = sorted(tds, key=lambda td: td[0][0].shape, reverse=True)
-        largest_td = tds_sorted[0]
+        total_prog_channels = sum(td.num_prognostic_channels for td in tds_sorted)
+        TD = TrainData(total_prog_channels)
 
-        TD = TrainData(largest_td.num_prognostic_channels)
+        largest_td = tds_sorted.pop(0)
+
+        ref_lat, ref_lon = largest_td[0][0].shape[-2:]
 
         for step in range(len(largest_td)):
-            combined_input, combined_label = largest_td[step]
-            combined_input_mask, combined_label_mask = (
-                torch.ones_like(combined_input),
-                torch.ones_like(combined_label),
-            )
+            largest_input, largest_label = largest_td[step]
+            largest_prog = largest_input[:, : largest_td.num_prognostic_channels]
+            largest_bound = largest_input[:, largest_td.num_prognostic_channels :]
 
-            for td in tds_sorted[1:]:
+            all_prognostics = [largest_prog]
+            all_boundaries = [largest_bound]
+            all_labels = [largest_label]
+            all_prognostic_masks = [torch.ones_like(largest_prog, dtype=torch.bool)]
+            all_boundary_masks = [torch.ones_like(largest_bound, dtype=torch.bool)]
+            all_label_masks = [torch.ones_like(largest_label, dtype=torch.bool)]
+
+            for td in tds_sorted:
                 src_input, src_label = td[step]
 
-                lat, lon = combined_input.shape[-2:]
-                lat_p, lon_p = src_input.shape[-2:]
-                assert lat % lat_p == 0 and lon % lon_p == 0, (
-                    f"Spatial dimensions not evenly divisible: {lat=} vs {lat_p=}; {lon=} vs {lon_p=}"
+                src_prog = src_input[:, : td.num_prognostic_channels]
+                src_bound = src_input[:, td.num_prognostic_channels :]
+
+                lat, lon = src_input.shape[-2:]
+                assert ref_lat % lat == 0 and ref_lon % lon == 0, (
+                    f"Spatial dimensions not evenly divisible: {ref_lat=} vs {lat=}; {ref_lon=} vs {lon=}"
                 )
 
-                lat_stride = lat // lat_p
-                lon_stride = lon // lon_p
+                lat_stride = ref_lat // lat
+                lon_stride = ref_lon // lon
 
-                src_input_stride = torch.zeros_like(
-                    combined_input[:, : src_input.shape[1]]
+                # Create strided tensors at reference resolution
+                prog_strided = torch.zeros(
+                    (src_prog.shape[0], src_prog.shape[1], ref_lat, ref_lon),
+                    dtype=src_prog.dtype,
+                    device=src_prog.device,
                 )
-                src_label_stride = torch.zeros_like(
-                    combined_label[:, : src_label.shape[1]]
+                bound_strided = torch.zeros(
+                    (src_bound.shape[0], src_bound.shape[1], ref_lat, ref_lon),
+                    dtype=src_bound.dtype,
+                    device=src_bound.device,
                 )
-                src_input_stride[:, :, ::lat_stride, ::lon_stride] = src_input
-                src_label_stride[:, :, ::lat_stride, ::lon_stride] = src_label
-
-                src_input_mask = torch.zeros_like(src_input_stride, dtype=torch.bool)
-                src_label_mask = torch.zeros_like(src_label_stride, dtype=torch.bool)
-
-                src_input_mask[:, :, ::lat_stride, ::lon_stride] = True
-                src_label_mask[:, :, ::lat_stride, ::lon_stride] = True
-
-                combined_input = torch.cat([combined_input, src_input_stride], dim=1)
-                combined_label = torch.cat([combined_label, src_label_stride], dim=1)
-
-                combined_input_mask = torch.cat(
-                    [combined_input_mask, src_input_mask], dim=1
+                label_strided = torch.zeros(
+                    (src_label.shape[0], src_label.shape[1], ref_lat, ref_lon),
+                    dtype=src_label.dtype,
+                    device=src_label.device,
                 )
-                combined_label_mask = torch.cat(
-                    [combined_label_mask, src_label_mask], dim=1
-                )
+
+                prog_strided[:, :, ::lat_stride, ::lon_stride] = src_prog
+                bound_strided[:, :, ::lat_stride, ::lon_stride] = src_bound
+                label_strided[:, :, ::lat_stride, ::lon_stride] = src_label
+
+                prog_mask = torch.zeros_like(prog_strided, dtype=torch.bool)
+                bound_mask = torch.zeros_like(bound_strided, dtype=torch.bool)
+                label_mask = torch.zeros_like(label_strided, dtype=torch.bool)
+
+                prog_mask[:, :, ::lat_stride, ::lon_stride] = True
+                bound_mask[:, :, ::lat_stride, ::lon_stride] = True
+                label_mask[:, :, ::lat_stride, ::lon_stride] = True
+
+                all_prognostics.append(prog_strided)
+                all_boundaries.append(bound_strided)
+                all_labels.append(label_strided)
+                all_prognostic_masks.append(prog_mask)
+                all_boundary_masks.append(bound_mask)
+                all_label_masks.append(label_mask)
+
+            # Concatenate: all prognostics first, then all boundaries
+            # This maintains the invariant that input[:, :num_prognostic_channels] are prognostics
+            combined_input = torch.cat(all_prognostics + all_boundaries, dim=1)
+            combined_label = torch.cat(all_labels, dim=1)  # Labels are prognostic-only
+
+            combined_input_mask = torch.cat(
+                all_prognostic_masks + all_boundary_masks, dim=1
+            )
+            combined_label_mask = torch.cat(all_label_masks, dim=1)
 
             TD.insert_with_mask(
                 step,

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -375,7 +375,6 @@ class TrainData:
         input_mask: InputMask,
         label_mask: PrognosticMask,
     ):
-        # TODO(alxmrs): check for off-by-one error.
         if step == len(self.example_by_step):
             self.example_by_step.append((input_, label))
             self.nodata_masks.append((input_mask, label_mask))

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -17,8 +17,10 @@ from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 from ocean_emulators.constants import (
     BoundaryVarNames,
     Example,
+    ExampleMask,
     GridMask,
     Input,
+    InputMask,
     LoaderVersion,
     Prognostic,
     PrognosticMask,
@@ -358,11 +360,28 @@ class TrainData:
     def __init__(self, num_prognostic_channels: int):
         self.num_prognostic_channels = num_prognostic_channels
         self.example_by_step: list[Example] = []
+        self.nodata_masks: list[ExampleMask] = []
         self.load_stats: LoadStats | None = None
 
     def append(self, input_: Input, label: Prognostic):
         """Add another Example as a new step."""
         self.example_by_step.append((input_, label))
+
+    def insert_with_mask(
+        self,
+        step: int,
+        input_: Input,
+        label: Prognostic,
+        input_mask: InputMask,
+        label_mask: PrognosticMask,
+    ):
+        # TODO(alxmrs): check for off-by-one error.
+        if step == len(self.example_by_step):
+            self.example_by_step.append((input_, label))
+            self.nodata_masks.append((input_mask, label_mask))
+        else:
+            self.example_by_step[step] = (input_, label)
+            self.nodata_masks[step] = (input_mask, label_mask)
 
     def get_initial_input(self) -> Input:
         return self.get_input(0)
@@ -381,6 +400,10 @@ class TrainData:
 
     def values(self):
         return self.example_by_step
+
+    def example_shape(self) -> tuple[tuple[int], tuple[int]]:
+        input_, prognostic = self.get_initial_input()
+        return input_.shape, prognostic.shape
 
     def __getitem__(self, step: int) -> Example:
         """Converts index (step) into (data, label) tuple."""
@@ -702,9 +725,95 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
         tds = [ds[idx] for ds in self.datasets]
         return RawMultiscaleTrainData(dataset_id=self.id, datasets=tds)
 
+    # TODO(alxmrs): I'll probably want to extract this into a new Masking Op class.
     def merge(self, tds: list[TrainData]) -> TrainData:
-        TD = TrainData(tds[0].num_prognostic_channels)
-        # TODO(alxmrs): Merge datasets of different dimensions (with masks).
+        """Merge multiple TrainData objects at different spatial resolutions into a single TrainData.
+
+        This method combines training data from multiple spatial scales by upsampling lower-resolution
+        data to match the highest resolution dataset. Lower-resolution data is placed at strided
+        intervals in a zero-padded tensor, effectively creating a sparse representation at the target
+        resolution. All datasets are concatenated along the channel dimension with corresponding masks
+        to indicate which spatial locations contain valid data.
+
+        The merging process:
+        1. Identifies the highest resolution dataset (largest spatial dimensions)
+        2. For each lower-resolution dataset:
+           - Computes the stride ratio between resolutions
+           - Creates strided tensors by placing values at regular intervals with zeros elsewhere
+           - Generates binary masks indicating valid data locations
+           - Concatenates both data and masks as additional channels
+        3. Returns a merged TrainData with all scales combined
+
+        Args:
+            tds: List of TrainData objects at different spatial resolutions. Each TrainData
+                should have the same number of steps but may have different spatial dimensions
+                (lat, lon). The spatial dimensions must be evenly divisible (e.g., 360x180 and
+                180x90 where the stride is exactly 2).
+
+        Returns:
+            TrainData: A merged dataset at the highest resolution with shape
+                [batch, total_channels, max_lat, max_lon] where total_channels includes
+                the original channels from the highest-resolution dataset plus additional
+                channels from each lower-resolution dataset (both data and mask channels).
+
+        Note:
+            The function assumes that spatial dimensions of lower-resolution datasets evenly
+            divide the dimensions of the highest-resolution dataset (i.e., the stride is an
+            integer value). This is typical for datasets downsampled by factors of 2, 4, etc.
+        """
+        tds_sorted = sorted(tds, key=lambda td: td[0][0].shape, reverse=True)
+        largest_td = tds_sorted.pop(0)
+
+        TD = TrainData(largest_td.num_prognostic_channels)
+
+        src_input: torch.Tensor
+        src_label: torch.Tensor
+        dst_input: Input
+        dst_label: Prognostic
+
+        for td in tds_sorted:
+            for step, (src_input, src_label), (dst_input, dst_label) in zip(
+                range(len(td)), td.example_by_step, largest_td.example_by_step
+            ):
+                lat, lon = dst_input.shape[-3:-1]
+                lat_p, lon_p = src_input.shape[-3:-1]
+                assert (lat / lat_p) % 2 == 0 and (lon / lon_p) % 2 == 0, (
+                    "Multi-scale datasets are not downscaled by factors of 2!"
+                )
+
+                lat_stride = lat // lat_p
+                lon_stride = lon // lon_p
+
+                src_input_stride = torch.zeros_like(dst_input)
+                src_input_mask = torch.zeros_like(dst_input)
+                src_label_stride = torch.zeros_like(dst_label)
+                src_label_mask = torch.zeros_like(dst_label)
+
+                src_input_stride[:, :, ::lat_stride, ::lon_stride] = src_input
+                src_input_mask[:, :, ::lat_stride, ::lon_stride] = torch.ones_like(
+                    src_input
+                )
+                src_label_stride[:, :, ::lat_stride, ::lon_stride] = src_label
+                src_label_mask[:, :, ::lat_stride, ::lon_stride] = torch.ones_like(
+                    src_label
+                )
+
+                combined_input = torch.cat((dst_input, src_input_stride), dim=1)
+                combined_label = torch.cat((dst_label, src_label_stride), dim=1)
+                combined_input_mask = torch.cat(
+                    (torch.ones_like(dst_input), src_label_mask), dim=1
+                )
+                combined_label_mask = torch.cat(
+                    (torch.ones_like(dst_label), src_label_mask), dim=1
+                )
+
+                TD.insert_with_mask(
+                    step,
+                    combined_input,
+                    combined_label,
+                    combined_input_mask,
+                    combined_label_mask,
+                )
 
         return TD
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -17,10 +17,8 @@ from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 from ocean_emulators.constants import (
     BoundaryVarNames,
     Example,
-    ExampleMask,
     GridMask,
     Input,
-    InputMask,
     LoaderVersion,
     Prognostic,
     PrognosticMask,
@@ -360,27 +358,11 @@ class TrainData:
     def __init__(self, num_prognostic_channels: int):
         self.num_prognostic_channels = num_prognostic_channels
         self.example_by_step: list[Example] = []
-        self.nodata_masks: list[ExampleMask] = []
         self.load_stats: LoadStats | None = None
 
     def append(self, input_: Input, label: Prognostic):
         """Add another Example as a new step."""
         self.example_by_step.append((input_, label))
-
-    def insert_with_mask(
-        self,
-        step: int,
-        input_: Input,
-        label: Prognostic,
-        input_mask: InputMask,
-        label_mask: PrognosticMask,
-    ):
-        if step == len(self.example_by_step):
-            self.example_by_step.append((input_, label))
-            self.nodata_masks.append((input_mask, label_mask))
-        else:
-            self.example_by_step[step] = (input_, label)
-            self.nodata_masks[step] = (input_mask, label_mask)
 
     def get_initial_input(self) -> Input:
         return self.get_input(0)
@@ -724,13 +706,11 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
         tds = [ds[idx] for ds in self.datasets]
         return RawMultiscaleTrainData(dataset_id=self.id, datasets=tds)
 
-    # TODO(alxmrs): I'll probably want to extract this into a new Masking Op class.
     def merge(self, tds: list[TrainData]) -> TrainData:
         """Merge multiple TrainData at different spatial resolutions into a single TrainData.
 
         Lower-resolution data is upsampled to the largest resolution by placing values at
-        strided intervals in zero-padded tensors. Masks track which spatial locations contain
-        valid data from each scale.
+        strided intervals in zero-padded tensors.
 
         Channel layout: input = [all_scale_prognostics, all_scale_boundaries]
                        label = [all_scale_prognostics]
@@ -759,9 +739,6 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             all_prognostics = [largest_prog]
             all_boundaries = [largest_bound]
             all_labels = [largest_label]
-            all_prognostic_masks = [torch.ones_like(largest_prog, dtype=torch.bool)]
-            all_boundary_masks = [torch.ones_like(largest_bound, dtype=torch.bool)]
-            all_label_masks = [torch.ones_like(largest_label, dtype=torch.bool)]
 
             # Iterate through the remaining `TrainData`s at smaller scales.
             for td in tds_sorted:
@@ -798,38 +775,16 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
                 bound_strided[:, :, ::lat_stride, ::lon_stride] = src_bound
                 label_strided[:, :, ::lat_stride, ::lon_stride] = src_label
 
-                prog_mask = torch.zeros_like(prog_strided, dtype=torch.bool)
-                bound_mask = torch.zeros_like(bound_strided, dtype=torch.bool)
-                label_mask = torch.zeros_like(label_strided, dtype=torch.bool)
-
-                prog_mask[:, :, ::lat_stride, ::lon_stride] = True
-                bound_mask[:, :, ::lat_stride, ::lon_stride] = True
-                label_mask[:, :, ::lat_stride, ::lon_stride] = True
-
                 all_prognostics.append(prog_strided)
                 all_boundaries.append(bound_strided)
                 all_labels.append(label_strided)
-                all_prognostic_masks.append(prog_mask)
-                all_boundary_masks.append(bound_mask)
-                all_label_masks.append(label_mask)
 
             # Concatenate: all prognostics first, then all boundaries
             # This maintains the invariant that input[:, :num_prognostic_channels] are prognostics
             combined_input = torch.cat(all_prognostics + all_boundaries, dim=1)
             combined_label = torch.cat(all_labels, dim=1)  # Labels are prognostic-only
 
-            combined_input_mask = torch.cat(
-                all_prognostic_masks + all_boundary_masks, dim=1
-            )
-            combined_label_mask = torch.cat(all_label_masks, dim=1)
-
-            TD.insert_with_mask(
-                step,
-                combined_input,
-                combined_label,
-                combined_input_mask,
-                combined_label_mask,
-            )
+            TD.append(combined_input, combined_label)
 
         return TD
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -686,6 +686,89 @@ def concurrent_compute(
     wait(futures)
 
 
+def merge(tds: list[TrainData]) -> TrainData:
+    """Merge multiple TrainData at different spatial resolutions into a single TrainData.
+
+    Lower-resolution data is upsampled to the largest resolution by placing values at
+    strided intervals in zero-padded tensors.
+
+    Channel layout: input = [all_scale_prognostics, all_scale_boundaries]
+                   label = [all_scale_prognostics]
+
+    Args:
+        tds: TrainData objects at different resolutions. Spatial dimensions must be
+            evenly divisible (e.g., 360x180 and 180x90 with stride=2).
+
+    Returns:
+        TrainData with inputs/labels at the largest resolution, where num_prognostic_channels
+        equals the sum of prognostic channels across all scales.
+    """
+    tds_sorted = sorted(tds, key=lambda td: td[0][0].shape, reverse=True)
+    total_prog_channels = sum(td.num_prognostic_channels for td in tds_sorted)
+    TD = TrainData(total_prog_channels)
+
+    largest_td = tds_sorted.pop(0)
+
+    ref_lat, ref_lon = largest_td[0][0].shape[-2:]
+
+    for step in range(len(largest_td)):
+        largest_input, largest_label = largest_td[step]
+        largest_prog = largest_input[:, : largest_td.num_prognostic_channels]
+        largest_bound = largest_input[:, largest_td.num_prognostic_channels :]
+
+        prognostics = [largest_prog]
+        boundaries = [largest_bound]
+        labels = [largest_label]
+
+        # Iterate through the remaining `TrainData`s at smaller scales.
+        for td in tds_sorted:
+            src_input, src_label = td[step]
+
+            lat, lon = src_input.shape[-2:]
+            assert ref_lat % lat == 0 and ref_lon % lon == 0, (
+                f"Spatial dimensions not evenly divisible: {ref_lat=} vs {lat=}; {ref_lon=} vs {lon=}"
+            )
+            lat_stride = ref_lat // lat
+            lon_stride = ref_lon // lon
+
+            src_prog = src_input[:, : td.num_prognostic_channels]
+            src_bound = src_input[:, td.num_prognostic_channels :]
+
+            # Create strided tensors at reference resolution
+            prognostic_per_scale = torch.zeros(
+                (src_prog.shape[0], src_prog.shape[1], ref_lat, ref_lon),
+                dtype=src_prog.dtype,
+                device=src_prog.device,
+            )
+            boundary_per_scale = torch.zeros(
+                (src_bound.shape[0], src_bound.shape[1], ref_lat, ref_lon),
+                dtype=src_bound.dtype,
+                device=src_bound.device,
+            )
+            label_per_scale = torch.zeros(
+                (src_label.shape[0], src_label.shape[1], ref_lat, ref_lon),
+                dtype=src_label.dtype,
+                device=src_label.device,
+            )
+
+            prognostic_per_scale[:, :, ::lat_stride, ::lon_stride] = src_prog
+            boundary_per_scale[:, :, ::lat_stride, ::lon_stride] = src_bound
+            label_per_scale[:, :, ::lat_stride, ::lon_stride] = src_label
+
+            prognostics.append(prognostic_per_scale)
+            boundaries.append(boundary_per_scale)
+            labels.append(label_per_scale)
+
+        # Concatenate: all prognostics first, then all boundaries
+        # This maintains the invariant that input[:, :num_prognostic_channels] are prognostics
+        combined_input = torch.cat(prognostics + boundaries, dim=1)
+        combined_label = torch.cat(labels, dim=1)  # Labels are prognostic-only
+
+        TD.append(combined_input, combined_label)
+
+    return TD
+
+
 @final
 class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     Id: TypeAlias = str
@@ -707,95 +790,13 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     def __len__(self) -> int:
         return len(self.datasets[0])
 
-    def merge(self, tds: list[TrainData]) -> TrainData:
-        """Merge multiple TrainData at different spatial resolutions into a single TrainData.
-
-        Lower-resolution data is upsampled to the largest resolution by placing values at
-        strided intervals in zero-padded tensors.
-
-        Channel layout: input = [all_scale_prognostics, all_scale_boundaries]
-                       label = [all_scale_prognostics]
-
-        Args:
-            tds: TrainData objects at different resolutions. Spatial dimensions must be
-                evenly divisible (e.g., 360x180 and 180x90 with stride=2).
-
-        Returns:
-            TrainData with inputs/labels at the largest resolution, where num_prognostic_channels
-            equals the sum of prognostic channels across all scales.
-        """
-        tds_sorted = sorted(tds, key=lambda td: td[0][0].shape, reverse=True)
-        total_prog_channels = sum(td.num_prognostic_channels for td in tds_sorted)
-        TD = TrainData(total_prog_channels)
-
-        largest_td = tds_sorted.pop(0)
-
-        ref_lat, ref_lon = largest_td[0][0].shape[-2:]
-
-        for step in range(len(largest_td)):
-            largest_input, largest_label = largest_td[step]
-            largest_prog = largest_input[:, : largest_td.num_prognostic_channels]
-            largest_bound = largest_input[:, largest_td.num_prognostic_channels :]
-
-            prognostics = [largest_prog]
-            boundaries = [largest_bound]
-            labels = [largest_label]
-
-            # Iterate through the remaining `TrainData`s at smaller scales.
-            for td in tds_sorted:
-                src_input, src_label = td[step]
-
-                lat, lon = src_input.shape[-2:]
-                assert ref_lat % lat == 0 and ref_lon % lon == 0, (
-                    f"Spatial dimensions not evenly divisible: {ref_lat=} vs {lat=}; {ref_lon=} vs {lon=}"
-                )
-                lat_stride = ref_lat // lat
-                lon_stride = ref_lon // lon
-
-                src_prog = src_input[:, : td.num_prognostic_channels]
-                src_bound = src_input[:, td.num_prognostic_channels :]
-
-                # Create strided tensors at reference resolution
-                prognostic_per_scale = torch.zeros(
-                    (src_prog.shape[0], src_prog.shape[1], ref_lat, ref_lon),
-                    dtype=src_prog.dtype,
-                    device=src_prog.device,
-                )
-                boundary_per_scale = torch.zeros(
-                    (src_bound.shape[0], src_bound.shape[1], ref_lat, ref_lon),
-                    dtype=src_bound.dtype,
-                    device=src_bound.device,
-                )
-                label_per_scale = torch.zeros(
-                    (src_label.shape[0], src_label.shape[1], ref_lat, ref_lon),
-                    dtype=src_label.dtype,
-                    device=src_label.device,
-                )
-
-                prognostic_per_scale[:, :, ::lat_stride, ::lon_stride] = src_prog
-                boundary_per_scale[:, :, ::lat_stride, ::lon_stride] = src_bound
-                label_per_scale[:, :, ::lat_stride, ::lon_stride] = src_label
-
-                prognostics.append(prognostic_per_scale)
-                boundaries.append(boundary_per_scale)
-                labels.append(label_per_scale)
-
-            # Concatenate: all prognostics first, then all boundaries
-            # This maintains the invariant that input[:, :num_prognostic_channels] are prognostics
-            combined_input = torch.cat(prognostics + boundaries, dim=1)
-            combined_label = torch.cat(labels, dim=1)  # Labels are prognostic-only
-
-            TD.append(combined_input, combined_label)
-
-        return TD
-
     def to_train_data(self, raw_train_dataset: RawMultiscaleTrainData) -> TrainData:
         """Converts each RawTrainData into a TrainData, then merges it into a single TrainData."""
         tds = [
             ds.to_train_data(rtd)
             for ds, rtd in zip(self.datasets, raw_train_dataset.datasets)
         ]
-        return self.merge(tds)
+        return merge(tds)
 
 
 @final

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -644,6 +644,25 @@ def concurrent_compute(
 
 
 @final
+class MulitscaleTorchTrainDataset(Dataset[RawTrainData]):
+    def __init__(
+        self,
+        srcs: list[DataSource],
+        prognostic_var_names: PrognosticVarNames,
+        boundary_var_names: BoundaryVarNames,
+        wet: PrognosticMask,
+        wet_surface: GridMask,
+        hist: int,
+        steps: int,
+        normalize_before_mask: bool,
+        masked_fill_value: float,
+        stride: int = 1,
+        executor: ThreadPoolExecutor | None = None,
+    ):
+        pass
+
+
+@final
 class TrainDataLoader:
     """Wrapper around a torch DataLoader that handles GPU post-processing.
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -761,58 +761,61 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             integer value). This is typical for datasets downsampled by factors of 2, 4, etc.
         """
         tds_sorted = sorted(tds, key=lambda td: td[0][0].shape, reverse=True)
-        largest_td = tds_sorted.pop(0)
+        largest_td = tds_sorted[0]
 
         TD = TrainData(largest_td.num_prognostic_channels)
 
-        src_input: torch.Tensor
-        src_label: torch.Tensor
-        dst_input: Input
-        dst_label: Prognostic
+        for step in range(len(largest_td)):
+            combined_input, combined_label = largest_td[step]
+            combined_input_mask, combined_label_mask = (
+                torch.ones_like(combined_input),
+                torch.ones_like(combined_label),
+            )
 
-        for td in tds_sorted:
-            for step, (src_input, src_label), (dst_input, dst_label) in zip(
-                range(len(td)), td.example_by_step, largest_td.example_by_step
-            ):
-                lat, lon = dst_input.shape[-3:-1]
-                lat_p, lon_p = src_input.shape[-3:-1]
+            for td in tds_sorted[1:]:
+                src_input, src_label = td[step]
+
+                lat, lon = combined_input.shape[-2:]
+                lat_p, lon_p = src_input.shape[-2:]
                 assert lat % lat_p == 0 and lon % lon_p == 0, (
-                    f"The smaller datasets spatial dimensions are not an even factor of the largest multi-scale dataset! {lat=} vs {lat_p=}; {lon=} vs {lon_p=}."
+                    f"Spatial dimensions not evenly divisible: {lat=} vs {lat_p=}; {lon=} vs {lon_p=}"
                 )
 
                 lat_stride = lat // lat_p
                 lon_stride = lon // lon_p
 
-                src_input_stride = torch.zeros_like(dst_input)
-                src_input_mask = torch.zeros_like(dst_input)
-                src_label_stride = torch.zeros_like(dst_label)
-                src_label_mask = torch.zeros_like(dst_label)
-
+                src_input_stride = torch.zeros_like(
+                    combined_input[:, : src_input.shape[1]]
+                )
+                src_label_stride = torch.zeros_like(
+                    combined_label[:, : src_label.shape[1]]
+                )
                 src_input_stride[:, :, ::lat_stride, ::lon_stride] = src_input
-                src_input_mask[:, :, ::lat_stride, ::lon_stride] = torch.ones_like(
-                    src_input
-                )
                 src_label_stride[:, :, ::lat_stride, ::lon_stride] = src_label
-                src_label_mask[:, :, ::lat_stride, ::lon_stride] = torch.ones_like(
-                    src_label
-                )
 
-                combined_input = torch.cat((dst_input, src_input_stride), dim=1)
-                combined_label = torch.cat((dst_label, src_label_stride), dim=1)
+                src_input_mask = torch.zeros_like(src_input_stride, dtype=torch.bool)
+                src_label_mask = torch.zeros_like(src_label_stride, dtype=torch.bool)
+
+                src_input_mask[:, :, ::lat_stride, ::lon_stride] = True
+                src_label_mask[:, :, ::lat_stride, ::lon_stride] = True
+
+                combined_input = torch.cat([combined_input, src_input_stride], dim=1)
+                combined_label = torch.cat([combined_label, src_label_stride], dim=1)
+
                 combined_input_mask = torch.cat(
-                    (torch.ones_like(dst_input), src_input_mask), dim=1
+                    [combined_input_mask, src_input_mask], dim=1
                 )
                 combined_label_mask = torch.cat(
-                    (torch.ones_like(dst_label), src_label_mask), dim=1
+                    [combined_label_mask, src_label_mask], dim=1
                 )
 
-                TD.insert_with_mask(
-                    step,
-                    combined_input,
-                    combined_label,
-                    combined_input_mask,
-                    combined_label_mask,
-                )
+            TD.insert_with_mask(
+                step,
+                combined_input,
+                combined_label,
+                combined_input_mask,
+                combined_label_mask,
+            )
 
         return TD
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -31,7 +31,7 @@ from ocean_emulators.aggregator.loss import (
     get_variable_loss_dict,
 )
 from ocean_emulators.backend import init_train_backend
-from ocean_emulators.config import TrainConfig, build_loss_fn
+from ocean_emulators.config import TrainConfig, build_loss_fn, build_nodata_masks
 from ocean_emulators.constants import (
     BOUNDARY_VARS,
     MAX_TRAIN_MODEL_STEPS_FORWARD,
@@ -142,8 +142,9 @@ class Trainer:
             else:
                 self.mp_context = multiprocessing.get_context("spawn")
 
-        self.num_in = int((cfg.data.hist + 1) * (self.N_prog + self.N_bound))
-        self.num_out = int((cfg.data.hist + 1) * self.N_prog)
+        self.hist: int = cfg.data.hist
+        self.num_in = int((self.hist + 1) * (self.N_prog + self.N_bound))
+        self.num_out = int((self.hist + 1) * self.N_prog)
 
         self.tensor_map = TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
@@ -181,11 +182,24 @@ class Trainer:
         # TODO(jder): Could rewrite inference dataset like we did for TorchTrainDataset
         # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/208
         self.inference_src = self.data_container.source_using_dask
-
         self.loader_version = self.data_container.loader_version
 
+        # This nodata mask is backwards compatible: when there is only one data source (i.e. one scale), the "mask"
+        # will be all ones (i.e., there is data everywhere).
+        data_sources = [
+            self.src
+        ]  # TODO(alxmrs): replace with multiple sources when we have a config system.
+        _, prognostic_nodata_mask = build_nodata_masks(
+            data_sources,
+            num_prognostic_channels=(self.hist + 1) * self.N_prog * len(data_sources),
+            num_boundary_channels=(self.hist + 1) * self.N_bound * len(data_sources),
+        )
+
         self.metadata = construct_metadata(self.data)
-        self.wet = self.src.masks.prognostic_with_hist(cfg.data.hist).to(self.device)
+        wet = self.src.masks.prognostic_with_hist_and_scales(
+            self.hist, len(data_sources)
+        )
+        self.mask = (wet & prognostic_nodata_mask).to(self.device)
         self.area_weights: Grid = spherical_area_weights(self.data)
 
         self.area_weights = self.area_weights.to(self.device)
@@ -199,8 +213,8 @@ class Trainer:
         self.model = cfg.model.build(
             in_channels=self.num_in,
             out_channels=self.num_out,
-            hist=cfg.data.hist,
-            wet=self.wet,
+            hist=self.hist,
+            wet=self.mask,
             area_weights=self.area_weights,
             static_data=self.static_data,
             lat=torch.from_numpy(self.data.lat.values),
@@ -213,7 +227,7 @@ class Trainer:
         # Loss function
         self.loss_fn: LossFn = build_loss_fn(
             cfg.loss,
-            wet=self.wet,
+            wet=self.mask,
             y_coord=self.data.lat,
             stds=self.src.filter(self.prognostic_var_names, prefix="prog_stds").stds,
             device=self.device,
@@ -301,7 +315,6 @@ class Trainer:
         # Training
         self.epochs = cfg.epochs
         self.test_using_ema = cfg.test_using_ema
-        self.hist: int = cfg.data.hist
         self.steps = cfg.steps
         self.step_transition = cfg.step_transition
         self.save_freq = cfg.save_freq

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -186,9 +186,8 @@ class Trainer:
 
         # This nodata mask is backwards compatible: when there is only one data source (i.e. one scale), the "mask"
         # will be all ones (i.e., there is data everywhere).
-        data_sources = [
-            self.src
-        ]  # TODO(alxmrs): replace with multiple sources when we have a config system.
+        # TODO(alxmrs): replace with multiple sources when we have a config system.
+        data_sources = [self.src]
         _, prognostic_nodata_mask = build_nodata_masks(
             data_sources,
             num_prognostic_channels=(self.hist + 1) * self.N_prog * len(data_sources),

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -69,6 +69,12 @@ class Masks:
     ) -> Bool[GridMask, " prognostic_vars*({hist}+1)"]:
         return torch.concat([self.prognostic] * (hist + 1), dim=0)
 
+    # TODO(alxmrs): It would probably be better to make a "repeat_prognostic" method, right?
+    def prognostic_with_hist_and_scales(
+        self, hist: int, scales: int
+    ) -> Bool[GridMask, " prognostic_vars*({hist}+1)*{scales}"]:
+        return torch.concat([self.prognostic] * (hist + 1) * scales, dim=0)
+
 
 @dataclasses.dataclass
 class DataSource:

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -48,6 +48,7 @@ def collate_raw_multiscale_train_data(
     # Since `RawMultiscaleTrainData` is a list of lists, we can think of this
     # `zip` as a transpose of these lists. This is what we want, since we want to
     # process every first `RawTrainData` via the collate_fn, then the second, and so on.
+    # After each stage is processed, we add it to the final multiscale TD.
     for tds in zip(*data):
         batched_data.datasets.append(collate_raw_train_data(tds))
 

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -46,8 +46,8 @@ def collate_raw_multiscale_train_data(
     batched_data = RawMultiscaleTrainData(data[0].dataset_id, [])
 
     # Since `RawMultiscaleTrainData` is a list of lists, we can think of this
-    # `zip` as a transpose of these lists. This is what we want, since we want to
-    # process every first `RawTrainData` via the collate_fn, then the second, and so on.
+    # `zip` as a transpose of these lists. This is what we want, since we process
+    # every first `RawTrainData` via the collate_fn, then the second, and so on.
     # After each stage is processed, we add it to the final multiscale TD.
     for tds in zip(*data):
         batched_data.datasets.append(collate_raw_train_data(tds))

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -45,6 +45,9 @@ def collate_raw_multiscale_train_data(
 ) -> RawMultiscaleTrainData:
     batched_data = RawMultiscaleTrainData(data[0].dataset_id, [])
 
+    # Since `RawMultiscaleTrainData` is a list of lists, we can think of this
+    # `zip` as a transpose of these lists. This is what we want, since we want to
+    # process every first `RawTrainData` via the collate_fn, then the second, and so on.
     for tds in zip(*data):
         batched_data.datasets.append(collate_raw_train_data(tds))
 

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import torch
 from xarray_einstats.einops import rearrange  # noqa: F401
 
-from ocean_emulators.datasets import InferenceDataset, RawTrainData
+from ocean_emulators.datasets import (
+    InferenceDataset,
+    RawMultiscaleTrainData,
+    RawTrainData,
+)
 from ocean_emulators.utils.data import LoadStats
 
 
@@ -26,12 +30,23 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
     for step in range(steps):
         all_prognostic = torch.stack([d.raw_data[step][0] for d in data])
         all_boundary = torch.stack([d.raw_data[step][1] for d in data])
-        batched_data.insert(all_prognostic, all_boundary)
+        batched_data.append(all_prognostic, all_boundary)
 
     stats = LoadStats.accumulated(
         [d.load_stats for d in data if d.load_stats is not None]
     )
     batched_data.load_stats = stats
+
+    return batched_data
+
+
+def collate_raw_multiscale_train_data(
+    data: Sequence[RawMultiscaleTrainData],
+) -> RawMultiscaleTrainData:
+    batched_data = RawMultiscaleTrainData(data[0].dataset_id, [])
+
+    for tds in zip(*data):
+        batched_data.datasets.append(collate_raw_train_data(tds))
 
     return batched_data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,7 +299,7 @@ def config_name(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
-@pytest.fixture(scope="session", params=[e for e in c.LoaderVersion])
+@pytest.fixture(scope="session", params=[c.LoaderVersion.OM4_TORCH])
 def loader_version(request: pytest.FixtureRequest) -> c.LoaderVersion:
     return request.param
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,7 +299,7 @@ def config_name(request: pytest.FixtureRequest) -> str:
     return request.param
 
 
-@pytest.fixture(scope="session", params=[c.LoaderVersion.OM4_TORCH])
+@pytest.fixture(scope="session", params=[e for e in c.LoaderVersion])
 def loader_version(request: pytest.FixtureRequest) -> c.LoaderVersion:
     return request.param
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,6 +4,7 @@ import contextlib
 import dataclasses
 import datetime
 from collections.abc import Generator
+from functools import partial
 
 import cftime
 import numpy as np
@@ -25,13 +26,17 @@ from ocean_emulators.constants import (
 )
 from ocean_emulators.datasets import (
     InferenceDataset,
+    MultiscaleTrainDataset,
     TorchTrainDataset,
     TrainData,
     TrainDataLoader,
 )
 from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
-from ocean_emulators.utils.train import collate_raw_train_data
+from ocean_emulators.utils.train import (
+    collate_raw_multiscale_train_data,
+    collate_raw_train_data,
+)
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
 
 
@@ -88,21 +93,45 @@ def make_loader(
                     )
                     for stride in cfg.data_stride
                 ]
+                collate_fn = collate_raw_train_data  # type: ignore
 
-                data: ConcatDataset = ConcatDataset(dataset_list)
-                collate_fn = collate_raw_train_data
+            case LoaderVersion.OM4_MULTISCALE_TORCH:
+                srcs = [src]
 
-                raw_loader = DataLoader(
-                    data,
-                    batch_size=cfg.batch_size,
-                    drop_last=drop_last,
-                    collate_fn=collate_fn,
-                )
+                def make_dataset(s, stride):
+                    return TorchTrainDataset(
+                        src=s.slice(time_config),
+                        prognostic_var_names=prognostic,
+                        boundary_var_names=boundary,
+                        hist=cfg.data.hist,
+                        steps=cfg.steps[0],
+                        normalize_before_mask=cfg.data.normalize_before_mask,
+                        masked_fill_value=cfg.data.masked_fill_value,
+                        stride=stride,
+                    )
 
-                loader = TrainDataLoader(raw_loader, dataset_list, torch.device("cpu"))
-                yield loader
+                dataset_list = [
+                    MultiscaleTrainDataset(
+                        srcs=srcs,
+                        make_dataset=partial(make_dataset, stride=stride),
+                    )
+                    for stride in cfg.data_stride
+                ]
+                collate_fn = collate_raw_multiscale_train_data  # type: ignore
             case _:
                 raise ValueError(f"Unknown loader version: {version}")
+
+        data: ConcatDataset = ConcatDataset(dataset_list)
+
+        raw_loader = DataLoader(
+            data,
+            batch_size=cfg.batch_size,
+            drop_last=drop_last,
+            collate_fn=collate_fn,
+        )
+
+        loader = TrainDataLoader(raw_loader, dataset_list, torch.device("cpu"))
+        yield loader
 
 
 def extract_sample_arrays(td: TrainData) -> tuple[np.ndarray, np.ndarray]:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -30,6 +30,7 @@ from ocean_emulators.datasets import (
     TorchTrainDataset,
     TrainData,
     TrainDataLoader,
+    merge,
 )
 from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
@@ -447,6 +448,34 @@ def test_multiscale_loader__equals_standard_loader(
         new_samples = [extract_sample_arrays(sample) for sample in multi_scale]
 
     assert_equal_samples(original_samples, new_samples)
+
+
+def test_multiscale_merge():
+    tds = []
+    scale = 1
+    num_scales = 4
+    for i in range(num_scales):
+        scale = 2 ** (i + 1)
+        td = TrainData(10)
+
+        prognostic = torch.rand((1, 10, scale, scale * 2))
+        label = prognostic * 2
+        boundary = torch.rand((1, 3, scale, scale * 2))
+        input_ = torch.cat((prognostic, boundary), dim=1)
+
+        for step in range(4):
+            td.append(input_ + step * 37, label + step * 17)
+
+        tds.append(td)
+
+    merged = merge(tds)
+
+    assert len(merged) == 4
+    merged_input, merged_label = merged[0]
+
+    assert merged_input.shape == (1, 13 * num_scales, scale, scale * 2)
+    assert merged_label.shape == (1, 10 * num_scales, scale, scale * 2)
+    assert merged.num_prognostic_channels == 10 * num_scales
 
 
 @pytest.fixture

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -419,6 +419,36 @@ def test_compact_loader__equals_flat_loader(
     assert_equal_samples(original_samples, new_samples)
 
 
+@pytest.mark.parametrize("data_source", ["remote-om4"], indirect=True)
+def test_multiscale_loader__equals_standard_loader(
+    data_source: DataSource, pytestconfig: pytest.Config
+):
+    cache = cache_dir(pytestconfig)
+    default_config = str(pytestconfig.rootpath / "configs" / DEFAULT_CONFIG)
+
+    def make_config(src: DataSource):
+        return TrainConfig.from_yaml_and_cli(
+            [
+                default_config,
+                "--experiment.data_root",
+                str(cache / src.name),
+            ]
+        )
+
+    # The standard data source config, which only includes one scale, should make the multi-scale loader
+    # behave like the standard torch loader.
+    flat_config = make_config(data_source)
+
+    with make_loader(flat_config, version=LoaderVersion.OM4_TORCH) as flat_loader:
+        original_samples = [extract_sample_arrays(sample) for sample in flat_loader]
+    with make_loader(
+        flat_config, version=LoaderVersion.OM4_MULTISCALE_TORCH
+    ) as multi_scale:
+        new_samples = [extract_sample_arrays(sample) for sample in multi_scale]
+
+    assert_equal_samples(original_samples, new_samples)
+
+
 @pytest.fixture
 def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
     # Create data

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -446,18 +446,19 @@ def test_multiscale_loader__equals_standard_loader(
             ]
         )
 
-    # The standard data source config, which only includes one scale, should make the multi-scale loader
+    # The standard data source config, which only includes one scale, should make the multiscale loader
     # behave like the standard torch loader.
-    flat_config = make_config(data_source)
+    config = make_config(data_source)
 
-    with make_loader(flat_config, version=LoaderVersion.OM4_TORCH) as flat_loader:
+    with make_loader(config, version=LoaderVersion.OM4_TORCH) as flat_loader:
         original_samples = [extract_sample_arrays(sample) for sample in flat_loader]
-    with make_loader(
-        flat_config, version=LoaderVersion.OM4_MULTISCALE_TORCH
-    ) as multi_scale:
-        new_samples = [extract_sample_arrays(sample) for sample in multi_scale]
+    with make_loader(config, version=LoaderVersion.OM4_MULTISCALE_TORCH) as multi_scale:
+        multi_samples = [extract_sample_arrays(sample) for sample in multi_scale]
+    with make_loader(config, version=LoaderVersion.OM4_MULTISCALE_MERGE) as merge_scale:
+        merge_samples = [extract_sample_arrays(sample) for sample in merge_scale]
 
-    assert_equal_samples(original_samples, new_samples)
+    assert_equal_samples(original_samples, multi_samples)
+    assert_equal_samples(original_samples, merge_samples)
 
 
 def test_multiscale_merge():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -458,14 +458,13 @@ def test_multiscale_merge():
         scale = 2 ** (i + 1)
         td = TrainData(10)
 
-        prognostic = torch.rand((1, 10, scale, scale * 2))
+        prognostic = torch.ones((1, 10, scale, scale * 2)) + i
         label = prognostic * 2
-        boundary = torch.rand((1, 3, scale, scale * 2))
+        boundary = torch.ones((1, 3, scale, scale * 2)) + scale
         input_ = torch.cat((prognostic, boundary), dim=1)
 
         for step in range(4):
             td.append(input_ + step * 37, label + step * 17)
-
         tds.append(td)
 
     merged = merge(tds)
@@ -476,6 +475,7 @@ def test_multiscale_merge():
     assert merged_input.shape == (1, 13 * num_scales, scale, scale * 2)
     assert merged_label.shape == (1, 10 * num_scales, scale, scale * 2)
     assert merged.num_prognostic_channels == 10 * num_scales
+    assert set(merged_input[0, :, 0, 0].tolist()) == set(range(1, 6)) | {9, 17}
 
 
 @pytest.fixture

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -26,6 +26,7 @@ from ocean_emulators.constants import (
 )
 from ocean_emulators.datasets import (
     InferenceDataset,
+    MultiscaleMode,
     MultiscaleTrainDataset,
     TorchTrainDataset,
     TrainData,
@@ -96,8 +97,16 @@ def make_loader(
                 ]
                 collate_fn = collate_raw_train_data  # type: ignore
 
-            case LoaderVersion.OM4_MULTISCALE_TORCH:
+            case (
+                LoaderVersion.OM4_MULTISCALE_TORCH | LoaderVersion.OM4_MULTISCALE_MERGE
+            ):
                 srcs = [src]
+
+                mode: MultiscaleMode = (
+                    "merge"
+                    if version == LoaderVersion.OM4_MULTISCALE_TORCH
+                    else "multi"
+                )
 
                 def make_dataset(s, stride):
                     return TorchTrainDataset(
@@ -115,6 +124,7 @@ def make_loader(
                     MultiscaleTrainDataset(
                         srcs=srcs,
                         make_dataset=partial(make_dataset, stride=stride),
+                        mode=mode,
                     )
                     for stride in cfg.data_stride
                 ]

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -104,7 +104,7 @@ def make_loader(
 
                 mode: MultiscaleMode = (
                     "merge"
-                    if version == LoaderVersion.OM4_MULTISCALE_TORCH
+                    if version == LoaderVersion.OM4_MULTISCALE_MERGE
                     else "multi"
                 )
 


### PR DESCRIPTION
This PR provides two types of multi-scale data loading: "merge" and "multi". The former merges all representations into the highest resolution grid and pads missing data with zeros, the latter returns a collection of examples at different scales. 

This is the initial part of a multi-step change to get multi-scale data loading to work. After this change, the multi-scale data loader will function only on a single scale, since we have no configuration system to register multiple data sources at different scales (that will come soon). However, the multi-scale loader and masking system is fully "backwards compatible" -- it behaves like the standard torch loader when used at a single scale. 