### PR TITLE
Introduce a cap on max ratio of DMSE weights 

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -658,9 +658,9 @@ TrainBackendConfig = Literal["cpu", "cuda", "nccl", "auto"]
 class DynamicLossConfig(pydantic.BaseModel):
     type: Literal["dynamic"] = "dynamic"
     metric: LossMetric = "mse"
-    limit: bool = Field(
-        description="For dynamic loss, should we limit the range of weighted loss by the variance. Default: off.",
-        default=False,
+    limit: float | None = Field(
+        description="The ratio of the largest weight to the smallest weight across all channels which we'll allow. Default of None means no limit.",
+        default=None,
     )
 
 
@@ -701,7 +701,7 @@ def build_loss_fn(
             return DynamicLoss(
                 loss_fn=loss_fn,
                 stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
-                should_limit=limit,
+                limit=limit,
                 device=device,
             )
         case GradientLossConfig(metric=metric, alpha=alpha):

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -691,8 +691,8 @@ def build_loss_fn(
     loss_cfg: Loss,
     wet: Grid,
     y_coord: xr.DataArray,
-    stds: xr.Dataset,
     device: torch.device,
+    num_channels: int,
     pad_mode: str,
 ) -> LossFn:
     match loss_cfg:
@@ -706,9 +706,9 @@ def build_loss_fn(
             )
             return DynamicLoss(
                 loss_fn=loss_fn,
-                stds=torch.from_numpy(stds.to_array().to_numpy()).to(device=device),
                 limit=limit,
                 device=device,
+                num_channels=num_channels,
             )
         case GradientLossConfig(metric=metric, alpha=alpha):
             loss_fn = loss_fn_from_metric(

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -666,6 +666,7 @@ class DynamicLossConfig(pydantic.BaseModel):
     limit: float | None = Field(
         description="The ratio of the largest weight to the smallest weight across all channels which we'll allow. Default of None means no limit.",
         default=None,
+        ge=1.0,
     )
 
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -215,8 +215,8 @@ class Trainer:
             cfg.loss,
             wet=self.wet,
             y_coord=self.data.lat,
-            stds=self.src.filter(self.prognostic_var_names, prefix="prog_stds").stds,
             device=self.device,
+            num_channels=self.N_prog,
             pad_mode=cfg.model.pad,
         )
 

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -225,7 +225,7 @@ class DynamicLoss:
                 self._per_channel_scale.shape[0], -1
             ).mean(dim=1)
         )
-        if self._limits:
+        if self._limits is not None:
             new_target_weights = new_target_weights.min(self._limits)
 
         if get_world_size() > 1:

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -178,7 +178,7 @@ class DynamicLoss:
         loss_fn: LossFn,
         stds: Float[torch.Tensor, " var"],
         *,
-        should_limit: bool,
+        limit: float | None,
         device: torch.device,
     ):
         self.loss_fn = loss_fn
@@ -186,11 +186,7 @@ class DynamicLoss:
         self._per_channel_scale: Float[torch.Tensor, " var"] = torch.ones(
             stds.shape[0], device=self._device
         )
-        if should_limit:
-            variances: Float[torch.Tensor, " var"] = stds.pow(2)
-            self._limits: Float[torch.Tensor, " var"] | None = 1.0 / variances
-        else:
-            self._limits = None
+        self._limit = limit
 
     def __call__(
         self,
@@ -225,11 +221,14 @@ class DynamicLoss:
                 self._per_channel_scale.shape[0], -1
             ).mean(dim=1)
         )
-        if self._limits is not None:
-            new_target_weights = new_target_weights.min(self._limits)
 
         if get_world_size() > 1:
             all_reduce_mean(new_target_weights)
+
+        if self._limit is not None:
+            min_scale = new_target_weights.min()
+            max_scale = min_scale * self._limit
+            new_target_weights = new_target_weights.clamp(min_scale, max_scale)
 
         self._per_channel_scale = (
             self._per_channel_scale * (DynamicLoss.N_WINDOW - 1) + new_target_weights

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -176,15 +176,15 @@ class DynamicLoss:
     def __init__(
         self,
         loss_fn: LossFn,
-        stds: Float[torch.Tensor, " var"],
         *,
         limit: float | None,
         device: torch.device,
+        num_channels: int,
     ):
         self.loss_fn = loss_fn
         self._device = device
         self._per_channel_scale: Float[torch.Tensor, " var"] = torch.ones(
-            stds.shape[0], device=self._device
+            num_channels, device=self._device
         )
         self._limit = limit
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -5,8 +5,10 @@ from pathlib import Path
 import pytest
 import torch
 
+from ocean_emulators.config import DynamicLossConfig
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.train import Trainer
+from ocean_emulators.utils.loss import DynamicLoss
 from ocean_emulators.utils.multiton import MultitonScope
 from tests.conftest import DEFAULT_CONFIG, TrainPair
 
@@ -57,6 +59,29 @@ def test_checkpoint_ema(train_config, caplog):
     # TODO(jder): would be nice to generalize to testing the whole trainer state,
     # or even running it forward and checking the output is identical
     assert resume_trainer._ema == e2e_trainer._ema
+
+
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("remote-om4", "test/train_default_2step.yaml")],
+    indirect=True,
+)
+def test_checkpoint_dynamic_loss_state(train_config, caplog):
+    """DynamicLoss has internal rolling state; ensure it round-trips via checkpoints."""
+    caplog.set_level(logging.INFO)
+    train_config.epochs = 1
+    train_config.save_freq = 1
+    train_config.loss = DynamicLossConfig(metric="mse", limit=100.0)
+
+    with MultitonScope():
+        e2e_trainer = Trainer(train_config)
+        assert isinstance(e2e_trainer.loss_fn, DynamicLoss)
+        e2e_trainer.run()
+        scale_before = e2e_trainer.loss_fn.loss_scale_per_channel().detach().cpu()
+
+        # Make the test meaningful: ensure at least one update away from the init value.
+        assert torch.isfinite(scale_before).all()
+        assert not torch.allclose(scale_before, torch.ones_like(scale_before))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
"Unlimited" DMSE seems to produce unwanted artifacts in rollouts due to increased variance. This lets us trade off between the positive effects of DMSE (reducing imprinting) and these negative ones. More context: https://openathena.slack.com/archives/C08CYM42DT3/p1766175789740149?thread_ts=1765824627.046769&cid=C08CYM42DT3

Note that the previous limit by stddev was in fact broken (we intended to limit by temporal stddev, not spatial as was written; again see details in the above thread).