### PR TITLE
Multi-scale data loading on a "match" or "mix" schedule.

### DIFF
--- a/configs/test/train_default_2step.yaml
+++ b/configs/test/train_default_2step.yaml
@@ -7,7 +7,7 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 1
-batch_size: 1
+batch_size: 2
 preemptible: false
 learning_rate: 0.0001
 scheduler: null

--- a/configs/test/train_default_2step.yaml
+++ b/configs/test/train_default_2step.yaml
@@ -7,7 +7,7 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 1
-batch_size: 2
+batch_size: 1
 preemptible: false
 learning_rate: 0.0001
 scheduler: null

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -234,7 +234,8 @@ def construct_metadata(data: xr.Dataset) -> dict[str, dict[str, str]]:
 
 class LoaderVersion(enum.Enum):
     OM4_TORCH = "om4-torch"
-    OM4_MULTI = "om4-multi"
+    OM4_MULTI_MATCH = "om4-multi-match"
+    OM4_MULTI_MIX = "om4-multi-mix"
 
 
 # TODO(#95): See if this can be removed and replaced.

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -234,6 +234,7 @@ def construct_metadata(data: xr.Dataset) -> dict[str, dict[str, str]]:
 
 class LoaderVersion(enum.Enum):
     OM4_TORCH = "om4-torch"
+    OM4_MULTI = "om4-multi"
 
 
 # TODO(#95): See if this can be removed and replaced.

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -755,7 +755,7 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
         sub_idx, rem = self.index_by_schedule(idx)
         # In this optimization, we only look up the `TrainData`s that we might eventually use.
-        needed = list(self.multiplex[rem]) if self.schedule == "mix" else [rem]
+        needed = self.multiplex[rem] if self.schedule == "mix" else [rem]
         tds = {i: ds[sub_idx] for i, ds in enumerate(self.datasets) if i in needed}
         return RawMultiscaleTrainData(dataset_id=self.id, datasets=tds, index=idx)
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -746,19 +746,20 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
 
     def to_train_data(self, raw_train_dataset: RawMultiscaleTrainData) -> TrainData:
         """Converts each RawTrainData into a TrainData, then merges it into a single TrainData."""
-        # TODO(alxmrs): Only call `to_train_data()` on data that will be used!
-        tds = [
-            ds.to_train_data(rtd)
-            for ds, rtd in zip(self.datasets, raw_train_dataset.datasets)
-        ]
+        deferred_tds = list(zip(self.datasets, raw_train_dataset.datasets))
+
+        def get_scale(idx_: int) -> TrainData:
+            ds, rtd = deferred_tds[idx_]
+            return ds.to_train_data(rtd)
+
         match self.schedule:
             case "match":
-                idx = raw_train_dataset.index % len(tds)
-                return tds[idx]
+                idx = raw_train_dataset.index % len(deferred_tds)
+                return get_scale(idx)
             case "mix":
                 macro_idx = raw_train_dataset.index % len(self.multiplex)
                 left_idx, right_idx = self.multiplex[macro_idx]
-                return mix_examples(tds[left_idx], tds[right_idx])
+                return mix_examples(get_scale(left_idx), get_scale(right_idx))
             case _:
                 assert_never(self.schedule)
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -12,7 +12,7 @@ import torch
 import xarray as xr
 from einops import rearrange
 from jaxtyping import Float
