### PR TITLE
Remove extra forward pass from dynamic MSE loss

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -766,6 +766,7 @@ class TrainConfig(TopLevelConfig):
     test_using_ema: bool = True
     ema_decay: float = 0.999
     faster_decay_at_start: bool = True
+    delayed_loss_estimate: bool = False
     backend: TrainBackendConfig = "auto"
 
     # Profiling parameters

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -599,7 +599,7 @@ class Trainer:
             metric_logger.update(loss=loss_value_reduce.item())
             metric_logger.update(lr=lr)
 
-            self._call_loss_update(data)
+            self._call_loss_update(TO.loss_per_channel)
 
             self.profiler.after_batch(self.num_batches_seen)
 
@@ -609,16 +609,24 @@ class Trainer:
         logger.info(f"Aggregating train logs")
         return train_aggregator.get_logs()
 
-    def _call_loss_update(self, data: TrainData):
-        # This is a separate function to ensure locals are dropped immediately after use
+    def _call_loss_update(self, loss_per_channel: torch.Tensor):
+        # Use the already-computed per-channel loss from the training rollout
+        # to update DynamicLoss scales, avoiding an second forward pass.
+        # This introduces delayed estimate but should be more efficient
         if update := getattr(self.loss_fn, "update", None):
-            with torch.no_grad():
-                single_step_data = TrainData(data.num_prognostic_channels, data.ctx)
-                # Each entry in data is one step in a rollout.
-                input, label = data[0]
-                single_step_data.append(input, label)
-                pred = self.model(single_step_data)
-                update(pred[0], label, ctx=data.ctx)
+            # Undo the dynamic scaling to recover the raw per-channel loss.
+            if scale_fn := getattr(self.loss_fn, "loss_scale_per_channel", None):
+                scale = scale_fn()
+                raw_loss = (
+                    loss_per_channel.detach().reshape(-1, scale.shape[0]).mean(dim=0)
+                    / scale
+                )
+                # Expand back to the full hist*var shape expected by update.
+                n_hist = self.hist + 1
+                raw_loss = raw_loss.repeat(n_hist)
+            else:
+                raw_loss = loss_per_channel.detach()
+            update(raw_loss)
 
     def validate_one_epoch(self, epoch):
         self.model.eval()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -599,7 +599,7 @@ class Trainer:
             metric_logger.update(loss=loss_value_reduce.item())
             metric_logger.update(lr=lr)
 
-            self._call_loss_update(TO.loss_per_channel)
+            self._maybe_update_loss(TO)
 
             self.profiler.after_batch(self.num_batches_seen)
 
@@ -609,19 +609,23 @@ class Trainer:
         logger.info(f"Aggregating train logs")
         return train_aggregator.get_logs()
 
-    def _call_loss_update(self, loss_per_channel: torch.Tensor):
+    def _maybe_update_loss(self, output: TrainBatchOutput):
         # Use the already-computed per-channel loss from the training rollout
-        # to update DynamicLoss scales, avoiding an second forward pass.
+        # to update DynamicLoss scales, avoiding a second forward pass.
         # This introduces delayed estimate but should be more efficient
         if update := getattr(self.loss_fn, "update", None):
+            loss_per_channel = output.loss_per_channel
             # Undo the dynamic scaling to recover the raw per-channel loss.
             if get_scales := getattr(self.loss_fn, "loss_scale_per_channel", None):
                 per_channel_scale = get_scales()
                 raw_loss = (
-                    loss_per_channel.detach().reshape(-1, scale.shape[0]) / per_channel_scale
+                    loss_per_channel.detach().reshape(-1, per_channel_scale.shape[0])
+                    / per_channel_scale
                 ).reshape(-1)
             else:
-                raw_loss = loss_per_channel.detach()
+                raise RuntimeError(
+                    f"no `loss_scale_per_channel` — cannot recover unscaled per-channel loss."
+                )
             update(raw_loss)
 
     def validate_one_epoch(self, epoch):

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -68,7 +68,7 @@ from ocean_emulators.utils.logging import (
     handle_logging,
     handle_warnings,
 )
-from ocean_emulators.utils.loss import LossFnWithContext
+from ocean_emulators.utils.loss import DynamicLoss, LossFnWithContext
 from ocean_emulators.utils.samplers import (
     DistributedEquivalenceGroupBatchSampler,
     EquivalenceGroupBatchSampler,
@@ -325,6 +325,7 @@ class Trainer:
         )
         self.normalize_before_mask: bool = cfg.data.normalize_before_mask
         self.normalize_fill_value: float = cfg.data.masked_fill_value
+        self.delayed_loss_estimate: bool = cfg.delayed_loss_estimate
 
         self.profiler = cfg.profiler.build(self.output_dir, self.device)
 
@@ -599,7 +600,7 @@ class Trainer:
             metric_logger.update(loss=loss_value_reduce.item())
             metric_logger.update(lr=lr)
 
-            self._maybe_update_loss(TO)
+            self._maybe_update_loss(TO, data)
 
             self.profiler.after_batch(self.num_batches_seen)
 
