### PR TITLE
Warn on non-contiguous inference history stride and add failing regression test

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -90,6 +90,20 @@ class InferenceDataset(Dataset):
         )  # Skip indices based on history
         self.rolling_indices = self.rolling_indices.astype(int)
 
+        if self.hist > 0:
+            first_window = self.rolling_indices.isel(time=0).values
+            if len(first_window) > 1:
+                inferred_stride = int(first_window[1] - first_window[0])
+                if inferred_stride != 1:
+                    logger.warning(
+                        "InferenceDataset history uses stride=%d between history steps; "
+                        "expected contiguous history (stride=1). This means hist=%d "
+                        "samples t and t+%d for the first input window.",
+                        inferred_stride,
+                        self.hist,
+                        inferred_stride,
+                    )
+
         if long_rollout:
             logger.info(
                 f"Long rollout will use input at time {data.time.values[0]} and produce"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -707,6 +707,28 @@ def test_train_dataset_normalize_pre_fill(
         assert inference_dataset[0][0][0][0, 0, 0] == data
 
 
+@pytest.mark.parametrize("normalize_before_mask", [True, False])
+@pytest.mark.parametrize("masked_fill_value", [0.0, -1.0])
+def test_inference_dataset_histories_are_contiguous(
+    tiny_dataset_input, normalize_before_mask, masked_fill_value
+):
+    _, inference_dataset = tiny_dataset_input
+    input_tensor, _ = inference_dataset[0]
+
+    # Data is constructed so that each time step has value == time index.
+    # With hist=1 we expect the first inference input to contain t=0 and t=1.
+    expected_time0 = (0.0 - 0.5) / 1.0
+    expected_time1 = (1.0 - 0.5) / 1.0
+
+    # Prognostic channels are ordered by time then variable:
+    # [t0 var1, t0 var2, t1 var1, t1 var2, ...]
+    time0_value = input_tensor[0, 0, 0, 1]
+    time1_value = input_tensor[0, 2, 0, 1]
+
+    assert torch.isclose(time0_value, torch.tensor(expected_time0))
+    assert torch.isclose(time1_value, torch.tensor(expected_time1))
+
+
 @pytest.mark.manual
 @pytest.mark.parametrize(
     "data_source,config_name", [("mock", DEFAULT_CONFIG)], indirect=True


### PR DESCRIPTION
### Motivation
- Make inference data stride issues visible during evaluation by logging a warning when inference history indices skip timesteps.
- Provide a minimal failing regression test that reproduces the non-contiguous history behavior for the inference dataset so the problem is obvious when running the test suite.

### Description
- Add a check in `InferenceDataset` initialization (`src/ocean_emulators/datasets.py`) that inspects the first rolling index window and logs a `logger.warning` when the inferred stride between history steps is not `1`.
- Add `test_inference_dataset_histories_are_contiguous` to `tests/test_datasets.py` which uses the `tiny_dataset_input` fixture and asserts that the first inference input contains contiguous time steps (for `hist=1`) by comparing normalized time values in the prognostic channels.
- The test is parametrized over `normalize_before_mask` and `masked_fill_value` to match existing dataset test coverage.

### Testing
- No automated tests were run as part of this change; the new regression test is expected to fail until the underlying stride issue is fixed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce98d7c348320acce1f3a47c14ff0)