-from torch.utils.data import Dataset
+from torch.utils.data import Dataset, Sampler
 from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 
 from ocean_emulators.constants import (
@@ -694,6 +694,85 @@ def concurrent_compute(
 
 
 MultiscaleSchedule = Literal["match", "mix"]
+
+
+class MultiscaleGroupedBatchSampler(Sampler[list[int]]):
+    """Groups indices by multiplex position to ensure batch consistency in multiscale training.
+
+    For multiscale datasets with the "mix" schedule, items in a batch must have the same
+    multiplex index (idx % multiplex_size) to ensure consistent scale combinations are
+    applied during GPU processing.
+
+    This sampler groups indices by their multiplex position and creates batches within
+    each group, preventing the collate function from combining incompatible indices.
+
+    Args:
+        dataset_len: Total number of samples in the dataset
+        multiplex_size: Number of scale combinations (e.g., 4 for 2 scales: (0,0), (0,1), (1,0), (1,1))
+        batch_size: Number of samples per batch
+        shuffle: Whether to shuffle indices within each group
+        drop_last: Whether to drop the last incomplete batch in each group
+        generator: Random number generator for shuffling
+    """
+
+    def __init__(
+        self,
+        dataset_len: int,
+        multiplex_size: int,
+        batch_size: int,
+        shuffle: bool = True,
+        drop_last: bool = False,
+        generator: torch.Generator | None = None,
+    ):
+        self.dataset_len = dataset_len
+        self.group_size = multiplex_size
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.drop_last = drop_last
+        self.generator = generator
+
+    def __iter__(self):
+        # Group indices by their multiplex position
+        groups: list[list[int]] = [[] for _ in range(self.group_size)]
+        for idx in range(self.dataset_len):
+            multiplex_pos = idx % self.group_size
+            groups[multiplex_pos].append(idx)
+
+        # Shuffle within each group if needed
+        if self.shuffle:
+            for group in groups:
+                # Use torch.randperm for consistent behavior with PyTorch
+                if self.generator is not None:
+                    perm = torch.randperm(len(group), generator=self.generator).tolist()
+                else:
+                    perm = torch.randperm(len(group)).tolist()
+                groups[groups.index(group)] = [group[i] for i in perm]
+
+        # Yield batches from each group
+        for group in groups:
+            for i in range(0, len(group), self.batch_size):
+                batch = group[i : i + self.batch_size]
+                # Drop last incomplete batch if drop_last is True
+                if self.drop_last and len(batch) < self.batch_size:
+                    continue
+                yield batch
+
+    def __len__(self) -> int:
+        # Calculate total number of batches across all groups
+        total_batches = 0
+        for multiplex_pos in range(self.group_size):
+            # Count items in this group
+            group_size = (
+                self.dataset_len + self.group_size - multiplex_pos - 1
+            ) // self.group_size
+            # Calculate number of batches for this group
+            if self.drop_last:
+                # Use floor division to drop incomplete batches
+                total_batches += group_size // self.batch_size
+            else:
+                # Use ceiling division to include all batches
+                total_batches += (group_size + self.batch_size - 1) // self.batch_size
+        return total_batches
 
 
 def mix_examples(left: TrainData, right: TrainData) -> TrainData:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -715,7 +715,7 @@ class EquivalenceGroupedBatchSampler(Sampler[list[int]]):
     globally shuffled each epoch to avoid sequential group processing.
 
     Args:
-        dataset_len: Total number of samples in the dataset
+        data_size: Total number of samples in the dataset
         group_size: Number of equivalence groups (e.g., 2 for MATCH mode, 4 for MIX mode)
         batch_size: Number of samples per batch
         shuffle: Whether to shuffle indices within groups and shuffle batches globally
@@ -724,13 +724,13 @@ class EquivalenceGroupedBatchSampler(Sampler[list[int]]):
 
     def __init__(
         self,
-        dataset_len: int,
+        data_size: int,
         group_size: int,
         batch_size: int,
         shuffle: bool = True,
         drop_last: bool = False,
     ):
-        self.dataset_len = dataset_len
+        self.data_size = data_size
         self.group_size = group_size
         self.batch_size = batch_size
         self.shuffle = shuffle
@@ -738,7 +738,7 @@ class EquivalenceGroupedBatchSampler(Sampler[list[int]]):
 
         # Pre-compute group indices for __len__ calculation
         self.groups = [
-            [i for i in range(dataset_len) if i % group_size == g]
+            [i for i in range(data_size) if i % group_size == g]
             for g in range(group_size)
         ]
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -727,9 +727,8 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
         schedule: MultiscaleSchedule,
     ):
         self.datasets = [make_dataset(src) for src in srcs]
-        assert all(len(self.datasets[0]) == len(ds) for ds in self.datasets[1:]), (
-            "All datasets must be the same length."
-        )
+        if not all(len(self.datasets[0]) == len(ds) for ds in self.datasets[1:]):
+            raise ValueError("All datasets must have the same length")
         self.schedule = schedule
         self.FLAG = (
             LoaderVersion.OM4_MULTI_MATCH

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -5,16 +5,7 @@ from collections.abc import Callable, Iterator
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
 from itertools import product
-from typing import (
-    Generic,
-    Literal,
-    Protocol,
-    Self,
-    TypeAlias,
-    TypeVar,
-    assert_never,
-    final,
-)
+from typing import Generic, Literal, Protocol, Self, TypeVar, assert_never, final
 
 import numpy as np
 import torch
@@ -459,8 +450,6 @@ class TorchTrainDataset(GpuResolvedDataset[RawTrainData]):
             step=2->[[6, 7, 8], [9, 10, 11]];
             step=3->[[9, 10, 11], [12, 13, 14]]
     """
-
-    Id: TypeAlias = tuple[str, DataSource]
 
     FLAG = LoaderVersion.OM4_TORCH
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,5 +1,7 @@
 import dataclasses
+import itertools
 import logging
+import random
 import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import wait
@@ -12,7 +14,7 @@ import torch
 import xarray as xr
 from einops import rearrange
 from jaxtyping import Float
-from torch.utils.data import Dataset, Sampler
+from torch.utils.data import BatchSampler, Dataset, Sampler, SubsetRandomSampler
 from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 
 from ocean_emulators.constants import (
@@ -693,26 +695,31 @@ def concurrent_compute(
     wait(futures)
 
 
-MultiscaleSchedule = Literal["match", "mix"]
+class _SimpleSubsetSampler(torch.utils.data.Sampler):
+    def __init__(self, indices):
+        super().__init__()
+        self.indices = indices
+
+    def __iter__(self):
+        return iter(self.indices)
+
+    def __len__(self):
+        return len(self.indices)
 
 
-class MultiscaleGroupedBatchSampler(Sampler[list[int]]):
-    """Groups indices by equivalence to ensure batch consistency in multiscale training.
+class EquivalenceGroupedBatchSampler(Sampler[list[int]]):
+    """Groups indices by equivalence class (modulo), batches within groups, and optionally shuffles.
 
-    For multiscale datasets with the "mix" schedule, items in a batch must have the same
-    group index (idx % group_size) to ensure consistent scale combinations are
-    applied during GPU processing.
-
-    This sampler collects indices by their group position and creates batches within
-    each group, preventing the collate function from combining incompatible indices.
+    This sampler partitions dataset indices into groups based on `idx % group_size`, creates
+    batches within each group, then chains them together. When shuffle=True, batches are
+    globally shuffled each epoch to avoid sequential group processing.
 
     Args:
         dataset_len: Total number of samples in the dataset
-        group_size: Number of scale combinations
+        group_size: Number of equivalence groups (e.g., 2 for MATCH mode, 4 for MIX mode)
         batch_size: Number of samples per batch
-        shuffle: Whether to shuffle indices within each group
-        drop_last: Whether to drop the last incomplete batch in each group
-        generator: Random number generator for shuffling
+        shuffle: Whether to shuffle indices within groups and shuffle batches globally
+        drop_last: Whether to drop incomplete batches at the end of each group
     """
 
     def __init__(
@@ -722,57 +729,57 @@ class MultiscaleGroupedBatchSampler(Sampler[list[int]]):
         batch_size: int,
         shuffle: bool = True,
         drop_last: bool = False,
-        generator: torch.Generator | None = None,
     ):
         self.dataset_len = dataset_len
         self.group_size = group_size
         self.batch_size = batch_size
         self.shuffle = shuffle
         self.drop_last = drop_last
-        self.generator = generator
+
+        # Pre-compute group indices for __len__ calculation
+        self.groups = [
+            [i for i in range(dataset_len) if i % group_size == g]
+            for g in range(group_size)
+        ]
 
     def __iter__(self):
-        # Group indices by their position
-        groups: list[list[int]] = [[] for _ in range(self.group_size)]
-        for idx in range(self.dataset_len):
-            group_pos = idx % self.group_size
-            groups[group_pos].append(idx)
+        # Choose sampler based on shuffle setting
+        SubsetSampler = SubsetRandomSampler if self.shuffle else _SimpleSubsetSampler
 
-        # Shuffle within each group if needed
-        if self.shuffle:
-            for group in groups:
-                # Use torch.randperm for consistent behavior with PyTorch
-                if self.generator is not None:
-                    perm = torch.randperm(len(group), generator=self.generator).tolist()
-                else:
-                    perm = torch.randperm(len(group)).tolist()
-                groups[groups.index(group)] = [group[i] for i in perm]
+        # Create batch samplers for each group
+        batch_sampler = itertools.chain(
+            *[
+                BatchSampler(
+                    SubsetSampler(group),
+                    batch_size=self.batch_size,
+                    drop_last=self.drop_last,
+                )
+                for group in self.groups
+            ]
+        )
 
-        # Yield batches from each group
-        for group in groups:
-            for i in range(0, len(group), self.batch_size):
-                batch = group[i : i + self.batch_size]
-                # Drop last incomplete batch if drop_last is True
-                if self.drop_last and len(batch) < self.batch_size:
-                    continue
-                yield batch
+        if not self.shuffle:
+            # No global shuffle: return batches in sequential group order
+            yield from batch_sampler
+        else:
+            # Shuffle batches globally to avoid sequential group processing
+            # This is regenerated each epoch, giving different orderings
+            all_batches = list(batch_sampler)
+            random.shuffle(all_batches)
+            yield from all_batches
 
-    def __len__(self) -> int:
-        # Calculate total number of batches across all groups
+    def __len__(self):
+        """Calculate total number of batches across all groups."""
         total_batches = 0
-        for group_pos in range(self.group_size):
-            # Count items in this group
-            group_size = (
-                self.dataset_len + self.group_size - group_pos - 1
-            ) // self.group_size
-            # Calculate number of batches for this group
+        for group in self.groups:
             if self.drop_last:
-                # Use floor division to drop incomplete batches
-                total_batches += group_size // self.batch_size
+                total_batches += len(group) // self.batch_size
             else:
-                # Use ceiling division to include all batches
-                total_batches += (group_size + self.batch_size - 1) // self.batch_size
+                total_batches += (len(group) + self.batch_size - 1) // self.batch_size
         return total_batches
+
+
+MultiscaleSchedule = Literal["match", "mix"]
 
 
 def mix_examples(left: TrainData, right: TrainData) -> TrainData:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -755,10 +755,8 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
         sub_idx, rem = self.index_by_schedule(idx)
         # In this optimization, we only look up the `TrainData`s that we might eventually use.
-        maybe_needed = list(self.multiplex[rem]) if self.schedule == "mix" else [rem]
-        tds = {
-            i: ds[sub_idx] for i, ds in enumerate(self.datasets) if i in maybe_needed
-        }
+        needed = list(self.multiplex[rem]) if self.schedule == "mix" else [rem]
+        tds = {i: ds[sub_idx] for i, ds in enumerate(self.datasets) if i in needed}
         return RawMultiscaleTrainData(dataset_id=self.id, datasets=tds, index=idx)
 
     def __len__(self) -> int:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -333,21 +333,25 @@ class RawTrainData:
 
 @dataclasses.dataclass
 class RawMultiscaleTrainData:
-    """A collection of `RawTrainData` stores of `Example`s at multiple scales."""
+    """A collection of `RawTrainData` stores of `Example`s at multiple scales.
+
+    Uses a sparse representation where only loaded datasets are stored in the dict.
+    Keys are dataset indices, values are the corresponding RawTrainData.
+    """
 
     dataset_id: DatasetId
-    datasets: list[RawTrainData]
+    datasets: dict[int, RawTrainData]
     index: int
 
     def __iter__(self) -> Iterator[RawTrainData]:
-        yield from self.datasets
+        yield from self.datasets.values()
 
     def to(self, device: torch.device) -> None:
-        for dataset in self.datasets:
+        for dataset in self:
             dataset.to(device=device)
 
     def pin_memory(self) -> Self:
-        for dataset in self.datasets:
+        for dataset in self:
             dataset.pin_memory()
         return self
 
@@ -705,6 +709,17 @@ def mix_examples(left: TrainData, right: TrainData) -> TrainData:
 
 @final
 class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
+    """A dataset that loads `TrainData` at multiple scales, in either a "match" or "mix" schedule.
+
+    In a "match" schedule, the resolved `TrainData` Examples have matching scales, but scales vary by index.
+    In a "mix" schedule, the resolved `TrainData` Examples are combinations of scales, where the input is one scale and
+    the label is another scale.
+
+    This Dataset includes a sparse lookup optimization where we only load the data from scales that are used (depending
+    on the schedule). For instance, when two datasets of two scales are used, this loader will only load either one or
+    two `TrainData` batches only (if it is "match" or "mix" schedules, respectively).
+    """
+
     FLAG = LoaderVersion.OM4_MULTI
 
     def __init__(
@@ -714,6 +729,9 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
         schedule: MultiscaleSchedule,
     ):
         self.datasets = [make_dataset(src) for src in srcs]
+        assert all(len(self.datasets[0]) == len(ds) for ds in self.datasets[1:]), (
+            "All datasets must be the same length."
+        )
         self.schedule = schedule
         self.id: DatasetId = f"{self.__class__.__name__}({str(id(self))}, {schedule}, {', '.join([ds.id for ds in self.datasets])})"
         self.multiplex = {
@@ -721,45 +739,52 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             for i, pair in enumerate(product(range(len(self.datasets)), repeat=2))
         }
 
-    @elapsed(level=logging.DEBUG)
-    def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
+    def index_by_schedule(self, idx: int) -> tuple[int, int]:
         match self.schedule:
             case "match":
-                sub_idx = idx // len(self.datasets)
+                return divmod(idx, len(self.datasets))
             case "mix":
-                sub_idx = idx // len(self.multiplex)
+                return divmod(idx, len(self.multiplex))
             case _:
                 assert_never(self.schedule)
-        tds = [ds[sub_idx] for ds in self.datasets]
+
+    @elapsed(level=logging.DEBUG)
+    def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
+        sub_idx, rem = self.index_by_schedule(idx)
+        # In this optimization, we only look up the `TrainData`s that we might eventually use.
+        maybe_needed = list(self.multiplex[rem]) if self.schedule == "mix" else [rem]
+        tds = {
+            i: ds[sub_idx] for i, ds in enumerate(self.datasets) if i in maybe_needed
+        }
         return RawMultiscaleTrainData(dataset_id=self.id, datasets=tds, index=idx)
 
     def __len__(self) -> int:
         match self.schedule:
             case "match":
-                # this should be len(datasets[0]) * len(datasets)
+                # this is the same as len(datasets[0]) * len(datasets)
                 return sum(len(ds) for ds in self.datasets)
             case "mix":
-                # assume all datasets are the same size
+                # All datasets must be the same length
                 return len(self.datasets[0]) * len(self.multiplex)
             case _:
                 assert_never(self.schedule)
 
     def to_train_data(self, raw_train_dataset: RawMultiscaleTrainData) -> TrainData:
         """Converts each RawTrainData into a TrainData, then merges it into a single TrainData."""
-        deferred_tds = list(zip(self.datasets, raw_train_dataset.datasets))
 
-        def get_scale(idx_: int) -> TrainData:
-            ds, rtd = deferred_tds[idx_]
+        def lazy_get_from(idx_: int) -> TrainData:
+            """Deferred GPU processing - only process scales that will be used."""
+            ds, rtd = self.datasets[idx_], raw_train_dataset.datasets[idx_]
             return ds.to_train_data(rtd)
+
+        _, idx = self.index_by_schedule(raw_train_dataset.index)
 
         match self.schedule:
             case "match":
-                idx = raw_train_dataset.index % len(deferred_tds)
-                return get_scale(idx)
+                return lazy_get_from(idx)
             case "mix":
-                macro_idx = raw_train_dataset.index % len(self.multiplex)
-                left_idx, right_idx = self.multiplex[macro_idx]
-                return mix_examples(get_scale(left_idx), get_scale(right_idx))
+                left_idx, right_idx = self.multiplex[idx]
+                return mix_examples(lazy_get_from(left_idx), lazy_get_from(right_idx))
             case _:
                 assert_never(self.schedule)
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -697,18 +697,18 @@ MultiscaleSchedule = Literal["match", "mix"]
 
 
 class MultiscaleGroupedBatchSampler(Sampler[list[int]]):
-    """Groups indices by multiplex position to ensure batch consistency in multiscale training.
+    """Groups indices by equivalence to ensure batch consistency in multiscale training.
 
     For multiscale datasets with the "mix" schedule, items in a batch must have the same
-    multiplex index (idx % multiplex_size) to ensure consistent scale combinations are
+    group index (idx % group_size) to ensure consistent scale combinations are
     applied during GPU processing.
 
-    This sampler groups indices by their multiplex position and creates batches within
+    This sampler collects indices by their group position and creates batches within
     each group, preventing the collate function from combining incompatible indices.
 
     Args:
         dataset_len: Total number of samples in the dataset
-        multiplex_size: Number of scale combinations (e.g., 4 for 2 scales: (0,0), (0,1), (1,0), (1,1))
+        group_size: Number of scale combinations
         batch_size: Number of samples per batch
         shuffle: Whether to shuffle indices within each group
         drop_last: Whether to drop the last incomplete batch in each group
@@ -718,25 +718,25 @@ class MultiscaleGroupedBatchSampler(Sampler[list[int]]):
     def __init__(
         self,
         dataset_len: int,
-        multiplex_size: int,
+        group_size: int,
         batch_size: int,
         shuffle: bool = True,
         drop_last: bool = False,
         generator: torch.Generator | None = None,
     ):
         self.dataset_len = dataset_len
-        self.group_size = multiplex_size
+        self.group_size = group_size
         self.batch_size = batch_size
         self.shuffle = shuffle
         self.drop_last = drop_last
         self.generator = generator
 
     def __iter__(self):
-        # Group indices by their multiplex position
+        # Group indices by their position
         groups: list[list[int]] = [[] for _ in range(self.group_size)]
         for idx in range(self.dataset_len):
-            multiplex_pos = idx % self.group_size
-            groups[multiplex_pos].append(idx)
+            group_pos = idx % self.group_size
+            groups[group_pos].append(idx)
 
         # Shuffle within each group if needed
         if self.shuffle:
@@ -760,10 +760,10 @@ class MultiscaleGroupedBatchSampler(Sampler[list[int]]):
     def __len__(self) -> int:
         # Calculate total number of batches across all groups
         total_batches = 0
-        for multiplex_pos in range(self.group_size):
+        for group_pos in range(self.group_size):
             # Count items in this group
             group_size = (
-                self.dataset_len + self.group_size - multiplex_pos - 1
+                self.dataset_len + self.group_size - group_pos - 1
             ) // self.group_size
             # Calculate number of batches for this group
             if self.drop_last:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -720,8 +720,6 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
     two `TrainData` batches only (if it is "match" or "mix" schedules, respectively).
     """
 
-    FLAG = LoaderVersion.OM4_MULTI
-
     def __init__(
         self,
         srcs: list[DataSource],
@@ -733,6 +731,11 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
             "All datasets must be the same length."
         )
         self.schedule = schedule
+        self.FLAG = (
+            LoaderVersion.OM4_MULTI_MATCH
+            if schedule == "match"
+            else LoaderVersion.OM4_MULTI_MIX
+        )
         self.id: DatasetId = f"{self.__class__.__name__}({str(id(self))}, {schedule}, {', '.join([ds.id for ds in self.datasets])})"
         self.multiplex = {
             i: pair

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -723,12 +723,11 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
 
     @elapsed(level=logging.DEBUG)
     def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
-        # TODO(alxmrs): Check the math here.
         match self.schedule:
             case "match":
                 sub_idx = idx // len(self.datasets)
             case "mix":
-                sub_idx = idx // sum(len(ds) for ds in self.datasets)
+                sub_idx = idx // len(self.multiplex)
             case _:
                 assert_never(self.schedule)
         tds = [ds[sub_idx] for ds in self.datasets]
@@ -740,13 +739,14 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
                 # this should be len(datasets[0]) * len(datasets)
                 return sum(len(ds) for ds in self.datasets)
             case "mix":
-                # this should be len(datasets[0]) ** len(datasets)
-                return int(np.prod([len(ds) for ds in self.datasets]))
+                # assume all datasets are the same size
+                return len(self.datasets[0]) * len(self.multiplex)
             case _:
                 assert_never(self.schedule)
 
     def to_train_data(self, raw_train_dataset: RawMultiscaleTrainData) -> TrainData:
         """Converts each RawTrainData into a TrainData, then merges it into a single TrainData."""
+        # TODO(alxmrs): Only call `to_train_data()` on data that will be used!
         tds = [
             ds.to_train_data(rtd)
             for ds, rtd in zip(self.datasets, raw_train_dataset.datasets)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,8 +1,20 @@
+import dataclasses
 import logging
 import time
+from collections.abc import Callable, Iterator
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import TypeAlias, final
+from itertools import product
+from typing import (
+    Generic,
+    Literal,
+    Protocol,
+    Self,
+    TypeAlias,
+    TypeVar,
+    assert_never,
+    final,
+)
 
 import numpy as np
 import torch
@@ -292,9 +304,19 @@ class InferenceDatasets(Dataset):
         return (self.datasets[idx], self.lengths[idx])
 
 
+DatasetId = str
+
+
+class HasDatasetId(Protocol):
+    dataset_id: DatasetId
+
+
+DataBoundToDataset = TypeVar("DataBoundToDataset", bound=HasDatasetId)
+
+
 class RawTrainData:
-    def __init__(self, dataset_id: "TorchTrainDataset.Id"):
-        self.dataset_id: TorchTrainDataset.Id = dataset_id
+    def __init__(self, dataset_id: DatasetId):
+        self.dataset_id = dataset_id
         self.raw_data: list[tuple[torch.Tensor, torch.Tensor]] = []
         self.load_stats: LoadStats | None = None
 
@@ -315,6 +337,27 @@ class RawTrainData:
             (all_prognostic.pin_memory(), all_boundary.pin_memory())
             for all_prognostic, all_boundary in self.raw_data
         ]
+        return self
+
+
+@dataclasses.dataclass
+class RawMultiscaleTrainData:
+    """A collection of `RawTrainData` stores of `Example`s at multiple scales."""
+
+    dataset_id: DatasetId
+    datasets: list[RawTrainData]
+    index: int = -1
+
+    def __iter__(self) -> Iterator[RawTrainData]:
+        yield from self.datasets
+
+    def to(self, device: torch.device) -> None:
+        for dataset in self.datasets:
+            dataset.to(device=device)
+
+    def pin_memory(self) -> Self:
+        for dataset in self.datasets:
+            dataset.pin_memory()
         return self
 
 
@@ -382,8 +425,22 @@ class TrainData:
         return self
 
 
+class GpuResolvedDataset(Dataset[DataBoundToDataset]):
+    """A `torch.utils.data.Dataset` of bound data used to perform normalization
+    and other final processing operations on GPU.
+
+    Args:
+        id (str): The ID of the dataset - must be consistent with each data's `dataset_id`.
+    """
+
+    id: DatasetId
+
+    def to_train_data(self, raw_train_data: DataBoundToDataset) -> TrainData:
+        raise NotImplementedError()
+
+
 @final
-class TorchTrainDataset(Dataset[RawTrainData]):
+class TorchTrainDataset(GpuResolvedDataset[RawTrainData]):
     """
     This class is used for training and validation.
 
@@ -403,7 +460,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             step=3->[[9, 10, 11], [12, 13, 14]]
     """
 
-    Id: TypeAlias = str
+    Id: TypeAlias = tuple[str, DataSource]
 
     FLAG = LoaderVersion.OM4_TORCH
 
@@ -421,7 +478,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         executor: ThreadPoolExecutor | None = None,
     ):
         super().__init__()
-        self.id = f"{self.__class__.__name__}_{str(id(self))}"
+        self.id = f"{self.__class__.__name__}({str(id(self))})"
         self.device = get_device()
 
         self.hist: int = hist
@@ -643,8 +700,81 @@ def concurrent_compute(
     wait(futures)
 
 
+MultiscaleSchedule = Literal["match", "mix"]
+
+
+def mix_examples(left: TrainData, right: TrainData) -> TrainData:
+    """Mixes the examples for all steps: uses the 'left' for Input and 'right' for Label."""
+    assert left.num_prognostic_channels == right.num_prognostic_channels
+    out = TrainData(left.num_prognostic_channels)
+    for left_eg, right_eg in zip(
+        left.example_by_step, right.example_by_step, strict=True
+    ):
+        out.append(left_eg[0], right_eg[1])
+    return out
+
+
 @final
-class TrainDataLoader:
+class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
+    FLAG = LoaderVersion.OM4_MULTI
+
+    def __init__(
+        self,
+        srcs: list[DataSource],
+        make_dataset: Callable[[DataSource], TorchTrainDataset],
+        schedule: MultiscaleSchedule,
+    ):
+        self.datasets = [make_dataset(src) for src in srcs]
+        self.schedule = schedule
+        self.id: DatasetId = f"{self.__class__.__name__}({str(id(self))}, {schedule}, {', '.join([ds.id for ds in self.datasets])})"
+        self.multiplex = {
+            i: pair
+            for i, pair in enumerate(product(range(len(self.datasets)), repeat=2))
+        }
+
+    @elapsed(level=logging.DEBUG)
+    def __getitem__(self, idx: int) -> RawMultiscaleTrainData:
+        # TODO(alxmrs): Check the math here.
+        match self.schedule:
+            case "match":
+                sub_idx = idx // len(self.datasets)
+            case "mix":
+                sub_idx = idx // sum(len(ds) for ds in self.datasets)
+            case _:
+                assert_never(self.schedule)
+        tds = [ds[sub_idx] for ds in self.datasets]
+        return RawMultiscaleTrainData(dataset_id=self.id, datasets=tds, index=idx)
+
+    def __len__(self) -> int:
+        match self.schedule:
+            case "match":
+                # this should be len(datasets[0]) * len(datasets)
+                return sum(len(ds) for ds in self.datasets)
+            case "mix":
+                return int(np.prod([len(ds) for ds in self.datasets]))
+            case _:
+                assert_never(self.schedule)
+
+    def to_train_data(self, raw_train_dataset: RawMultiscaleTrainData) -> TrainData:
+        """Converts each RawTrainData into a TrainData, then merges it into a single TrainData."""
+        tds = [
+            ds.to_train_data(rtd)
+            for ds, rtd in zip(self.datasets, raw_train_dataset.datasets)
+        ]
+        match self.schedule:
+            case "match":
+                idx = raw_train_dataset.index % len(tds)
+                return tds[idx]
+            case "mix":
+                macro_idx = raw_train_dataset.index % len(self.multiplex)
+                left_idx, right_idx = self.multiplex[macro_idx]
+                return mix_examples(tds[left_idx], tds[right_idx])
+            case _:
+                assert_never(self.schedule)
+
+
+@final
+class TrainDataLoader(Generic[DataBoundToDataset]):
     """Wrapper around a torch DataLoader that handles GPU post-processing.
 
     This class wraps a DataLoader[RawTrainData] and converts the raw data
@@ -661,8 +791,8 @@ class TrainDataLoader:
 
     def __init__(
         self,
-        dataloader: torch.utils.data.DataLoader[RawTrainData],
-        datasets: list[TorchTrainDataset],
+        dataloader: torch.utils.data.DataLoader[DataBoundToDataset],
+        datasets: list[GpuResolvedDataset[DataBoundToDataset]],
         device: torch.device,
     ):
         self._dataloader = dataloader

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -346,7 +346,7 @@ class RawMultiscaleTrainData:
 
     dataset_id: DatasetId
     datasets: list[RawTrainData]
-    index: int = -1
+    index: int
 
     def __iter__(self) -> Iterator[RawTrainData]:
         yield from self.datasets
@@ -751,6 +751,7 @@ class MultiscaleTrainDataset(GpuResolvedDataset[RawMultiscaleTrainData]):
                 # this should be len(datasets[0]) * len(datasets)
                 return sum(len(ds) for ds in self.datasets)
             case "mix":
+                # this should be len(datasets[0]) ** len(datasets)
                 return int(np.prod([len(ds) for ds in self.datasets]))
             case _:
                 assert_never(self.schedule)

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -5,7 +5,11 @@ from pathlib import Path
 import torch
 from xarray_einstats.einops import rearrange  # noqa: F401
 
-from ocean_emulators.datasets import InferenceDataset, RawTrainData
+from ocean_emulators.datasets import (
+    InferenceDataset,
+    RawMultiscaleTrainData,
+    RawTrainData,
+)
 from ocean_emulators.utils.data import LoadStats
 
 
@@ -32,6 +36,21 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
         [d.load_stats for d in data if d.load_stats is not None]
     )
     batched_data.load_stats = stats
+
+    return batched_data
+
+
+def collate_raw_multiscale_train_data(
+    data: Sequence[RawMultiscaleTrainData],
+) -> RawMultiscaleTrainData:
+    batched_data = RawMultiscaleTrainData(data[0].dataset_id, [])
+
+    # Since `RawMultiscaleTrainData` is a list of lists, we can think of this
+    # `zip` as a transpose of these lists. This is what we want, since we process
+    # every first `RawTrainData` via the collate_fn, then the second, and so on.
+    # After each stage is processed, we add it to the final multiscale TD.
+    for tds in zip(*data):
+        batched_data.datasets.append(collate_raw_train_data(tds))
 
     return batched_data
 

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -43,14 +43,16 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
 def collate_raw_multiscale_train_data(
     data: Sequence[RawMultiscaleTrainData],
 ) -> RawMultiscaleTrainData:
-    batched_data = RawMultiscaleTrainData(data[0].dataset_id, [], data[0].index)
+    batched_data = RawMultiscaleTrainData(data[0].dataset_id, {}, data[0].index)
 
-    # Since `RawMultiscaleTrainData` is a list of lists, we can think of this
-    # `zip` as a transpose of these lists. This is what we want, since we process
-    # every first `RawTrainData` via the collate_fn, then the second, and so on.
-    # After each stage is processed, we add it to the final multiscale TD.
-    for tds in zip(*data):
-        batched_data.datasets.append(collate_raw_train_data(tds))
+    # Collect all dataset indices present in any batch item
+    all_indices: set[int] = {k for d in data for k in d.datasets.keys()}
+
+    # For each index, collate the RawTrainData from all batch items that have it
+    for idx in sorted(all_indices):
+        tds = [d.datasets[idx] for d in data if idx in d.datasets]
+        if tds:
+            batched_data.datasets[idx] = collate_raw_train_data(tds)
 
     return batched_data
 

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -43,6 +43,9 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
 def collate_raw_multiscale_train_data(
     data: Sequence[RawMultiscaleTrainData],
 ) -> RawMultiscaleTrainData:
+    assert all(data[0].index == d.index for d in data), (
+        "Multiscale data must be associated with the same index!"
+    )
     batched_data = RawMultiscaleTrainData(data[0].dataset_id, {}, data[0].index)
 
     # Collect all dataset indices present in any batch item

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -43,9 +43,10 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
 def collate_raw_multiscale_train_data(
     data: Sequence[RawMultiscaleTrainData],
 ) -> RawMultiscaleTrainData:
-    assert all(data[0].index == d.index for d in data), (
-        "Multiscale data must be associated with the same index!"
-    )
+    # When using MultiscaleGroupedBatchSampler, items in a batch have the same multiplex
+    # position (idx % multiplex_size) but not necessarily the same exact index.
+    # For example, indices [0, 4, 8] all have multiplex position 0 when multiplex_size=4.
+    # We use data[0].index as the representative since all items map to the same position.
     batched_data = RawMultiscaleTrainData(data[0].dataset_id, {}, data[0].index)
 
     # Collect all dataset indices present in any batch item

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -43,9 +43,9 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
 def collate_raw_multiscale_train_data(
     data: Sequence[RawMultiscaleTrainData],
 ) -> RawMultiscaleTrainData:
-    # When using MultiscaleGroupedBatchSampler, items in a batch have the same multiplex
-    # position (idx % multiplex_size) but not necessarily the same exact index.
-    # For example, indices [0, 4, 8] all have multiplex position 0 when multiplex_size=4.
+    # When using EquivalenceGroupedBatchSampler, items in a batch have the same group
+    # position (idx % group_size) but not necessarily the same exact index.
+    # For example, indices [0, 4, 8] all have group position 0 when group_size=4.
     # We use data[0].index as the representative since all items map to the same position.
     batched_data = RawMultiscaleTrainData(data[0].dataset_id, {}, data[0].index)
 

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -43,7 +43,7 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
 def collate_raw_multiscale_train_data(
     data: Sequence[RawMultiscaleTrainData],
 ) -> RawMultiscaleTrainData:
-    batched_data = RawMultiscaleTrainData(data[0].dataset_id, [])
+    batched_data = RawMultiscaleTrainData(data[0].dataset_id, [], data[0].index)
 
     # Since `RawMultiscaleTrainData` is a list of lists, we can think of this
     # `zip` as a transpose of these lists. This is what we want, since we process

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -85,6 +85,18 @@ def make_loader(
     prognostic = PROGNOSTIC_VARS[cfg.experiment.prognostic_vars_key]
     boundary = BOUNDARY_VARS[cfg.experiment.boundary_vars_key]
 
+    def make_dataset(s: DataSource, stride: int):
+        return TorchTrainDataset(
+            src=s.slice(time_config),
+            prognostic_var_names=prognostic,
+            boundary_var_names=boundary,
+            hist=cfg.data.hist,
+            steps=cfg.steps[0],
+            normalize_before_mask=cfg.data.normalize_before_mask,
+            masked_fill_value=cfg.data.masked_fill_value,
+            stride=stride,
+        )
+
     data_config = (
         cfg.data
         if version is None
@@ -106,19 +118,7 @@ def make_loader(
 
         match version:
             case LoaderVersion.OM4_TORCH:
-                dataset_list = [
-                    TorchTrainDataset(
-                        src=src.slice(time_config),
-                        prognostic_var_names=prognostic,
-                        boundary_var_names=boundary,
-                        hist=cfg.data.hist,
-                        steps=cfg.steps[0],
-                        normalize_before_mask=cfg.data.normalize_before_mask,
-                        masked_fill_value=cfg.data.masked_fill_value,
-                        stride=stride,
-                    )
-                    for stride in cfg.data_stride
-                ]
+                dataset_list = [make_dataset(src, stride) for stride in cfg.data_stride]
                 collate_fn = collate_raw_train_data
             case LoaderVersion.OM4_MULTI_MATCH | LoaderVersion.OM4_MULTI_MIX:
                 # Create coarsened datasource with both coarsened data and masks
@@ -127,18 +127,6 @@ def make_loader(
                     coarsened_src, masks=coarsen_masks(src.masks)
                 )
                 srcs = [src, coarsened_src]
-
-                def make_dataset(s, stride):
-                    return TorchTrainDataset(
-                        src=s.slice(time_config),
-                        prognostic_var_names=prognostic,
-                        boundary_var_names=boundary,
-                        hist=cfg.data.hist,
-                        steps=cfg.steps[0],
-                        normalize_before_mask=cfg.data.normalize_before_mask,
-                        masked_fill_value=cfg.data.masked_fill_value,
-                        stride=stride,
-                    )
 
                 schedule: MultiscaleSchedule = (
                     "match" if version == LoaderVersion.OM4_MULTI_MATCH else "mix"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -47,14 +47,29 @@ def inference_loader_pair(trainer_pair: TrainPair) -> tuple[TrainConfig, DataLoa
     return cfg, trainer.inference_loader
 
 
-def coarsen(
-    ds: xr.Dataset, mean: xr.Dataset, stds: xr.Dataset
-) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]:
-    return (
-        ds.coarsen(lat=2, lon=2).mean(),  # type: ignore
-        mean.coarsen(lat=2, lon=2).mean(),  # type: ignore
-        stds.coarsen(lat=2, lon=2).mean(),  # type: ignore
-    )
+def coarsen_data(ds: xr.Dataset) -> xr.Dataset:
+    return ds.coarsen(lat=2, lon=2).mean()  # type: ignore
+
+
+def coarsen_masks(masks: Masks) -> Masks:
+    """Coarsen masks to half resolution using max pooling (any True -> True)."""
+    # For masks, we use max pooling: if any cell in the 2x2 block is True (valid),
+    # the coarsened cell is True
+    import torch.nn.functional as F
+
+    # Coarsen prognostic mask (3D: channels x lat x lon)
+    prog_mask = masks.prognostic.float().unsqueeze(0)  # Add batch dim
+    prog_coarsened = F.max_pool2d(prog_mask, kernel_size=2, stride=2)
+    prog_coarsened = prog_coarsened.squeeze(0).bool()  # Remove batch dim, back to bool
+
+    # Coarsen boundary mask (2D: lat x lon)
+    bound_mask = (
+        masks.boundary.float().unsqueeze(0).unsqueeze(0)
+    )  # Add batch and channel dims
+    bound_coarsened = F.max_pool2d(bound_mask, kernel_size=2, stride=2)
+    bound_coarsened = bound_coarsened.squeeze(0).squeeze(0).bool()  # Remove extra dims
+
+    return Masks(prognostic=prog_coarsened, boundary=bound_coarsened)
 
 
 @contextlib.contextmanager
@@ -106,7 +121,12 @@ def make_loader(
                 ]
                 collate_fn = collate_raw_train_data
             case LoaderVersion.OM4_MULTI_MATCH | LoaderVersion.OM4_MULTI_MIX:
-                srcs = [src, src]
+                # Create coarsened datasource with both coarsened data and masks
+                coarsened_src = src.map_data(coarsen_data, suffix="half-size")
+                coarsened_src = dataclasses.replace(
+                    coarsened_src, masks=coarsen_masks(src.masks)
+                )
+                srcs = [src, coarsened_src]
 
                 def make_dataset(s, stride):
                     return TorchTrainDataset(
@@ -121,7 +141,7 @@ def make_loader(
                     )
 
                 schedule: MultiscaleSchedule = (
-                    "match" if LoaderVersion.OM4_MULTI_MATCH else "mix"
+                    "match" if version == LoaderVersion.OM4_MULTI_MATCH else "mix"
                 )
 
                 dataset_list = [
@@ -295,11 +315,11 @@ def test_loader__data_shape(
         )
 
         n_samples = calc_num_samples(train_config, train_config.train_time.time_slice)
-        if (
-            loader_version == LoaderVersion.OM4_MULTI_MATCH
-            or loader_version == LoaderVersion.OM4_MULTI_MIX
-        ):
+        if loader_version == LoaderVersion.OM4_MULTI_MATCH:
             n_samples *= 2
+        elif loader_version == LoaderVersion.OM4_MULTI_MIX:
+            n_samples *= 4
+
         samples = list(loader)
 
         assert len(samples) == n_samples, (
@@ -307,24 +327,48 @@ def test_loader__data_shape(
             f"got {len(samples)}."
         )
 
-        # Only check the first 2 samples; this should be proof enough that everything is
+        cross_resolutions = []
+        # Only check the first 4 samples; this should be proof enough that everything is
         # the right shape.
-        for sample in samples[:2]:
+        for sample in samples[:4]:
             X, y = extract_sample_arrays(sample)
-            assert X.shape == (
+            # Exclude the coordinate shape information for now; we'll test that separately.
+            assert X.shape[:-2] == (
                 train_config.steps[0],
                 batch_size,
                 input_var_dim,
-                180,
-                360,
             )
-            assert y.shape == (
+            assert y.shape[:-2] == (
                 train_config.steps[0],
                 batch_size,
                 output_var_dim,
-                180,
-                360,
             )
+            cross_resolutions.append((X.shape[-2:], y.shape[-2:]))
+
+        match loader_version:
+            case LoaderVersion.OM4_TORCH:
+                assert cross_resolutions[0][0] == cross_resolutions[0][1], (
+                    "The input and output should be equal"
+                )
+                assert all(
+                    cross_resolutions[0] == cr for cr in cross_resolutions[1:]
+                ), "All resolutions should be equal"
+            case LoaderVersion.OM4_MULTI_MATCH:
+                for x_res, y_res in cross_resolutions:
+                    assert x_res == y_res, (
+                        f"Resolutions must match across batches for 'match' schedule multiscale loader. {cross_resolutions=}"
+                    )
+            case LoaderVersion.OM4_MULTI_MIX:
+                # In mix mode with 2 scales, multiplex creates pattern: (0,0), (0,1), (1,0), (1,1)
+                # Expected: same, different, different, same
+                assert cross_resolutions == [
+                    ((180, 360), (180, 360)),
+                    ((180, 360), (90, 180)),
+                    ((90, 180), (180, 360)),
+                    ((90, 180), (90, 180)),
+                ], (
+                    "Resolutions should follow a cartesian product for the 'mix' schedule multiscale loader."
+                )
 
 
 def test_inference__data_shape(inference_loader_pair):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -120,13 +120,12 @@ def make_loader(
         match version:
             case LoaderVersion.OM4_TORCH:
                 dataset_list = [make_dataset(src, stride) for stride in cfg.data_stride]
-                collate_fn = collate_raw_train_data
                 data: ConcatDataset = ConcatDataset(dataset_list)
                 raw_loader = DataLoader(
                     data,
                     batch_size=cfg.batch_size,
                     drop_last=drop_last,
-                    collate_fn=collate_fn,
+                    collate_fn=collate_raw_train_data,
                 )
             case LoaderVersion.OM4_MULTI_MATCH | LoaderVersion.OM4_MULTI_MIX:
                 # Create coarsened datasource with both coarsened data and masks
@@ -148,7 +147,6 @@ def make_loader(
                     )
                     for stride in cfg.data_stride
                 ]
-                collate_fn = collate_raw_multiscale_train_data  # type: ignore
                 data = ConcatDataset(dataset_list)
 
                 group_size = (
@@ -161,7 +159,7 @@ def make_loader(
                 )
                 raw_loader = DataLoader(
                     data,
-                    collate_fn=collate_fn,
+                    collate_fn=collate_raw_multiscale_train_data,  # type: ignore
                     batch_sampler=batch_sampler,
                 )
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,6 +4,7 @@ import contextlib
 import dataclasses
 import datetime
 from collections.abc import Generator
+from functools import partial
 
 import cftime
 import numpy as np
@@ -25,13 +26,17 @@ from ocean_emulators.constants import (
 )
 from ocean_emulators.datasets import (
     InferenceDataset,
+    MultiscaleTrainDataset,
     TorchTrainDataset,
     TrainData,
     TrainDataLoader,
 )
 from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
-from ocean_emulators.utils.train import collate_raw_train_data
+from ocean_emulators.utils.train import (
+    collate_raw_multiscale_train_data,
+    collate_raw_train_data,
+)
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
 
 
@@ -39,6 +44,16 @@ from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
 def inference_loader_pair(trainer_pair: TrainPair) -> tuple[TrainConfig, DataLoader]:
     cfg, trainer = trainer_pair
     return cfg, trainer.inference_loader
+
+
+def coarsen(
+    ds: xr.Dataset, mean: xr.Dataset, stds: xr.Dataset
+) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]:
+    return (
+        ds.coarsen(lat=2, lon=2).mean(),
+        mean.coarsen(lat=2, lon=2).mean(),
+        stds.coarsen(lat=2, lon=2).mean(),
+    )
 
 
 @contextlib.contextmanager
@@ -88,21 +103,44 @@ def make_loader(
                     )
                     for stride in cfg.data_stride
                 ]
-
-                data: ConcatDataset = ConcatDataset(dataset_list)
                 collate_fn = collate_raw_train_data
+            case LoaderVersion.OM4_MULTI:
+                srcs = [src, src]
 
-                raw_loader = DataLoader(
-                    data,
-                    batch_size=cfg.batch_size,
-                    drop_last=drop_last,
-                    collate_fn=collate_fn,
-                )
+                def make_dataset(s, stride):
+                    return TorchTrainDataset(
+                        src=s.slice(time_config),
+                        prognostic_var_names=prognostic,
+                        boundary_var_names=boundary,
+                        hist=cfg.data.hist,
+                        steps=cfg.steps[0],
+                        normalize_before_mask=cfg.data.normalize_before_mask,
+                        masked_fill_value=cfg.data.masked_fill_value,
+                        stride=stride,
+                    )
 
-                loader = TrainDataLoader(raw_loader, dataset_list, torch.device("cpu"))
-                yield loader
+                dataset_list = [
+                    MultiscaleTrainDataset(
+                        srcs=srcs,
+                        make_dataset=partial(make_dataset, stride=stride),
+                        schedule="match",
+                    )
+                    for stride in cfg.data_stride
+                ]
+                collate_fn = collate_raw_multiscale_train_data  # type: ignore
             case _:
                 raise ValueError(f"Unknown loader version: {version}")
+
+        data: ConcatDataset = ConcatDataset(dataset_list)
+        raw_loader = DataLoader(
+            data,
+            batch_size=cfg.batch_size,
+            drop_last=drop_last,
+            collate_fn=collate_fn,
+        )
+
+        loader = TrainDataLoader(raw_loader, dataset_list, torch.device("cpu"))
+        yield loader
 
 
 def extract_sample_arrays(td: TrainData) -> tuple[np.ndarray, np.ndarray]:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -664,5 +664,5 @@ def test_multiscale_mix__batch_consistency(train_config: TrainConfig, batch_size
             # Verify batch dimension matches (or is <= for last batch which might be smaller)
             actual_batch_size = X.shape[1]
             assert actual_batch_size == batch_size, (
-                f"Batch size {actual_batch_size} should not exceed configured batch_size {batch_size}"
+                f"Batch size {actual_batch_size} should equal configured batch_size {batch_size}"
             )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -121,6 +121,13 @@ def make_loader(
             case LoaderVersion.OM4_TORCH:
                 dataset_list = [make_dataset(src, stride) for stride in cfg.data_stride]
                 collate_fn = collate_raw_train_data
+                data: ConcatDataset = ConcatDataset(dataset_list)
+                raw_loader = DataLoader(
+                    data,
+                    batch_size=cfg.batch_size,
+                    drop_last=drop_last,
+                    collate_fn=collate_fn,
+                )
             case LoaderVersion.OM4_MULTI_MATCH | LoaderVersion.OM4_MULTI_MIX:
                 # Create coarsened datasource with both coarsened data and masks
                 coarsened_src = src.map_data(coarsen_data, suffix="half-size")
@@ -142,44 +149,24 @@ def make_loader(
                     for stride in cfg.data_stride
                 ]
                 collate_fn = collate_raw_multiscale_train_data  # type: ignore
+                data = ConcatDataset(dataset_list)
+
+                group_size = (
+                    len(dataset_list[0].datasets)
+                    if version == LoaderVersion.OM4_MULTI_MATCH
+                    else len(dataset_list[0].multiplex)
+                )
+                batch_sampler = EquivalenceGroupedBatchSampler(
+                    len(data), group_size, cfg.batch_size, drop_last=drop_last
+                )
+                raw_loader = DataLoader(
+                    data,
+                    collate_fn=collate_fn,
+                    batch_sampler=batch_sampler,
+                )
 
             case _:
                 raise ValueError(f"Unknown loader version: {version}")
-
-        data: ConcatDataset = ConcatDataset(dataset_list)
-
-        # Use MultiscaleGroupedBatchSampler for both MATCH and MIX modes with batch_size > 1
-        # This ensures all items in a batch have the same multiplex position (same resolution)
-        # For batch_size=1, use normal DataLoader (no batching consistency issues)
-        if (
-            version in (LoaderVersion.OM4_MULTI_MATCH, LoaderVersion.OM4_MULTI_MIX)
-            and cfg.batch_size > 1
-        ):
-            # For multiscale modes with batch_size > 1, use grouped batch sampler
-            # MATCH mode: groups by resolution index (idx % len(datasets))
-            # MIX mode: groups by multiplex position (idx % len(multiplex))
-            group_size = (
-                len(dataset_list[0].datasets)
-                if version == LoaderVersion.OM4_MULTI_MATCH
-                else len(dataset_list[0].multiplex)
-            )
-            batch_sampler = EquivalenceGroupedBatchSampler(
-                len(data), group_size, cfg.batch_size, drop_last=drop_last
-            )
-            # When using batch_sampler, we cannot pass batch_size, shuffle, sampler, or drop_last
-            raw_loader = DataLoader(
-                data,
-                collate_fn=collate_fn,
-                batch_sampler=batch_sampler,
-            )
-        else:
-            # For standard datasets or batch_size=1, use normal DataLoader construction
-            raw_loader = DataLoader(
-                data,
-                batch_size=cfg.batch_size,
-                drop_last=drop_last,
-                collate_fn=collate_fn,
-            )
 
         loader = TrainDataLoader(raw_loader, dataset_list, torch.device("cpu"))
         yield loader

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -339,7 +339,7 @@ def test_loader__data_shape(
                     "The input and output should be equal"
                 )
                 assert all(
-                    example_resolutions[0] == cr for cr in example_resolutions[1:]
+                    example_resolutions[0] == eg for eg in example_resolutions[1:]
                 ), "All resolutions should be equal"
             case LoaderVersion.OM4_MULTI_MATCH:
                 for x_res, y_res in example_resolutions:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -647,13 +647,6 @@ def test_profile__inference_loader__1gb(inference_loader_pair, benchmark):
 )
 @pytest.mark.parametrize("batch_size", [1, 2, 4])
 def test_multiscale_mix__batch_consistency(train_config: TrainConfig, batch_size: int):
-    """Test that batch_size > 1 works correctly with MultiscaleGroupedBatchSampler.
-
-    This test verifies that when using batch_size > 1 with the MIX schedule:
-    1. All items in a batch have the same multiplex index
-    2. The collate function produces consistent indices
-    3. Batching doesn't break the multiplex scheduling logic
-    """
     # Update config to use desired batch size
     train_config = train_config.model_copy(update={"batch_size": batch_size})
 
@@ -670,13 +663,6 @@ def test_multiscale_mix__batch_consistency(train_config: TrainConfig, batch_size
 
             # Verify batch dimension matches (or is <= for last batch which might be smaller)
             actual_batch_size = X.shape[1]
-            assert actual_batch_size <= batch_size, (
+            assert actual_batch_size == batch_size, (
                 f"Batch size {actual_batch_size} should not exceed configured batch_size {batch_size}"
             )
-
-            # If we have the full batch size, verify consistency within the batch
-            if actual_batch_size == batch_size:
-                # All items in batch should have same resolution pattern
-                # (though we can't easily check the multiplex index here without
-                # accessing internal state)
-                pass

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -26,6 +26,7 @@ from ocean_emulators.constants import (
 )
 from ocean_emulators.datasets import (
     InferenceDataset,
+    MultiscaleGroupedBatchSampler,
     MultiscaleSchedule,
     MultiscaleTrainDataset,
     TorchTrainDataset,
@@ -141,16 +142,48 @@ def make_loader(
                     for stride in cfg.data_stride
                 ]
                 collate_fn = collate_raw_multiscale_train_data  # type: ignore
+
             case _:
                 raise ValueError(f"Unknown loader version: {version}")
 
         data: ConcatDataset = ConcatDataset(dataset_list)
-        raw_loader = DataLoader(
-            data,
-            batch_size=cfg.batch_size,
-            drop_last=drop_last,
-            collate_fn=collate_fn,
-        )
+
+        # Use MultiscaleGroupedBatchSampler for both MATCH and MIX modes with batch_size > 1
+        # This ensures all items in a batch have the same multiplex position (same resolution)
+        # For batch_size=1, use normal DataLoader (no batching consistency issues)
+        if (
+            version in (LoaderVersion.OM4_MULTI_MATCH, LoaderVersion.OM4_MULTI_MIX)
+            and cfg.batch_size > 1
+        ):
+            # For multiscale modes with batch_size > 1, use grouped batch sampler
+            # MATCH mode: groups by resolution index (idx % len(datasets))
+            # MIX mode: groups by multiplex position (idx % len(multiplex))
+            multiplex_size = (
+                len(dataset_list[0].datasets)
+                if version == LoaderVersion.OM4_MULTI_MATCH
+                else len(dataset_list[0].multiplex)
+            )
+            batch_sampler = MultiscaleGroupedBatchSampler(
+                dataset_len=len(data),
+                multiplex_size=multiplex_size,
+                batch_size=cfg.batch_size,
+                shuffle=True,
+                drop_last=drop_last,
+            )
+            # When using batch_sampler, we cannot pass batch_size, shuffle, sampler, or drop_last
+            raw_loader = DataLoader(
+                data,
+                collate_fn=collate_fn,
+                batch_sampler=batch_sampler,
+            )
+        else:
+            # For standard datasets or batch_size=1, use normal DataLoader construction
+            raw_loader = DataLoader(
+                data,
+                batch_size=cfg.batch_size,
+                drop_last=drop_last,
+                collate_fn=collate_fn,
+            )
 
         loader = TrainDataLoader(raw_loader, dataset_list, torch.device("cpu"))
         yield loader
@@ -163,17 +196,6 @@ def extract_sample_arrays(td: TrainData) -> tuple[np.ndarray, np.ndarray]:
     y_arrays = [td.get_label(s).numpy(force=True) for s in range(steps)]
 
     return np.stack(x_arrays, axis=0), np.stack(y_arrays, axis=0)
-
-
-def calc_num_samples(cfg: TrainConfig, time_slice: slice) -> int:
-    ds = cfg.experiment.resolved_data_root.resolve(cfg.data.data_location).open()
-
-    data_size = ds.sel(time=time_slice).time.size
-    steps = cfg.steps[0]
-    hist = cfg.data.hist
-    stride = cfg.data_stride[0]
-
-    return data_size - (steps * (cfg.data.hist + 1) * stride) - hist * stride
 
 
 def vector_of(max_vec_size: int, min_vec_size=1):
@@ -302,23 +324,12 @@ def test_loader__data_shape(
             len(PROGNOSTIC_VARS[exp.prognostic_vars_key]) * num_input_timesteps
         )
 
-        n_samples = calc_num_samples(train_config, train_config.train_time.time_slice)
-        if loader_version == LoaderVersion.OM4_MULTI_MATCH:
-            n_samples *= 2
-        elif loader_version == LoaderVersion.OM4_MULTI_MIX:
-            n_samples *= 4
-
         samples = list(loader)
 
-        assert len(samples) == n_samples, (
-            f"Current config {train_config} only supports {n_samples} examples; "
-            f"got {len(samples)}."
-        )
-
         example_resolutions = []
-        # Only check the first 4 samples; this should be proof enough that everything is
+        # Only check the first 8 samples; this should be proof enough that everything is
         # the right shape.
-        for sample in samples[:4]:
+        for sample in samples[:8]:
             X, y = extract_sample_arrays(sample)
             # Exclude the coordinate shape information for now; we'll test that separately.
             assert X.shape[:-2] == (
@@ -348,15 +359,23 @@ def test_loader__data_shape(
                     )
             case LoaderVersion.OM4_MULTI_MIX:
                 # In mix mode with 2 scales, multiplex creates pattern: (0,0), (0,1), (1,0), (1,1)
-                # Expected: same, different, different, same
-                assert example_resolutions == [
-                    ((180, 360), (180, 360)),
-                    ((180, 360), (90, 180)),
-                    ((90, 180), (180, 360)),
-                    ((90, 180), (90, 180)),
-                ], (
-                    "Resolutions should follow a cartesian product for the 'mix' schedule multiscale loader."
+                # With grouped batch sampler, order may vary due to shuffling within groups.
+                # With drop_last=True and small sample counts, some groups might not produce any batches
+                valid_patterns = {
+                    ((180, 360), (180, 360)),  # (0,0): full-res input, full-res label
+                    ((180, 360), (90, 180)),  # (0,1): full-res input, half-res label
+                    ((90, 180), (180, 360)),  # (1,0): half-res input, full-res label
+                    ((90, 180), (90, 180)),  # (1,1): half-res input, half-res label
+                }
+                observed_patterns = set(example_resolutions)
+                # All observed patterns must be valid
+                assert observed_patterns <= valid_patterns, (
+                    f"All resolutions must be valid members of the cartesian product for 'mix' schedule. "
+                    f"Valid patterns: {valid_patterns}, got {observed_patterns}, "
+                    f"invalid patterns: {observed_patterns - valid_patterns}"
                 )
+                # We should have at least 1 pattern
+                assert len(observed_patterns) > 0, "Should have at least one pattern"
 
 
 def test_inference__data_shape(inference_loader_pair):
@@ -640,3 +659,43 @@ def test_profile__inference_loader__1gb(inference_loader_pair, benchmark):
             dataset, n = sample
             for X, y in dataset:
                 _, _ = X, y
+
+
+@pytest.mark.parametrize(
+    "data_source,config_name", [("mock", DEFAULT_CONFIG)], indirect=True
+)
+@pytest.mark.parametrize("batch_size", [1, 2, 4])
+def test_multiscale_mix__batch_consistency(train_config: TrainConfig, batch_size: int):
+    """Test that batch_size > 1 works correctly with MultiscaleGroupedBatchSampler.
+
+    This test verifies that when using batch_size > 1 with the MIX schedule:
+    1. All items in a batch have the same multiplex index
+    2. The collate function produces consistent indices
+    3. Batching doesn't break the multiplex scheduling logic
+    """
+    # Update config to use desired batch size
+    train_config = train_config.model_copy(update={"batch_size": batch_size})
+
+    with make_loader(train_config, version=LoaderVersion.OM4_MULTI_MIX) as loader:
+        # Check that we can iterate through the loader
+        samples = list(loader)
+
+        # Verify we got samples
+        assert len(samples) > 0, "Should have at least one batch"
+
+        # For each batch, verify the data has correct batch dimension
+        for sample in samples[:4]:  # Check first 4 batches
+            X, y = extract_sample_arrays(sample)
+
+            # Verify batch dimension matches (or is <= for last batch which might be smaller)
+            actual_batch_size = X.shape[1]
+            assert actual_batch_size <= batch_size, (
+                f"Batch size {actual_batch_size} should not exceed configured batch_size {batch_size}"
+            )
+
+            # If we have the full batch size, verify consistency within the batch
+            if actual_batch_size == batch_size:
+                # All items in batch should have same resolution pattern
+                # (though we can't easily check the multiplex index here without
+                # accessing internal state)
+                pass

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -661,7 +661,7 @@ def test_multiscale_mix__batch_consistency(train_config: TrainConfig, batch_size
         for sample in samples[:4]:  # Check first 4 batches
             X, y = extract_sample_arrays(sample)
 
-            # Verify batch dimension matches (or is <= for last batch which might be smaller)
+            # Verify batch dimension matches
             actual_batch_size = X.shape[1]
             assert actual_batch_size == batch_size, (
                 f"Batch size {actual_batch_size} should equal configured batch_size {batch_size}"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -26,6 +26,7 @@ from ocean_emulators.constants import (
 )
 from ocean_emulators.datasets import (
     InferenceDataset,
+    MultiscaleSchedule,
     MultiscaleTrainDataset,
     TorchTrainDataset,
     TrainData,
@@ -104,7 +105,7 @@ def make_loader(
                     for stride in cfg.data_stride
                 ]
                 collate_fn = collate_raw_train_data
-            case LoaderVersion.OM4_MULTI:
+            case LoaderVersion.OM4_MULTI_MATCH | LoaderVersion.OM4_MULTI_MIX:
                 srcs = [src, src]
 
                 def make_dataset(s, stride):
@@ -119,11 +120,15 @@ def make_loader(
                         stride=stride,
                     )
 
+                schedule: MultiscaleSchedule = (
+                    "match" if LoaderVersion.OM4_MULTI_MATCH else "mix"
+                )
+
                 dataset_list = [
                     MultiscaleTrainDataset(
                         srcs=srcs,
                         make_dataset=partial(make_dataset, stride=stride),
-                        schedule="match",
+                        schedule=schedule,
                     )
                     for stride in cfg.data_stride
                 ]
@@ -290,7 +295,10 @@ def test_loader__data_shape(
         )
 
         n_samples = calc_num_samples(train_config, train_config.train_time.time_slice)
-        if loader_version == LoaderVersion.OM4_MULTI:
+        if (
+            loader_version == LoaderVersion.OM4_MULTI_MATCH
+            or loader_version == LoaderVersion.OM4_MULTI_MIX
+        ):
             n_samples *= 2
         samples = list(loader)
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -290,6 +290,8 @@ def test_loader__data_shape(
         )
 
         n_samples = calc_num_samples(train_config, train_config.train_time.time_slice)
+        if loader_version == LoaderVersion.OM4_MULTI:
+            n_samples *= 2
         samples = list(loader)
 
         assert len(samples) == n_samples, (

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -315,7 +315,7 @@ def test_loader__data_shape(
             f"got {len(samples)}."
         )
 
-        cross_resolutions = []
+        example_resolutions = []
         # Only check the first 4 samples; this should be proof enough that everything is
         # the right shape.
         for sample in samples[:4]:
@@ -331,25 +331,25 @@ def test_loader__data_shape(
                 batch_size,
                 output_var_dim,
             )
-            cross_resolutions.append((X.shape[-2:], y.shape[-2:]))
+            example_resolutions.append((X.shape[-2:], y.shape[-2:]))
 
         match loader_version:
             case LoaderVersion.OM4_TORCH:
-                assert cross_resolutions[0][0] == cross_resolutions[0][1], (
+                assert example_resolutions[0][0] == example_resolutions[0][1], (
                     "The input and output should be equal"
                 )
                 assert all(
-                    cross_resolutions[0] == cr for cr in cross_resolutions[1:]
+                    example_resolutions[0] == cr for cr in example_resolutions[1:]
                 ), "All resolutions should be equal"
             case LoaderVersion.OM4_MULTI_MATCH:
-                for x_res, y_res in cross_resolutions:
+                for x_res, y_res in example_resolutions:
                     assert x_res == y_res, (
-                        f"Resolutions must match across batches for 'match' schedule multiscale loader. {cross_resolutions=}"
+                        f"Resolutions must match across batches for 'match' schedule multiscale loader. {example_resolutions=}"
                     )
             case LoaderVersion.OM4_MULTI_MIX:
                 # In mix mode with 2 scales, multiplex creates pattern: (0,0), (0,1), (1,0), (1,1)
                 # Expected: same, different, different, same
-                assert cross_resolutions == [
+                assert example_resolutions == [
                     ((180, 360), (180, 360)),
                     ((180, 360), (90, 180)),
                     ((90, 180), (180, 360)),

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -50,9 +50,9 @@ def coarsen(
     ds: xr.Dataset, mean: xr.Dataset, stds: xr.Dataset
 ) -> tuple[xr.Dataset, xr.Dataset, xr.Dataset]:
     return (
-        ds.coarsen(lat=2, lon=2).mean(),
-        mean.coarsen(lat=2, lon=2).mean(),
-        stds.coarsen(lat=2, lon=2).mean(),
+        ds.coarsen(lat=2, lon=2).mean(),  # type: ignore
+        mean.coarsen(lat=2, lon=2).mean(),  # type: ignore
+        stds.coarsen(lat=2, lon=2).mean(),  # type: ignore
     )
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -25,8 +25,8 @@ from ocean_emulators.constants import (
     TensorMap,
 )
 from ocean_emulators.datasets import (
+    EquivalenceGroupedBatchSampler,
     InferenceDataset,
-    MultiscaleGroupedBatchSampler,
     MultiscaleSchedule,
     MultiscaleTrainDataset,
     TorchTrainDataset,
@@ -163,12 +163,8 @@ def make_loader(
                 if version == LoaderVersion.OM4_MULTI_MATCH
                 else len(dataset_list[0].multiplex)
             )
-            batch_sampler = MultiscaleGroupedBatchSampler(
-                dataset_len=len(data),
-                group_size=group_size,
-                batch_size=cfg.batch_size,
-                shuffle=True,
-                drop_last=drop_last,
+            batch_sampler = EquivalenceGroupedBatchSampler(
+                len(data), group_size, cfg.batch_size, drop_last=drop_last
             )
             # When using batch_sampler, we cannot pass batch_size, shuffle, sampler, or drop_last
             raw_loader = DataLoader(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -158,14 +158,14 @@ def make_loader(
             # For multiscale modes with batch_size > 1, use grouped batch sampler
             # MATCH mode: groups by resolution index (idx % len(datasets))
             # MIX mode: groups by multiplex position (idx % len(multiplex))
-            multiplex_size = (
+            group_size = (
                 len(dataset_list[0].datasets)
                 if version == LoaderVersion.OM4_MULTI_MATCH
                 else len(dataset_list[0].multiplex)
             )
             batch_sampler = MultiscaleGroupedBatchSampler(
                 dataset_len=len(data),
-                multiplex_size=multiplex_size,
+                group_size=group_size,
                 batch_size=cfg.batch_size,
                 shuffle=True,
                 drop_last=drop_last,


### PR DESCRIPTION
A simpler alternative to #504. In our multi-scale model, we need one of two things: a `TrainData` batch that varies by scale per the sample index, or a "mixed" `TrainData` batch, where each Input/Label pair may come from one of the input scales. This new data loader accomplishes this need by providing a "schedule" interface and by delegating the actual loading to the existing Torch loader. In addition, this new load accomplishes a necessary IO-bound optimization: we only ever load the `TrainData`(s) batch that will actually get used. So, instead of loading `TrainData` batches for every scale per index, we only load the data source that actually gets returned for that index. For this "match" case, this means we only look up one data source, for the "mix" case, this means we look up two.

Last, since data loading is no longer one-to-one (a single index in a batch could refer to multiple sources of data), this PR also includes a new batch sampler that samples across equivalence classes.