### PR TITLE
Fix performance regression introduced by new multi modal data loader.

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -436,7 +436,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
 
-        # If the src and dst DataSource are the same, we can skip one set of normalizations.
+        # If the src and dst DataSource are the same, we can do a lot less work.
         self.independent_label = src != dst
 
         self.hist: int = hist

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -435,9 +435,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         super().__init__()
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
-
         # If the src and dst DataSource are the same, we can do a lot less work.
-        self.independent_label = src != dst
+        srcs = [src] if src is dst else [src, dst]
 
         self.hist: int = hist
         self.steps: int = steps
@@ -451,11 +450,10 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             "src and dst DataSource have different time slices!"
         )
         time_ = src.data.time
-        self._input_src = src.filter(prognostic_var_names, prefix="input")
+        self._prognostic_srcs = [
+            src.filter(prognostic_var_names, prefix="prog") for src in srcs
+        ]
         self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
-        self._label_src = self._input_src
-        if self.independent_label:
-            self._label_src = dst.filter(prognostic_var_names, prefix="label")
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
@@ -475,11 +473,10 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
-        self.wet_input: PrognosticMask = src.masks.prognostic.to(self.device)
+        self.wet_prognostic: list[PrognosticMask] = [
+            src.masks.prognostic.to(self.device) for src in srcs
+        ]
         self.wet_surface: GridMask = src.masks.boundary.to(self.device)
-        self.wet_label: PrognosticMask = self.wet_input
-        if self.independent_label:
-            self.wet_label = dst.masks.prognostic.to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
             if "lev" in means_or_stds.dims:
@@ -492,17 +489,15 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 array = means_or_stds.to_dataarray()
             return torch.from_numpy(array.to_numpy().flatten()).to(self.device)
 
-        self.input_means = flatten_to_device(self._input_src.means)
-        self.input_stds = flatten_to_device(self._input_src.stds)
+        self.prognostic_means = [
+            flatten_to_device(src.means) for src in self._prognostic_srcs
+        ]
+        self.prognostic_stds = [
+            flatten_to_device(dst.stds) for dst in self._prognostic_srcs
+        ]
 
         self.boundary_means = flatten_to_device(self._boundary_src.means)
         self.boundary_stds = flatten_to_device(self._boundary_src.stds)
