### PR TITLE
Handle loss_fn masking in one place.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -715,7 +715,6 @@ def build_loss_fn(
             )
             return GradientLoss(
                 loss_fn=loss_fn,
-                wet=wet,
                 gradient_weight=alpha,
                 pad_mode=pad_mode,
             )

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -25,47 +25,43 @@ def loss_fn_from_metric(
 ) -> LossFn:
     match metric:
         case "mse":
-            loss_fn: LossFn = partial(decomposed_mse, wet=wet)
+            loss_fn: LossFn = decomposed_mse
         case "mae":
-            loss_fn = partial(decomposed_mae, wet=wet)
+            loss_fn = decomposed_mae
         case "mse_mae":
-            loss_fn = partial(decomposed_mse_mae, wet=wet)
+            loss_fn = decomposed_mse_mae
         case "mse_diff_weighted":
-            loss_fn = partial(decomposed_mse_diff_weighted, wet=wet)
+            loss_fn = decomposed_mse_diff_weighted
         case "mse_cos_weighted":
             area_weights = np.sqrt(np.cos(np.deg2rad(y_coord))).to_numpy()
             area_weights = torch.from_numpy(area_weights).to(device=device)
-            loss_fn = partial(decomposed_mse_cos_weighted, wet=wet, cos=area_weights)
+            loss_fn = partial(decomposed_mse_cos_weighted, cos=area_weights)
         case _:
             assert_never(metric)
-    return loss_fn
+
+    def loss_fn_with_mask(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        pred = pred * wet
+        target = target * wet
+        return loss_fn(pred, target)
+
+    return loss_fn_with_mask
 
 
-def decomposed_mse(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
-) -> torch.Tensor:
+def decomposed_mse(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     """Standard MSE loss (l2) computed per channel."""
-    pred = pred * wet
-    target = target * wet
     return F.mse_loss(pred, target, reduction="none").mean(dim=(0, 2, 3))
 
 
-def decomposed_mae(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
-) -> torch.Tensor:
+def decomposed_mae(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     """Standard MAE loss (l1) computed per channel."""
-    pred = pred * wet
-    target = target * wet
     return F.l1_loss(pred, target, reduction="none").mean(dim=(0, 2, 3))
 
 
 # TODO(alxmrs): This used to assume that hist=1; it may need to be fixed in the future.
 def decomposed_mse_diff_weighted(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
+    pred: torch.Tensor, target: torch.Tensor
 ) -> torch.Tensor:
     """MSE loss with weighted differences."""
-    pred = pred * wet
-    target = target * wet
     # Compute standard MSE
     mse = F.mse_loss(pred, target, reduction="none")
 
@@ -84,11 +80,9 @@ def decomposed_mse_diff_weighted(
 
 
 def decomposed_mse_cos_weighted(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor, cos: torch.Tensor
+    pred: torch.Tensor, target: torch.Tensor, cos: torch.Tensor
 ) -> torch.Tensor:
     """MSE loss weighted by cosine of latitude."""
-    pred = pred * wet
-    target = target * wet
     weights = cos.view(1, 1, -1, 1)  # Reshape for broadcasting
     mse = F.mse_loss(pred, target, reduction="none")
     weighted_mse = mse * weights
@@ -96,22 +90,16 @@ def decomposed_mse_cos_weighted(
 
 
 def decomposed_mse_scaled(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor, scaling: torch.Tensor
+    pred: torch.Tensor, target: torch.Tensor, scaling: torch.Tensor
 ) -> torch.Tensor:
     """MSE loss with scaled residuals."""
-    pred = pred * wet
-    target = target * wet
     scaled_pred = pred * scaling.view(1, -1, 1, 1)
     scaled_target = target * scaling.view(1, -1, 1, 1)
     return F.mse_loss(scaled_pred, scaled_target, reduction="none").mean(dim=(0, 2, 3))
 
 
-def decomposed_mse_mae(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
-) -> torch.Tensor:
+def decomposed_mse_mae(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     """Combined MSE and MAE loss."""
-    pred = pred * wet
-    target = target * wet
     mse = F.mse_loss(pred, target, reduction="none")
     mae = F.l1_loss(pred, target, reduction="none")
     combined = (mse + mae) / 2
@@ -132,12 +120,9 @@ def _spatial_gradients(
 
 
 def gradient_l1_loss(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor, pad_mode: str
+    pred: torch.Tensor, target: torch.Tensor, pad_mode: str
 ) -> torch.Tensor:
     """L1 loss on spatial gradients, averaged per channel."""
-    pred = pred * wet
-    target = target * wet
-
     pred_grad_y, pred_grad_x = _spatial_gradients(pred, pad_mode=pad_mode)
     target_grad_y, target_grad_x = _spatial_gradients(target, pad_mode=pad_mode)
 
@@ -151,13 +136,12 @@ def gradient_l1_loss(
 def decomposed_mae_gradient_weighted(
     pred: torch.Tensor,
     target: torch.Tensor,
-    wet: torch.Tensor,
     gradient_weight: float,
     pad_mode: str = "constant",
 ) -> torch.Tensor:
     """MAE loss with spatial gradient matching penalty."""
-    mae_per_channel = decomposed_mae(pred, target, wet)
-    grad_loss = gradient_l1_loss(pred, target, wet, pad_mode)
+    mae_per_channel = decomposed_mae(pred, target)
+    grad_loss = gradient_l1_loss(pred, target, pad_mode)
     return mae_per_channel + gradient_weight * grad_loss
 
 
@@ -260,12 +244,10 @@ class GradientLoss:
         self,
         loss_fn: LossFn,
         *,
-        wet: Grid,
         gradient_weight: float,
         pad_mode: str,
     ):
         self.loss_fn = loss_fn
-        self._wet = wet
         self._gradient_weight = gradient_weight
         self._pad_mode = pad_mode
 
@@ -275,7 +257,5 @@ class GradientLoss:
         target: Float[torch.Tensor, "batch hist*var lat lon"],
     ) -> Float[torch.Tensor, " hist*var"]:
         base_loss = self.loss_fn(pred, target)
-        grad_loss = gradient_l1_loss(
-            pred=pred, target=target, wet=self._wet, pad_mode=self._pad_mode
-        )
+        grad_loss = gradient_l1_loss(pred=pred, target=target, pad_mode=self._pad_mode)
         return base_loss + self._gradient_weight * grad_loss


### PR DESCRIPTION
It appears we apply a wet mast at the start of every loss function (ironically, very [WET](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself#WET) code). This PR handles this logic in one place. While this may add a small amount of object overhead, this refactor will make it easier to handle multi-scale data loading. In such a scenario, the scale of the wetmask will be different depending on the "training schedule".