### PR TITLE
TorchTrainDataset now contains a `src` _and_ `dst`.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -134,6 +134,9 @@ LOCATION_DOCS = (
 )
 
 
+TrainSchedule = Literal["standard", "match", "mix"]
+
+
 class DataConfig(BaseConfig):
     data_location: Location = Field(
         description="Location of the data; " + LOCATION_DOCS
@@ -607,9 +610,6 @@ class DistributedConfig(BaseConfig):
     rank: int | None = None
     gpu: int | None = None
     dist_backend: str | None = None
-
-
-TrainSchedule = Literal["standard", "match", "mix"]
 
 
 class ExperimentConfig(BaseConfig):

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -609,6 +609,9 @@ class DistributedConfig(BaseConfig):
     dist_backend: str | None = None
 
 
+TrainSchedule = Literal["standard", "match", "mix"]
+
+
 class ExperimentConfig(BaseConfig):
     name: str = "cm4_samudra"
     rand_seed: int = 1

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -2,9 +2,10 @@ import itertools
 import logging
 import random
 import time
+from collections.abc import Callable
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import TypeAlias, final
+from typing import Any, Self, TypeAlias, final
 
 import numpy as np
 import torch
@@ -718,8 +719,8 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
     batches are globally shuffled each epoch to avoid sequential group processing.
 
     Args:
-        dataset_sizes: Optional list of individual dataset sizes. If provided, groups are created
-            based on dataset boundaries.
+        dataset_sizes: List of individual dataset sizes. Groups are created based on dataset boundaries,
+            where each dataset forms its own equivalence group.
         batch_size: Number of samples per batch
         shuffle: Whether to shuffle indices within groups and shuffle batches globally
         drop_last: Whether to drop incomplete batches at the end of each group
@@ -744,6 +745,77 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         for size in dataset_sizes:
             self.groups.append(list(range(cumsum, cumsum + size)))
             cumsum += size
+
+    @classmethod
+    def from_datasets(
+        cls,
+        datasets: list["TorchTrainDataset"],
+        group_key: Callable[["TorchTrainDataset"], Any],
+        batch_size: int,
+        shuffle: bool,
+        drop_last: bool,
+    ) -> Self:
+        """Create sampler by grouping datasets using a key function.
+
+        This factory method allows grouping datasets by arbitrary criteria (e.g., resolution,
+        regardless of other parameters like stride). Datasets with the same key are batched together.
+
+        Args:
+            datasets: List of TorchTrainDataset instances to group
+            group_key: Callable that extracts grouping key from a dataset.
+            batch_size: Number of samples per batch
+            shuffle: Whether to shuffle indices within groups and shuffle batches globally
+            drop_last: Whether to drop incomplete batches at the end of each group
+
+        Examples:
+                - lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon'])  # group by resolution
+                - lambda ds: ds._input_src.data.sizes['lat']  # group by latitude size only
+            batch_size: Number of samples per batch
+            shuffle: Whether to shuffle indices within groups and shuffle batches globally
+            drop_last: Whether to drop incomplete batches at the end of each group
+
+        Returns:
+            EquivalenceGroupBatchSampler configured to group by the provided key
+
+        Example:
+            >>> # Group datasets by resolution, allowing different strides to be batched together
+            >>> sampler = EquivalenceGroupBatchSampler.from_datasets(
+            ...     datasets=dataset_list,
+            ...     group_key=lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon']),
+            ...     batch_size=32,
+            ...     shuffle=True,
+            ...     drop_last=True,
+            ... )
+        """
+        from collections import defaultdict
+
+        # Group indices by their key
+        groups: dict[tuple, list[int]] = defaultdict(list)
+
+        cumsum = 0
+        for ds in datasets:
+            key = group_key(ds)
+            # Make key hashable if it isn't already
+            if not isinstance(key, (int, str, tuple)):
+                key = tuple(key) if hasattr(key, "__iter__") else (key,)
+            groups[key].extend(range(cumsum, cumsum + len(ds)))
+            cumsum += len(ds)
+
+        # Convert groups to dataset_sizes format
+        # Sort by key for deterministic ordering across runs
+        sorted_groups = sorted(groups.items(), key=lambda x: str(x[0]))
+
+        # Create instance with computed dataset_sizes
+        instance = cls.__new__(cls)
+        instance.batch_size = batch_size
+        instance.shuffle = shuffle
+        instance.drop_last = drop_last
+        instance.group_size = len(sorted_groups)
+
+        # Store the actual grouped indices (not just sizes)
+        instance.groups = [indices for _, indices in sorted_groups]
+
+        return instance
 
     def __iter__(self):
         # Choose sampler based on shuffle setting

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -470,8 +470,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
-        self.wet: PrognosticMask = src.masks.prognostic.to(self.device)
+        self.wet_input: PrognosticMask = src.masks.prognostic.to(self.device)
         self.wet_surface: GridMask = src.masks.boundary.to(self.device)
+        self.wet_label: PrognosticMask = dst.masks.prognostic.to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
             if "lev" in means_or_stds.dims:
@@ -591,11 +592,15 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             input_all[:, : self.hist + 1, :, :, :],
             self.input_means,
             self.input_stds,
+            self.wet_input,
             boundary_all[:, : self.hist + 1, :, :, :],
         )
         # grab future steps, repeat as we do for input
         label = self._prep_tensor_steps(
-            label_all[:, self.hist + 1 :, :, :, :], self.label_means, self.label_stds
+            label_all[:, self.hist + 1 :, :, :, :],
+            self.label_means,
+            self.label_stds,
+            self.wet_label,
         )
         return total_input, label
 
@@ -604,6 +609,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         prognostic_steps: Float[torch.Tensor, "batch time variable lat lon"],
         prognostic_means: Float[torch.Tensor, " variable"],
         prognostic_stds: Float[torch.Tensor, " variable"],
+        prognostic_mask: Float[torch.Tensor, " variable"],
         boundary_steps: Float[torch.Tensor, "batch time variable lat lon"]
         | None = None,
     ) -> Input:
@@ -641,7 +647,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             prognostic_steps,
             prognostic_means,
             prognostic_stds,