-
-        self.label_means = self.input_means
-        self.label_stds = self.input_stds
-        if self.independent_label:
-            self.label_means = flatten_to_device(self._label_src.means)
-            self.label_stds = flatten_to_device(self._label_src.stds)
 
         self.size: int = (
             time_.size
@@ -520,37 +515,23 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         for step in range(self.steps):
             x_index = self._get_x_index(idx, step)
-            input_selected = self._input_src.data.isel(time=x_index)
+            prognostic_selected = [
+                src.data.isel(time=x_index) for src in self._prognostic_srcs
+            ]
             boundary_selected = self._boundary_src.data.isel(time=x_index)
-            label_selected = input_selected
-            if self.independent_label:
-                label_selected = self._label_src.data.isel(time=x_index)
 
             if self._executor is not None:
-                datasets = [input_selected, boundary_selected]
-                if self.independent_label:
-                    datasets.append(label_selected)
+                datasets = prognostic_selected + [boundary_selected]
                 concurrent_compute(
                     *datasets,
                     executor=self._executor,
                 )
 
-            if "lev" in input_selected.dims:
-                input_ = torch.from_numpy(
-                    conditional_rearrange(
-                        input_selected,
-                        "time (variable lev)=var lat lon",
-                        concat_dim="var",
-                    )
-                    .rename({"var": "variable"})
-                    .to_numpy()
-                    .astype(np.float32, copy=False)
-                )
-                label = input_
-                if self.independent_label:
-                    label = torch.from_numpy(
+            if "lev" in prognostic_selected[0].dims:
+                prognostics = [
+                    torch.from_numpy(
                         conditional_rearrange(
-                            label_selected,
+                            prog,
                             "time (variable lev)=var lat lon",
                             concat_dim="var",
                         )
@@ -558,27 +539,25 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                         .to_numpy()
                         .astype(np.float32, copy=False)
                     )
+                    for prog in prognostic_selected
+                ]
             else:
-                input_ = torch.from_numpy(
-                    input_selected.to_array()
-                    .transpose("time", "variable", "lat", "lon")
-                    .to_numpy()
-                    .astype(np.float32, copy=False)
-                )
-                label = input_
-                if self.independent_label:
-                    label = torch.from_numpy(
-                        label_selected.to_array()
+                prognostics = [
+                    torch.from_numpy(
+                        prog.to_array()
                         .transpose("time", "variable", "lat", "lon")
                         .to_numpy()
                         .astype(np.float32, copy=False)
                     )
+                    for prog in prognostic_selected
+                ]
             boundary = torch.from_numpy(
                 boundary_selected.to_array()
                 .transpose("time", "variable", "lat", "lon")
                 .to_numpy()
                 .astype(np.float32, copy=False)
             )
+            input_, label = prognostics[0], prognostics[-1]
             TD.insert(input_, boundary, label)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
@@ -587,15 +566,11 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
         train_data = TrainData(self.num_prognostic_channels)
         for input_, boundary, label in raw_train_data.raw_data:
-            input_ = input_.to(device=self.device, non_blocking=True)
-            if self.independent_label:
-                label = label.to(device=self.device, non_blocking=True)
-            else:
-                label = input_
             input_, label = self._to_example(
-                input_,
+                input_.to(device=self.device, non_blocking=True),
                 boundary.to(device=self.device, non_blocking=True),
-                label,
+                # If this is the same as input_, `to` should return without copying.
+                label.to(device=self.device, non_blocking=True),
             )
             train_data.append(input_, label)
         train_data.load_stats = raw_train_data.load_stats
@@ -611,17 +586,17 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         # grab past steps and prep for model
         total_input = self._prep_tensor_steps(
             input_[:, : self.hist + 1, :, :, :],
-            self.input_means,
-            self.input_stds,
-            self.wet_input,
+            self.prognostic_means[0],
+            self.prognostic_stds[0],
+            self.wet_prognostic[0],
             boundary[:, : self.hist + 1, :, :, :],
         )
         # grab future steps, repeat as we do for input
         label = self._prep_tensor_steps(
             label[:, self.hist + 1 :, :, :, :],
-            self.label_means,
-            self.label_stds,
-            self.wet_label,
+            self.prognostic_means[-1],
+            self.prognostic_stds[-1],
+            self.wet_prognostic[-1],
         )
         return total_input, label
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -588,9 +588,10 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         train_data = TrainData(self.num_prognostic_channels)
         for input_, boundary, label in raw_train_data.raw_data:
             input_ = input_.to(device=self.device, non_blocking=True)
-            label = input_
             if self.independent_label:
                 label = label.to(device=self.device, non_blocking=True)
+            else:
+                label = input_
             input_, label = self._to_example(
                 input_,
                 boundary.to(device=self.device, non_blocking=True),

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -453,9 +453,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         time_ = src.data.time
         self._input_src = src.filter(prognostic_var_names, prefix="input")
         self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
-        if self.enable_input_only_opt:
-            self._label_src = self._input_src
-        else:
+        self._label_src = self._input_src
+        if not self.enable_input_only_opt:
             self._label_src = dst.filter(prognostic_var_names, prefix="label")
 
         # This class will be used only for training and validation
@@ -478,9 +477,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         self.wet_input: PrognosticMask = src.masks.prognostic.to(self.device)
         self.wet_surface: GridMask = src.masks.boundary.to(self.device)
-        if self.enable_input_only_opt:
-            self.wet_label: PrognosticMask = self.wet_input
-        else:
+        self.wet_label: PrognosticMask = self.wet_input
+        if not self.enable_input_only_opt:
             self.wet_label = dst.masks.prognostic.to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
@@ -500,10 +498,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.boundary_means = flatten_to_device(self._boundary_src.means)
         self.boundary_stds = flatten_to_device(self._boundary_src.stds)
 
-        if self.enable_input_only_opt:
-            self.label_means = self.input_means
-            self.label_stds = self.input_stds
-        else:
+        self.label_means = self.input_means
+        self.label_stds = self.input_stds
+        if not self.enable_input_only_opt:
             self.label_means = flatten_to_device(self._label_src.means)
             self.label_stds = flatten_to_device(self._label_src.stds)
 
@@ -549,6 +546,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .to_numpy()
                     .astype(np.float32, copy=False)
                 )
+                label = input_
                 if not self.enable_input_only_opt:
                     label = torch.from_numpy(
                         conditional_rearrange(
@@ -567,6 +565,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .to_numpy()
                     .astype(np.float32, copy=False)
                 )
+                label = input_
                 if not self.enable_input_only_opt:
                     label = torch.from_numpy(
                         label_selected.to_array()
@@ -580,9 +579,6 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 .to_numpy()
                 .astype(np.float32, copy=False)
             )
-
-            if self.enable_input_only_opt:
-                label = input_
             TD.insert(input_, boundary, label)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
@@ -592,12 +588,14 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         train_data = TrainData(self.num_prognostic_channels)
         for input_, boundary, label in raw_train_data.raw_data:
             input_ = input_.to(device=self.device, non_blocking=True)
-            boundary = boundary.to(device=self.device, non_blocking=True)
-            if self.enable_input_only_opt:
-                label = input_
-            else:
+            label = input_
+            if not self.enable_input_only_opt:
                 label = label.to(device=self.device, non_blocking=True)
-            input_, label = self._to_example(input_, boundary, label)
+            input_, label = self._to_example(
+                input_,
+                boundary.to(device=self.device, non_blocking=True),
+                label,
+            )
             train_data.append(input_, label)
         train_data.load_stats = raw_train_data.load_stats
         return train_data

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -436,6 +436,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
 
+        # If the src and dst DataSource are the same, we can skip one set of normalizations.
+        self.enable_input_only_opt = src == dst
+
         self.hist: int = hist
         self.steps: int = steps
         self.stride: int = stride
@@ -450,7 +453,10 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         time_ = src.data.time
         self._input_src = src.filter(prognostic_var_names, prefix="input")
         self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
-        self._label_src = dst.filter(prognostic_var_names, prefix="label")
+        if self.enable_input_only_opt:
+            self._label_src = self._input_src
+        else:
+            self._label_src = dst.filter(prognostic_var_names, prefix="label")
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
@@ -472,7 +478,10 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         self.wet_input: PrognosticMask = src.masks.prognostic.to(self.device)
         self.wet_surface: GridMask = src.masks.boundary.to(self.device)
-        self.wet_label: PrognosticMask = dst.masks.prognostic.to(self.device)
+        if self.enable_input_only_opt:
+            self.wet_label: PrognosticMask = self.wet_input
+        else:
+            self.wet_label = dst.masks.prognostic.to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
             if "lev" in means_or_stds.dims:
@@ -491,8 +500,12 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.boundary_means = flatten_to_device(self._boundary_src.means)
         self.boundary_stds = flatten_to_device(self._boundary_src.stds)
 
-        self.label_means = flatten_to_device(self._label_src.means)
-        self.label_stds = flatten_to_device(self._label_src.stds)
+        if self.enable_input_only_opt:
+            self.label_means = self.input_means
+            self.label_stds = self.input_stds
+        else:
+            self.label_means = flatten_to_device(self._label_src.means)
+            self.label_stds = flatten_to_device(self._label_src.stds)
 
         self.size: int = (
             time_.size
@@ -512,13 +525,16 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             x_index = self._get_x_index(idx, step)
             input_selected = self._input_src.data.isel(time=x_index)
             boundary_selected = self._boundary_src.data.isel(time=x_index)
-            label_selected = self._label_src.data.isel(time=x_index)
+            label_selected = input_selected
+            if not self.enable_input_only_opt:
+                label_selected = self._label_src.data.isel(time=x_index)
 
             if self._executor is not None:
+                datasets = [input_selected, boundary_selected]
+                if not self.enable_input_only_opt:
+                    datasets.append(label_selected)
                 concurrent_compute(
-                    input_selected,
-                    boundary_selected,
-                    label_selected,
+                    *datasets,
                     executor=self._executor,
                 )
 
@@ -533,16 +549,17 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .to_numpy()
                     .astype(np.float32, copy=False)
                 )
-                label = torch.from_numpy(
-                    conditional_rearrange(
-                        label_selected,
-                        "time (variable lev)=var lat lon",
-                        concat_dim="var",
+                if not self.enable_input_only_opt:
+                    label = torch.from_numpy(
+                        conditional_rearrange(
+                            label_selected,
+                            "time (variable lev)=var lat lon",
+                            concat_dim="var",
+                        )
+                        .rename({"var": "variable"})
+                        .to_numpy()
+                        .astype(np.float32, copy=False)
                     )
-                    .rename({"var": "variable"})
-                    .to_numpy()
-                    .astype(np.float32, copy=False)
-                )
             else:
                 input_ = torch.from_numpy(
                     input_selected.to_array()
@@ -550,12 +567,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .to_numpy()
                     .astype(np.float32, copy=False)
                 )
-                label = torch.from_numpy(
-                    label_selected.to_array()
-                    .transpose("time", "variable", "lat", "lon")
-                    .to_numpy()
-                    .astype(np.float32, copy=False)
-                )
+                if not self.enable_input_only_opt:
+                    label = torch.from_numpy(
+                        label_selected.to_array()
+                        .transpose("time", "variable", "lat", "lon")
+                        .to_numpy()
+                        .astype(np.float32, copy=False)
+                    )
             boundary = torch.from_numpy(
                 boundary_selected.to_array()
                 .transpose("time", "variable", "lat", "lon")
@@ -563,6 +581,8 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 .astype(np.float32, copy=False)
             )
 
+            if self.enable_input_only_opt:
+                label = input_
             TD.insert(input_, boundary, label)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
@@ -571,11 +591,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
         train_data = TrainData(self.num_prognostic_channels)
         for input_, boundary, label in raw_train_data.raw_data:
-            input_, label = self._to_example(
-                input_.to(device=self.device, non_blocking=True),
-                boundary.to(device=self.device, non_blocking=True),
-                label.to(device=self.device, non_blocking=True),
-            )
+            input_ = input_.to(device=self.device, non_blocking=True)
+            boundary = boundary.to(device=self.device, non_blocking=True)
+            if self.enable_input_only_opt:
+                label = input_
+            else:
+                label = label.to(device=self.device, non_blocking=True)
+            input_, label = self._to_example(input_, boundary, label)
             train_data.append(input_, label)
         train_data.load_stats = raw_train_data.load_stats
         return train_data

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -437,7 +437,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.device = get_device()
 
         # If the src and dst DataSource are the same, we can skip one set of normalizations.
-        self.enable_input_only_opt = src == dst
+        self.independent_label = src != dst
 
         self.hist: int = hist
         self.steps: int = steps
@@ -454,7 +454,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self._input_src = src.filter(prognostic_var_names, prefix="input")
         self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
         self._label_src = self._input_src
-        if not self.enable_input_only_opt:
+        if self.independent_label:
             self._label_src = dst.filter(prognostic_var_names, prefix="label")
 
         # This class will be used only for training and validation
@@ -478,7 +478,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.wet_input: PrognosticMask = src.masks.prognostic.to(self.device)
         self.wet_surface: GridMask = src.masks.boundary.to(self.device)
         self.wet_label: PrognosticMask = self.wet_input
-        if not self.enable_input_only_opt:
+        if self.independent_label:
             self.wet_label = dst.masks.prognostic.to(self.device)
 
         def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
@@ -500,7 +500,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         self.label_means = self.input_means
         self.label_stds = self.input_stds
-        if not self.enable_input_only_opt:
+        if self.independent_label:
             self.label_means = flatten_to_device(self._label_src.means)
             self.label_stds = flatten_to_device(self._label_src.stds)
 
@@ -523,12 +523,12 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             input_selected = self._input_src.data.isel(time=x_index)
             boundary_selected = self._boundary_src.data.isel(time=x_index)
             label_selected = input_selected
-            if not self.enable_input_only_opt:
+            if self.independent_label:
                 label_selected = self._label_src.data.isel(time=x_index)
 
             if self._executor is not None:
                 datasets = [input_selected, boundary_selected]
-                if not self.enable_input_only_opt:
+                if self.independent_label:
                     datasets.append(label_selected)
                 concurrent_compute(
                     *datasets,
@@ -547,7 +547,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .astype(np.float32, copy=False)
                 )
                 label = input_
-                if not self.enable_input_only_opt:
+                if self.independent_label:
                     label = torch.from_numpy(
                         conditional_rearrange(
                             label_selected,
@@ -566,7 +566,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     .astype(np.float32, copy=False)
                 )
                 label = input_
-                if not self.enable_input_only_opt:
+                if self.independent_label:
                     label = torch.from_numpy(
                         label_selected.to_array()
                         .transpose("time", "variable", "lat", "lon")
@@ -589,7 +589,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         for input_, boundary, label in raw_train_data.raw_data:
             input_ = input_.to(device=self.device, non_blocking=True)
             label = input_
-            if not self.enable_input_only_opt:
+            if self.independent_label:
                 label = label.to(device=self.device, non_blocking=True)
             input_, label = self._to_example(
                 input_,

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -531,7 +531,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 prognostics = [
                     torch.from_numpy(
                         conditional_rearrange(
-                            prog,
+                            selected,
                             "time (variable lev)=var lat lon",
                             concat_dim="var",
                         )
@@ -539,17 +539,17 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                         .to_numpy()
                         .astype(np.float32, copy=False)
                     )
-                    for prog in prognostic_selected
+                    for selected in prognostic_selected
                 ]
             else:
                 prognostics = [
                     torch.from_numpy(
-                        prog.to_array()
+                        selected.to_array()
                         .transpose("time", "variable", "lat", "lon")
                         .to_numpy()
                         .astype(np.float32, copy=False)
                     )
-                    for prog in prognostic_selected
+                    for selected in prognostic_selected
                 ]
             boundary = torch.from_numpy(
                 boundary_selected.to_array()

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -120,7 +120,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             >>> # Group datasets by resolution, allowing different strides to be batched together
             >>> sampler = EquivalenceGroupBatchSampler.from_datasets(
             ...     datasets=dataset_list,
-            ...     group_key=lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon']),
+            ...     group_key=lambda ds: tuple(prog.data.sizes["lat"], prog.data.sizes["lon"] for prog in ds._prognostic_srcs),
             ...     batch_size=32,
             ...     shuffle=True,
             ...     drop_last=True,

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -148,11 +148,9 @@ def make_loader(
                 # This ensures datasets with same (src, dst) resolution pair but different strides can batch
                 batch_sampler = EquivalenceGroupBatchSampler.from_datasets(
                     datasets=dataset_list,
-                    group_key=lambda ds: (
-                        ds._input_src.data.sizes["lat"],
-                        ds._input_src.data.sizes["lon"],
-                        ds._label_src.data.sizes["lat"],
-                        ds._label_src.data.sizes["lon"],
+                    group_key=lambda ds: tuple(
+                        (prog.data.sizes["lat"], prog.data.sizes["lon"])
+                        for prog in ds._prognostic_srcs
                     ),
                     batch_size=cfg.batch_size,
                     drop_last=drop_last,


### PR DESCRIPTION
This only fixes the performance regression when loading single datasets (i.e. "standard"). Loading multiple datasets is inherently slower. We will only know the final benchmark results when the are automatically run. Short of that, here is some evidence that the changes in this PR is an improvement: 

Start: 
```
------------------------------------------------------------------------------------------- benchmark: 1 tests ------------------------------------------------------------------------------------------
Name (time in ms)                                                                                               Min       Max      Mean   StdDev    Median      IQR  Outliers     OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_profile__loader__1gb[LoaderVersion.OM4_TORCH-cpu-extra_config_args0-mock-test/train_default.yaml]     766.8572  866.5532  806.3264  38.8650  806.3489  51.7769       2;0  1.2402       5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

Finish:
```
------------------------------------------------------------------------------------------- benchmark: 1 tests ------------------------------------------------------------------------------------------
Name (time in ms)                                                                                               Min       Max      Mean   StdDev    Median      IQR  Outliers     OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_profile__loader__1gb[LoaderVersion.OM4_TORCH-cpu-extra_config_args0-mock-test/train_default.yaml]     414.9687  524.9424  458.3332  44.6805  448.1001  68.2806       1;0  2.1818       5           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

TL;DR: This cuts standard data loading time in half on average.