### PR TITLE
Ohc plots rescale

### DIFF
--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -473,35 +473,35 @@ def spherical_area_weights(data: xr.Dataset) -> Grid:
 def spherical_area_weights_real(data: xr.Dataset) -> Grid:
     """
     Compute real grid cell areas on a spherical Earth.
-    
+
     Uses the spherical geometry formula:
     A = R² × Δλ × (sin(φ₂) - sin(φ₁))
-    
+
     where:
     - R is Earth's radius (6371 km)
     - Δλ is the longitude spacing in radians
     - φ₁, φ₂ are the latitude bounds of the cell in radians
-    
+
     Args:
         data: Dataset containing lat/lon coordinates
-        
+
     Returns:
         Grid cell areas in m²
     """
     R = 6371000  # Earth radius in meters
-    
+
     lats = data.lat.to_numpy()
     lons = data.lon.to_numpy()
-    
+
     # Compute grid spacing (assuming uniform spacing)
     dlat = np.abs(np.diff(lats).mean())
     dlon = np.abs(np.diff(lons).mean())
-    
+
     # Convert to radians
     dlat_rad = np.deg2rad(dlat)
     dlon_rad = np.deg2rad(dlon)
     lats_rad = np.deg2rad(lats)
-    
+
     # Compute cell areas: A = R² × dlon × (sin(lat + dlat/2) - sin(lat - dlat/2))
     areas = np.zeros((len(lats), len(lons)))
     for i, lat_rad in enumerate(lats_rad):
@@ -509,7 +509,7 @@ def spherical_area_weights_real(data: xr.Dataset) -> Grid:
         lat_south = lat_rad - dlat_rad / 2
         area = R**2 * dlon_rad * (np.sin(lat_north) - np.sin(lat_south))
         areas[i, :] = area
-    
+
     return torch.from_numpy(areas)
 
 

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -470,7 +470,7 @@ def spherical_area_weights(data: xr.Dataset) -> Grid:
     return weights
 
 
-def spherical_area_weights_real(data: xr.Dataset) -> Grid:
+def spherical_area(data: xr.Dataset) -> Grid:
     """
     Compute real grid cell areas on a spherical Earth.
 

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -470,6 +470,49 @@ def spherical_area_weights(data: xr.Dataset) -> Grid:
     return weights
 
 
+def spherical_area_weights_real(data: xr.Dataset) -> Grid:
+    """
+    Compute real grid cell areas on a spherical Earth.
+    
+    Uses the spherical geometry formula:
+    A = R² × Δλ × (sin(φ₂) - sin(φ₁))
+    
+    where:
+    - R is Earth's radius (6371 km)
+    - Δλ is the longitude spacing in radians
+    - φ₁, φ₂ are the latitude bounds of the cell in radians
+    
+    Args:
+        data: Dataset containing lat/lon coordinates
+        
+    Returns:
+        Grid cell areas in m²
+    """
+    R = 6371000  # Earth radius in meters
+    
+    lats = data.lat.to_numpy()
+    lons = data.lon.to_numpy()
+    
+    # Compute grid spacing (assuming uniform spacing)
+    dlat = np.abs(np.diff(lats).mean())
+    dlon = np.abs(np.diff(lons).mean())
+    
+    # Convert to radians
+    dlat_rad = np.deg2rad(dlat)
+    dlon_rad = np.deg2rad(dlon)
+    lats_rad = np.deg2rad(lats)
+    
+    # Compute cell areas: A = R² × dlon × (sin(lat + dlat/2) - sin(lat - dlat/2))
+    areas = np.zeros((len(lats), len(lons)))
+    for i, lat_rad in enumerate(lats_rad):
+        lat_north = lat_rad + dlat_rad / 2
+        lat_south = lat_rad - dlat_rad / 2
+        area = R**2 * dlon_rad * (np.sin(lat_north) - np.sin(lat_south))
+        areas[i, :] = area
+    
+    return torch.from_numpy(areas)
+
+
 def get_inference_steps(data_source: DataSource, hist: int = 1):
     """
     Get the number of inference/rollout steps for the given time configuration.

--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -29,8 +29,8 @@ from xarrayutils.plotting import box_plot, linear_piecewise_scale  # type: ignor
 
 from ocean_emulators.constants import DEPTH_LEVELS, DEPTH_THICKNESS
 from ocean_emulators.utils.data import (
-    spherical_area_weights,
     spherical_area,
+    spherical_area_weights,
     with_level_index_vars,
 )
 

