### PR TITLE
Drive by: don't do an unnecessary copy

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -507,20 +507,20 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     )
                     .rename({"var": "variable"})
                     .to_numpy()
-                    .astype(np.float32)
+                    .astype(np.float32, copy=False)
                 )
             else:
                 prognostic_all = torch.from_numpy(
                     prognostic_selected.to_array()
                     .transpose("time", "variable", "lat", "lon")
                     .to_numpy()
-                    .astype(np.float32)
+                    .astype(np.float32, copy=False)
                 )
             boundary = torch.from_numpy(
                 boundary_selected.to_array()
                 .transpose("time", "variable", "lat", "lon")
                 .to_numpy()
-                .astype(np.float32)
+                .astype(np.float32, copy=False)
             )
 
             TD.insert(prognostic_all, boundary)


### PR DESCRIPTION
`astype` defaults to `copy=True` for mutation reasons but we don't mutate these so this is just wasted work.