-            self.wet,
+            prognostic_mask,
         )
         if boundary_steps is not None:
             boundary_steps = normalize_and_mask(

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,18 +1,15 @@
-import itertools
 import logging
-import random
 import time
-from collections.abc import Callable
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import Any, Self, TypeAlias, final
+from typing import TypeAlias, final
 
 import numpy as np
 import torch
 import xarray as xr
 from einops import rearrange
 from jaxtyping import Float
-from torch.utils.data import BatchSampler, Dataset, Sampler, SubsetRandomSampler
+from torch.utils.data import Dataset
 from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 
 from ocean_emulators.constants import (
@@ -697,160 +694,6 @@ def concurrent_compute(
             futures.append(executor.submit(load_variable_data, var))
 
     wait(futures)
-
-
-class _SimpleSubsetSampler(Sampler):
-    def __init__(self, indices):
-        super().__init__()
-        self.indices = indices
-
-    def __iter__(self):
-        return iter(self.indices)
-
-    def __len__(self):
-        return len(self.indices)
-
-
-class EquivalenceGroupBatchSampler(Sampler[list[int]]):
-    """Groups indices by dataset membership in ConcatDataset, batches within groups, and optionally shuffles.
-
-    This sampler partitions dataset indices into groups based on their source dataset when using
-    ConcatDataset. It creates batches within each group, then chains them together. When shuffle=True,
-    batches are globally shuffled each epoch to avoid sequential group processing.
-
-    Args:
-        dataset_sizes: List of individual dataset sizes. Groups are created based on dataset boundaries,
-            where each dataset forms its own equivalence group.
-        batch_size: Number of samples per batch
-        shuffle: Whether to shuffle indices within groups and shuffle batches globally
-        drop_last: Whether to drop incomplete batches at the end of each group
-    """
-
-    def __init__(
-        self,
-        dataset_sizes: list[int],
-        batch_size: int,
-        shuffle: bool = True,
-        drop_last: bool = False,
-    ):
-        super().__init__()
-        self.group_size = len(dataset_sizes)
-        self.batch_size = batch_size
-        self.shuffle = shuffle
-        self.drop_last = drop_last
-
-        # Create groups based on cumulative dataset boundaries
-        cumsum = 0
-        self.groups = []
-        for size in dataset_sizes:
-            self.groups.append(list(range(cumsum, cumsum + size)))
-            cumsum += size
-
-    @classmethod
-    def from_datasets(
-        cls,
-        datasets: list["TorchTrainDataset"],
-        group_key: Callable[["TorchTrainDataset"], Any],
-        batch_size: int,
-        shuffle: bool,
-        drop_last: bool,
-    ) -> Self:
-        """Create sampler by grouping datasets using a key function.
-
-        This factory method allows grouping datasets by arbitrary criteria (e.g., resolution,
-        regardless of other parameters like stride). Datasets with the same key are batched together.
-
-        Args:
-            datasets: List of TorchTrainDataset instances to group
-            group_key: Callable that extracts grouping key from a dataset.
-            batch_size: Number of samples per batch
-            shuffle: Whether to shuffle indices within groups and shuffle batches globally
-            drop_last: Whether to drop incomplete batches at the end of each group
-
-        Examples:
-                - lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon'])  # group by resolution
-                - lambda ds: ds._input_src.data.sizes['lat']  # group by latitude size only
-            batch_size: Number of samples per batch
-            shuffle: Whether to shuffle indices within groups and shuffle batches globally
-            drop_last: Whether to drop incomplete batches at the end of each group
-
-        Returns:
-            EquivalenceGroupBatchSampler configured to group by the provided key
-
-        Example:
-            >>> # Group datasets by resolution, allowing different strides to be batched together
-            >>> sampler = EquivalenceGroupBatchSampler.from_datasets(
-            ...     datasets=dataset_list,
-            ...     group_key=lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon']),
-            ...     batch_size=32,
-            ...     shuffle=True,
-            ...     drop_last=True,
-            ... )
-        """
-        from collections import defaultdict
-
-        # Group indices by their key
-        groups: dict[tuple, list[int]] = defaultdict(list)
-
-        cumsum = 0
-        for ds in datasets:
-            key = group_key(ds)
-            # Make key hashable if it isn't already
-            if not isinstance(key, (int, str, tuple)):
-                key = tuple(key) if hasattr(key, "__iter__") else (key,)
-            groups[key].extend(range(cumsum, cumsum + len(ds)))
-            cumsum += len(ds)
-
-        # Convert groups to dataset_sizes format
-        # Sort by key for deterministic ordering across runs
-        sorted_groups = sorted(groups.items(), key=lambda x: str(x[0]))
-
-        # Create instance with computed dataset_sizes
-        instance = cls.__new__(cls)
-        instance.batch_size = batch_size
-        instance.shuffle = shuffle
-        instance.drop_last = drop_last
-        instance.group_size = len(sorted_groups)
-
-        # Store the actual grouped indices (not just sizes)
-        instance.groups = [indices for _, indices in sorted_groups]
-
-        return instance
-
-    def __iter__(self):
-        # Choose sampler based on shuffle setting
-        SubsetSampler = SubsetRandomSampler if self.shuffle else _SimpleSubsetSampler
-
-        # Create batch samplers for each group
-        batch_sampler = itertools.chain(
-            *[
-                BatchSampler(
-                    SubsetSampler(group),
-                    batch_size=self.batch_size,
-                    drop_last=self.drop_last,
-                )
-                for group in self.groups
-            ]
-        )
-
-        if not self.shuffle:
-            # No global shuffle: return batches in sequential group order
-            yield from batch_sampler
-        else:
-            # Shuffle batches globally to avoid sequential group processing
-            # This is regenerated each epoch, giving different orderings
-            all_batches = list(batch_sampler)
-            random.shuffle(all_batches)
-            yield from all_batches
-
-    def __len__(self):
-        """Calculate total number of batches across all groups."""
-        total_batches = 0
-        for group in self.groups:
-            if self.drop_last:
-                total_batches += len(group) // self.batch_size
-            else:
-                total_batches += (len(group) + self.batch_size - 1) // self.batch_size
 
 
 @final

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -448,7 +448,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             "src and dst DataSource have different time slices!"
         )
         time_ = src.data.time
-        self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
+        self._input_src = src.filter(prognostic_var_names, prefix="input")
         self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
         self._label_src = dst.filter(prognostic_var_names, prefix="label")
 
@@ -484,8 +484,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 array = means_or_stds.to_dataarray()
             return torch.from_numpy(array.to_numpy().flatten()).to(self.device)
 
-        self.prognostic_means = flatten_to_device(self._prognostic_src.means)
-        self.prognostic_stds = flatten_to_device(self._prognostic_src.stds)
+        self.input_means = flatten_to_device(self._input_src.means)
+        self.input_stds = flatten_to_device(self._input_src.stds)
 
         self.boundary_means = flatten_to_device(self._boundary_src.means)
         self.boundary_stds = flatten_to_device(self._boundary_src.stds)
@@ -509,7 +509,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         for step in range(self.steps):
             x_index = self._get_x_index(idx, step)
-            prognostic_selected = self._prognostic_src.data.isel(time=x_index)
+            prognostic_selected = self._input_src.data.isel(time=x_index)
             boundary_selected = self._boundary_src.data.isel(time=x_index)
             label_selected = self._label_src.data.isel(time=x_index)
 
@@ -589,15 +589,21 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         # grab past steps and prep for model
         total_input = self._prep_tensor_steps(
             input_all[:, : self.hist + 1, :, :, :],
+            self.input_means,
+            self.input_stds,
             boundary_all[:, : self.hist + 1, :, :, :],
         )
         # grab future steps, repeat as we do for input
-        label = self._prep_tensor_steps(label_all[:, self.hist + 1 :, :, :, :])
+        label = self._prep_tensor_steps(
+            label_all[:, self.hist + 1 :, :, :, :], self.label_means, self.label_stds
+        )
         return total_input, label
 
     def _prep_tensor_steps(
         self,
         prognostic_steps: Float[torch.Tensor, "batch time variable lat lon"],
+        prognostic_means: Float[torch.Tensor, " variable"],
+        prognostic_stds: Float[torch.Tensor, " variable"],
         boundary_steps: Float[torch.Tensor, "batch time variable lat lon"]
         | None = None,
     ) -> Input:
@@ -633,8 +639,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         prognostic_steps = normalize_and_mask(
             prognostic_steps,
-            self.prognostic_means,
-            self.prognostic_stds,
+            prognostic_means,
+            prognostic_stds,
             self.wet,
         )
         if boundary_steps is not None:

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -2,7 +2,7 @@ import logging
 import time
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import Literal, TypeAlias, final
+from typing import TypeAlias, final
 
 import numpy as np
 import torch
@@ -391,9 +391,6 @@ class TrainData:
                 self[step][1].pin_memory(),
             )
         return self
-
-
-TrainSchedule = Literal["standard", "match", "mix"]
 
 
 @final

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -1,4 +1,6 @@
+import itertools
 import logging
+import random
 import time
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
@@ -9,7 +11,7 @@ import torch
 import xarray as xr
 from einops import rearrange
 from jaxtyping import Float
-from torch.utils.data import Dataset
+from torch.utils.data import BatchSampler, Dataset, Sampler, SubsetRandomSampler
 from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 
 from ocean_emulators.constants import (
@@ -694,6 +696,89 @@ def concurrent_compute(
             futures.append(executor.submit(load_variable_data, var))
 
     wait(futures)
+
+
+class _SimpleSubsetSampler(torch.utils.data.Sampler):
+    def __init__(self, indices):
+        super().__init__()
+        self.indices = indices
+
+    def __iter__(self):
+        return iter(self.indices)
+
+    def __len__(self):
+        return len(self.indices)
+
+
+class EquivalenceGroupBatchSampler(Sampler[list[int]]):
+    """Groups indices by dataset membership in ConcatDataset, batches within groups, and optionally shuffles.
+
+    This sampler partitions dataset indices into groups based on their source dataset when using
+    ConcatDataset. It creates batches within each group, then chains them together. When shuffle=True,
+    batches are globally shuffled each epoch to avoid sequential group processing.
+
+    Args:
+        dataset_sizes: Optional list of individual dataset sizes. If provided, groups are created
+            based on dataset boundaries.
+        batch_size: Number of samples per batch
+        shuffle: Whether to shuffle indices within groups and shuffle batches globally
+        drop_last: Whether to drop incomplete batches at the end of each group
+    """
+
+    def __init__(
+        self,
+        dataset_sizes: list[int],
+        batch_size: int,
+        shuffle: bool = True,
+        drop_last: bool = False,
+    ):
+        super().__init__()
+        self.group_size = len(dataset_sizes)
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.drop_last = drop_last
+
+        # Create groups based on cumulative dataset boundaries
+        cumsum = 0
+        self.groups = []
+        for size in dataset_sizes:
+            self.groups.append(list(range(cumsum, cumsum + size)))
+            cumsum += size
+
+    def __iter__(self):
+        # Choose sampler based on shuffle setting
+        SubsetSampler = SubsetRandomSampler if self.shuffle else _SimpleSubsetSampler
+
+        # Create batch samplers for each group
+        batch_sampler = itertools.chain(
+            *[
+                BatchSampler(
+                    SubsetSampler(group),
+                    batch_size=self.batch_size,
+                    drop_last=self.drop_last,
+                )
+                for group in self.groups
+            ]
+        )
+
+        if not self.shuffle:
+            # No global shuffle: return batches in sequential group order
+            yield from batch_sampler
+        else:
+            # Shuffle batches globally to avoid sequential group processing
+            # This is regenerated each epoch, giving different orderings
+            all_batches = list(batch_sampler)
+            random.shuffle(all_batches)
+            yield from all_batches
+
+    def __len__(self):
+        """Calculate total number of batches across all groups."""
+        total_batches = 0
+        for group in self.groups:
+            if self.drop_last:
+                total_batches += len(group) // self.batch_size
+            else:
+                total_batches += (len(group) + self.batch_size - 1) // self.batch_size
 
 
 @final

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -534,7 +534,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 )
                 label_all = torch.from_numpy(
                     conditional_rearrange(
-                        input_selected,
+                        label_selected,
                         "time (variable lev)=var lat lon",
                         concat_dim="var",
                     )
@@ -550,7 +550,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .astype(np.float32, copy=False)
                 )
                 label_all = torch.from_numpy(
-                    input_selected.to_array()
+                    label_selected.to_array()
                     .transpose("time", "variable", "lat", "lon")
                     .to_numpy()
                     .astype(np.float32, copy=False)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -569,9 +569,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
     def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
         train_data = TrainData(self.num_prognostic_channels)
-        for prognostic_all, boundary_all, label_all in raw_train_data.raw_data:
+        for input_all, boundary_all, label_all in raw_train_data.raw_data:
             input_, label = self._get_input_and_label(
-                prognostic_all.to(device=self.device, non_blocking=True),
+                input_all.to(device=self.device, non_blocking=True),
                 boundary_all.to(device=self.device, non_blocking=True),
                 label_all.to(device=self.device, non_blocking=True),
             )

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -446,7 +446,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self._executor = executor
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
-        # assert src.data.time == dst.data.time, "src and dst DataSource have different time slices!"
+        assert np.array_equal(src.data.time, dst.data.time), (
+            "src and dst DataSource have different time slices!"
+        )
         time_ = src.data.time
         self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
         self._boundary_src = src.filter(boundary_var_names, prefix="boundary")

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -300,11 +300,12 @@ class RawTrainData:
 
     def insert(
         self,
-        all_prognostic: torch.Tensor,
+        all_input: torch.Tensor,
         all_boundary: torch.Tensor,
         all_label: torch.Tensor,
     ):
-        self.raw_data.append((all_prognostic, all_boundary, all_label))
+        """Add a prognostic input, boundary, and prognostic label as the last step."""
+        self.raw_data.append((all_input, all_boundary, all_label))
 
     def to(self, device: torch.device):
         self.raw_data = [
@@ -524,7 +525,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 )
 
             if "lev" in prognostic_selected.dims:
-                prognostic_all = torch.from_numpy(
+                input_all = torch.from_numpy(
                     conditional_rearrange(
                         prognostic_selected,
                         "time (variable lev)=var lat lon",
@@ -545,7 +546,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .astype(np.float32, copy=False)
                 )
             else:
-                prognostic_all = torch.from_numpy(
+                input_all = torch.from_numpy(
                     prognostic_selected.to_array()
                     .transpose("time", "variable", "lat", "lon")
                     .to_numpy()
@@ -564,7 +565,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 .astype(np.float32, copy=False)
             )
 
-            TD.insert(prognostic_all, boundary, label_all)
+            TD.insert(input_all, boundary, label_all)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
         return TD

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -571,7 +571,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
         train_data = TrainData(self.num_prognostic_channels)
         for input_, boundary, label in raw_train_data.raw_data:
-            input_, label = self._get_full_input_and_label(
+            input_, label = self._to_example(
                 input_.to(device=self.device, non_blocking=True),
                 boundary.to(device=self.device, non_blocking=True),
                 label.to(device=self.device, non_blocking=True),
@@ -580,7 +580,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         train_data.load_stats = raw_train_data.load_stats
         return train_data
 
-    def _get_full_input_and_label(
+    def _to_example(
         self,
         # time includes (self.hist + 1) past steps and the (label) future steps
         input_: Float[torch.Tensor, "batch time variable lat lon"],

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -310,21 +310,21 @@ class RawTrainData:
     def to(self, device: torch.device):
         self.raw_data = [
             (
-                all_prognostic.to(device, non_blocking=True),
+                all_input.to(device, non_blocking=True),
                 all_boundary.to(device, non_blocking=True),
                 all_label.to(device, non_blocking=True),
             )
-            for all_prognostic, all_boundary, all_label in self.raw_data
+            for all_input, all_boundary, all_label in self.raw_data
         ]
 
     def pin_memory(self):
         self.raw_data = [
             (
-                all_prognostic.pin_memory(),
+                all_input.pin_memory(),
                 all_boundary.pin_memory(),
                 all_label.pin_memory(),
             )
-            for all_prognostic, all_boundary, all_label in self.raw_data
+            for all_input, all_boundary, all_label in self.raw_data
         ]
         return self
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -582,13 +582,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def _get_input_and_label(
         self,
         # time includes (self.hist + 1) past steps and the (label) future steps
-        prognostic_all: Float[torch.Tensor, "batch time variable lat lon"],
+        input_all: Float[torch.Tensor, "batch time variable lat lon"],
         boundary_all: Float[torch.Tensor, "batch time variable lat lon"],
         label_all: Float[torch.Tensor, "batch time variable lat lon"],
     ) -> tuple[Input, Prognostic]:
         # grab past steps and prep for model
         total_input = self._prep_tensor_steps(
-            prognostic_all[:, : self.hist + 1, :, :, :],
+            input_all[:, : self.hist + 1, :, :, :],
             boundary_all[:, : self.hist + 1, :, :, :],
         )
         # grab future steps, repeat as we do for input

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -509,22 +509,22 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         for step in range(self.steps):
             x_index = self._get_x_index(idx, step)
-            prognostic_selected = self._input_src.data.isel(time=x_index)
+            input_selected = self._input_src.data.isel(time=x_index)
             boundary_selected = self._boundary_src.data.isel(time=x_index)
             label_selected = self._label_src.data.isel(time=x_index)
 
             if self._executor is not None:
                 concurrent_compute(
-                    prognostic_selected,
+                    input_selected,
                     boundary_selected,
                     label_selected,
                     executor=self._executor,
                 )
 
-            if "lev" in prognostic_selected.dims:
+            if "lev" in input_selected.dims:
                 input_all = torch.from_numpy(
                     conditional_rearrange(
-                        prognostic_selected,
+                        input_selected,
                         "time (variable lev)=var lat lon",
                         concat_dim="var",
                     )
@@ -534,7 +534,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 )
                 label_all = torch.from_numpy(
                     conditional_rearrange(
-                        prognostic_selected,
+                        input_selected,
                         "time (variable lev)=var lat lon",
                         concat_dim="var",
                     )
@@ -544,13 +544,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 )
             else:
                 input_all = torch.from_numpy(
-                    prognostic_selected.to_array()
+                    input_selected.to_array()
                     .transpose("time", "variable", "lat", "lon")
                     .to_numpy()
                     .astype(np.float32, copy=False)
                 )
                 label_all = torch.from_numpy(
-                    prognostic_selected.to_array()
+                    input_selected.to_array()
                     .transpose("time", "variable", "lat", "lon")
                     .to_numpy()
                     .astype(np.float32, copy=False)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -2,7 +2,7 @@ import logging
 import time
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import TypeAlias, final
+from typing import Literal, TypeAlias, final
 
 import numpy as np
 import torch
@@ -295,25 +295,35 @@ class InferenceDatasets(Dataset):
 class RawTrainData:
     def __init__(self, dataset_id: "TorchTrainDataset.Id"):
         self.dataset_id: TorchTrainDataset.Id = dataset_id
-        self.raw_data: list[tuple[torch.Tensor, torch.Tensor]] = []
+        self.raw_data: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
         self.load_stats: LoadStats | None = None
 
-    def insert(self, all_prognostic: torch.Tensor, all_boundary: torch.Tensor):
-        self.raw_data.append((all_prognostic, all_boundary))
+    def insert(
+        self,
+        all_prognostic: torch.Tensor,
+        all_boundary: torch.Tensor,
+        all_label: torch.Tensor,
+    ):
+        self.raw_data.append((all_prognostic, all_boundary, all_label))
 
     def to(self, device: torch.device):
         self.raw_data = [
             (
                 all_prognostic.to(device, non_blocking=True),
                 all_boundary.to(device, non_blocking=True),
+                all_label.to(device, non_blocking=True),
             )
-            for all_prognostic, all_boundary in self.raw_data
+            for all_prognostic, all_boundary, all_label in self.raw_data
         ]
 
     def pin_memory(self):
         self.raw_data = [
-            (all_prognostic.pin_memory(), all_boundary.pin_memory())
-            for all_prognostic, all_boundary in self.raw_data
+            (
+                all_prognostic.pin_memory(),
+                all_boundary.pin_memory(),
+                all_label.pin_memory(),
+            )
+            for all_prognostic, all_boundary, all_label in self.raw_data
         ]
         return self
 
@@ -382,6 +392,9 @@ class TrainData:
         return self
 
 
+TrainSchedule = Literal["standard", "match", "mix"]
+
+
 @final
 class TorchTrainDataset(Dataset[RawTrainData]):
     """
@@ -411,6 +424,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def __init__(
         self,
         src: DataSource,
+        dst: DataSource,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
         hist: int,
@@ -432,15 +446,17 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self._executor = executor
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
-        data = src.data
+        # assert src.data.time == dst.data.time, "src and dst DataSource have different time slices!"
+        time_ = src.data.time
         self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
         self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
+        self._label_src = dst.filter(prognostic_var_names, prefix="label")
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
 
         # Calculate the number of windows
-        num_windows = data.time.size - (total_steps - 1) * self.stride
+        num_windows = time_.size - (total_steps - 1) * self.stride
 
         # Create base indices
         indices = np.arange(num_windows)
@@ -474,8 +490,11 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.boundary_means = flatten_to_device(self._boundary_src.means)
         self.boundary_stds = flatten_to_device(self._boundary_src.stds)
 
+        self.label_means = flatten_to_device(self._label_src.means)
+        self.label_stds = flatten_to_device(self._label_src.stds)
+
         self.size: int = (
-            data.time.size
+            time_.size
             - self.steps * (self.hist + 1) * self.stride
             - self.hist * self.stride
         )
@@ -492,14 +511,28 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             x_index = self._get_x_index(idx, step)
             prognostic_selected = self._prognostic_src.data.isel(time=x_index)
             boundary_selected = self._boundary_src.data.isel(time=x_index)
+            label_selected = self._label_src.data.isel(time=x_index)
 
             if self._executor is not None:
                 concurrent_compute(
-                    prognostic_selected, boundary_selected, executor=self._executor
+                    prognostic_selected,
+                    boundary_selected,
+                    label_selected,
+                    executor=self._executor,
                 )
 
             if "lev" in prognostic_selected.dims:
                 prognostic_all = torch.from_numpy(
+                    conditional_rearrange(
+                        prognostic_selected,
+                        "time (variable lev)=var lat lon",
+                        concat_dim="var",
+                    )
+                    .rename({"var": "variable"})
+                    .to_numpy()
+                    .astype(np.float32, copy=False)
+                )
+                label_all = torch.from_numpy(
                     conditional_rearrange(
                         prognostic_selected,
                         "time (variable lev)=var lat lon",
@@ -516,6 +549,12 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .to_numpy()
                     .astype(np.float32, copy=False)
                 )
+                label_all = torch.from_numpy(
+                    prognostic_selected.to_array()
+                    .transpose("time", "variable", "lat", "lon")
+                    .to_numpy()
+                    .astype(np.float32, copy=False)
+                )
             boundary = torch.from_numpy(
                 boundary_selected.to_array()
                 .transpose("time", "variable", "lat", "lon")
@@ -523,19 +562,20 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 .astype(np.float32, copy=False)
             )
 
-            TD.insert(prognostic_all, boundary)
+            TD.insert(prognostic_all, boundary, label_all)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
         return TD
 
     def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
         train_data = TrainData(self.num_prognostic_channels)
-        for prognostic_all, boundary_all in raw_train_data.raw_data:
-            input, label = self._get_input_and_label(
+        for prognostic_all, boundary_all, label_all in raw_train_data.raw_data:
+            input_, label = self._get_input_and_label(
                 prognostic_all.to(device=self.device, non_blocking=True),
                 boundary_all.to(device=self.device, non_blocking=True),
+                label_all.to(device=self.device, non_blocking=True),
             )
-            train_data.append(input, label)
+            train_data.append(input_, label)
         train_data.load_stats = raw_train_data.load_stats
         return train_data
 
@@ -544,6 +584,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         # time includes (self.hist + 1) past steps and the (label) future steps
         prognostic_all: Float[torch.Tensor, "batch time variable lat lon"],
         boundary_all: Float[torch.Tensor, "batch time variable lat lon"],
+        label_all: Float[torch.Tensor, "batch time variable lat lon"],
     ) -> tuple[Input, Prognostic]:
         # grab past steps and prep for model
         total_input = self._prep_tensor_steps(
@@ -551,7 +592,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             boundary_all[:, : self.hist + 1, :, :, :],
         )
         # grab future steps, repeat as we do for input
-        label = self._prep_tensor_steps(prognostic_all[:, self.hist + 1 :, :, :, :])
+        label = self._prep_tensor_steps(label_all[:, self.hist + 1 :, :, :, :])
         return total_input, label
 
     def _prep_tensor_steps(

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -303,31 +303,31 @@ class RawTrainData:
 
     def insert(
         self,
-        all_input: torch.Tensor,
-        all_boundary: torch.Tensor,
-        all_label: torch.Tensor,
+        input_: torch.Tensor,
+        boundary: torch.Tensor,
+        label: torch.Tensor,
     ):
         """Add a prognostic input, boundary, and prognostic label as the last step."""
-        self.raw_data.append((all_input, all_boundary, all_label))
+        self.raw_data.append((input_, boundary, label))
 
     def to(self, device: torch.device):
         self.raw_data = [
             (
-                all_input.to(device, non_blocking=True),
-                all_boundary.to(device, non_blocking=True),
-                all_label.to(device, non_blocking=True),
+                input_.to(device, non_blocking=True),
+                boundary.to(device, non_blocking=True),
+                label.to(device, non_blocking=True),
             )
-            for all_input, all_boundary, all_label in self.raw_data
+            for input_, boundary, label in self.raw_data
         ]
 
     def pin_memory(self):
         self.raw_data = [
             (
-                all_input.pin_memory(),
-                all_boundary.pin_memory(),
-                all_label.pin_memory(),
+                input_.pin_memory(),
+                boundary.pin_memory(),
+                label.pin_memory(),
             )
-            for all_input, all_boundary, all_label in self.raw_data
+            for input_, boundary, label in self.raw_data
         ]
         return self
 
@@ -526,7 +526,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 )
 
             if "lev" in input_selected.dims:
-                input_all = torch.from_numpy(
+                input_ = torch.from_numpy(
                     conditional_rearrange(
                         input_selected,
                         "time (variable lev)=var lat lon",
@@ -536,7 +536,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .to_numpy()
                     .astype(np.float32, copy=False)
                 )
-                label_all = torch.from_numpy(
+                label = torch.from_numpy(
                     conditional_rearrange(
                         label_selected,
                         "time (variable lev)=var lat lon",
@@ -547,13 +547,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .astype(np.float32, copy=False)
                 )
             else:
-                input_all = torch.from_numpy(
+                input_ = torch.from_numpy(
                     input_selected.to_array()
                     .transpose("time", "variable", "lat", "lon")
                     .to_numpy()
                     .astype(np.float32, copy=False)
                 )
-                label_all = torch.from_numpy(
+                label = torch.from_numpy(
                     label_selected.to_array()
                     .transpose("time", "variable", "lat", "lon")
                     .to_numpy()
@@ -566,18 +566,18 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 .astype(np.float32, copy=False)
             )
 
-            TD.insert(input_all, boundary, label_all)
+            TD.insert(input_, boundary, label)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
         return TD
 
     def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
         train_data = TrainData(self.num_prognostic_channels)
-        for input_all, boundary_all, label_all in raw_train_data.raw_data:
+        for input_, boundary, label in raw_train_data.raw_data:
             input_, label = self._get_input_and_label(
-                input_all.to(device=self.device, non_blocking=True),
-                boundary_all.to(device=self.device, non_blocking=True),
-                label_all.to(device=self.device, non_blocking=True),
+                input_.to(device=self.device, non_blocking=True),
+                boundary.to(device=self.device, non_blocking=True),
+                label.to(device=self.device, non_blocking=True),
             )
             train_data.append(input_, label)
         train_data.load_stats = raw_train_data.load_stats
@@ -586,21 +586,21 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def _get_input_and_label(
         self,
         # time includes (self.hist + 1) past steps and the (label) future steps
-        input_all: Float[torch.Tensor, "batch time variable lat lon"],
-        boundary_all: Float[torch.Tensor, "batch time variable lat lon"],
-        label_all: Float[torch.Tensor, "batch time variable lat lon"],
+        input_: Float[torch.Tensor, "batch time variable lat lon"],
+        boundary: Float[torch.Tensor, "batch time variable lat lon"],
+        label: Float[torch.Tensor, "batch time variable lat lon"],
     ) -> tuple[Input, Prognostic]:
         # grab past steps and prep for model
         total_input = self._prep_tensor_steps(
-            input_all[:, : self.hist + 1, :, :, :],
+            input_[:, : self.hist + 1, :, :, :],
             self.input_means,
             self.input_stds,
             self.wet_input,
-            boundary_all[:, : self.hist + 1, :, :, :],
+            boundary[:, : self.hist + 1, :, :, :],
         )
         # grab future steps, repeat as we do for input
         label = self._prep_tensor_steps(
-            label_all[:, self.hist + 1 :, :, :, :],
+            label[:, self.hist + 1 :, :, :, :],
             self.label_means,
             self.label_stds,
             self.wet_label,

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -574,7 +574,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
         train_data = TrainData(self.num_prognostic_channels)
         for input_, boundary, label in raw_train_data.raw_data:
-            input_, label = self._get_input_and_label(
+            input_, label = self._get_full_input_and_label(
                 input_.to(device=self.device, non_blocking=True),
                 boundary.to(device=self.device, non_blocking=True),
                 label.to(device=self.device, non_blocking=True),
@@ -583,7 +583,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         train_data.load_stats = raw_train_data.load_stats
         return train_data
 
-    def _get_input_and_label(
+    def _get_full_input_and_label(
         self,
         # time includes (self.hist + 1) past steps and the (label) future steps
         input_: Float[torch.Tensor, "batch time variable lat lon"],

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -699,7 +699,7 @@ def concurrent_compute(
     wait(futures)
 
 
-class _SimpleSubsetSampler(torch.utils.data.Sampler):
+class _SimpleSubsetSampler(Sampler):
     def __init__(self, indices):
         super().__init__()
         self.indices = indices

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -718,6 +718,7 @@ class Trainer:
         train_datasets = [
             TorchTrainDataset(
                 src=self.src.slice(self.train_time),
+                dst=self.src.slice(self.train_time),
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 hist=self.hist,
@@ -733,6 +734,7 @@ class Trainer:
         val_datasets = [
             TorchTrainDataset(
                 src=self.src.slice(self.val_time),
+                dst=self.src.slice(self.val_time),
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 hist=self.hist,

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -141,7 +141,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             cumsum += len(ds)
 
         # Sort by key for deterministic ordering across runs
-        sorted_groups = sorted(groups.items(), key=lambda x: str(x[0]))
+        sorted_groups = sorted(groups.items(), key=lambda x: x[0])
         group_indices = [indices for _, indices in sorted_groups]
 
         return cls(group_indices, batch_size, shuffle, drop_last)

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -1,7 +1,7 @@
 import itertools
 import random
 from collections.abc import Callable, Hashable
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Self
 
 from torch.utils.data import BatchSampler, Sampler, SubsetRandomSampler
 
@@ -89,7 +89,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
     def from_datasets(
         cls,
         datasets: list["TorchTrainDataset"],
-        group_key: Callable[["TorchTrainDataset"], Any],
+        group_key: Callable[["TorchTrainDataset"], Hashable],
         batch_size: int,
         shuffle: bool,
         drop_last: bool,
@@ -129,14 +129,14 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         from collections import defaultdict
 
         # Group indices by their key
-        groups: dict[tuple, list[int]] = defaultdict(list)
+        groups: dict[Hashable, list[int]] = defaultdict(list)
 
         cumsum = 0
         for ds in datasets:
             key = group_key(ds)
-            # Make key hashable if it isn't already
-            if not isinstance(key, Hashable):
-                key = tuple(key) if hasattr(key, "__iter__") else (key,)
+            assert isinstance(key, (int, str, tuple, Hashable)), (
+                "`group_key` must be hashable."
+            )
             groups[key].extend(range(cumsum, cumsum + len(ds)))
             cumsum += len(ds)
 

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -134,7 +134,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         cumsum = 0
         for ds in datasets:
             key = group_key(ds)
-            assert isinstance(key, (int, str, tuple, Hashable)), (
+            assert isinstance(key, Hashable), (
                 "`group_key` must be hashable."
             )
             groups[key].extend(range(cumsum, cumsum + len(ds)))

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -1,0 +1,169 @@
+import itertools
+import random
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Self
+
+from torch.utils.data import BatchSampler, Sampler, SubsetRandomSampler
+
+if TYPE_CHECKING:
+    from ocean_emulators.datasets import TorchTrainDataset
+
+
+class _SimpleSubsetSampler(Sampler):
+    def __init__(self, indices):
+        super().__init__()
+        self.indices = indices
+
+    def __iter__(self):
+        return iter(self.indices)
+
+    def __len__(self):
+        return len(self.indices)
+
+
+class EquivalenceGroupBatchSampler(Sampler[list[int]]):
+    """Groups indices into equivalence classes, batches within groups, and optionally shuffles.
+
+    This sampler partitions dataset indices into groups. It creates batches within each group,
+    then chains them together. When shuffle=True, batches are globally shuffled each epoch
+    to avoid sequential group processing.
+
+    Args:
+        groups: List of index lists, where each inner list contains indices belonging to
+            the same equivalence group.
+        batch_size: Number of samples per batch
+        shuffle: Whether to shuffle indices within groups and shuffle batches globally
+        drop_last: Whether to drop incomplete batches at the end of each group
+    """
+
+    def __init__(
+        self,
+        groups: list[list[int]],
+        batch_size: int,
+        shuffle: bool = True,
+        drop_last: bool = False,
+    ):
+        super().__init__()
+        self.groups = groups
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.drop_last = drop_last
+
+        # Choose sampler based on shuffle setting
+        SubsetSampler = SubsetRandomSampler if self.shuffle else _SimpleSubsetSampler
+
+        self._samplers = [
+            BatchSampler(
+                SubsetSampler(group),
+                batch_size=self.batch_size,
+                drop_last=self.drop_last,
+            )
+            for group in self.groups
+        ]
+
+    @classmethod
+    def from_dataset_sizes(
+        cls,
+        dataset_sizes: list[int],
+        batch_size: int,
+        shuffle: bool = True,
+        drop_last: bool = False,
+    ) -> Self:
+        """Create sampler from dataset sizes, treating each as a contiguous group.
+
+        Args:
+            dataset_sizes: List of individual dataset sizes. Groups are created based on
+                cumulative boundaries, where each dataset forms its own equivalence group.
+            batch_size: Number of samples per batch
+            shuffle: Whether to shuffle indices within groups and shuffle batches globally
+            drop_last: Whether to drop incomplete batches at the end of each group
+        """
+        cumsum = 0
+        groups = []
+        for size in dataset_sizes:
+            groups.append(list(range(cumsum, cumsum + size)))
+            cumsum += size
+        return cls(groups, batch_size, shuffle, drop_last)
+
+    @classmethod
+    def from_datasets(
+        cls,
+        datasets: list["TorchTrainDataset"],
+        group_key: Callable[["TorchTrainDataset"], Any],
+        batch_size: int,
+        shuffle: bool,
+        drop_last: bool,
+    ) -> Self:
+        """Create sampler by grouping datasets using a key function.
+
+        This factory method allows grouping datasets by arbitrary criteria (e.g., resolution,
+        regardless of other parameters like stride). Datasets with the same key are batched together.
+
+        Args:
+            datasets: List of TorchTrainDataset instances to group
+            group_key: Callable that extracts grouping key from a dataset.
+            batch_size: Number of samples per batch
+            shuffle: Whether to shuffle indices within groups and shuffle batches globally
+            drop_last: Whether to drop incomplete batches at the end of each group
+
+        Examples:
+                - lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon'])  # group by resolution
+                - lambda ds: ds._input_src.data.sizes['lat']  # group by latitude size only
+            batch_size: Number of samples per batch
+            shuffle: Whether to shuffle indices within groups and shuffle batches globally
+            drop_last: Whether to drop incomplete batches at the end of each group
+
+        Returns:
+            EquivalenceGroupBatchSampler configured to group by the provided key
+
+        Example:
+            >>> # Group datasets by resolution, allowing different strides to be batched together
+            >>> sampler = EquivalenceGroupBatchSampler.from_datasets(
+            ...     datasets=dataset_list,
+            ...     group_key=lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon']),
+            ...     batch_size=32,
+            ...     shuffle=True,
+            ...     drop_last=True,
+            ... )
+        """
+        from collections import defaultdict
+
+        # Group indices by their key
+        groups: dict[tuple, list[int]] = defaultdict(list)
+
+        cumsum = 0
+        for ds in datasets:
+            key = group_key(ds)
+            # Make key hashable if it isn't already
+            if not isinstance(key, (int, str, tuple)):
+                key = tuple(key) if hasattr(key, "__iter__") else (key,)
+            groups[key].extend(range(cumsum, cumsum + len(ds)))
+            cumsum += len(ds)
+
+        # Sort by key for deterministic ordering across runs
+        sorted_groups = sorted(groups.items(), key=lambda x: str(x[0]))
+        group_indices = [indices for _, indices in sorted_groups]
+
+        return cls(group_indices, batch_size, shuffle, drop_last)
+
+    def __iter__(self):
+        # Create batch samplers for each group
+        batch_sampler = itertools.chain(*self._samplers)
+
+        if not self.shuffle:
+            # No global shuffle: return batches in sequential group order
+            yield from batch_sampler
+        else:
+            # Shuffle batches globally to avoid sequential group processing
+            # This is regenerated each epoch, giving different orderings
+            all_batches = list(batch_sampler)
+            random.shuffle(all_batches)
+            yield from all_batches
+
+    def __len__(self):
+        """Calculate total number of batches across all groups."""
+        total_batches = 0
+        for sampler in self._samplers:
+            total_batches += len(sampler)
+
+        return total_batches

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -1,6 +1,6 @@
 import itertools
 import random
-from collections.abc import Callable
+from collections.abc import Callable, Hashable
 from typing import TYPE_CHECKING, Any, Self
 
 from torch.utils.data import BatchSampler, Sampler, SubsetRandomSampler
@@ -135,7 +135,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         for ds in datasets:
             key = group_key(ds)
             # Make key hashable if it isn't already
-            if not isinstance(key, (int, str, tuple)):
+            if not isinstance(key, Hashable):
                 key = tuple(key) if hasattr(key, "__iter__") else (key,)
             groups[key].extend(range(cumsum, cumsum + len(ds)))
             cumsum += len(ds)

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -134,14 +134,12 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         cumsum = 0
         for ds in datasets:
             key = group_key(ds)
-            assert isinstance(key, Hashable), (
-                "`group_key` must be hashable."
-            )
+            assert isinstance(key, Hashable), "`group_key` must be hashable."
             groups[key].extend(range(cumsum, cumsum + len(ds)))
             cumsum += len(ds)
 
         # Sort by key for deterministic ordering across runs
-        sorted_groups = sorted(groups.items(), key=lambda x: x[0])
+        sorted_groups = sorted(groups.items(), key=lambda x: x[0])  # type: ignore
         group_indices = [indices for _, indices in sorted_groups]
 
         return cls(group_indices, batch_size, shuffle, drop_last)

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -24,10 +24,10 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
 
     steps = len(data[0].raw_data)
     for step in range(steps):
-        all_prognostic = torch.stack([d.raw_data[step][0] for d in data])
+        all_input = torch.stack([d.raw_data[step][0] for d in data])
         all_boundary = torch.stack([d.raw_data[step][1] for d in data])
         all_label = torch.stack([d.raw_data[step][2] for d in data])
-        batched_data.insert(all_prognostic, all_boundary, all_label)
+        batched_data.insert(all_input, all_boundary, all_label)
 
     stats = LoadStats.accumulated(
         [d.load_stats for d in data if d.load_stats is not None]

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -24,10 +24,10 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
 
     steps = len(data[0].raw_data)
     for step in range(steps):
-        all_input = torch.stack([d.raw_data[step][0] for d in data])
-        all_boundary = torch.stack([d.raw_data[step][1] for d in data])
-        all_label = torch.stack([d.raw_data[step][2] for d in data])
-        batched_data.insert(all_input, all_boundary, all_label)
+        input_ = torch.stack([d.raw_data[step][0] for d in data])
+        boundary = torch.stack([d.raw_data[step][1] for d in data])
+        label = torch.stack([d.raw_data[step][2] for d in data])
+        batched_data.insert(input_, boundary, label)
 
     stats = LoadStats.accumulated(
         [d.load_stats for d in data if d.load_stats is not None]

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -26,7 +26,8 @@ def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
     for step in range(steps):
         all_prognostic = torch.stack([d.raw_data[step][0] for d in data])
         all_boundary = torch.stack([d.raw_data[step][1] for d in data])
-        batched_data.insert(all_prognostic, all_boundary)
+        all_label = torch.stack([d.raw_data[step][2] for d in data])
+        batched_data.insert(all_prognostic, all_boundary, all_label)
 
     stats = LoadStats.accumulated(
         [d.load_stats for d in data if d.load_stats is not None]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from numpy.typing import ArrayLike, NDArray
 import ocean_emulators.constants as c
 from ocean_emulators.config import JulianDate, TrainBackendConfig, TrainConfig
 from ocean_emulators.constants import BOUNDARY_VARS
+from ocean_emulators.datasets import TrainSchedule
 from ocean_emulators.train import Trainer
 from ocean_emulators.utils.data import DataSource, _is_compact, compact_dataset
 from ocean_emulators.utils.multiton import MultitonScope
@@ -306,6 +307,11 @@ def loader_version(request: pytest.FixtureRequest) -> c.LoaderVersion:
 
 @pytest.fixture(scope="session", params=[0, 1], ids=lambda x: f"hist{x}")
 def history(request: pytest.FixtureRequest) -> int:
+    return request.param
+
+
+@pytest.fixture(scope="session", params=["standard", "match", "mix"])
+def schedule(request: pytest.FixtureRequest) -> TrainSchedule:
     return request.param
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,13 @@ from aiohttp import ServerDisconnectedError
 from numpy.typing import ArrayLike, NDArray
 
 import ocean_emulators.constants as c
-from ocean_emulators.config import JulianDate, TrainBackendConfig, TrainConfig
+from ocean_emulators.config import (
+    JulianDate,
+    TrainBackendConfig,
+    TrainConfig,
+    TrainSchedule,
+)
 from ocean_emulators.constants import BOUNDARY_VARS
-from ocean_emulators.datasets import TrainSchedule
 from ocean_emulators.train import Trainer
 from ocean_emulators.utils.data import DataSource, _is_compact, compact_dataset
 from ocean_emulators.utils.multiton import MultitonScope

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -373,9 +373,9 @@ def test_loader__data_shape__across_schedules(
         )
 
         example_resolutions = []
-        # Only check the first 4 samples; this should be proof enough that everything is
+        # Only check the first 8 samples; this should be proof enough that everything is
         # the right shape.
-        for sample in samples[:4]:
+        for sample in samples[::3]:
             X, y = extract_sample_arrays(sample)
             # Exclude the coordinate shape information for now; we'll test that separately.
             assert X.shape[:-2] == (
@@ -415,13 +415,11 @@ def test_loader__data_shape__across_schedules(
                 }
                 observed_patterns = set(example_resolutions)
                 # All observed patterns must be valid
-                assert observed_patterns <= valid_patterns, (
+                assert observed_patterns == valid_patterns, (
                     f"All resolutions must be valid members of the cartesian product for 'mix' schedule. "
                     f"Valid patterns: {valid_patterns}, got {observed_patterns}, "
                     f"invalid patterns: {observed_patterns - valid_patterns}"
                 )
-                # We should have at least 1 pattern
-                assert len(observed_patterns) > 0, "Should have at least one pattern"
 
 
 def test_inference__data_shape(inference_loader_pair):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -373,8 +373,7 @@ def test_loader__data_shape__across_schedules(
         )
 
         example_resolutions = []
-        # Subsample the examples; this should be proof enough that everything is
-        # the right shape.
+        # Subsample the examples; this should be proof enough that everything is the right shape.
         for sample in samples[::3]:
             X, y = extract_sample_arrays(sample)
             # Exclude the coordinate shape information for now; we'll test that separately.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,7 +3,9 @@
 import contextlib
 import dataclasses
 import datetime
-from collections.abc import Generator
+import itertools
+from collections.abc import Generator, Iterable
+from typing import assert_never
 
 import cftime
 import numpy as np
@@ -28,6 +30,7 @@ from ocean_emulators.datasets import (
     TorchTrainDataset,
     TrainData,
     TrainDataLoader,
+    TrainSchedule,
 )
 from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
@@ -41,12 +44,38 @@ def inference_loader_pair(trainer_pair: TrainPair) -> tuple[TrainConfig, DataLoa
     return cfg, trainer.inference_loader
 
 
+def coarsen_data(ds: xr.Dataset) -> xr.Dataset:
+    return ds.coarsen(lat=2, lon=2).mean()  # type: ignore
+
+
+def coarsen_masks(masks: Masks) -> Masks:
+    """Coarsen masks to half resolution using max pooling (any True -> True)."""
+    # For masks, we use max pooling: if any cell in the 2x2 block is True (valid),
+    # the coarsened cell is True
+    import torch.nn.functional as F
+
+    # Coarsen prognostic mask (3D: channels x lat x lon)
+    prog_mask = masks.prognostic.float().unsqueeze(0)  # Add batch dim
+    prog_coarsened = F.max_pool2d(prog_mask, kernel_size=2, stride=2)
+    prog_coarsened = prog_coarsened.squeeze(0).bool()  # Remove batch dim, back to bool
+
+    # Coarsen boundary mask (2D: lat x lon)
+    bound_mask = (
+        masks.boundary.float().unsqueeze(0).unsqueeze(0)
+    )  # Add batch and channel dims
+    bound_coarsened = F.max_pool2d(bound_mask, kernel_size=2, stride=2)
+    bound_coarsened = bound_coarsened.squeeze(0).squeeze(0).bool()  # Remove extra dims
+
+    return Masks(prognostic=prog_coarsened, boundary=bound_coarsened)
+
+
 @contextlib.contextmanager
 def make_loader(
     cfg: TrainConfig,
     time_config: TimeConfig | None = None,
     drop_last: bool = True,
     version: LoaderVersion | None = None,
+    schedule: TrainSchedule = "standard",
 ) -> Generator[DataLoader | TrainDataLoader, None, None]:
     if time_config is None:
         time_config = cfg.train_time
@@ -73,11 +102,32 @@ def make_loader(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
         )
 
+        match schedule:
+            case "standard":
+                srcs: Iterable[tuple[DataSource, DataSource]] = [(src, src)]
+            case "match":
+                coarsened_src = src.map_data(coarsen_data, suffix="half-size")
+                coarsened_src = dataclasses.replace(
+                    coarsened_src, masks=coarsen_masks(src.masks)
+                )
+                scales = [src, coarsened_src]
+                srcs = itertools.permutations(scales, 2)
+            case "mix":
+                coarsened_src = src.map_data(coarsen_data, suffix="half-size")
+                coarsened_src = dataclasses.replace(
+                    coarsened_src, masks=coarsen_masks(src.masks)
+                )
+                scales = [src, coarsened_src]
+                srcs = itertools.product(scales, repeat=2)  # type: ignore
+            case _:
+                assert_never(schedule)
+
         match version:
             case LoaderVersion.OM4_TORCH:
                 dataset_list = [
                     TorchTrainDataset(
                         src=src.slice(time_config),
+                        dst=dst.slice(time_config),
                         prognostic_var_names=prognostic,
                         boundary_var_names=boundary,
                         hist=cfg.data.hist,
@@ -87,6 +137,7 @@ def make_loader(
                         stride=stride,
                     )
                     for stride in cfg.data_stride
+                    for src, dst in srcs
                 ]
 
                 data: ConcatDataset = ConcatDataset(dataset_list)
@@ -114,7 +165,9 @@ def extract_sample_arrays(td: TrainData) -> tuple[np.ndarray, np.ndarray]:
     return np.stack(x_arrays, axis=0), np.stack(y_arrays, axis=0)
 
 
-def calc_num_samples(cfg: TrainConfig, time_slice: slice) -> int:
+def calc_num_samples(
+    cfg: TrainConfig, time_slice: slice, schedule: TrainSchedule
+) -> int:
     ds = cfg.experiment.resolved_data_root.resolve(cfg.data.data_location).open()
 
     data_size = ds.sel(time=time_slice).time.size
@@ -122,7 +175,13 @@ def calc_num_samples(cfg: TrainConfig, time_slice: slice) -> int:
     hist = cfg.data.hist
     stride = cfg.data_stride[0]
 
-    return data_size - (steps * (cfg.data.hist + 1) * stride) - hist * stride
+    n_samples = data_size - (steps * (cfg.data.hist + 1) * stride) - hist * stride
+    if schedule == "match":
+        n_samples *= 2
+    if schedule == "mix":
+        n_samples *= 4
+
+    return n_samples
 
 
 def vector_of(max_vec_size: int, min_vec_size=1):
@@ -251,7 +310,9 @@ def test_loader__data_shape(
             len(PROGNOSTIC_VARS[exp.prognostic_vars_key]) * num_input_timesteps
         )
 
-        n_samples = calc_num_samples(train_config, train_config.train_time.time_slice)
+        n_samples = calc_num_samples(
+            train_config, train_config.train_time.time_slice, "standard"
+        )
         samples = list(loader)
 
         assert len(samples) == n_samples, (
@@ -277,6 +338,91 @@ def test_loader__data_shape(
                 180,
                 360,
             )
+
+
+@pytest.mark.parametrize(
+    "data_source,config_name", [("mock", DEFAULT_CONFIG)], indirect=True
+)
+def test_loader__data_shape__across_schedules(
+    train_config: TrainConfig, schedule: TrainSchedule
+):
+    history = train_config.data.hist
+
+    with make_loader(
+        train_config, version=LoaderVersion.OM4_TORCH, schedule=schedule
+    ) as loader:
+        exp = train_config.experiment
+        batch_size = train_config.batch_size
+        num_input_timesteps = history + 1
+
+        input_var_dim = (
+            len(PROGNOSTIC_VARS[exp.prognostic_vars_key])
+            + len(BOUNDARY_VARS[exp.boundary_vars_key])
+        ) * num_input_timesteps
+        output_var_dim = (
+            len(PROGNOSTIC_VARS[exp.prognostic_vars_key]) * num_input_timesteps
+        )
+
+        n_samples = calc_num_samples(
+            train_config, train_config.train_time.time_slice, schedule
+        )
+        samples = list(loader)
+
+        assert len(samples) == n_samples, (
+            f"Current config {train_config} only supports {n_samples} examples; "
+            f"got {len(samples)}."
+        )
+
+        example_resolutions = []
+        # Only check the first 4 samples; this should be proof enough that everything is
+        # the right shape.
+        for sample in samples[:4]:
+            X, y = extract_sample_arrays(sample)
+            # Exclude the coordinate shape information for now; we'll test that separately.
+            assert X.shape[:-2] == (
+                train_config.steps[0],
+                batch_size,
+                input_var_dim,
+            )
+            assert y.shape[:-2] == (
+                train_config.steps[0],
+                batch_size,
+                output_var_dim,
+            )
+            example_resolutions.append((X.shape[-2:], y.shape[-2:]))
+
+        match schedule:
+            case "standard":
+                assert example_resolutions[0][0] == example_resolutions[0][1], (
+                    "The input and output should be equal"
+                )
+                assert all(
+                    example_resolutions[0] == eg for eg in example_resolutions[1:]
+                ), "All resolutions should be equal"
+            case "match":
+                for x_res, y_res in example_resolutions:
+                    assert x_res == y_res, (
+                        f"Resolutions must match across batches for 'match' schedule multiscale loader. {example_resolutions=}"
+                    )
+            case "mix":
+                # In mix mode with 2 scales, multiplex creates pattern: (0,0), (0,1), (1,0), (1,1)
+                # With grouped batch sampler, order may vary due to shuffling within groups.
+                # With drop_last=True and small sample counts, some groups might not produce any batches
+                valid_patterns = {
+                    ((180, 360), (180, 360)),  # (0,0): full-res input, full-res label
+                    ((180, 360), (90, 180)),  # (0,1): full-res input, half-res label
+                    ((90, 180), (180, 360)),  # (1,0): half-res input, full-res label
+                    ((90, 180), (90, 180)),  # (1,1): half-res input, half-res label
+                }
+                observed_patterns = set(example_resolutions)
+                # All observed patterns must be valid
+                assert observed_patterns <= valid_patterns, (
+                    f"All resolutions must be valid members of the cartesian product for 'mix' schedule. "
+                    f"Valid patterns: {valid_patterns}, got {observed_patterns}, "
+                    f"invalid patterns: {observed_patterns - valid_patterns}"
+                )
+                # We should have at least 1 pattern
+                assert len(observed_patterns) > 0, "Should have at least one pattern"
 
 
 def test_inference__data_shape(inference_loader_pair):
@@ -453,6 +599,7 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
         )
         torch_train_dataset = TorchTrainDataset(
             src=test,
+            dst=test,
             prognostic_var_names=prognostic_var_names,
             boundary_var_names=boundary_var_names,
             hist=1,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -532,6 +532,18 @@ def test_compact_loader__equals_flat_loader(
     assert_equal_samples(original_samples, new_samples)
 
 
+@pytest.mark.parametrize("data_source", ["remote-om4"], indirect=True)
+def test_mixed_schedule__has_consistent_collated_batches(train_config: TrainConfig):
+    schedule: TrainSchedule = "match"
+
+    # Exposes underling consistency issue
+    train_config.batch_size = 4
+
+    with make_loader(train_config, schedule=schedule) as loader:
+        for _ in loader:
+            pass
+
+
 @pytest.fixture
 def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
     # Create data

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -373,7 +373,7 @@ def test_loader__data_shape__across_schedules(
         )
 
         example_resolutions = []
-        # Only check the first 8 samples; this should be proof enough that everything is
+        # Subsample the examples; this should be proof enough that everything is
         # the right shape.
         for sample in samples[::3]:
             X, y = extract_sample_arrays(sample)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -26,7 +26,6 @@ from ocean_emulators.constants import (
     TensorMap,
 )
 from ocean_emulators.datasets import (
-    EquivalenceGroupBatchSampler,
     InferenceDataset,
     TorchTrainDataset,
     TrainData,
@@ -34,6 +33,7 @@ from ocean_emulators.datasets import (
 )
 from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
+from ocean_emulators.utils.samplers import EquivalenceGroupBatchSampler
 from ocean_emulators.utils.train import collate_raw_train_data
 from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -18,7 +18,7 @@ from hypothesis.extra.numpy import arrays
 from numpy.typing import NDArray
 from torch.utils.data import ConcatDataset, DataLoader
 
-from ocean_emulators.config import TimeConfig, TrainConfig
+from ocean_emulators.config import TimeConfig, TrainConfig, TrainSchedule
 from ocean_emulators.constants import (
     BOUNDARY_VARS,
     PROGNOSTIC_VARS,
@@ -30,7 +30,6 @@ from ocean_emulators.datasets import (
     TorchTrainDataset,
     TrainData,
     TrainDataLoader,
-    TrainSchedule,
 )
 from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -136,17 +136,20 @@ def make_loader(
                         masked_fill_value=cfg.data.masked_fill_value,
                         stride=stride,
                     )
-                    for stride in cfg.data_stride
                     for src, dst in srcs
+                    for stride in cfg.data_stride
                 ]
 
                 data: ConcatDataset = ConcatDataset(dataset_list)
                 collate_fn = collate_raw_train_data
 
-                # TODO(alxmrs): Is this correct? This includes multiple lens for each stride!
-                dataset_sizes = [len(ds) for ds in dataset_list]
-                batch_sampler = EquivalenceGroupBatchSampler(
-                    dataset_sizes=dataset_sizes,
+                # Group datasets by resolution (lat, lon sizes), allowing different strides to batch together
+                batch_sampler = EquivalenceGroupBatchSampler.from_datasets(
+                    datasets=dataset_list,
+                    group_key=lambda ds: (
+                        ds._input_src.data.sizes["lat"],
+                        ds._input_src.data.sizes["lon"],
+                    ),
                     batch_size=cfg.batch_size,
                     drop_last=drop_last,
                     shuffle=True,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -26,6 +26,7 @@ from ocean_emulators.constants import (
     TensorMap,
 )
 from ocean_emulators.datasets import (
+    EquivalenceGroupBatchSampler,
     InferenceDataset,
     TorchTrainDataset,
     TrainData,
@@ -142,10 +143,18 @@ def make_loader(
                 data: ConcatDataset = ConcatDataset(dataset_list)
                 collate_fn = collate_raw_train_data
 
-                raw_loader = DataLoader(
-                    data,
+                # TODO(alxmrs): Is this correct? This includes multiple lens for each stride!
+                dataset_sizes = [len(ds) for ds in dataset_list]
+                batch_sampler = EquivalenceGroupBatchSampler(
+                    dataset_sizes=dataset_sizes,
                     batch_size=cfg.batch_size,
                     drop_last=drop_last,
+                    shuffle=True,
+                )
+
+                raw_loader = DataLoader(
+                    data,
+                    batch_sampler=batch_sampler,
                     collate_fn=collate_fn,
                 )
 
@@ -533,14 +542,14 @@ def test_compact_loader__equals_flat_loader(
 
 
 @pytest.mark.parametrize("data_source", ["remote-om4"], indirect=True)
-def test_mixed_schedule__has_consistent_collated_batches(train_config: TrainConfig):
-    schedule: TrainSchedule = "match"
-
+def test_mixed_schedule__has_consistent_collated_batches(
+    train_config: TrainConfig, schedule: TrainSchedule
+):
     # Exposes underling consistency issue
     train_config.batch_size = 4
 
     with make_loader(train_config, schedule=schedule) as loader:
-        for _ in loader:
+        for _ in itertools.islice(loader, 2):
             pass
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -143,12 +143,15 @@ def make_loader(
                 data: ConcatDataset = ConcatDataset(dataset_list)
                 collate_fn = collate_raw_train_data
 
-                # Group datasets by resolution (lat, lon sizes), allowing different strides to batch together
+                # Group datasets by input AND label resolution, allowing different strides to batch together
+                # This ensures datasets with same (src, dst) resolution pair but different strides can batch
                 batch_sampler = EquivalenceGroupBatchSampler.from_datasets(
                     datasets=dataset_list,
                     group_key=lambda ds: (
                         ds._input_src.data.sizes["lat"],
                         ds._input_src.data.sizes["lon"],
+                        ds._label_src.data.sizes["lat"],
+                        ds._label_src.data.sizes["lon"],
                     ),
                     batch_size=cfg.batch_size,
                     drop_last=drop_last,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -110,7 +110,7 @@ def make_loader(
                     coarsened_src, masks=coarsen_masks(src.masks)
                 )
                 scales = [src, coarsened_src]
-                srcs = itertools.permutations(scales, 2)
+                srcs = [(s, s) for s in scales]
             case "mix":
                 coarsened_src = src.map_data(coarsen_data, suffix="half-size")
                 coarsened_src = dataclasses.replace(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -76,6 +76,7 @@ def make_loader(
     drop_last: bool = True,
     version: LoaderVersion | None = None,
     schedule: TrainSchedule = "standard",
+    shuffle: bool = True,
 ) -> Generator[DataLoader | TrainDataLoader, None, None]:
     if time_config is None:
         time_config = cfg.train_time
@@ -155,7 +156,7 @@ def make_loader(
                     ),
                     batch_size=cfg.batch_size,
                     drop_last=drop_last,
-                    shuffle=True,
+                    shuffle=shuffle,
                 )
 
                 raw_loader = DataLoader(
@@ -539,9 +540,13 @@ def test_compact_loader__equals_flat_loader(
     compact_source = dataclasses.replace(data_source, name="compact")
     compact_config = make_config(compact_source)
 
-    with make_loader(flat_config, version=LoaderVersion.OM4_TORCH) as flat_loader:
+    with make_loader(
+        flat_config, version=LoaderVersion.OM4_TORCH, shuffle=False
+    ) as flat_loader:
         original_samples = [extract_sample_arrays(sample) for sample in flat_loader]
-    with make_loader(compact_config, version=LoaderVersion.OM4_TORCH) as compact_loader:
+    with make_loader(
+        compact_config, version=LoaderVersion.OM4_TORCH, shuffle=False
+    ) as compact_loader:
         new_samples = [extract_sample_arrays(sample) for sample in compact_loader]
 
     assert_equal_samples(original_samples, new_samples)

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,0 +1,81 @@
+import random
+
+from ocean_emulators.utils.samplers import EquivalenceGroupBatchSampler
+
+
+class TestEquivalenceGroupBatchSampler:
+    def test_groups_created_from_dataset_sizes(self):
+        """Groups should partition indices based on cumulative dataset boundaries."""
+        sampler = EquivalenceGroupBatchSampler.from_dataset_sizes(
+            dataset_sizes=[3, 5, 2],
+            batch_size=2,
+            shuffle=False,
+        )
+
+        assert sampler.groups == [
+            [0, 1, 2],  # first dataset: indices 0-2
+            [3, 4, 5, 6, 7],  # second dataset: indices 3-7
+            [8, 9],  # third dataset: indices 8-9
+        ]
+
+    def test_len_without_drop_last(self):
+        """Length should count all batches, including partial ones."""
+        # Group sizes: 3, 5, 2 -> batches: ceil(3/2)=2, ceil(5/2)=3, ceil(2/2)=1 = 6
+        sampler = EquivalenceGroupBatchSampler.from_dataset_sizes(
+            dataset_sizes=[3, 5, 2],
+            batch_size=2,
+            shuffle=False,
+            drop_last=False,
+        )
+        assert len(sampler) == 6
+
+    def test_len_with_drop_last(self):
+        """Length should only count complete batches when drop_last=True."""
+        # Group sizes: 3, 5, 2 -> batches: 3//2=1, 5//2=2, 2//2=1 = 4
+        sampler = EquivalenceGroupBatchSampler.from_dataset_sizes(
+            dataset_sizes=[3, 5, 2],
+            batch_size=2,
+            shuffle=False,
+            drop_last=True,
+        )
+        assert len(sampler) == 4
+
+    def test_iter_shuffle_mixes_batch_order(self):
+        batches_per_seed = []
+
+        for seed in [42, 1337, 9]:
+            random.seed(seed)
+            sampler = EquivalenceGroupBatchSampler.from_dataset_sizes(
+                # group 0: indices [0..9], group 1: indices [10..19]
+                dataset_sizes=[10, 10],
+                batch_size=2,
+                shuffle=True,
+                drop_last=False,
+            )
+            batches = list(sampler)
+            batches_per_seed.append(batches)
+
+            # Ensure that no mixing across group boundaries occurs.
+            for batch in batches:
+                if batch[0] < 10:
+                    assert all(idx < 10 for idx in batch), "Batch mixes groups"
+                else:
+                    assert all(idx >= 10 for idx in batch), "Batch mixes groups"
+
+        assert all(batches_per_seed[0] != batches for batches in batches_per_seed[1:])
+
+    def test_all_indices_covered_exactly_once(self):
+        """Each index should appear in exactly one batch (no shuffle, no drop_last)."""
+        sampler = EquivalenceGroupBatchSampler.from_dataset_sizes(
+            dataset_sizes=[3, 5],
+            batch_size=2,
+            shuffle=False,
+            drop_last=False,
+        )
+
+        all_indices = []
+        for batch in sampler:
+            all_indices.extend(batch)
+
+        # Should cover all indices 0-7
+        assert set(all_indices) == set(range(8))


### PR DESCRIPTION
Our primary data loader has been modified to differentiate between loading input + boundary vs the label, where the input and label are prognostics. By separating these concepts into two different data sources (well, a data "source" and a data "destination"), we can easily create data loading schedules that allow for training across multiple scales. 

Having "match" or "mix" schedule training examples poses a problem when we have batch sizes greater than 1: we might get mixed resolution examples in a single batch, which will break during the collate step. To address this, this PR includes a batch sampler that we recommend to be used as the default sampler implementation.