### PR TITLE
skypilot train must use distributed backend

### DIFF
--- a/skypilot/train.sky.yaml
+++ b/skypilot/train.sky.yaml
@@ -101,5 +101,5 @@ run: |
     --experiment.data_root="${DATA_ROOT}" \
     --experiment.base_output_dir=/outputs/  \
     --experiment.wandb.mode=online \
-    --backend="cuda" \
+    --backend="nccl" \
     ${ARGS}

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -256,7 +256,7 @@ class Trainer:
         logger.info(
             f"Effective batch size: {effective_batch_size} "
             f"(batch_size={cfg.batch_size} × "
-            f"gradient_accumulation_steps={cfg.gradient_accumulation_steps} × "
+            f"gradient_accumulation_steps={cfg.gradient_accumulation_steps})"
         )
         if self.is_wandb_enabled():
             self.wandb_logger.log(


### PR DESCRIPTION
When I tried to force a non-CPU backend here I forgot that we separate "cuda" from "nccl". As a result our runs were training individually on each GPU (cc @alxmrs I think this also affected your recent multi-scale runs)

also fix a typo that's been bugging me :) 