### PR TITLE
container: upgrade nsys CLI for nccl trace support

### DIFF
--- a/containers/Dockerfile.physicsnemo-25.11
+++ b/containers/Dockerfile.physicsnemo-25.11
@@ -6,6 +6,8 @@ WORKDIR /workspace
 ARG VCS_REF=unknown
 ARG VCS_URL=unknown
 ARG BUILD_DATE=unknown
+ARG NSYS_CLI_VERSION=2026.1.1.204-3717666
+ARG NSYS_CLI_DEB_URL="https://developer.download.nvidia.com/devtools/nsight-systems/NsightSystems-linux-cli-public-${NSYS_CLI_VERSION}.deb"
 
 LABEL org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.source="${VCS_URL}" \
@@ -14,6 +16,16 @@ LABEL org.opencontainers.image.revision="${VCS_REF}" \
 ENV WANDB_GIT_COMMIT="${VCS_REF}" \
     WANDB_GIT_REMOTE_URL="${VCS_URL}" \
     WANDB_DISABLE_GIT=true
+
+# Upgrade to a newer Nsight Systems CLI build so `--trace=nccl` is available.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL "${NSYS_CLI_DEB_URL}" -o /tmp/nsight-systems-cli.deb \
+    && apt-get install -y --no-install-recommends /tmp/nsight-systems-cli.deb \
+    && rm -f /tmp/nsight-systems-cli.deb \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/local/bin/nsys /usr/local/cuda/bin/nsys \
+    && nsys --version
 
 COPY LICENSE README.md pyproject.toml uv.lock ./
 COPY src ./src

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -75,6 +75,10 @@ Key behavior:
 
 ### Example: 1 Node, 8x RTX6000 on the NYU Torch HPC
 
+For `rtx6000_lzanna` nodes, request CPUs at the node's full CPU:GPU ratio
+(`128 CPU / 8 GPU = 16 CPU per GPU`). For an 8-GPU run, set
+`--cpus-per-task=128`.
+
 ```bash
 export CONFIG=configs/samudra_om4/train.yaml
 export NAME_SUFFIX=om4_samudra_baseline
@@ -92,7 +96,7 @@ sbatch \
   --account=torch_pr_347_courant \
   --nodes=1 \
   --ntasks-per-node=1 \
-  --cpus-per-task=16 \
+  --cpus-per-task=128 \
   --mem=1000GB \
   --gres=gpu:rtx6000:8 \
   --time=24:00:00 \

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -81,17 +81,14 @@ request all GPUs on a node, also request the node's full CPU and memory.
 Current `gr102` capacity:
 - `8` GPUs (`rtx6000`)
 - `128` CPUs total
-- `1,545,000M` memory total
+- `1,400G` memory available via SLURM
 
-Per-GPU proportional share on this node:
-- `16` CPUs per GPU (`128 / 8`)
-- `193,125M` memory per GPU (`1,545,000M / 8`)
-
-Sizing rule for this node:
+So, sizing rule for this node when using our sbatch script which spawns a process
+per GPU within a task:
 - `--cpus-per-task=16 * <num_gpus>`
-- memory is physically proportional, but Slurm QOS currently caps requestable memory at `1400G` for this partition/account
+- `--mem=175G * <num_gpus>`
 
-For an 8-GPU run, use `--cpus-per-task=128 --mem=1400G`.
+ie for an 8-GPU run, use `--cpus-per-task=128 --mem=1400G`.
 
 ```bash
 export CONFIG=configs/samudra_om4/train.yaml

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -75,7 +75,7 @@ Key behavior:
 
 ### Example: 1 Node, 8x RTX6000 on the NYU Torch HPC
 
-For `rtx6000_lzanna`, size CPU and memory proportionally to GPUs. If you
+For Torch RTX6000 nodes, size CPU and memory proportionally to GPUs. If you
 request all GPUs on a node, also request the node's full CPU and memory.
 
 Current `gr102` capacity:
@@ -89,6 +89,10 @@ per GPU within a task:
 - `--mem=175G * <num_gpus>`
 
 ie for an 8-GPU run, use `--cpus-per-task=128 --mem=1400G`.
