### PR TITLE
Subtle equality fix allows us to take advantage of performance fix.

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -443,7 +443,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
         # If the src and dst DataSource are the same, we can do a lot less work.
-        srcs = [src] if src is dst else [src, dst]
+        srcs = [src] if src.name == dst.name else [src, dst]
 
         self.hist: int = hist
         self.steps: int = steps

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -429,7 +429,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def __init__(
         self,
         src: DataSource,
-        dst: DataSource,
+        dst: DataSource | None,
         prognostic_var_names: PrognosticVarNames,
         boundary_var_names: BoundaryVarNames,
         hist: int,
@@ -443,7 +443,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
         # If the src and dst DataSource are the same, we can do a lot less work.
-        srcs = [src] if src.name == dst.name else [src, dst]
+        srcs = [src, dst] if dst else [src]
 
         self.hist: int = hist
         self.steps: int = steps
@@ -453,7 +453,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self._executor = executor
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
-        assert np.array_equal(src.data.time, dst.data.time), (
+        assert np.array_equal(srcs[0].data.time, srcs[-1].data.time), (
             "src and dst DataSource have different time slices!"
         )
         time_ = src.data.time

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -443,7 +443,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
         # If the src and dst DataSource are the same, we can do a lot less work.
-        srcs = [src] if src.name == dst.name else [src, dst]
+        srcs = [src] if src == dst else [src, dst]
 
         self.hist: int = hist
         self.steps: int = steps

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -443,7 +443,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
         # If the src and dst DataSource are the same, we can do a lot less work.
-        srcs = [src] if src == dst else [src, dst]
+        srcs = [src] if src.name == dst.name else [src, dst]
 
         self.hist: int = hist
         self.steps: int = steps

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -722,10 +722,10 @@ class Trainer:
         Args:
             cur_step: Current training step size
         """
-        srcs: Iterable[tuple[DataSource, DataSource]] = []
+        srcs: Iterable[tuple[DataSource, DataSource | None]] = []
         match self.train_schedule:
             case "standard":
-                srcs = [(self.src, self.src)]
+                srcs = [(self.src, None)]
             case "match" | "mix":
                 raise ValueError(f"{self.train_schedule} is not supported (yet).")
             case _:
@@ -734,7 +734,7 @@ class Trainer:
         train_datasets = [
             TorchTrainDataset(
                 src=src.slice(self.train_time),
-                dst=dst.slice(self.train_time),
+                dst=dst.slice(self.train_time) if dst else None,
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 hist=self.hist,
@@ -751,7 +751,7 @@ class Trainer:
         val_datasets = [
             TorchTrainDataset(
                 src=src.slice(self.val_time),
-                dst=dst.slice(self.val_time),
+                dst=dst.slice(self.val_time) if dst else None,
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 hist=self.hist,

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -88,6 +88,19 @@ class DataSource:
     stds: xr.Dataset
     masks: Masks
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, DataSource):
+            return False
+
+        try:
+            xr.testing.assert_allclose(self.data, other.data)
+            xr.testing.assert_allclose(self.means, other.means)
+            xr.testing.assert_allclose(self.stds, other.stds)
+        except AssertionError:
+            return False
+
+        return self.name == other.name and self.masks == other.masks
+
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -65,11 +65,11 @@ class Masks:
         self.boundary = self.boundary.bool()
 
     def __eq__(self, other) -> bool:
-        rtol = 0.05
+        # Since mask data are boolean, we don't need tolerances in our equality.
         return (
             isinstance(other, Masks)
-            and torch.allclose(self.prognostic, other.prognostic, rtol)
-            and torch.allclose(self.boundary, other.boundary, rtol)
+            and torch.equal(self.prognostic, other.prognostic)
+            and torch.equal(self.boundary, other.boundary)
         )
 
     def prognostic_with_hist(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -65,11 +65,11 @@ class Masks:
         self.boundary = self.boundary.bool()
 
     def __eq__(self, other) -> bool:
-        tol = 0.05
+        rtol = 0.05
         return (
             isinstance(other, Masks)
-            and torch.allclose(self.prognostic, other.prognostic, tol)
-            and torch.allclose(self.boundary, other.boundary, tol)
+            and torch.allclose(self.prognostic, other.prognostic, rtol)
+            and torch.allclose(self.boundary, other.boundary, rtol)
         )
 
     def prognostic_with_hist(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -64,6 +64,14 @@ class Masks:
         self.prognostic = self.prognostic.bool()
         self.boundary = self.boundary.bool()
 
+    def __eq__(self, other) -> bool:
+        tol = 0.05
+        return (
+            isinstance(other, Masks)
+            and torch.allclose(self.prognostic, other.prognostic, tol)
+            and torch.allclose(self.boundary, other.boundary, tol)
+        )
+
     def prognostic_with_hist(
         self, hist: int
     ) -> Bool[GridMask, " prognostic_vars*({hist}+1)"]:
@@ -82,7 +90,18 @@ class DataSource:
 
     def __eq__(self, other) -> bool:
         """Since we encode all data loading and transformations via name, we can use name to test for equality."""
-        return isinstance(other, DataSource) and self.name == other.name
+        return (
+            isinstance(other, DataSource)
+            and self.name == other.name
+            and all(
+                [
+                    self.data.equals(other.data),
+                    self.means.equals(other.means),
+                    self.stds.equals(other.stds),
+                ]
+            )
+            and self.masks == other.masks
+        )
 
     @cached_property
     def is_compact(self) -> bool:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -88,19 +88,6 @@ class DataSource:
     stds: xr.Dataset
     masks: Masks
 
-    def __eq__(self, other) -> bool:
-        if not isinstance(other, DataSource):
-            return False
-
-        try:
-            xr.testing.assert_allclose(self.data, other.data)
-            xr.testing.assert_allclose(self.means, other.means)
-            xr.testing.assert_allclose(self.stds, other.stds)
-        except AssertionError:
-            return False
-
-        return self.name == other.name and self.masks == other.masks
-
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -80,6 +80,10 @@ class DataSource:
     stds: xr.Dataset
     masks: Masks
 
+    def __eq__(self, other) -> bool:
+        """Since we encode all data loading and transformations via name, we can use name to test for equality."""
+        return isinstance(other, DataSource) and self.name == other.name
+
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -64,14 +64,6 @@ class Masks:
         self.prognostic = self.prognostic.bool()
         self.boundary = self.boundary.bool()
 
-    def __eq__(self, other) -> bool:
-        # Since mask data are boolean, we don't need tolerances in our equality.
-        return (
-            isinstance(other, Masks)
-            and torch.equal(self.prognostic, other.prognostic)
-            and torch.equal(self.boundary, other.boundary)
-        )
-
     def prognostic_with_hist(
         self, hist: int
     ) -> Bool[GridMask, " prognostic_vars*({hist}+1)"]:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -88,21 +88,6 @@ class DataSource:
     stds: xr.Dataset
     masks: Masks
 
-    def __eq__(self, other) -> bool:
-        """Since we encode all data loading and transformations via name, we can use name to test for equality."""
-        return (
-            isinstance(other, DataSource)
-            and self.name == other.name
-            and all(
-                [
-                    self.data.equals(other.data),
-                    self.means.equals(other.means),
-                    self.stds.equals(other.stds),
-                ]
-            )
-            and self.masks == other.masks
-        )
-
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -107,7 +107,7 @@ def make_loader(
 
         match schedule:
             case "standard":
-                srcs: Iterable[tuple[DataSource, DataSource]] = [(src, src)]
+                srcs: Iterable[tuple[DataSource, DataSource | None]] = [(src, None)]
             case "match":
                 coarsened_src = src.map_data(coarsen_data, suffix="half-size")
                 coarsened_src = dataclasses.replace(
@@ -130,7 +130,7 @@ def make_loader(
                 dataset_list = [
                     TorchTrainDataset(
                         src=src.slice(time_config),
-                        dst=dst.slice(time_config),
+                        dst=dst.slice(time_config) if dst else None,
                         prognostic_var_names=prognostic,
                         boundary_var_names=boundary,
                         hist=cfg.data.hist,
@@ -628,7 +628,7 @@ def tiny_dataset_input(normalize_before_mask: bool, masked_fill_value: float):
         )
         torch_train_dataset = TorchTrainDataset(
             src=test,
-            dst=test,
+            dst=None,
             prognostic_var_names=prognostic_var_names,
             boundary_var_names=boundary_var_names,
             hist=1,


### PR DESCRIPTION
The suggestion to use `is` over `==` was valid, but it didn't account for the fact that since we `slice()` each DataSource, we inevitably make two different references for the same data. Thus, we weren't actually making use of the performance optimization that was implemented. This PR uses a better test (if `dst` is the same as `src`, we pass it as None and do a null check). With this small change, we actually get to take advantage of the previous attempt to fix performance. This perf gain works by simply making less IO operations by only loading one dataset for the input and label prognostic. 

Performance data collected by Claude via our contrib guide: 

```
 Results                                                                                                                                                                  
  ┌────────────┬────────────┬───────────┬───────────────┐                                                                                                                  
  │   Metric   │ Before Fix │ After Fix │ Original Fast │                                                                                                                  
  ├────────────┼────────────┼───────────┼───────────────┤                                                                                                                  
  │ Mean time  │ ~815ms     │ ~450ms    │ ~440ms        │                                                                                                                  
  ├────────────┼────────────┼───────────┼───────────────┤                                                                                                                  
  │ OPS        │ ~1.23      │ ~2.22     │ ~2.28         │                                                                                                                  
  ├────────────┼────────────┼───────────┼───────────────┤                                                                                                                  
  │ Zarr calls │ 585        │ 312       │ 312           │                                                                                                                  
  └────────────┴────────────┴───────────┴───────────────┘                                                                                                                  
```