### PR TITLE
Renaming ctx variable to make it clear that it always stays on the CPU.

### DIFF
--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -98,8 +98,8 @@ class FOMO(BaseModel):
 
         with autocast(enabled=self.use_bfloat16, dtype=torch.bfloat16):
             if self.maybe_add_3d_coordinates is not None:
-                fts = self.maybe_add_3d_coordinates(fts, ctx.input_resolution)
-            fts = self.encoder(fts, ctx.input_resolution)
+                fts = self.maybe_add_3d_coordinates(fts, ctx.input_resolution_cpu)
+            fts = self.encoder(fts, ctx.input_resolution_cpu)
             fts = self.processor(fts)
 
         # Convert back to float32 for decoder and unpatchify operations

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -61,7 +61,7 @@ class Samudra(BaseModel):
                 fts = torch.cat([fts, pos], dim=1)
 
             if self.add_3d_coordinates is not None:
-                fts = self.add_3d_coordinates(fts, ctx.input_resolution)
+                fts = self.add_3d_coordinates(fts, ctx.input_resolution_cpu)
 
             fts = self.unet(fts)
             fts = torch.nn.functional.pad(

--- a/src/ocean_emulators/utils/ctx.py
+++ b/src/ocean_emulators/utils/ctx.py
@@ -17,12 +17,12 @@ class GridContext:
     Attributes:
         label_mask: Boolean mask indicating valid ocean cells for each prognostic
             variable. Shape: (num_prognostic_vars, lat, lon). Land cells are False.
-        input_resolution: Tuple of (latitude, longitude) coordinate tensors defining
+        input_resolution_cpu: Tuple of (latitude, longitude) coordinate tensors defining
             the spatial grid. Used for cosine-latitude weighting in loss functions.
     """
 
     label_mask: PrognosticMask
-    input_resolution: tuple[Lat, Lon]
+    input_resolution_cpu: tuple[Lat, Lon]
 
     def to(self, device: torch.device) -> Self:
         """Move the label mask to the specified device."""


### PR DESCRIPTION
This was one of the remaining notes of feedback from the big multi-scale PR. I thought I pushed it before the auto-merge, but I had to click one additional "push" button on my IDE for it to have actually gone through! This tine PR addresses the suggestion and applies a rename. 