### PR TITLE
Extract similar concerns from the torch data loader into a `TorchDataSource`.

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -25,7 +25,7 @@ from ocean_emulators.constants import (
 from ocean_emulators.utils.data import (
     DataSource,
     LoadStats,
-    TorchDataSource,
+    OceanData,
     conditional_rearrange,
 )
 from ocean_emulators.utils.device import get_device, using_gpu
@@ -568,17 +568,17 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         for input_, boundary, label in raw_train_data.raw_data:
             input_, label = self._to_example(
-                TorchDataSource.from_data_source(
+                OceanData.from_data_source(
                     input_,
                     self.wet_prognostic[0],
                     self._prognostic_srcs[0],
                 ).to(device=device, non_blocking=True),
-                TorchDataSource.from_data_source(
+                OceanData.from_data_source(
                     boundary,
                     self.wet_surface,
                     self._boundary_src,
                 ).to(device=device, non_blocking=True),
-                TorchDataSource.from_data_source(
+                OceanData.from_data_source(
                     label, self.wet_prognostic[-1], self._prognostic_srcs[-1]
                 ).to(device=device, non_blocking=True),
             )
@@ -589,26 +589,26 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def _to_example(
         self,
         # time includes (self.hist + 1) past steps and the (label) future steps
-        input_: TorchDataSource,
-        boundary: TorchDataSource,
-        label: TorchDataSource,
+        input_: OceanData,
+        boundary: OceanData,
+        label: OceanData,
     ) -> tuple[Input, Prognostic]:
         # Move normalization parameters to the same device as input data
         # grab past steps and prep for model
         total_input = self._prep_tensor_steps(
-            input_.map(lambda data: data[:, : self.hist + 1, :, :, :]),
-            boundary.map(lambda data: data[:, : self.hist + 1, :, :, :]),
+            input_.with_time(slice(0, self.hist + 1)),
+            boundary.with_time(slice(0, self.hist + 1)),
         )
         # grab future steps, repeat as we do for input
         label_tensor = self._prep_tensor_steps(
-            label.map(lambda data: data[:, self.hist + 1 :, :, :, :])
+            label.with_time(slice(self.hist + 1, None))
         )
         return total_input, label_tensor
 
     def _prep_tensor_steps(
         self,
-        prognostic: TorchDataSource,
-        boundary: TorchDataSource | None = None,
+        prognostic: OceanData,
+        boundary: OceanData | None = None,
     ) -> Input:
         """Prepare tensor steps by normalizing, masking and flattening dimensions."""
         prognostic_steps = prognostic.normalize_and_mask(

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -22,7 +22,12 @@ from ocean_emulators.constants import (
     PrognosticMask,
     PrognosticVarNames,
 )
-from ocean_emulators.utils.data import DataSource, LoadStats, conditional_rearrange
+from ocean_emulators.utils.data import (
+    DataSource,
+    LoadStats,
+    TorchDataSource,
+    conditional_rearrange,
+)
 from ocean_emulators.utils.device import get_device, using_gpu
 from ocean_emulators.utils.logging import elapsed
 
@@ -475,12 +480,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             indices_da + stride * window_dim
         )
 
+        # NB(alxmrs): Keep masks on CPU - will be moved to GPU in to_train_data()
         self.wet_prognostic: list[PrognosticMask] = [
-            src.masks.prognostic.to(self.device) for src in srcs
+            src.masks.prognostic for src in srcs
         ]
-        self.wet_surface: GridMask = src.masks.boundary.to(self.device)
+        self.wet_surface: GridMask = src.masks.boundary
 
-        def flatten_to_device(means_or_stds: xr.Dataset) -> torch.Tensor:
+        def flatten(means_or_stds: xr.Dataset) -> torch.Tensor:
             if "lev" in means_or_stds.dims:
                 array = conditional_rearrange(
                     means_or_stds,
@@ -489,17 +495,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                 ).rename({"var": "variable"})
             else:
                 array = means_or_stds.to_dataarray()
-            return torch.from_numpy(array.to_numpy().flatten()).to(self.device)
+            return torch.from_numpy(array.to_numpy().flatten())
 
-        self.prognostic_means = [
-            flatten_to_device(src.means) for src in self._prognostic_srcs
-        ]
-        self.prognostic_stds = [
-            flatten_to_device(dst.stds) for dst in self._prognostic_srcs
-        ]
+        self.prognostic_means = [flatten(src.means) for src in self._prognostic_srcs]
+        self.prognostic_stds = [flatten(dst.stds) for dst in self._prognostic_srcs]
 
-        self.boundary_means = flatten_to_device(self._boundary_src.means)
-        self.boundary_stds = flatten_to_device(self._boundary_src.stds)
+        self.boundary_means = flatten(self._boundary_src.means)
+        self.boundary_stds = flatten(self._boundary_src.stds)
 
         self.size: int = (
             time_.size
@@ -567,14 +569,34 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         return TD
 
-    def to_train_data(self, raw_train_data: RawTrainData) -> TrainData:
+    def to_train_data(
+        self, raw_train_data: RawTrainData, device: torch.device
+    ) -> TrainData:
+        """Convert RawTrainData to TrainData, moving tensors to the specified device.
+
+        Args:
+            raw_train_data: CPU data from worker process
+            device: Target device (typically GPU) to move tensors to
+
+        Returns:
+            TrainData with tensors on the target device
+        """
         train_data = TrainData(self.num_prognostic_channels, raw_train_data.label_mask)
+
         for input_, boundary, label in raw_train_data.raw_data:
             input_, label = self._to_example(
-                input_.to(device=self.device, non_blocking=True),
-                boundary.to(device=self.device, non_blocking=True),
-                # If this is the same as input_, `to` should return without copying.
-                label.to(device=self.device, non_blocking=True),
+                TorchDataSource(
+                    input_, self.prognostic_means[0], self.prognostic_stds[0], self.wet_prognostic[0],
+                ).to(device=device, non_blocking=True),
+                TorchDataSource(
+                    boundary,
+                    self.boundary_means,
+                    self.boundary_stds,
+                    self.wet_surface,
+                ).to(device=device, non_blocking=True),
+                TorchDataSource(
+                label, self.prognostic_means[-1], self.prognostic_stds[-1], self.wet_prognostic[-1],
+                ).to(device=device, non_blocking=True),
             )
             train_data.append(input_, label)
         train_data.load_stats = raw_train_data.load_stats
@@ -583,79 +605,31 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def _to_example(
         self,
         # time includes (self.hist + 1) past steps and the (label) future steps
-        input_: Float[torch.Tensor, "batch time variable lat lon"],
-        boundary: Float[torch.Tensor, "batch time variable lat lon"],
-        label: Float[torch.Tensor, "batch time variable lat lon"],
+        input_: TorchDataSource,
+        boundary: TorchDataSource,
+        label: TorchDataSource,
     ) -> tuple[Input, Prognostic]:
+        # Move normalization parameters to the same device as input data
         # grab past steps and prep for model
         total_input = self._prep_tensor_steps(
-            input_[:, : self.hist + 1, :, :, :],
-            self.prognostic_means[0],
-            self.prognostic_stds[0],
-            self.wet_prognostic[0],
-            boundary[:, : self.hist + 1, :, :, :],
+            input_.map(lambda data: data[:, : self.hist + 1, :, :, :]),
+            boundary.map(lambda data: data[:, : self.hist + 1, :, :, :]),
         )
         # grab future steps, repeat as we do for input
-        label = self._prep_tensor_steps(
-            label[:, self.hist + 1 :, :, :, :],
-            self.prognostic_means[-1],
-            self.prognostic_stds[-1],
-            self.wet_prognostic[-1],
+        label_tensor = self._prep_tensor_steps(
+            label.map(lambda data: data[:, self.hist + 1 :, :, :, :])
         )
-        return total_input, label
+        return total_input, label_tensor
 
     def _prep_tensor_steps(
         self,
-        prognostic_steps: Float[torch.Tensor, "batch time variable lat lon"],
-        prognostic_means: Float[torch.Tensor, " variable"],
-        prognostic_stds: Float[torch.Tensor, " variable"],
-        prognostic_mask: Float[torch.Tensor, " variable"],
-        boundary_steps: Float[torch.Tensor, "batch time variable lat lon"]
-        | None = None,
+        prognostic: TorchDataSource,
+        boundary: TorchDataSource | None = None,
     ) -> Input:
         """Prepare tensor steps by normalizing, masking and flattening dimensions."""
-
-        def normalize(
-            data: Float[torch.Tensor, "batch time var lat lon"],
-            means: Float[torch.Tensor, " var"],
-            stds: Float[torch.Tensor, " var"],
-            fill_nan: bool = True,
-            fill_value: float = 0.0,
-        ) -> Float[torch.Tensor, "batch time var lat lon"]:
-            """Normalize input data treated as torch Tensors."""
-            norm = (data - means.view(1, 1, -1, 1, 1)) / stds.view(1, 1, -1, 1, 1)
-            if fill_nan:
-                norm = norm.nan_to_num(nan=fill_value)
-            norm = norm.to(data.dtype)
-            return norm
-
-        # Normalize and mask tensors
-        def normalize_and_mask(
-            tensor: torch.Tensor,
-            means: torch.Tensor,
-            stds: torch.Tensor,
-            mask: torch.Tensor,
-        ) -> torch.Tensor:
-            if self.normalize_before_mask:
-                tensor = normalize(tensor, means, stds)
-            tensor = torch.where(mask, tensor, self.masked_fill_value)
-            if not self.normalize_before_mask:
-                tensor = normalize(tensor, means, stds)
-            return tensor
-
-        prognostic_steps = normalize_and_mask(
-            prognostic_steps,
-            prognostic_means,
-            prognostic_stds,
-            prognostic_mask,
+        prognostic_steps = prognostic.normalize_and_mask(
+            self.normalize_before_mask, self.masked_fill_value
         )
-        if boundary_steps is not None:
-            boundary_steps = normalize_and_mask(
-                boundary_steps,
-                self.boundary_means,
-                self.boundary_stds,
-                self.wet_surface,
-            )
 
         # Flatten time and variable dimensions
         def flatten_dims(tensor: torch.Tensor) -> torch.Tensor:
@@ -664,7 +638,10 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             )
 
         prognostic_steps = flatten_dims(prognostic_steps)
-        if boundary_steps is not None:
+        if boundary is not None:
+            boundary_steps = boundary.normalize_and_mask(
+                self.normalize_before_mask, self.masked_fill_value
+            )
             boundary_steps = flatten_dims(boundary_steps)
             return torch.cat((prognostic_steps, boundary_steps), dim=1)
 
@@ -726,7 +703,7 @@ class TrainDataLoader:
         """Iterate over the dataloader, converting RawTrainData to TrainData."""
         for raw_train_data in self._dataloader:
             dataset = self._datasets[raw_train_data.dataset_id]
-            train_data = dataset.to_train_data(raw_train_data)
+            train_data = dataset.to_train_data(raw_train_data, self._device)
             yield train_data
 
     def __len__(self) -> int:
@@ -740,14 +717,14 @@ class TrainDataLoader:
         """
         # Access the underlying dataset directly
         raw_train_data = self._dataloader.dataset[index]
-        # Apply collate function to add batch dimension (expects a list)
+        # Apply the collate function to add batch dimension (expects a list)
         collate_fn = self._dataloader.collate_fn
         if collate_fn is not None:
             raw_train_data = collate_fn([raw_train_data])
         # Get the dataset that created this raw data
         dataset = self._datasets[raw_train_data.dataset_id]
         # Convert to TrainData
-        train_data = dataset.to_train_data(raw_train_data)
+        train_data = dataset.to_train_data(raw_train_data, self._device)
         return train_data
 
     @property

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -486,23 +486,6 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         ]
         self.wet_surface: GridMask = src.masks.boundary
 
-        def flatten(means_or_stds: xr.Dataset) -> torch.Tensor:
-            if "lev" in means_or_stds.dims:
-                array = conditional_rearrange(
-                    means_or_stds,
-                    "(variable lev)=var",
-                    concat_dim="var",
-                ).rename({"var": "variable"})
-            else:
-                array = means_or_stds.to_dataarray()
-            return torch.from_numpy(array.to_numpy().flatten())
-
-        self.prognostic_means = [flatten(src.means) for src in self._prognostic_srcs]
-        self.prognostic_stds = [flatten(dst.stds) for dst in self._prognostic_srcs]
-
-        self.boundary_means = flatten(self._boundary_src.means)
-        self.boundary_stds = flatten(self._boundary_src.stds)
-
         self.size: int = (
             time_.size
             - self.steps * (self.hist + 1) * self.stride
@@ -585,23 +568,16 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         for input_, boundary, label in raw_train_data.raw_data:
             input_, label = self._to_example(
-                TorchDataSource(
-                    input_,
-                    self.prognostic_means[0],
-                    self.prognostic_stds[0],
-                    self.wet_prognostic[0],
+                TorchDataSource.from_data_source(
+                    input_, self.wet_input, self._prognostic_srcs[0],
                 ).to(device=device, non_blocking=True),
-                TorchDataSource(
+                TorchDataSource.from_data_source(
                     boundary,
-                    self.boundary_means,
-                    self.boundary_stds,
                     self.wet_surface,
+                    self._boundary_src,
                 ).to(device=device, non_blocking=True),
-                TorchDataSource(
-                    label,
-                    self.prognostic_means[-1],
-                    self.prognostic_stds[-1],
-                    self.wet_prognostic[-1],
+                TorchDataSource.from_data_source(
+                    label, self.wet_label, self._prognostic_srcs[-1]
                 ).to(device=device, non_blocking=True),
             )
             train_data.append(input_, label)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -586,7 +586,10 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         for input_, boundary, label in raw_train_data.raw_data:
             input_, label = self._to_example(
                 TorchDataSource(
-                    input_, self.prognostic_means[0], self.prognostic_stds[0], self.wet_prognostic[0],
+                    input_,
+                    self.prognostic_means[0],
+                    self.prognostic_stds[0],
+                    self.wet_prognostic[0],
                 ).to(device=device, non_blocking=True),
                 TorchDataSource(
                     boundary,
@@ -595,7 +598,10 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     self.wet_surface,
                 ).to(device=device, non_blocking=True),
                 TorchDataSource(
-                label, self.prognostic_means[-1], self.prognostic_stds[-1], self.wet_prognostic[-1],
+                    label,
+                    self.prognostic_means[-1],
+                    self.prognostic_stds[-1],
+                    self.wet_prognostic[-1],
                 ).to(device=device, non_blocking=True),
             )
             train_data.append(input_, label)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -569,7 +569,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         for input_, boundary, label in raw_train_data.raw_data:
             input_, label = self._to_example(
                 TorchDataSource.from_data_source(
-                    input_, self.wet_input, self._prognostic_srcs[0],
+                    input_,
+                    self.wet_prognostic[0],
+                    self._prognostic_srcs[0],
                 ).to(device=device, non_blocking=True),
                 TorchDataSource.from_data_source(
                     boundary,
@@ -577,7 +579,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     self._boundary_src,
                 ).to(device=device, non_blocking=True),
                 TorchDataSource.from_data_source(
-                    label, self.wet_label, self._prognostic_srcs[-1]
+                    label, self.wet_prognostic[-1], self._prognostic_srcs[-1]
                 ).to(device=device, non_blocking=True),
             )
             train_data.append(input_, label)

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -312,7 +312,9 @@ def _flatten(means_or_stds: xr.Dataset) -> torch.Tensor:
 
 
 @dataclasses.dataclass
-class TorchDataSource:
+class OceanData:
+    """A slice of either boundary or prognostic ocean data. An intermediary tensor for creating `Example`s."""
+
     data: Float[torch.Tensor, "batch time variable lat lon"]
     means: Float[torch.Tensor, " variable"]
     stds: Float[torch.Tensor, " variable"]
@@ -329,8 +331,9 @@ class TorchDataSource:
         stds_torch = _flatten(src.stds)
         return cls(data, means_torch, stds_torch, mask)
 
-    def map(self, data_func: Callable) -> Self:
-        return dataclasses.replace(self, data=data_func(self.data))
+    def with_time(self, time_range: slice) -> Self:
+        """Slice data across the time dimension."""
+        return dataclasses.replace(self, data=self.data[:, time_range, :, :, :])
 
     def _normalize(
         self,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -313,7 +313,25 @@ def _flatten(means_or_stds: xr.Dataset) -> torch.Tensor:
 
 @dataclasses.dataclass
 class OceanData:
-    """A slice of either boundary or prognostic ocean data. An intermediary tensor for creating `Example`s."""
+    """A slice of ocean data (boundary or prognostic) with normalization statistics.
+
+    This dataclass bundles raw tensor data with the statistics needed to normalize it
+    and the mask needed to handle land/invalid values. It serves as an intermediary
+    representation used when constructing training `Example`s from raw xarray data.
+
+    The typical workflow is:
+        1. Load raw data from a `DataSource` via `from_data_source()`
+        2. Slice to the desired time range with `with_time()`
+        3. Apply normalization and masking with `normalize_and_mask()`
+        4. Flatten time/variable dims to create the final `Input` or `Prognostic` tensor
+
+    Attributes:
+        data: Raw ocean variable values with shape (batch, time, variable, lat, lon).
+        means: Per-variable means for normalization, shape (variable,).
+        stds: Per-variable standard deviations for normalization, shape (variable,).
+        mask: Boolean mask indicating valid ocean points (True) vs land (False),
+            broadcast-compatible with the variable dimension.
+    """
 
     data: Float[torch.Tensor, "batch time variable lat lon"]
     means: Float[torch.Tensor, " variable"]

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -387,15 +387,6 @@ class OceanData:
             mask=self.mask.to(device, non_blocking=non_blocking),
         )
 
-    def pin_memory(self, device: torch.device | None = None) -> Self:
-        return dataclasses.replace(
-            self,
-            data=self.data.pin_memory(device=device),
-            means=self.means.pin_memory(device=device),
-            stds=self.stds.pin_memory(device=device),
-            mask=self.mask.pin_memory(device=device),
-        )
-
 
 @dataclasses.dataclass
 class DataContainer:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -309,16 +309,17 @@ class TorchDataSource:
     def map(self, data_func: Callable) -> Self:
         return dataclasses.replace(self, data=data_func(self.data))
 
-    def normalize(
-        self, fill_nan: bool = True, fill_value: float = 0.0
+    def _normalize(
+        self,
+        data: Float[torch.Tensor, "batch time var lat lon"],
+        fill_nan: bool = True,
+        fill_value: float = 0.0,
     ) -> Float[torch.Tensor, "batch time var lat lon"]:
         """Normalize input data treated as torch Tensors."""
-        norm = (self.data - self.means.view(1, 1, -1, 1, 1)) / self.stds.view(
-            1, 1, -1, 1, 1
-        )
+        norm = (data - self.means.view(1, 1, -1, 1, 1)) / self.stds.view(1, 1, -1, 1, 1)
         if fill_nan:
             norm = norm.nan_to_num(nan=fill_value)
-        norm = norm.to(self.data.dtype)
+        norm = norm.to(data.dtype)
         return norm
 
     def normalize_and_mask(
@@ -327,10 +328,10 @@ class TorchDataSource:
         """Normalize and mask tensors."""
         tensor = self.data
         if normalize_before_mask:
-            tensor = self.normalize()
+            tensor = self._normalize(tensor)
         tensor = torch.where(self.mask, tensor, masked_fill_value)
         if not normalize_before_mask:
-            tensor = self.normalize()
+            tensor = self._normalize(tensor, fill_nan=False)
         return tensor
 
     def to(self, device: torch.device, non_blocking: bool = False) -> Self:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -331,7 +331,7 @@ class TorchDataSource:
             tensor = self._normalize(tensor)
         tensor = torch.where(self.mask, tensor, masked_fill_value)
         if not normalize_before_mask:
-            tensor = self._normalize(tensor, fill_nan=False)
+            tensor = self._normalize(tensor)
         return tensor
 
     def to(self, device: torch.device, non_blocking: bool = False) -> Self:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -378,7 +378,7 @@ class OceanData:
             tensor = self._normalize(tensor)
         return tensor
 
-    def to(self, device: torch.device, non_blocking: bool = False) -> Self:
+    def to(self, device: torch.device, non_blocking: bool = True) -> Self:
         return dataclasses.replace(
             self,
             data=self.data.to(device, non_blocking=non_blocking),

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 import xarray as xr
 from einops import rearrange
-from jaxtyping import Bool
+from jaxtyping import Bool, Float
 
 if TYPE_CHECKING:
     from ocean_emulators.config import TimeConfig
@@ -296,6 +296,59 @@ class DataSource:
             means=means,
             stds=stds,
             masks=masks,
+        )
+
+
+@dataclasses.dataclass
+class TorchDataSource:
+    data: Float[torch.Tensor, "batch time variable lat lon"]
+    means: Float[torch.Tensor, " variable"]
+    stds: Float[torch.Tensor, " variable"]
+    mask: Bool[torch.Tensor, " variable"]
+
+    def map(self, data_func: Callable) -> Self:
+        return dataclasses.replace(self, data=data_func(self.data))
+
+    def normalize(
+        self, fill_nan: bool = True, fill_value: float = 0.0
+    ) -> Float[torch.Tensor, "batch time var lat lon"]:
+        """Normalize input data treated as torch Tensors."""
+        norm = (self.data - self.means.view(1, 1, -1, 1, 1)) / self.stds.view(
+            1, 1, -1, 1, 1
+        )
+        if fill_nan:
+            norm = norm.nan_to_num(nan=fill_value)
+        norm = norm.to(self.data.dtype)
+        return norm
+
+    def normalize_and_mask(
+        self, normalize_before_mask: bool, masked_fill_value: float
+    ) -> Float[torch.Tensor, "batch time var lat lon"]:
+        """Normalize and mask tensors."""
+        tensor = self.data
+        if normalize_before_mask:
+            tensor = self.normalize()
+        tensor = torch.where(self.mask, tensor, masked_fill_value)
+        if not normalize_before_mask:
+            tensor = self.normalize()
+        return tensor
+
+    def to(self, device: torch.device, non_blocking: bool = False) -> Self:
+        return dataclasses.replace(
+            self,
+            data=self.data.to(device, non_blocking=non_blocking),
+            means=self.means.to(device, non_blocking=non_blocking),
+            stds=self.stds.to(device, non_blocking=non_blocking),
+            mask=self.mask.to(device, non_blocking=non_blocking),
+        )
+
+    def pin_memory(self, device: torch.device | None = None) -> Self:
+        return dataclasses.replace(
+            self,
+            data=self.data.pin_memory(device=device),
+            means=self.means.pin_memory(device=device),
+            stds=self.stds.pin_memory(device=device),
+            mask=self.mask.pin_memory(device=device),
         )
 
 

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -299,12 +299,35 @@ class DataSource:
         )
 
 
+def _flatten(means_or_stds: xr.Dataset) -> torch.Tensor:
+    if "lev" in means_or_stds.dims:
+        array = conditional_rearrange(
+            means_or_stds,
+            "(variable lev)=var",
+            concat_dim="var",
+        ).rename({"var": "variable"})
+    else:
+        array = means_or_stds.to_dataarray()
+    return torch.from_numpy(array.to_numpy().flatten())
+
+
 @dataclasses.dataclass
 class TorchDataSource:
     data: Float[torch.Tensor, "batch time variable lat lon"]
     means: Float[torch.Tensor, " variable"]
     stds: Float[torch.Tensor, " variable"]
     mask: Bool[torch.Tensor, " variable"]
+
+    @classmethod
+    def from_data_source(
+        cls,
+        data: Float[torch.Tensor, "batch time variable lat lon"],
+        mask: Float[torch.Tensor, " variable"],
+        src: DataSource,
+    ) -> Self:
+        means_torch = _flatten(src.means)
+        stds_torch = _flatten(src.stds)
+        return cls(data, means_torch, stds_torch, mask)
 
     def map(self, data_func: Callable) -> Self:
         return dataclasses.replace(self, data=data_func(self.data))

--- a/tests/test_utils_data.py
+++ b/tests/test_utils_data.py
@@ -11,6 +11,7 @@ from ocean_emulators.utils.data import (
     DataSource,
     Masks,
     Normalize,
+    OceanData,
     compute_anomalies,
     flatten_masks,
     get_aggregator_dicts,
@@ -287,3 +288,70 @@ def test_get_norm_unnorm_dicts(data_init, input_type, long_rollout, hist):
     assert torch.isnan(data_dict[var_name][:, :, 0, 1]).all()
     assert torch.isnan(data_dict[var_name][:, :, 1, 0]).all()
     assert torch.isnan(data_dict[var_name][:, :, 1, 2]).all()
+
+
+def test_ocean_data_with_time():
+    """Test slicing OceanData across the time dimension."""
+    batch, time, var, lat, lon = 2, 5, 3, 4, 6
+    data = torch.randn(batch, time, var, lat, lon)
+    means = torch.tensor([1.0, 2.0, 3.0])
+    stds = torch.tensor([0.5, 1.0, 2.0])
+    mask = torch.ones(var, dtype=torch.bool)
+    ocean_data = OceanData(data=data, means=means, stds=stds, mask=mask)
+
+    sliced = ocean_data.with_time(slice(0, 3))
+
+    assert sliced.data.shape[1] == 3
+    assert torch.equal(sliced.data, ocean_data.data[:, 0:3, :, :, :])
+    # Other fields should be unchanged
+    assert torch.equal(sliced.means, ocean_data.means)
+    assert torch.equal(sliced.stds, ocean_data.stds)
+
+
+@pytest.mark.parametrize("masked_fill_value", [0.0, -1.0])
+def test_ocean_data_normalize_and_mask(masked_fill_value):
+    """Test that masked positions receive the fill value when normalizing first."""
+    batch, time, var, lat, lon = 2, 5, 3, 4, 6
+    data = torch.randn(batch, time, var, lat, lon)
+    data[:, :, :, 0, 0] = float("nan")  # Simulate land
+    means = torch.tensor([1.0, 2.0, 3.0])
+    stds = torch.tensor([0.5, 1.0, 2.0])
+    mask = torch.ones(var, lat, lon, dtype=torch.bool)
+    mask[:, 0, 0] = False  # Mark as land
+
+    ocean_data = OceanData(data=data, means=means, stds=stds, mask=mask)
+    result = ocean_data.normalize_and_mask(
+        normalize_before_mask=True, masked_fill_value=masked_fill_value
+    )
+
+    assert result.shape == ocean_data.data.shape
+    # Masked positions should have the fill value
+    mask_expanded = mask.unsqueeze(0).unsqueeze(0)
+    masked_positions = ~mask_expanded.expand_as(result)
+    assert torch.all(result[masked_positions] == masked_fill_value)
+    # Valid positions should not be NaN
+    valid_positions = mask_expanded.expand_as(result)
+    assert not torch.any(torch.isnan(result[valid_positions]))
+
+
+def test_ocean_data_normalize_and_mask_values():
+    """Test that normalization produces expected values with known inputs."""
+    batch, time, num_var, lat, lon = 1, 1, 2, 2, 2
+    data = torch.tensor(
+        [[[[[10.0, 10.0], [10.0, 10.0]], [[20.0, 20.0], [20.0, 20.0]]]]]
+    )
+    means = torch.tensor([5.0, 10.0])
+    stds = torch.tensor([5.0, 5.0])
+    mask = torch.ones(num_var, lat, lon, dtype=torch.bool)
+
+    ocean_data = OceanData(data=data, means=means, stds=stds, mask=mask)
+    result = ocean_data.normalize_and_mask(
+        normalize_before_mask=True, masked_fill_value=0.0
+    )
+
+    # Expected: (10 - 5) / 5 = 1.0 for var 0, (20 - 10) / 5 = 2.0 for var 1
+    expected_var0 = torch.ones(batch, time, lat, lon)
+    expected_var1 = torch.ones(batch, time, lat, lon) * 2.0
+
+    assert torch.allclose(result[:, :, 0, :, :], expected_var0)
+    assert torch.allclose(result[:, :, 1, :, :], expected_var1)


### PR DESCRIPTION
A drive by refactor made during #532. I noticed that the means/stds/mask arrays really should be grouped with their associated tensor (either input, label, or boundary). The interface mirrors `DataSource`, except all operations are on `torch.Tensor`s rather than Xarray `Dataset`s. 

As a sanity check, I ran a local performance profile before and after this change. On my machine, both take basically the same median amount of time.