### PR TITLE
Enable zonally-periodic upsampling for non-v1 runs

### DIFF
--- a/configs/fomo_om4/model.yaml
+++ b/configs/fomo_om4/model.yaml
@@ -26,4 +26,4 @@ processor:
     norm: "batch"
 
   down_sampling_block: "avg_pool"
-  up_sampling_block: "bilinear_upsample"
+  up_sampling_block: "zonally_periodic_upsample"

--- a/configs/samudra_om4/model.yaml
+++ b/configs/samudra_om4/model.yaml
@@ -18,7 +18,7 @@ unet:
     norm: "batch"
 
   down_sampling_block: "avg_pool"
-  up_sampling_block: "bilinear_upsample"
+  up_sampling_block: "zonally_periodic_upsample"
 
 corrector:
   non_negative_corrector_names: null

--- a/configs/test/train_default.yaml
+++ b/configs/test/train_default.yaml
@@ -17,14 +17,14 @@ resume_ckpt_path: null
 inference_epochs: [-1]
 data_percent: 1.0
 train_time:
-  start: '1975-08-15'
-  end: '1975-10-25'
+  start: "1975-08-15"
+  end: "1975-10-25"
 val_time:
-  start: '1975-10-25'
-  end: '1975-11-25'
+  start: "1975-10-25"
+  end: "1975-11-25"
 inference_times:
-  - start: '1975-11-25'
-    end: '1975-12-25'
+  - start: "1975-11-25"
+    end: "1975-12-25"
 data_stride: [1]
 steps: [1]
 step_transition: []
@@ -49,12 +49,11 @@ data:
   num_workers: 4
   hist: 0
 
-
 model:
   pred_residuals: false
   last_kernel_size: 3
   pad: "circular"
-  gradient_detach_interval: 0  # 0 means no gradient detaching (default for tests)
+  gradient_detach_interval: 0 # 0 means no gradient detaching (default for tests)
 
   unet:
     ch_width: [2, 2]
@@ -69,4 +68,4 @@ model:
       norm: "batch"
 
     down_sampling_block: "avg_pool"
-    up_sampling_block: "bilinear_upsample"
+    up_sampling_block: "zonally_periodic_upsample"

--- a/configs/test/train_default_2step.yaml
+++ b/configs/test/train_default_2step.yaml
@@ -49,7 +49,6 @@ data:
   num_workers: 4
   hist: 0
 
-
 model:
   pred_residuals: false
   last_kernel_size: 3
@@ -67,5 +66,4 @@ model:
       norm: "batch"
 
     down_sampling_block: "avg_pool"
-    up_sampling_block: "bilinear_upsample"
-
+    up_sampling_block: "zonally_periodic_upsample"

--- a/configs/test/train_fomo.yaml
+++ b/configs/test/train_fomo.yaml
@@ -17,14 +17,14 @@ resume_ckpt_path: null
 inference_epochs: [-1]
 data_percent: 1.0
 train_time:
-  start: '1975-08-15'
-  end: '1975-10-25'
+  start: "1975-08-15"
+  end: "1975-10-25"
 val_time:
-  start: '1975-10-25'
-  end: '1975-11-25'
+  start: "1975-10-25"
+  end: "1975-11-25"
 inference_times:
-  - start: '1975-11-25'
-    end: '1975-12-25'
+  - start: "1975-11-25"
+    end: "1975-12-25"
 data_stride: [1]
 steps: [1]
 step_transition: []
@@ -48,7 +48,6 @@ data:
   data_stds_location: stds.nc
   num_workers: 4
   hist: 0
-
 
 model:
   pred_residuals: false
@@ -74,4 +73,4 @@ model:
       norm: "batch"
 
     down_sampling_block: "avg_pool"
-    up_sampling_block: "bilinear_upsample"
+    up_sampling_block: "zonally_periodic_upsample"

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -413,7 +413,7 @@ class UNetBackboneConfig(BaseConfig):
     n_layers: list[int] = [1, 1, 1, 1]
     core_block: BlockConfig = BlockConfig()
     down_sampling_block: DownSamplingBlocks = "avg_pool"
-    up_sampling_block: UpSamplingBlocks = "bilinear_upsample"
+    up_sampling_block: UpSamplingBlocks = "zonally_periodic_upsample"
 
     def build(
         self,

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -60,28 +60,20 @@ class ZonallyPeriodicBilinearUpsample(torch.nn.Module):
         self.scale_h, self.scale_w = upsampling
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # First upsample along latitude/height using standard "bilinear" interpolation.
-        # (This is just linear interpolation but pytorch requires us to use "bilinear" for
-        # 2d data.)
-        up_height = torch.nn.functional.interpolate(
-            x,
-            scale_factor=(self.scale_h, 1),
+        # Upsample with periodic padding along longitude to avoid seams and
+        # keep interpolation aligned with PyTorch's bilinear sampling grid.
+        width = x.shape[-1]
+        padded = torch.nn.functional.pad(x, (1, 1, 0, 0), mode="circular")
+        upsampled = torch.nn.functional.interpolate(
+            padded,
+            scale_factor=(self.scale_h, self.scale_w),
             mode="bilinear",
+            align_corners=False,
         )
-
-        # Then upsample along longitude/width using a circular 1D linear interpolation.
-        left = up_height
-        right = torch.roll(up_height, shifts=-1, dims=-1)
-        midpoint = 0.5 * (left + right)
-
-        out = torch.empty(
-            (*up_height.shape[:-1], up_height.shape[-1] * self.scale_w),
-            dtype=up_height.dtype,
-            device=up_height.device,
-        )
-        out[..., ::2] = left
-        out[..., 1::2] = midpoint
-        return out
+        # Crop out the extra padded columns (scaled by the upsampling factor).
+        start = self.scale_w
+        end = start + width * self.scale_w
+        return upsampled[..., start:end]
 
 
 class AvgPool(torch.nn.Module):


### PR DESCRIPTION
I re-ran some comparisons in #506 and can confirm that at least at 1-degree, the bilinear upsample has an artifact at lon=0 but this one does not. Here is an example of a (doctored to increase contrast) run with the artifact in a zos snapshot:
<img width="221" height="482" alt="Screenshot 2026-01-22 at 5 10 33 PM" src="https://github.com/user-attachments/assets/fd018f76-b186-43c2-8fbd-7b163b26d32d" />

And the next identical one with the new upsampling and no artifact:
<img width="179" height="258" alt="Screenshot 2026-01-22 at 5 11 32 PM" src="https://github.com/user-attachments/assets/0f110ec9-fe13-4ec8-b0d3-b17414c8962f" />

I also replaced the upsampling with a simpler approach that does less funny stuff and is hopefully more obviously correct. 