### PR TITLE
Memory usage fix

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -443,7 +443,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
         # If the src and dst DataSource are the same, we can do a lot less work.
-        srcs = [src] if src is dst else [src, dst]
+        srcs = [src] if src.name == dst.name else [src, dst]
 
         self.hist: int = hist
         self.steps: int = steps

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -310,7 +310,7 @@ class RawTrainData:
         boundary: torch.Tensor,
         label: torch.Tensor,
     ):
-        """Add a prognostic input, boundary, and prognostic label as the last step."""
+        """Add past input/boundary and future label for the last step."""
         self.raw_data.append((input_, boundary, label))
 
     def to(self, device: torch.device):
@@ -504,49 +504,65 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
         for step in range(self.steps):
             x_index = self._get_x_index(idx, step)
-            prognostic_selected = [
-                src.data.isel(time=x_index) for src in self._prognostic_srcs
-            ]
-            boundary_selected = self._boundary_src.data.isel(time=x_index)
+            past_index = x_index.isel(time=slice(0, self.hist + 1))
+            future_index = x_index.isel(time=slice(self.hist + 1, None))
+
+            # Only materialize the time ranges we actually use to reduce memory.
+            input_selected = self._prognostic_srcs[0].data.isel(time=past_index)
+            label_selected = self._prognostic_srcs[-1].data.isel(time=future_index)
+            boundary_selected = self._boundary_src.data.isel(time=past_index)
 
             if self._executor is not None:
-                datasets = prognostic_selected + [boundary_selected]
                 concurrent_compute(
-                    *datasets,
+                    input_selected,
+                    boundary_selected,
+                    label_selected,
                     executor=self._executor,
                 )
 
