### PR TITLE
Allow using autocast for bfloat16

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -508,6 +508,10 @@ class SamudraConfig(BaseModelConfig):
         default=0,
         description="""Number of channels used for a learned positional embedding""",
     )
+    use_bfloat16: bool = Field(
+        default=False,
+        description="Use bfloat16 for most layers rather than float32.",
+    )
 
     def build(
         self,
@@ -547,6 +551,7 @@ class SamudraConfig(BaseModelConfig):
             wet=wet,
             static_data=static_data,
             gradient_detach_interval=self.gradient_detach_interval,
+            use_bfloat16=self.use_bfloat16,
         )
 
 

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -6,6 +6,7 @@ import xarray as xr
 from ocean_emulators.constants import Grid
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
+from ocean_emulators.utils.device import autocast
 
 
 class Samudra(BaseModel):
@@ -52,22 +53,29 @@ class Samudra(BaseModel):
         self.corrector = corrector
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
-        fts_input = fts.clone().detach()
+        if self.corrector is not None:
+            fts_input = fts.clone().detach()
 
-        if self.positional_params is not None:
-            pos = self.positional_params.unsqueeze(0).expand(fts.shape[0], -1, -1, -1)
-            fts = torch.cat([fts, pos], dim=1)
+        with autocast():
+            if self.positional_params is not None:
+                pos = self.positional_params.unsqueeze(0).expand(
+                    fts.shape[0], -1, -1, -1
+                )
+                fts = torch.cat([fts, pos], dim=1)
 
-        if self.add_3d_coordinates is not None:
-            fts = self.add_3d_coordinates(fts)
+            if self.add_3d_coordinates is not None:
+                fts = self.add_3d_coordinates(fts)
 
-        fts = self.unet(fts)
-        fts = torch.nn.functional.pad(
-            fts, (self.N_pad, self.N_pad, 0, 0), mode=self.pad
-        )
-        fts = torch.nn.functional.pad(
-            fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
-        )
+            fts = self.unet(fts)
+            fts = torch.nn.functional.pad(
+                fts, (self.N_pad, self.N_pad, 0, 0), mode=self.pad
+            )
+            fts = torch.nn.functional.pad(
+                fts, (0, 0, self.N_pad, self.N_pad), mode="constant"
+            )
+        # TODO(jder): would be nice to keep inputs in bfloat16 and
+        # have the convolution use float32 internally & in output dtype.
+        fts = fts.to(torch.float32)
         fts = self.decoder(fts)
 
         if self.corrector is not None:

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -25,6 +25,7 @@ class Samudra(BaseModel):
         wet: Grid,
         static_data: xr.Dataset | None,
         gradient_detach_interval: int,
+        use_bfloat16: bool,
     ):
         super().__init__(
             in_channels=in_channels,
@@ -51,12 +52,13 @@ class Samudra(BaseModel):
         self.decoder = nn.Conv2d(unet.out_channels, out_channels, last_kernel_size)
 
         self.corrector = corrector
+        self.use_bfloat16 = use_bfloat16
 
     def forward_once(self, fts: torch.Tensor) -> torch.Tensor:
         if self.corrector is not None:
             fts_input = fts.clone().detach()
 
-        with autocast():
+        with autocast(enabled=self.use_bfloat16, dtype=torch.bfloat16):
             if self.positional_params is not None:
                 pos = self.positional_params.unsqueeze(0).expand(
                     fts.shape[0], -1, -1, -1

--- a/src/ocean_emulators/utils/device.py
+++ b/src/ocean_emulators/utils/device.py
@@ -3,11 +3,11 @@ import torch
 _CHOSEN_DEVICE: torch.device | None = None
 
 
-def autocast(enabled: bool = True) -> torch.autocast:
+def autocast(enabled: bool, dtype: torch.dtype) -> torch.autocast:
     if using_gpu():
-        return torch.autocast("cuda", dtype=torch.bfloat16, enabled=enabled)
+        return torch.autocast("cuda", dtype=dtype, enabled=enabled)
     else:
-        return torch.autocast("cpu", dtype=torch.bfloat16, enabled=enabled)
+        return torch.autocast("cpu", dtype=dtype, enabled=enabled)
 
 
 def using_gpu() -> bool:

--- a/src/ocean_emulators/utils/device.py
+++ b/src/ocean_emulators/utils/device.py
@@ -3,6 +3,13 @@ import torch
 _CHOSEN_DEVICE: torch.device | None = None
 
 
+def autocast(enabled: bool = True) -> torch.autocast:
+    if using_gpu():
+        return torch.autocast("cuda", dtype=torch.bfloat16, enabled=enabled)
+    else:
+        return torch.autocast("cpu", dtype=torch.bfloat16, enabled=enabled)
+
+
 def using_gpu() -> bool:
     return get_device().type == "cuda"
 


### PR DESCRIPTION
This seems to largely be a memory win and neutral for our metrics. I haven't asked for review of the viz results but it seems worth at least having this option checked in for running quarter-degree runs.