@@ -609,11 +610,14 @@ class Trainer:
         logger.info(f"Aggregating train logs")
         return train_aggregator.get_logs()
 
-    def _maybe_update_loss(self, output: TrainBatchOutput):
-        # Use the already-computed per-channel loss from the training rollout
-        # to update DynamicLoss scales, avoiding a second forward pass.
-        # This introduces delayed estimate but should be more efficient
-        if update := getattr(self.loss_fn, "update", None):
+    def _maybe_update_loss(self, output: TrainBatchOutput, data: TrainData):
+        if (update := getattr(self.loss_fn, "update", None)) is None:
+            return
+
+        if self.delayed_loss_estimate:
+            # Use the already-computed per-channel loss from the training
+            # rollout to update DynamicLoss scales, avoiding a second forward
+            # pass.  This introduces a delayed estimate but is more efficient.
             loss_per_channel = output.loss_per_channel
             # Undo the dynamic scaling to recover the raw per-channel loss.
             if get_scales := getattr(self.loss_fn, "loss_scale_per_channel", None):
@@ -624,8 +628,22 @@ class Trainer:
                 ).reshape(-1)
             else:
                 raise RuntimeError(
-                    f"no `loss_scale_per_channel` — cannot recover unscaled per-channel loss."
+                    "no `loss_scale_per_channel` — cannot recover unscaled per-channel loss."
                 )
+            update(raw_loss)
+        else:
+            # Run a fresh single-step forward pass so DynamicLoss sees an
+            # up-to-date, unscaled loss signal
+            with torch.no_grad():
+                single_step_data = TrainData(data.num_prognostic_channels, data.ctx)
+                input_, label = data[0]
+                single_step_data.append(input_, label)
+                pred = self.model(single_step_data)
+                # Compute the raw (unscaled) per-channel loss via the inner
+                # loss function, bypassing DynamicLoss scaling.
+                if not isinstance(self.loss_fn, DynamicLoss):
+                    raise TypeError(f"Expected loss_fn to be DynamicLoss")
+                raw_loss = self.loss_fn.loss_fn(pred[0], label, ctx=data.ctx)
             update(raw_loss)
 
     def validate_one_epoch(self, epoch):

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -618,12 +618,8 @@ class Trainer:
             if scale_fn := getattr(self.loss_fn, "loss_scale_per_channel", None):
                 scale = scale_fn()
                 raw_loss = (
-                    loss_per_channel.detach().reshape(-1, scale.shape[0]).mean(dim=0)
-                    / scale
-                )
-                # Expand back to the full hist*var shape expected by update.
-                n_hist = self.hist + 1
-                raw_loss = raw_loss.repeat(n_hist)
+                    loss_per_channel.detach().reshape(-1, scale.shape[0]) / scale
+                ).reshape(-1)
             else:
                 raw_loss = loss_per_channel.detach()
             update(raw_loss)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -615,10 +615,10 @@ class Trainer:
         # This introduces delayed estimate but should be more efficient
         if update := getattr(self.loss_fn, "update", None):
             # Undo the dynamic scaling to recover the raw per-channel loss.
-            if scale_fn := getattr(self.loss_fn, "loss_scale_per_channel", None):
-                scale = scale_fn()
+            if get_scales := getattr(self.loss_fn, "loss_scale_per_channel", None):
+                per_channel_scale = get_scales()
                 raw_loss = (
-                    loss_per_channel.detach().reshape(-1, scale.shape[0]) / scale
+                    loss_per_channel.detach().reshape(-1, scale.shape[0]) / per_channel_scale
                 ).reshape(-1)
             else:
                 raw_loss = loss_per_channel.detach()

--- a/src/ocean_emulators/utils/loss.py
+++ b/src/ocean_emulators/utils/loss.py
@@ -186,15 +186,13 @@ class DynamicLoss:
 
     def update(
         self,
-        pred: Float[torch.Tensor, "batch hist*var lat lon"],
-        target: Float[torch.Tensor, "batch hist*var lat lon"],
-        ctx: GridContext,
+        loss_per_channel: Float[torch.Tensor, " hist*var"],
     ) -> None:
-        """Given the prediction & target for this step, update the per-channel scale."""
+        """Given the unscaled per-channel loss, update the per-channel scale."""
         # Local import is needed to prevent a circular import error.
         from ocean_emulators.utils.distributed import all_reduce_mean, get_world_size
 
-        loss = self.loss_fn(pred, target, ctx)
+        loss = loss_per_channel.detach()
         loss = torch.where(loss == 0, 1e-8, loss)
         new_target_weights_with_history: Float[torch.Tensor, " hist*var"] = 1.0 / loss
         # Reshape from channels * history to channels


### PR DESCRIPTION
Resolved this issue #443

Eliminates the redundant second model forward pass that was used solely to update DynamicLoss channel scales. Instead, we reuse the per-channel loss already computed during the training rollout.

This should introduce a delayed estimate (if i interpret it correctly)

We are also using the error from the end of the 4-step rollout rather than after a single step.