--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -30,7 +30,7 @@ from xarrayutils.plotting import box_plot, linear_piecewise_scale  # type: ignor
 from ocean_emulators.constants import DEPTH_LEVELS, DEPTH_THICKNESS
 from ocean_emulators.utils.data import (
     spherical_area_weights,
-    spherical_area_weights_real,
+    spherical_area,
     with_level_index_vars,
 )
 
@@ -78,9 +78,9 @@ class Viz:
         )
 
         # Compute real grid cell areas for physical calculations
-        groundtruth_rollout["areacello_real"] = (
+        groundtruth_rollout["areacello_spherical"] = (
             ["lat", "lon"],
-            spherical_area_weights_real(groundtruth_rollout),
+            spherical_area(groundtruth_rollout),
         )
 
         # This function processes the ds_groundtruth and predictions for plotting
@@ -749,7 +749,7 @@ class Viz:
         rho_0 = 1025  # kg/m^3
 
         # Use real areacello for physical calculations
-        areacello = data["areacello_real"]
+        areacello = data["areacello_spherical"]
 
         OHC = ((data["thetao"] * c_p * rho_0) * areacello * data["dz"]).sum(
             ["x", "y", "lev"]
@@ -3799,7 +3799,7 @@ def combine_variables_by_level(ds_groundtruth, pred_dict):
 def _postprocess_for_plot(
     ds,
     areacello: np.ndarray,
-    areacello_real: np.ndarray,
+    areacello_spherical: np.ndarray,
     dz,
     times,
     wetmask,
@@ -3836,7 +3836,7 @@ def _postprocess_for_plot(
             ds[var] = ds[var].where(wetmask.isel(lev=0))
 
     ds["areacello"] = (["lat", "lon"], areacello)
-    ds["areacello_real"] = (["lat", "lon"], areacello_real)
+    ds["areacello_spherical"] = (["lat", "lon"], areacello_spherical)
     ds["dz"] = ("lev", dz)
     return ds
 
@@ -3857,7 +3857,7 @@ def postprocess_for_plot(
     """
     areacello_values = areacello.values
     times = ds_groundtruth.time
-    areacello_real_values = ds_groundtruth["areacello_real"].values
+    areacello_spherical_values = ds_groundtruth["areacello_spherical"].values
 
     # Masking land with NaNs
     if "mask" in ds_groundtruth.data_vars:
@@ -3868,7 +3868,7 @@ def postprocess_for_plot(
         wetmask = ds_groundtruth.wetmask
 
     ds_groundtruth = _postprocess_for_plot(
-        ds_groundtruth, areacello_values, areacello_real_values, dz, times, wetmask
+        ds_groundtruth, areacello_values, areacello_spherical_values, dz, times, wetmask
     )
 
     coords = ds_groundtruth.coords
@@ -3877,7 +3877,7 @@ def postprocess_for_plot(
         pred_dict[key]["ds_prediction"] = _postprocess_for_plot(
             pred_dict[key]["ds_prediction"],
             areacello_values,
-            areacello_real_values,
+            areacello_spherical_values,
             dz,
             times,
             wetmask,

--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -159,19 +159,19 @@ class Viz:
             }
         )
 
-        # #Compute profile means
-        # with ProgressBar():
-        #     logger.info("Computing profile for ground truth " + dataset_name)
-        #     profile_groundtruth = profile_mean(data).load()
+        #Compute profile means
+        with ProgressBar():
+            logger.info("Computing profile for ground truth " + dataset_name)
+            profile_groundtruth = profile_mean(data).load()
 
-        #     for k in pred_dict.keys():
-        #         logger.info("Computing profile for prediction " + k)
-        #         pred_dict[k]["profile_prediction"] = profile_mean(
-        #             pred_dict[k]["ds_prediction"]
-        #         ).load()
+            for k in pred_dict.keys():
+                logger.info("Computing profile for prediction " + k)
+                pred_dict[k]["profile_prediction"] = profile_mean(
+                    pred_dict[k]["ds_prediction"]
+                ).load()
 
         self.data: xr.Dataset = data
-        # self.profile_groundtruth: xr.Dataset = profile_groundtruth
+        self.profile_groundtruth: xr.Dataset = profile_groundtruth
         self.pred_dict: dict[str, dict[str, Any]] = pred_dict
         self.dataset_name: str = dataset_name
         self.clist: list[str] = clist

--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -746,7 +746,7 @@ class Viz:
         rho_0 = 1025  # kg/m^3
         
         # Use real areacello for physical calculations
-        areacello = data.get("areacello_real", data["areacello"])
+        areacello = data["areacello_real"]
         
         OHC = ((data["thetao"] * c_p * rho_0) * areacello * data["dz"]).sum(
             ["x", "y", "lev"]

--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -28,7 +28,11 @@ from tqdm.auto import tqdm
 from xarrayutils.plotting import box_plot, linear_piecewise_scale  # type: ignore
 
 from ocean_emulators.constants import DEPTH_LEVELS, DEPTH_THICKNESS
-from ocean_emulators.utils.data import spherical_area_weights, with_level_index_vars
+from ocean_emulators.utils.data import (
+    spherical_area_weights,
+    spherical_area_weights_real,
+    with_level_index_vars,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +66,7 @@ class Viz:
         levels = len(DEPTH_LEVELS)
 
         groundtruth_rollout = groundtruth_rollout.sel(time=time_range)
+        
         if "y" in groundtruth_rollout.coords:
             groundtruth_rollout = groundtruth_rollout.drop_vars(
                 ["lat", "lon"], errors="ignore"
@@ -71,6 +76,9 @@ class Viz:
         groundtruth_rollout = groundtruth_rollout.assign(
             areacello=(["lat", "lon"], spherical_area_weights(groundtruth_rollout))
         )
+        
+        # Compute real grid cell areas for physical calculations
+        groundtruth_rollout["areacello_real"] = (["lat", "lon"], spherical_area_weights_real(groundtruth_rollout))
 
         # This function processes the ds_groundtruth and predictions for plotting
         # The predictions are loaded into pred_dict
@@ -151,19 +159,19 @@ class Viz:
             }
         )
 
-        # Compute profile means
-        with ProgressBar():
-            logger.info("Computing profile for ground truth " + dataset_name)
-            profile_groundtruth = profile_mean(data).load()
+        # #Compute profile means
+        # with ProgressBar():
+        #     logger.info("Computing profile for ground truth " + dataset_name)
+        #     profile_groundtruth = profile_mean(data).load()
 
-            for k in pred_dict.keys():
-                logger.info("Computing profile for prediction " + k)
-                pred_dict[k]["profile_prediction"] = profile_mean(
-                    pred_dict[k]["ds_prediction"]
-                ).load()
+        #     for k in pred_dict.keys():
+        #         logger.info("Computing profile for prediction " + k)
+        #         pred_dict[k]["profile_prediction"] = profile_mean(
+        #             pred_dict[k]["ds_prediction"]
+        #         ).load()
 
         self.data: xr.Dataset = data
-        self.profile_groundtruth: xr.Dataset = profile_groundtruth
+        # self.profile_groundtruth: xr.Dataset = profile_groundtruth
         self.pred_dict: dict[str, dict[str, Any]] = pred_dict
         self.dataset_name: str = dataset_name
         self.clist: list[str] = clist
@@ -736,10 +744,16 @@ class Viz:
     def ohc_anomaly_global(self, data: xr.Dataset) -> xr.DataArray:
         c_p = 3850  # J/(kg C)
         rho_0 = 1025  # kg/m^3
-        OHC = ((data["thetao"] * c_p * rho_0) * data["areacello"] * data["dz"]).sum(
+        
+        # Use real areacello for physical calculations
+        areacello = data.get("areacello_real", data["areacello"])
+        
+        OHC = ((data["thetao"] * c_p * rho_0) * areacello * data["dz"]).sum(
             ["x", "y", "lev"]
         ) / 1e21
+        
         OHC = remove_climatology(OHC)
+        
         OHC = OHC.rename("OHC Anomaly")
         OHC = OHC.assign_attrs(units="ZJ")
         return OHC
@@ -3779,7 +3793,7 @@ def combine_variables_by_level(ds_groundtruth, pred_dict):
     return ds_groundtruth, pred_dict
 
 
-def _postprocess_for_plot(ds, areacello: np.ndarray, dz, times, wetmask, coords=None):
+def _postprocess_for_plot(ds, areacello: np.ndarray, areacello_real: np.ndarray, dz, times, wetmask, coords=None):
     """
     Postprocess the dataset to make it compatible with plotting functions.
     """
@@ -3811,6 +3825,7 @@ def _postprocess_for_plot(ds, areacello: np.ndarray, dz, times, wetmask, coords=
             ds[var] = ds[var].where(wetmask.isel(lev=0))
 
     ds["areacello"] = (["lat", "lon"], areacello)
+    ds["areacello_real"] = (["lat", "lon"], areacello_real)
     ds["dz"] = ("lev", dz)
     return ds
 
@@ -3831,6 +3846,7 @@ def postprocess_for_plot(
     """
     areacello_values = areacello.values
     times = ds_groundtruth.time
+    areacello_real_values = ds_groundtruth["areacello_real"].values
 
     # Masking land with NaNs
     if "mask" in ds_groundtruth.data_vars:
@@ -3841,19 +3857,22 @@ def postprocess_for_plot(
         wetmask = ds_groundtruth.wetmask
 
     ds_groundtruth = _postprocess_for_plot(
-        ds_groundtruth, areacello_values, dz, times, wetmask
+        ds_groundtruth, areacello_values, areacello_real_values, dz, times, wetmask
     )
+    
     coords = ds_groundtruth.coords
 
     for key in pred_dict.keys():
         pred_dict[key]["ds_prediction"] = _postprocess_for_plot(
             pred_dict[key]["ds_prediction"],
             areacello_values,
+            areacello_real_values,
             dz,
             times,
             wetmask,
             coords=coords,
         )
+        
         # Rename lat and lon to y and x
         pred_dict[key]["ds_prediction"] = pred_dict[key]["ds_prediction"].rename(
             {"lat": "y", "lon": "x"}

--- a/src/ocean_emulators/viz/core.py
+++ b/src/ocean_emulators/viz/core.py
@@ -66,7 +66,7 @@ class Viz:
         levels = len(DEPTH_LEVELS)
 
         groundtruth_rollout = groundtruth_rollout.sel(time=time_range)
-        
+
         if "y" in groundtruth_rollout.coords:
             groundtruth_rollout = groundtruth_rollout.drop_vars(
                 ["lat", "lon"], errors="ignore"
@@ -76,9 +76,12 @@ class Viz:
         groundtruth_rollout = groundtruth_rollout.assign(
             areacello=(["lat", "lon"], spherical_area_weights(groundtruth_rollout))
         )
-        
+
         # Compute real grid cell areas for physical calculations
-        groundtruth_rollout["areacello_real"] = (["lat", "lon"], spherical_area_weights_real(groundtruth_rollout))
+        groundtruth_rollout["areacello_real"] = (
+            ["lat", "lon"],
+            spherical_area_weights_real(groundtruth_rollout),
+        )
 
         # This function processes the ds_groundtruth and predictions for plotting
         # The predictions are loaded into pred_dict
@@ -159,7 +162,7 @@ class Viz:
             }
         )
 
-        #Compute profile means
+        # Compute profile means
         with ProgressBar():
             logger.info("Computing profile for ground truth " + dataset_name)
             profile_groundtruth = profile_mean(data).load()
@@ -744,16 +747,16 @@ class Viz:
     def ohc_anomaly_global(self, data: xr.Dataset) -> xr.DataArray:
         c_p = 3850  # J/(kg C)
         rho_0 = 1025  # kg/m^3
-        
+
         # Use real areacello for physical calculations
         areacello = data["areacello_real"]
-        
+
         OHC = ((data["thetao"] * c_p * rho_0) * areacello * data["dz"]).sum(
             ["x", "y", "lev"]
         ) / 1e21
-        
+
         OHC = remove_climatology(OHC)
-        
+
         OHC = OHC.rename("OHC Anomaly")
         OHC = OHC.assign_attrs(units="ZJ")
         return OHC
@@ -3793,7 +3796,15 @@ def combine_variables_by_level(ds_groundtruth, pred_dict):
     return ds_groundtruth, pred_dict
 
 
-def _postprocess_for_plot(ds, areacello: np.ndarray, areacello_real: np.ndarray, dz, times, wetmask, coords=None):
+def _postprocess_for_plot(
+    ds,
+    areacello: np.ndarray,
+    areacello_real: np.ndarray,
+    dz,
+    times,
+    wetmask,
+    coords=None,
+):
     """
     Postprocess the dataset to make it compatible with plotting functions.
     """
@@ -3859,7 +3870,7 @@ def postprocess_for_plot(
     ds_groundtruth = _postprocess_for_plot(
         ds_groundtruth, areacello_values, areacello_real_values, dz, times, wetmask
     )
-    
+
     coords = ds_groundtruth.coords
 
     for key in pred_dict.keys():
@@ -3872,7 +3883,7 @@ def postprocess_for_plot(
             wetmask,
             coords=coords,
         )
-        
+
         # Rename lat and lon to y and x
         pred_dict[key]["ds_prediction"] = pred_dict[key]["ds_prediction"].rename(
             {"lat": "y", "lon": "x"}


### PR DESCRIPTION
This PR fixes OHC scaling by real grid-cell areas.

Key changes

- Added spherical_area_weights_real to compute true cell areas using spherical geometry.
- Updated OHC computation and post-processing pipelines to propagate both areacello and areacello_real. 
- Ensures OHC anomaly now matches expected magnitude (±50 ZJ)