+
+Partition guidance:
+- Do not set `--partition` by default.
+- Let Slurm place the job unless you have a specific partition requirement.
 
 ```bash
 export CONFIG=configs/samudra_om4/train.yaml
@@ -157,7 +161,7 @@ srun --overlap --jobid=<jobid> -N1 -n1 nvidia-smi
 
 ## NCCL Gotcha On RTX6000 Nodes
 
-On `rtx6000_lzanna` we observed NCCL hangs for 8-GPU single-node training unless P2P is disabled.
+On Torch RTX6000 nodes we observed NCCL hangs for 8-GPU single-node training unless P2P is disabled.
 
 Recommended env vars:
 

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -75,9 +75,23 @@ Key behavior:
 
 ### Example: 1 Node, 8x RTX6000 on the NYU Torch HPC
 
-For `rtx6000_lzanna` nodes, request CPUs at the node's full CPU:GPU ratio
-(`128 CPU / 8 GPU = 16 CPU per GPU`). For an 8-GPU run, set
-`--cpus-per-task=128`.
+For `rtx6000_lzanna`, size CPU and memory proportionally to GPUs. If you
+request all GPUs on a node, also request the node's full CPU and memory.
+
+Current `gr102` capacity:
+- `8` GPUs (`rtx6000`)
+- `128` CPUs total
+- `1,545,000M` memory total
+
+Per-GPU proportional share on this node:
+- `16` CPUs per GPU (`128 / 8`)
+- `193,125M` memory per GPU (`1,545,000M / 8`)
+
+Sizing rule for this node:
+- `--cpus-per-task=16 * <num_gpus>`
+- `--mem=193125M * <num_gpus>`
+
+For an 8-GPU run, use `--cpus-per-task=128 --mem=1545000M`.
 
 ```bash
 export CONFIG=configs/samudra_om4/train.yaml
@@ -97,7 +111,7 @@ sbatch \
   --nodes=1 \
   --ntasks-per-node=1 \
   --cpus-per-task=128 \
-  --mem=1000GB \
+  --mem=1545000M \
   --gres=gpu:rtx6000:8 \
   --time=24:00:00 \
   scripts/slurm_apptainer_train.sbatch

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -89,9 +89,9 @@ Per-GPU proportional share on this node:
 
 Sizing rule for this node:
 - `--cpus-per-task=16 * <num_gpus>`
-- `--mem=193125M * <num_gpus>`
+- memory is physically proportional, but Slurm QOS currently caps requestable memory at `1400G` for this partition/account
 
-For an 8-GPU run, use `--cpus-per-task=128 --mem=1545000M`.
+For an 8-GPU run, use `--cpus-per-task=128 --mem=1400G`.
 
 ```bash
 export CONFIG=configs/samudra_om4/train.yaml
@@ -111,7 +111,7 @@ sbatch \
   --nodes=1 \
   --ntasks-per-node=1 \
   --cpus-per-task=128 \
-  --mem=1545000M \
+  --mem=1400G \
   --gres=gpu:rtx6000:8 \
   --time=24:00:00 \
   scripts/slurm_apptainer_train.sbatch

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -8,7 +8,7 @@
 #   export WANDB_API_KEY=...   # optional; if unset, wandb is disabled
 #   sbatch --nodes=1 --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
 #
-# Multi-node example (requires the partition to actually have >=N nodes available):
+# Multi-node example (requires enough nodes available):
 #   sbatch --nodes=2 --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
 #
 # Container selection (pick one):
@@ -23,7 +23,6 @@
 #SBATCH --job-name=oe-train
 #SBATCH --output=slurm-%j.out
 #SBATCH --account=torch_pr_347_courant
-#SBATCH --partition=rtx6000_lzanna
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 # For 8-GPU runs on gr102, request full-node CPUs and QOS-capped memory.

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -26,8 +26,9 @@
 #SBATCH --partition=rtx6000_lzanna
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
-#SBATCH --cpus-per-task=16
-#SBATCH --mem=128GB
+# For 8-GPU runs on gr102, request full-node CPUs and QOS-capped memory.
+#SBATCH --cpus-per-task=128
+#SBATCH --mem=1400G
 #SBATCH --gres=gpu:rtx6000:8
 #SBATCH --time=02:00:00
 


### PR DESCRIPTION
I wanted to do some profiling but the version of nsight systems in the NVIDIA image by default is a bit old, so we now install a new one. The image from https://github.com/Open-Athena/Ocean_Emulator/actions/runs/22362970435/job/64721289520 (this branch) successfully ran on torch with `nsys profile --trace=cuda,nvtx,osrt,nccl --sample=cpu` which is what we were using before (and did not work on the version installed by default). 