### PR TITLE
Apply wet mask to loss function late.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -44,7 +44,7 @@ from ocean_emulators.utils.location import LocalLocation, Location, ResolvedLoca
 from ocean_emulators.utils.loss import (
     DynamicLoss,
     GradientLoss,
-    LossFn,
+    LossFnWithMask,
     LossMetric,
     loss_fn_from_metric,
 )
@@ -721,21 +721,16 @@ Loss = LossMetric | DynamicLossConfig | GradientLossConfig
 
 def build_loss_fn(
     loss_cfg: Loss,
-    wet: Grid,
     y_coord: xr.DataArray,
     device: torch.device,
     num_channels: int,
     pad_mode: str,
-) -> LossFn:
+) -> LossFnWithMask:
     match loss_cfg:
         case str():
-            return loss_fn_from_metric(
-                loss_cfg, wet=wet, y_coord=y_coord, device=device
-            )
+            return loss_fn_from_metric(loss_cfg, y_coord=y_coord, device=device)
         case DynamicLossConfig(metric=metric, limit=limit):
-            loss_fn = loss_fn_from_metric(
-                metric, wet=wet, y_coord=y_coord, device=device
-            )
+            loss_fn = loss_fn_from_metric(metric, y_coord=y_coord, device=device)
             return DynamicLoss(
                 loss_fn=loss_fn,
                 limit=limit,
@@ -743,12 +738,9 @@ def build_loss_fn(
                 num_channels=num_channels,
             )
         case GradientLossConfig(metric=metric, alpha=alpha):
-            loss_fn = loss_fn_from_metric(
-                metric, wet=wet, y_coord=y_coord, device=device
-            )
+            loss_fn = loss_fn_from_metric(metric, y_coord=y_coord, device=device)
             return GradientLoss(
                 loss_fn=loss_fn,
-                wet=wet,
                 gradient_weight=alpha,
                 pad_mode=pad_mode,
             )

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -293,8 +293,9 @@ class InferenceDatasets(Dataset):
 
 
 class RawTrainData:
-    def __init__(self, dataset_id: "TorchTrainDataset.Id"):
+    def __init__(self, dataset_id: "TorchTrainDataset.Id", label_mask: PrognosticMask):
         self.dataset_id: TorchTrainDataset.Id = dataset_id
+        self.label_mask = label_mask
         self.raw_data: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
         self.load_stats: LoadStats | None = None
 
@@ -340,8 +341,9 @@ class TrainData:
     remaining bottom channels are boundary forcings.
     """
 
-    def __init__(self, num_prognostic_channels: int):
+    def __init__(self, num_prognostic_channels: int, label_mask: PrognosticMask):
         self.num_prognostic_channels = num_prognostic_channels
+        self.label_mask = label_mask
         self.example_by_step: list[Example] = []
         self.load_stats: LoadStats | None = None
 
@@ -511,7 +513,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     @elapsed(level=logging.DEBUG)
     def __getitem__(self, idx: int):
         start_time = time.perf_counter()
-        TD = RawTrainData(self.id)
+        TD = RawTrainData(
+            self.id, self._label_src.masks.prognostic_with_hist(self.hist)
+        )
 
         for step in range(self.steps):
             x_index = self._get_x_index(idx, step)
@@ -564,7 +568,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         return TD
 
     def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
-        train_data = TrainData(self.num_prognostic_channels)
+        train_data = TrainData(self.num_prognostic_channels, raw_train_data.label_mask)
         for input_, boundary, label in raw_train_data.raw_data:
             input_, label = self._to_example(
                 input_.to(device=self.device, non_blocking=True),

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -514,7 +514,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def __getitem__(self, idx: int):
         start_time = time.perf_counter()
         TD = RawTrainData(
-            self.id, self._label_src.masks.prognostic_with_hist(self.hist)
+            self.id, self._prognostic_srcs[-1].masks.prognostic_with_hist(self.hist)
         )
 
         for step in range(self.steps):

--- a/src/ocean_emulators/stepper.py
+++ b/src/ocean_emulators/stepper.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Callable
+from functools import partial
 from os import PathLike
 
 logger = logging.getLogger(__name__)
@@ -27,7 +28,7 @@ class Stepper:
     def train_batch(
         model: torch.nn.Module, batch: TrainData, loss_fn: Callable
     ) -> TrainBatchOutput:
-        loss_per_channel = model(batch, loss_fn=loss_fn)
+        loss_per_channel = model(batch, loss_fn=partial(loss_fn, wet=batch.label_mask))
         loss = torch.mean(loss_per_channel)
         return TrainBatchOutput(loss, loss_per_channel)
 
@@ -49,7 +50,7 @@ class Stepper:
             else model
         )
         outs = model.forward_once(input)
-        loss_per_channel = loss_fn(outs, label)
+        loss_per_channel = loss_fn(outs, label, wet=batch.label_mask)
         loss = torch.mean(loss_per_channel)
         return ValBatchOutput(loss, loss_per_channel, input, label, outs)
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -74,7 +74,7 @@ from ocean_emulators.utils.logging import (
     handle_logging,
     handle_warnings,
 )
-from ocean_emulators.utils.loss import LossFn
+from ocean_emulators.utils.loss import LossFnWithMask
 from ocean_emulators.utils.train import (
     CheckpointPaths,
     collate_inference_data,
@@ -217,10 +217,9 @@ class Trainer:
         self.network = self.model.__class__.__name__
 
         # Loss function
-        self.loss_fn: LossFn = build_loss_fn(
+        self.loss_fn: LossFnWithMask = build_loss_fn(
             cfg.loss,
-            wet=self.wet,
-            y_coord=self.data.lat,
+            y_coord=self.data.lat,  # TODO(alxmrs): Needs to be label lat vals. Remove?
             device=self.device,
             num_channels=self.N_prog,
             pad_mode=cfg.model.pad,
@@ -507,7 +506,8 @@ class Trainer:
                 r = self.gradient_accumulation_steps
 
             if self.num_batches_seen == 0:
-                get_model_summary(self.model, data, self.debug)
+                # Pass None since TrainData is not compatible with torchinfo's traversal
+                get_model_summary(self.model, None, self.debug)
 
             TO: TrainBatchOutput = Stepper.train_batch(self.model, data, self.loss_fn)
 
@@ -611,12 +611,14 @@ class Trainer:
         # This is a separate function to ensure locals are dropped immediately after use
         if update := getattr(self.loss_fn, "update", None):
             with torch.no_grad():
-                single_step_data = TrainData(data.num_prognostic_channels)
+                single_step_data = TrainData(
+                    data.num_prognostic_channels, data.label_mask
+                )
                 # Each entry in data is one step in a rollout.
                 input, label = data[0]
                 single_step_data.append(input, label)
                 pred = self.model(single_step_data)
-                update(pred[0], label)
+                update(pred[0], label, wet=data.label_mask)
 
     def validate_one_epoch(self, epoch):
         self.model.eval()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -506,8 +506,7 @@ class Trainer:
                 r = self.gradient_accumulation_steps
 
             if self.num_batches_seen == 0:
-                # Pass None since TrainData is not compatible with torchinfo's traversal
-                get_model_summary(self.model, None, self.debug)
+                get_model_summary(self.model, data, self.debug)
 
             TO: TrainBatchOutput = Stepper.train_batch(self.model, data, self.loss_fn)
 

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -8,16 +8,18 @@ import traceback
 import warnings
 from collections import defaultdict, deque
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
+from torch.nn.parallel import DistributedDataParallel
 from torchinfo import summary
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ocean_emulators.datasets import TrainDataLoader
+    from ocean_emulators.datasets import TrainData, TrainDataLoader
+    from ocean_emulators.models.base import BaseModel
 
 
 def handle_logging(debug: bool, output_dir: Path):
@@ -215,14 +217,40 @@ class MetricLogger:
         )
 
 
-def get_model_summary(model: torch.nn.Module, data: Any, debug: bool):
+class _ForwardOnceWrapper(torch.nn.Module):
+    """Wrapper that redirects forward() to forward_once() for torchinfo summary."""
+
+    def __init__(self, model: "BaseModel | DistributedDataParallel") -> None:
+        super().__init__()
+        self._underlying: BaseModel = getattr(model, "module", model)  # type: ignore
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Get the underlying model (handles DDP wrapping)
+        return self._underlying.forward_once(x)
+
+
+def get_model_summary(
+    model: "BaseModel | DistributedDataParallel", data: "TrainData | None", debug: bool
+) -> None:
     model_parameters = filter(lambda p: p.requires_grad, model.parameters())
     params = sum([np.prod(p.size()) for p in model_parameters])
     logger.info(f"Number of parameters: {params}")
     depth = 10 if debug else 2
     # we pass verbose = 0 because we log the summary ourselves
     if data is not None:
-        logger.info(summary(model, input_data=[data], depth=depth, verbose=0))
+        # TrainData is a complex wrapper that torchinfo cannot traverse.
+        # Extract the initial tensor and wrap the model to use forward_once.
+        input_tensor = data.get_initial_input()
+        # Wrap model to use forward_once for the summary
+        wrapper = _ForwardOnceWrapper(model)
+        logger.info(
+            summary(
+                wrapper,
+                input_data=[input_tensor],
+                depth=depth,
+                verbose=0,
+            )
+        )
     else:
         logger.info(summary(model, depth=depth, verbose=0))
 

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -8,9 +8,10 @@ import torch.nn.functional as F
 import xarray as xr
 from jaxtyping import Float
 
-from ocean_emulators.constants import Grid
+from ocean_emulators.constants import PrognosticMask
 
 LossFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+LossFnWithMask = Callable[[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor]
 LossMetric = Literal[
     "mse",
     "mae",
@@ -21,51 +22,50 @@ LossMetric = Literal[
 
 
 def loss_fn_from_metric(
-    metric: LossMetric, *, wet: Grid, y_coord: xr.DataArray, device: torch.device
-) -> LossFn:
+    metric: LossMetric, *, y_coord: xr.DataArray, device: torch.device
+) -> LossFnWithMask:
     match metric:
         case "mse":
-            loss_fn: LossFn = partial(decomposed_mse, wet=wet)
+            loss_fn: LossFn = decomposed_mse
         case "mae":
-            loss_fn = partial(decomposed_mae, wet=wet)
+            loss_fn = decomposed_mae
         case "mse_mae":
-            loss_fn = partial(decomposed_mse_mae, wet=wet)
+            loss_fn = decomposed_mse_mae
         case "mse_diff_weighted":
-            loss_fn = partial(decomposed_mse_diff_weighted, wet=wet)
+            loss_fn = decomposed_mse_diff_weighted
         case "mse_cos_weighted":
             area_weights = np.sqrt(np.cos(np.deg2rad(y_coord))).to_numpy()
             area_weights = torch.from_numpy(area_weights).to(device=device)
-            loss_fn = partial(decomposed_mse_cos_weighted, wet=wet, cos=area_weights)
+            loss_fn = partial(decomposed_mse_cos_weighted, cos=area_weights)
         case _:
             assert_never(metric)
-    return loss_fn
+
+    def loss_fn_with_mask(
+        pred: torch.Tensor, target: torch.Tensor, wet: PrognosticMask
+    ) -> torch.Tensor:
+        wet = wet.to(device=pred.device)
+        pred = pred * wet
+        target = target * wet
+        return loss_fn(pred, target)
+
+    return loss_fn_with_mask
 
 
-def decomposed_mse(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
-) -> torch.Tensor:
+def decomposed_mse(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     """Standard MSE loss (l2) computed per channel."""
-    pred = pred * wet
-    target = target * wet
     return F.mse_loss(pred, target, reduction="none").mean(dim=(0, 2, 3))
 
 
-def decomposed_mae(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
-) -> torch.Tensor:
+def decomposed_mae(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     """Standard MAE loss (l1) computed per channel."""
-    pred = pred * wet
-    target = target * wet
     return F.l1_loss(pred, target, reduction="none").mean(dim=(0, 2, 3))
 
 
 # TODO(alxmrs): This used to assume that hist=1; it may need to be fixed in the future.
 def decomposed_mse_diff_weighted(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
+    pred: torch.Tensor, target: torch.Tensor
 ) -> torch.Tensor:
     """MSE loss with weighted differences."""
-    pred = pred * wet
-    target = target * wet
     # Compute standard MSE
     mse = F.mse_loss(pred, target, reduction="none")
 
@@ -84,11 +84,9 @@ def decomposed_mse_diff_weighted(
 
 
 def decomposed_mse_cos_weighted(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor, cos: torch.Tensor
+    pred: torch.Tensor, target: torch.Tensor, cos: torch.Tensor
 ) -> torch.Tensor:
     """MSE loss weighted by cosine of latitude."""
-    pred = pred * wet
-    target = target * wet
     weights = cos.view(1, 1, -1, 1)  # Reshape for broadcasting
     mse = F.mse_loss(pred, target, reduction="none")
     weighted_mse = mse * weights
@@ -96,22 +94,16 @@ def decomposed_mse_cos_weighted(
 
 
 def decomposed_mse_scaled(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor, scaling: torch.Tensor
+    pred: torch.Tensor, target: torch.Tensor, scaling: torch.Tensor
 ) -> torch.Tensor:
     """MSE loss with scaled residuals."""
-    pred = pred * wet
-    target = target * wet
     scaled_pred = pred * scaling.view(1, -1, 1, 1)
     scaled_target = target * scaling.view(1, -1, 1, 1)
     return F.mse_loss(scaled_pred, scaled_target, reduction="none").mean(dim=(0, 2, 3))
 
 
-def decomposed_mse_mae(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor
-) -> torch.Tensor:
+def decomposed_mse_mae(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
     """Combined MSE and MAE loss."""
-    pred = pred * wet
-    target = target * wet
     mse = F.mse_loss(pred, target, reduction="none")
     mae = F.l1_loss(pred, target, reduction="none")
     combined = (mse + mae) / 2
@@ -132,12 +124,9 @@ def _spatial_gradients(
 
 
 def gradient_l1_loss(
-    pred: torch.Tensor, target: torch.Tensor, wet: torch.Tensor, pad_mode: str
+    pred: torch.Tensor, target: torch.Tensor, pad_mode: str
 ) -> torch.Tensor:
     """L1 loss on spatial gradients, averaged per channel."""
-    pred = pred * wet
-    target = target * wet
-
     pred_grad_y, pred_grad_x = _spatial_gradients(pred, pad_mode=pad_mode)
     target_grad_y, target_grad_x = _spatial_gradients(target, pad_mode=pad_mode)
 
@@ -151,13 +140,12 @@ def gradient_l1_loss(
 def decomposed_mae_gradient_weighted(
     pred: torch.Tensor,
     target: torch.Tensor,
-    wet: torch.Tensor,
     gradient_weight: float,
     pad_mode: str = "constant",
 ) -> torch.Tensor:
     """MAE loss with spatial gradient matching penalty."""
-    mae_per_channel = decomposed_mae(pred, target, wet)
-    grad_loss = gradient_l1_loss(pred, target, wet, pad_mode)
+    mae_per_channel = decomposed_mae(pred, target)
+    grad_loss = gradient_l1_loss(pred, target, pad_mode)
     return mae_per_channel + gradient_weight * grad_loss
 
 
@@ -175,7 +163,7 @@ class DynamicLoss:
 
     def __init__(
         self,
-        loss_fn: LossFn,
+        loss_fn: LossFnWithMask,
         *,
         limit: float | None,
         device: torch.device,
@@ -192,9 +180,10 @@ class DynamicLoss:
         self,
         pred: Float[torch.Tensor, "batch hist*var lat lon"],
         target: Float[torch.Tensor, "batch hist*var lat lon"],
+        wet: PrognosticMask,
     ) -> Float[torch.Tensor, " hist*var"]:
         loss_with_history_channels: Float[torch.Tensor, " hist*var"] = self.loss_fn(
-            pred, target
+            pred, target, wet
         )
         # Channels are time-major: (hist+1) * var.
         scaled_loss_including_history_dimension: Float[torch.Tensor, "hist var"] = (
@@ -207,12 +196,13 @@ class DynamicLoss:
         self,
         pred: Float[torch.Tensor, "batch hist*var lat lon"],
         target: Float[torch.Tensor, "batch hist*var lat lon"],
+        wet: PrognosticMask,
     ) -> None:
         """Given the prediction & target for this step, update the per-channel scale."""
         # Local import is needed to prevent a circular import error.
         from ocean_emulators.utils.distributed import all_reduce_mean, get_world_size
 
-        loss = self.loss_fn(pred, target)
+        loss = self.loss_fn(pred, target, wet)
         loss = torch.where(loss == 0, 1e-8, loss)
         new_target_weights_with_history: Float[torch.Tensor, " hist*var"] = 1.0 / loss
         # Reshape from channels * history to channels
@@ -258,14 +248,12 @@ class GradientLoss:
 
     def __init__(
         self,
-        loss_fn: LossFn,
+        loss_fn: LossFnWithMask,
         *,
-        wet: Grid,
         gradient_weight: float,
         pad_mode: str,
     ):
         self.loss_fn = loss_fn
-        self._wet = wet
         self._gradient_weight = gradient_weight
         self._pad_mode = pad_mode
 
@@ -273,9 +261,12 @@ class GradientLoss:
         self,
         pred: Float[torch.Tensor, "batch hist*var lat lon"],
         target: Float[torch.Tensor, "batch hist*var lat lon"],
+        wet: PrognosticMask,
     ) -> Float[torch.Tensor, " hist*var"]:
-        base_loss = self.loss_fn(pred, target)
-        grad_loss = gradient_l1_loss(
-            pred=pred, target=target, wet=self._wet, pad_mode=self._pad_mode
-        )
+        base_loss = self.loss_fn(pred, target, wet)
+        # Ensure mask is on the same device as pred for gradient computation
+        wet = wet.to(device=pred.device)
+        pred = pred * wet
+        target = target * wet
+        grad_loss = gradient_l1_loss(pred=pred, target=target, pad_mode=self._pad_mode)
         return base_loss + self._gradient_weight * grad_loss

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from functools import partial
-from typing import Literal, assert_never
+from typing import Literal, Protocol, assert_never
 
 import numpy as np
 import torch
@@ -11,7 +11,14 @@ from jaxtyping import Float
 from ocean_emulators.constants import PrognosticMask
 
 LossFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
-LossFnWithMask = Callable[[torch.Tensor, torch.Tensor, torch.Tensor], torch.Tensor]
+
+
+class LossFnWithMask(Protocol):
+    def __call__(
+        self, pred: torch.Tensor, target: torch.Tensor, wet: PrognosticMask
+    ) -> torch.Tensor: ...
+
+
 LossMetric = Literal[
     "mse",
     "mae",

--- a/src/ocean_emulators/utils/train.py
+++ b/src/ocean_emulators/utils/train.py
@@ -17,7 +17,7 @@ def pairwise(iterable):
 
 
 def collate_raw_train_data(data: Sequence[RawTrainData]) -> RawTrainData:
-    batched_data = RawTrainData(data[0].dataset_id)
+    batched_data = RawTrainData(data[0].dataset_id, data[0].label_mask)
     assert all(d.dataset_id == batched_data.dataset_id for d in data), (
         "we don't support heterogenous batches yet"
     )

--- a/tests/test_gradient_detaching.py
+++ b/tests/test_gradient_detaching.py
@@ -77,7 +77,9 @@ def create_samudra_model():
             )
 
             # Create TrainData compatible with model dimensions
-            train_data = TrainData(num_prognostic_channels=1)
+            train_data = TrainData(
+                num_prognostic_channels=1, label_mask=masks.prognostic
+            )
             for step in range(4):
                 input_tensor = torch.randn(1, 2, h, w, requires_grad=True)
                 label_tensor = torch.randn(1, 1, h, w)


### PR DESCRIPTION
To prepare for multi-scale training, we need to properly handle masking. In our loss function, making was previously done eagerly. This won't work when training on multiple scales, because the output resolution will differ based on the training schedule. Thus, this change applies masking late. To accomplish this, we make the label mask a primary property of TrainData and RawTrainData. 

This supersedes #531.