-            if "lev" in prognostic_selected[0].dims:
-                prognostics = [
-                    torch.from_numpy(
-                        conditional_rearrange(
-                            selected,
-                            "time (variable lev)=var lat lon",
-                            concat_dim="var",
-                        )
-                        .rename({"var": "variable"})
-                        .to_numpy()
-                        .astype(np.float32, copy=False)
+            if "lev" in input_selected.dims:
+                input_ = torch.from_numpy(
+                    conditional_rearrange(
+                        input_selected,
+                        "time (variable lev)=var lat lon",
+                        concat_dim="var",
                     )
-                    for selected in prognostic_selected
-                ]
+                    .rename({"var": "variable"})
+                    .to_numpy()
+                    .astype(np.float32, copy=False)
+                )
             else:
-                prognostics = [
-                    torch.from_numpy(
-                        selected.to_array()
-                        .transpose("time", "variable", "lat", "lon")
-                        .to_numpy()
-                        .astype(np.float32, copy=False)
+                input_ = torch.from_numpy(
+                    input_selected.to_array()
+                    .transpose("time", "variable", "lat", "lon")
+                    .to_numpy()
+                    .astype(np.float32, copy=False)
+                )
+
+            if "lev" in label_selected.dims:
+                label = torch.from_numpy(
+                    conditional_rearrange(
+                        label_selected,
+                        "time (variable lev)=var lat lon",
+                        concat_dim="var",
                     )
-                    for selected in prognostic_selected
-                ]
+                    .rename({"var": "variable"})
+                    .to_numpy()
+                    .astype(np.float32, copy=False)
+                )
+            else:
+                label = torch.from_numpy(
+                    label_selected.to_array()
+                    .transpose("time", "variable", "lat", "lon")
+                    .to_numpy()
+                    .astype(np.float32, copy=False)
+                )
             boundary = torch.from_numpy(
                 boundary_selected.to_array()
                 .transpose("time", "variable", "lat", "lon")
                 .to_numpy()
                 .astype(np.float32, copy=False)
             )
-            input_, label = prognostics[0], prognostics[-1]
             TD.insert(input_, boundary, label)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
@@ -588,21 +604,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
     def _to_example(
         self,
-        # time includes (self.hist + 1) past steps and the (label) future steps
         input_: OceanData,
         boundary: OceanData,
         label: OceanData,
     ) -> tuple[Input, Prognostic]:
-        # Move normalization parameters to the same device as input data
-        # grab past steps and prep for model
-        total_input = self._prep_tensor_steps(
-            input_.with_time(slice(0, self.hist + 1)),
-            boundary.with_time(slice(0, self.hist + 1)),
-        )
-        # grab future steps, repeat as we do for input
-        label_tensor = self._prep_tensor_steps(
-            label.with_time(slice(self.hist + 1, None))
-        )
+        # input/boundary include only past steps; label includes only future steps
+        total_input = self._prep_tensor_steps(input_, boundary)
+        label_tensor = self._prep_tensor_steps(label)
         return total_input, label_tensor
 
     def _prep_tensor_steps(

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -443,7 +443,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
         # If the src and dst DataSource are the same, we can do a lot less work.
-        srcs = [src] if src.name == dst.name else [src, dst]
+        srcs = [src] if src == dst else [src, dst]
 
         self.hist: int = hist
         self.steps: int = steps

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -443,7 +443,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         self.device = get_device()
         # If the src and dst DataSource are the same, we can do a lot less work.
-        srcs = [src] if src == dst else [src, dst]
+        srcs = [src] if src.name == dst.name else [src, dst]
 
         self.hist: int = hist
         self.steps: int = steps

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -88,6 +88,19 @@ class DataSource:
     stds: xr.Dataset
     masks: Masks
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, DataSource):
+            return False
+
+        try:
+            xr.testing.assert_allclose(self.data, other.data)
+            xr.testing.assert_allclose(self.means, other.means)
+            xr.testing.assert_allclose(self.stds, other.stds)
+        except AssertionError:
+            return False
+
+        return self.name == other.name and self.masks == other.masks
+
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -65,11 +65,11 @@ class Masks:
         self.boundary = self.boundary.bool()
 
     def __eq__(self, other) -> bool:
-        rtol = 0.05
+        # Since mask data are boolean, we don't need tolerances in our equality.
         return (
             isinstance(other, Masks)
-            and torch.allclose(self.prognostic, other.prognostic, rtol)
-            and torch.allclose(self.boundary, other.boundary, rtol)
+            and torch.equal(self.prognostic, other.prognostic)
+            and torch.equal(self.boundary, other.boundary)
         )
 
     def prognostic_with_hist(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -65,11 +65,11 @@ class Masks:
         self.boundary = self.boundary.bool()
 
     def __eq__(self, other) -> bool:
-        tol = 0.05
+        rtol = 0.05
         return (
             isinstance(other, Masks)
-            and torch.allclose(self.prognostic, other.prognostic, tol)
-            and torch.allclose(self.boundary, other.boundary, tol)
+            and torch.allclose(self.prognostic, other.prognostic, rtol)
+            and torch.allclose(self.boundary, other.boundary, rtol)
         )
 
     def prognostic_with_hist(

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -64,6 +64,14 @@ class Masks:
         self.prognostic = self.prognostic.bool()
         self.boundary = self.boundary.bool()
 
+    def __eq__(self, other) -> bool:
+        tol = 0.05
+        return (
+            isinstance(other, Masks)
+            and torch.allclose(self.prognostic, other.prognostic, tol)
+            and torch.allclose(self.boundary, other.boundary, tol)
+        )
+
     def prognostic_with_hist(
         self, hist: int
     ) -> Bool[GridMask, " prognostic_vars*({hist}+1)"]:
@@ -82,7 +90,18 @@ class DataSource:
 
     def __eq__(self, other) -> bool:
         """Since we encode all data loading and transformations via name, we can use name to test for equality."""
-        return isinstance(other, DataSource) and self.name == other.name
+        return (
+            isinstance(other, DataSource)
+            and self.name == other.name
+            and all(
+                [
+                    self.data.equals(other.data),
+                    self.means.equals(other.means),
+                    self.stds.equals(other.stds),
+                ]
+            )
+            and self.masks == other.masks
+        )
 
     @cached_property
     def is_compact(self) -> bool:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -88,19 +88,6 @@ class DataSource:
     stds: xr.Dataset
     masks: Masks
 
-    def __eq__(self, other) -> bool:
-        if not isinstance(other, DataSource):
-            return False
-
-        try:
-            xr.testing.assert_allclose(self.data, other.data)
-            xr.testing.assert_allclose(self.means, other.means)
-            xr.testing.assert_allclose(self.stds, other.stds)
-        except AssertionError:
-            return False
-
-        return self.name == other.name and self.masks == other.masks
-
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -80,6 +80,10 @@ class DataSource:
     stds: xr.Dataset
     masks: Masks
 
+    def __eq__(self, other) -> bool:
+        """Since we encode all data loading and transformations via name, we can use name to test for equality."""
+        return isinstance(other, DataSource) and self.name == other.name
+
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -64,14 +64,6 @@ class Masks:
         self.prognostic = self.prognostic.bool()
         self.boundary = self.boundary.bool()
 
-    def __eq__(self, other) -> bool:
-        # Since mask data are boolean, we don't need tolerances in our equality.
-        return (
-            isinstance(other, Masks)
-            and torch.equal(self.prognostic, other.prognostic)
-            and torch.equal(self.boundary, other.boundary)
-        )
-
     def prognostic_with_hist(
         self, hist: int
     ) -> Bool[GridMask, " prognostic_vars*({hist}+1)"]:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -88,21 +88,6 @@ class DataSource:
     stds: xr.Dataset
     masks: Masks
 
-    def __eq__(self, other) -> bool:
-        """Since we encode all data loading and transformations via name, we can use name to test for equality."""
-        return (
-            isinstance(other, DataSource)
-            and self.name == other.name
-            and all(
-                [
-                    self.data.equals(other.data),
-                    self.means.equals(other.means),
-                    self.stds.equals(other.stds),
-                ]
-            )
-            and self.masks == other.masks
-        )
-
     @cached_property
     def is_compact(self) -> bool:
         """Check if the data source is compact."""


### PR DESCRIPTION
I did some more digging as to why my jobs were failing. I reduced the range of commits to find it was introduced in a534fc887cdeb10cc5179e3bccdcdfd188c3013e and Codex proposed the below fix. No idea if this is the right one (I haven't looked at it carefully) but it resolves the problem I was having. 

I believe the reason you were unable to reproduce it is that you were using 1-degree data and I was using 1/2-degree data. The bug causes a doubling of memory usage for the prognostic/boundary data so at 1-degree it was not fatal. Here's a screenshot of available memory for the 1-degree runs you were doing to diagnose compared with 1/2-degree runs. 

<img width="2524" height="1634" alt="image" src="https://github.com/user-attachments/assets/b2b6de0d-936f-498c-a9b2-eea069785e19" />
