### PR TITLE
Adding a perceiver-based decoder that complements the encoder.

### DIFF
--- a/configs/fomo_om4/model.yaml
+++ b/configs/fomo_om4/model.yaml
@@ -5,10 +5,10 @@ last_kernel_size: 3
 pad: "circular"
 checkpointing: "all"
 embedding_dim: 128  # Reduced from 280
+perceiver_implementation: "naive"
 
 encoder:
   perceiver:
-    implementation: "naive"
     depth: 2  # Reduced from 3
     latent_dim: 48  # Reduced from 64
     num_latents: 128  # Reduced from 256

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ ini_options.markers = [
   "only_configs: used to mark tests that only run on specific configs (not used on command line)",
   "all_configs: used to mark tests that run on all configs (not used on command line)",
 ]
-ini_options.pythonpath = [ "src" ]
+ini_options.pythonpath = [ "src", "tests" ]
 ini_options.testpaths = [ "tests" ]
 ini_options.addopts = "--jaxtyping-packages=data,datasets,beartype.beartype --strict-markers"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,14 @@ ini_options.addopts = "--jaxtyping-packages=data,datasets,beartype.beartype --st
 [tool.mypy]
 check_untyped_defs = true
 overrides = [
-  { module = [ "cftime.*", "scipy.*", "fsspec.*", "perceiver_pytorch.*", "aurora.*" ], follow_untyped_imports = true },
+  { module = [
+    "cftime.*",
+    "scipy.*",
+    "fsspec.*",
+    "perceiver_pytorch.*",
+    "aurora.*",
+    "flash_perceiver.*",
+  ], follow_untyped_imports = true },
 ]
 
 [tool.uv]

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -495,7 +495,7 @@ class DecoderConfig(BaseConfig):
         description="Embedding dimension for pixel-position queries in the PerceiverIO decoder head.",
     )
     window_patches: int | None = Field(
-        default=None,
+        default=4096,
         description="Side length (in patches) of each spatial decode window. "
         "None = decode all patches at once (global attention). "
         "E.g. window_patches=8 means each PerceiverIO call covers an 8x8 block of patches.",

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -347,8 +347,6 @@ class PerceiverConfig(BaseConfig):
         # This is not really a "frequency" but a maximum of the width appears to be reasonable from looking at the code.
         max_freq = max(*max_patch_size)
 
-        # TODO(alxmrs,jder): Each implementation takes the mean of the num_latents dim to produce the final output_dim.
-        #  Why compute the mean? Is it better to directly project from the num_latents x latent_dim?
         if (
             self.implementation == "auto" and torch.cuda.is_available()
         ) or self.implementation == "flash":
@@ -358,7 +356,7 @@ class PerceiverConfig(BaseConfig):
                 raise ValueError(
                     "`implementation==flash` or flash was automatically chosen for `implementation==auto`, but the flash attention dependencies could not be imported. Please run `uv sync --extra cuda` or specify the `naive` attention implementation."
                 ) from e
-            perceiver = FlashPerceiver(
+            perceiver: nn.Module = FlashPerceiver(
                 latent_rotary_emb_dim=max_freq,
                 depth=self.depth,
                 input_dim=in_channels,
@@ -431,6 +429,7 @@ class DecoderConfig(BaseConfig):
             in_channels=in_channels,
             out_channels=out_channels,
             patch_extent=patch_extent,
+            latent_dim=self.perceiver.latent_dim,
             perceiver=self.perceiver.build(
                 perceiver_in_channels, out_channels, max_patch_size
             ),
@@ -663,7 +662,6 @@ class FOMOConfig(BaseModelConfig):
             hist=hist,
             checkpointing=self.checkpointing,
             gradient_detach_interval=self.gradient_detach_interval,
-            grid_sizes=all_grid_sizes,
             use_bfloat16=self.use_bfloat16,
         )
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -394,23 +394,21 @@ class PerceiverConfig(BaseConfig):
 
 
 class EncoderConfig(BaseConfig):
-    patch_extent: list[float] = Field(
-        default=[6.0, 10.0],
-        description="Target physical extent of each patch in degrees [height_deg, width_deg]. "
-        "Patch sizes will be calculated to match this extent for each grid resolution.",
-    )
     perceiver: PerceiverConfig = PerceiverConfig()
 
     def build(
-        self, in_channels: int, out_channels: int, max_lat_size: int, max_lon_size: int
+        self,
+        in_channels: int,
+        out_channels: int,
+        patch_extent: tuple[float, float],
+        max_lat_size: int,
+        max_lon_size: int,
     ) -> PerceiverEncoder:
-        assert len(self.patch_extent) == 2, "spatial extents must be a pair of floats."
-        extent = self.patch_extent[0], self.patch_extent[1]
-        max_patch_size = patch_from(extent, max_lat_size, max_lon_size)
+        max_patch_size = patch_from(patch_extent, max_lat_size, max_lon_size)
         return PerceiverEncoder(
             in_channels=in_channels,
             out_channels=out_channels,
-            patch_extent=extent,
+            patch_extent=patch_extent,
             perceiver=self.perceiver.build(in_channels, out_channels, max_patch_size),
         )
 
@@ -424,27 +422,21 @@ class DecoderConfig(BaseConfig):
     cross-attention from learned output queries.
     """
 
-    patch_extent: list[float] = Field(
-        default=[6.0, 10.0],
-        description="Target physical extent of each patch in degrees [height_deg, width_deg]. "
-        "Should match the encoder's patch_extent for consistent spatial semantics.",
-    )
     perceiver: PerceiverConfig = PerceiverConfig()
 
     def build(
         self,
         in_channels: int,
         out_channels: int,
+        patch_extent: tuple[float, float],
         max_lat_size: int,
         max_lon_size: int,
     ) -> PerceiverDecoder:
-        assert len(self.patch_extent) == 2, "patch_extent must be a pair of floats."
-        extent = self.patch_extent[0], self.patch_extent[1]
-        max_patch_size = patch_from(extent, max_lat_size, max_lon_size)
+        max_patch_size = patch_from(patch_extent, max_lat_size, max_lon_size)
         return PerceiverDecoder(
             in_channels=in_channels,
             out_channels=out_channels,
-            patch_extent=extent,
+            patch_extent=patch_extent,
             perceiver=self.perceiver.build(in_channels, out_channels, max_patch_size),
         )
 
@@ -606,6 +598,11 @@ class FOMOConfig(BaseModelConfig):
     encoder: EncoderConfig = EncoderConfig()
     processor: UNetBackboneConfig = UNetBackboneConfig()
     decoder: DecoderConfig = DecoderConfig()
+    patch_extent: list[float] = Field(
+        default=[6.0, 10.0],
+        description="Target physical extent of each patch in degrees [height_deg, width_deg]. "
+        "Shared by the encoder and decoder for consistent spatial semantics.",
+    )
     embedding_dim: int = 128
     use_bfloat16: bool = Field(
         default=True,
@@ -620,13 +617,16 @@ class FOMOConfig(BaseModelConfig):
         static_data_for_corrector: xr.Dataset | None,
         srcs: list[DataSource],
     ) -> FOMO:
+        assert len(self.patch_extent) == 2, "patch_extent must be a pair of floats."
+        extent = self.patch_extent[0], self.patch_extent[1]
+
         all_grid_sizes = [s.grid_size for s in srcs]
         max_lat_size, max_lon_size = (
             max(g[0] for g in all_grid_sizes),
             max(g[1] for g in all_grid_sizes),
         )
         encoder = self.encoder.build(
-            in_channels, self.embedding_dim, max_lat_size, max_lon_size
+            in_channels, self.embedding_dim, extent, max_lat_size, max_lon_size
         )
         if (
             hasattr(encoder.perceiver, "use_flash_attn")
@@ -645,6 +645,7 @@ class FOMOConfig(BaseModelConfig):
         decoder = self.decoder.build(
             processor.out_channels,
             out_channels,
+            extent,
             max_lat_size,
             max_lon_size,
         )

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -625,18 +625,10 @@ class FOMOConfig(BaseModelConfig):
             max(g[0] for g in all_grid_sizes),
             max(g[1] for g in all_grid_sizes),
         )
+
         encoder = self.encoder.build(
             in_channels, self.embedding_dim, extent, max_lat_size, max_lon_size
         )
-        if (
-            hasattr(encoder.perceiver, "use_flash_attn")
-            and encoder.perceiver.use_flash_attn
-            and not self.use_bfloat16
-        ):
-            raise ValueError(
-                "Encoder is configured to use flash attention. Please set `use_bfloat16=True`."
-            )
-
         processor = self.processor.build(
             self.embedding_dim,
             self.pad,
@@ -649,6 +641,16 @@ class FOMOConfig(BaseModelConfig):
             max_lat_size,
             max_lon_size,
         )
+
+        if any(
+            hasattr(layer.perceiver, "use_flash_attn")
+            and layer.perceiver.use_flash_attn
+            and not self.use_bfloat16
+            for layer in [encoder, decoder]
+        ):
+            raise ValueError(
+                "Encoder/decoder is configured to use flash attention. Please set `use_bfloat16=True`."
+            )
 
         total_in_channels = in_channels + (3 if self.add_3d_coordinates else 0)
         add_3d_coordinates = Concat3dCoordinates() if self.add_3d_coordinates else None

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -336,7 +336,7 @@ class PerceiverConfig(BaseConfig):
         description="The small, latent dimension of the Perceiver. This is the `N` dimension for the Perceiver's `O(M*N)` complexity",
     )
     num_latents: int = Field(
-        default=512,
+        default=1024,
         description="The number of latent vectors in the Perceiver. This is the `M` dimension for the Perceiver's `O(M*N)` complexity",
     )
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -493,7 +493,7 @@ class DecoderConfig(BaseConfig):
         description="Embedding dimension for pixel-position queries in the PerceiverIO decoder head.",
     )
     window_size: int | None = Field(
-        default=None,
+        default=8192,
         description="Max pixel queries per PerceiverIO call.  None = decode all pixels at once.  "
         "Set this to cap memory/compute at high resolutions.",
     )
@@ -503,8 +503,6 @@ class DecoderConfig(BaseConfig):
         in_channels: int,
         out_channels: int,
         patch_extent: tuple[float, float],
-        max_lat_size: int,
-        max_lon_size: int,
         implementation: PerceiverImpl,
     ) -> PerceiverDecoder:
         return PerceiverDecoder(
@@ -729,8 +727,6 @@ class FOMOConfig(BaseModelConfig):
             processor.out_channels,
             out_channels,
             extent,
-            max_lat_size,
-            max_lon_size,
             impl,
         )
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -717,8 +717,7 @@ class FOMOConfig(BaseModelConfig):
         )
 
         impl = self.perceiver_implementation
-        uses_flash = impl == "flash" or (impl == "auto" and torch.cuda.is_available())
-        if uses_flash and not self.use_bfloat16:
+        if _use_flash(impl) and not self.use_bfloat16:
             raise ValueError(
                 "Perceiver implementation resolves to flash attention. "
                 "Please set `use_bfloat16=True` or `perceiver_implementation='naive'`."

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -325,12 +325,8 @@ PerceiverImpl = Literal["auto", "naive", "flash"]
 
 
 class PerceiverConfig(BaseConfig):
-    """A standard config interface to various perceiver implementations.
+    """A standard config interface to various perceiver implementations."""
 
-    The `implementation="auto"` option will guess what is the best implementation given the runtime environment.
-    """
-
-    implementation: PerceiverImpl = "auto"
     depth: int = 6
     latent_dim: int = Field(
         default=128,
@@ -342,14 +338,18 @@ class PerceiverConfig(BaseConfig):
     )
 
     def build(
-        self, in_channels: int, out_channels: int, max_patch_size: tuple[int, int]
+        self,
+        in_channels: int,
+        out_channels: int,
+        max_patch_size: tuple[int, int],
+        implementation: PerceiverImpl,
     ) -> nn.Module:
         # This is not really a "frequency" but a maximum of the width appears to be reasonable from looking at the code.
         max_freq = max(*max_patch_size)
 
         if (
-            self.implementation == "auto" and torch.cuda.is_available()
-        ) or self.implementation == "flash":
+            implementation == "auto" and torch.cuda.is_available()
+        ) or implementation == "flash":
             try:
                 from flash_perceiver import Perceiver as FlashPerceiver  # type: ignore
             except ModuleNotFoundError as e:
@@ -369,8 +369,8 @@ class PerceiverConfig(BaseConfig):
                 self_per_cross_attn=2,  # ratio of self-attention (latent, small) per cross-attn (input, big) blocks
             )
         elif (
-            self.implementation == "auto" and not torch.cuda.is_available()
-        ) or self.implementation == "naive":
+            implementation == "auto" and not torch.cuda.is_available()
+        ) or implementation == "naive":
             perceiver = NaivePerceiver(
                 num_freq_bands=4,
                 max_freq=max_freq,
@@ -384,9 +384,7 @@ class PerceiverConfig(BaseConfig):
                 self_per_cross_attn=2,  # ratio of self-attn (latent, small) and cross-attn (input, big) blocks
             )
         else:
-            raise ValueError(
-                f"Unknown perceiver implementation: {self.implementation}."
-            )
+            raise ValueError(f"Unknown perceiver implementation: {implementation}.")
 
         return perceiver
 
@@ -401,13 +399,16 @@ class EncoderConfig(BaseConfig):
         patch_extent: tuple[float, float],
         max_lat_size: int,
         max_lon_size: int,
+        implementation: PerceiverImpl,
     ) -> PerceiverEncoder:
         max_patch_size = patch_from(patch_extent, max_lat_size, max_lon_size)
         return PerceiverEncoder(
             in_channels=in_channels,
             out_channels=out_channels,
             patch_extent=patch_extent,
-            perceiver=self.perceiver.build(in_channels, out_channels, max_patch_size),
+            perceiver=self.perceiver.build(
+                in_channels, out_channels, max_patch_size, implementation
+            ),
         )
 
 
@@ -433,6 +434,7 @@ class DecoderConfig(BaseConfig):
         patch_extent: tuple[float, float],
         max_lat_size: int,
         max_lon_size: int,
+        implementation: PerceiverImpl,
     ) -> PerceiverDecoder:
         max_patch_size = patch_from(patch_extent, max_lat_size, max_lon_size)
         # The perceiver sees (C + 2)-dim tokens: latent channels + 2D pixel query.
@@ -443,7 +445,7 @@ class DecoderConfig(BaseConfig):
             patch_extent=patch_extent,
             latent_dim=self.perceiver.latent_dim,
             perceiver=self.perceiver.build(
-                perceiver_in_channels, out_channels, max_patch_size
+                perceiver_in_channels, out_channels, max_patch_size, implementation
             ),
         )
 
@@ -605,6 +607,11 @@ class FOMOConfig(BaseModelConfig):
     encoder: EncoderConfig = EncoderConfig()
     processor: UNetBackboneConfig = UNetBackboneConfig()
     decoder: DecoderConfig = DecoderConfig()
+    perceiver_implementation: PerceiverImpl = Field(
+        default="auto",
+        description="Perceiver attention implementation shared by the encoder and decoder. "
+        "'auto' selects flash attention when CUDA is available, otherwise naive.",
+    )
     patch_extent: list[float] = Field(
         default=[6.0, 10.0],
         description="Target physical extent of each patch in degrees [height_deg, width_deg]. "
@@ -633,8 +640,16 @@ class FOMOConfig(BaseModelConfig):
             max(g[1] for g in all_grid_sizes),
         )
 
+        impl = self.perceiver_implementation
+        uses_flash = impl == "flash" or (impl == "auto" and torch.cuda.is_available())
+        if uses_flash and not self.use_bfloat16:
+            raise ValueError(
+                "Perceiver implementation resolves to flash attention. "
+                "Please set `use_bfloat16=True` or `perceiver_implementation='naive'`."
+            )
+
         encoder = self.encoder.build(
-            in_channels, self.embedding_dim, extent, max_lat_size, max_lon_size
+            in_channels, self.embedding_dim, extent, max_lat_size, max_lon_size, impl
         )
         processor = self.processor.build(
             self.embedding_dim,
@@ -647,17 +662,8 @@ class FOMOConfig(BaseModelConfig):
             extent,
             max_lat_size,
             max_lon_size,
+            impl,
         )
-
-        if any(
-            hasattr(layer.perceiver, "use_flash_attn")
-            and layer.perceiver.use_flash_attn
-            and not self.use_bfloat16
-            for layer in [encoder, decoder]
-        ):
-            raise ValueError(
-                "Encoder/decoder is configured to use flash attention. Please set `use_bfloat16=True`."
-            )
 
         total_in_channels = in_channels + (3 if self.add_3d_coordinates else 0)
         add_3d_coordinates = Concat3dCoordinates() if self.add_3d_coordinates else None

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -445,7 +445,7 @@ class DecoderConfig(BaseConfig):
         assert len(self.patch_extent) == 2, "patch_extent must be a pair of floats."
         extent = self.patch_extent[0], self.patch_extent[1]
         max_patch_size = patch_from(extent, max_lat_size, max_lon_size)
-        perceiver = self.perceiver.build(in_channels, out_channels, max_patch_size)
+        perceiver = self.perceiver.build(in_channels, self.latent_dim, max_patch_size)
         return PerceiverDecoder(
             in_channels=in_channels,
             out_channels=out_channels,

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -30,6 +30,7 @@ from ocean_emulators.models.modules import (
     CoreBlock,
     CoreBlockBuilder,
     MaxPool,
+    PerceiverDecoder,
     PerceiverEncoder,
     ReLU,
     TransposedConvUpsample,
@@ -414,6 +415,83 @@ class EncoderConfig(BaseConfig):
         )
 
 
+class DecoderConfig(BaseConfig):
+    """Configuration for the PerceiverDecoder.
+
+    The decoder mirrors the encoder: while the encoder compresses per-patch
+    data into latent tokens via perceiver cross-attention, the decoder expands
+    the processor's latent grid back to output channels via perceiver
+    cross-attention from learned output queries.
+    """
+
+    patch_extent: list[float] = Field(
+        default=[6.0, 10.0],
+        description="Target physical extent of each patch in degrees [height_deg, width_deg]. "
+        "Should match the encoder's patch_extent for consistent spatial semantics.",
+    )
+    depth: int = Field(
+        default=6,
+        description="Number of cross-attention + self-attention layer blocks.",
+    )
+    latent_dim: int = Field(
+        default=128,
+        description="Internal latent dimension for decoder queries and attention.",
+    )
+    cross_heads: int = Field(
+        default=1,
+        description="Number of attention heads for cross-attention (queries to context).",
+    )
+    latent_heads: int = Field(
+        default=8,
+        description="Number of attention heads for self-attention between output queries.",
+    )
+    cross_dim_head: int = Field(
+        default=64,
+        description="Dimension per head for cross-attention.",
+    )
+    latent_dim_head: int = Field(
+        default=64,
+        description="Dimension per head for self-attention.",
+    )
+    self_per_cross_attn: int = Field(
+        default=2,
+        description="Number of self-attention blocks per cross-attention block.",
+    )
+    weight_tie_layers: bool = Field(
+        default=True,
+        description="Share weights across depth layers (reduces parameters).",
+    )
+
+    def build(
+        self,
+        in_channels: int,
+        out_channels: int,
+        max_lat_size: int,
+        max_lon_size: int,
+    ) -> PerceiverDecoder:
+        assert len(self.patch_extent) == 2, "patch_extent must be a pair of floats."
+        extent = self.patch_extent[0], self.patch_extent[1]
+        max_patch_size = patch_from(extent, max_lat_size, max_lon_size)
+        # Number of spatial positions in the latent grid (same across all resolutions).
+        num_queries = (max_lat_size // max_patch_size[0]) * (
+            max_lon_size // max_patch_size[1]
+        )
+        return PerceiverDecoder(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            patch_extent=extent,
+            num_queries=num_queries,
+            latent_dim=self.latent_dim,
+            depth=self.depth,
+            cross_heads=self.cross_heads,
+            latent_heads=self.latent_heads,
+            cross_dim_head=self.cross_dim_head,
+            latent_dim_head=self.latent_dim_head,
+            self_per_cross_attn=self.self_per_cross_attn,
+            weight_tie_layers=self.weight_tie_layers,
+        )
+
+
 DownSamplingBlocks = Literal["avg_pool", "max_pool"]
 UpSamplingBlocks = Literal[
     "bilinear_upsample", "transposed_conv", "zonally_periodic_upsample"
@@ -570,7 +648,7 @@ class SamudraConfig(BaseModelConfig):
 class FOMOConfig(BaseModelConfig):
     encoder: EncoderConfig = EncoderConfig()
     processor: UNetBackboneConfig = UNetBackboneConfig()
-    # decoder will go here.
+    decoder: DecoderConfig = DecoderConfig()
     embedding_dim: int = 128
     use_bfloat16: bool = Field(
         default=True,
@@ -602,6 +680,18 @@ class FOMOConfig(BaseModelConfig):
                 "Encoder is configured to use flash attention. Please set `use_bfloat16=True`."
             )
 
+        processor = self.processor.build(
+            self.embedding_dim,
+            self.pad,
+            self.checkpointing,
+        )
+        decoder = self.decoder.build(
+            processor.out_channels,
+            out_channels,
+            max_lat_size,
+            max_lon_size,
+        )
+
         total_in_channels = in_channels + (3 if self.add_3d_coordinates else 0)
         add_3d_coordinates = Concat3dCoordinates() if self.add_3d_coordinates else None
         return FOMO(
@@ -611,12 +701,8 @@ class FOMOConfig(BaseModelConfig):
             last_kernel_size=self.last_kernel_size,
             pad=self.pad,
             encoder=encoder,
-            processor=self.processor.build(
-                self.embedding_dim,
-                self.pad,
-                self.checkpointing,
-            ),
-            # decoder = self.decoder.build(processor.out_channels, out_channels)  # will be something like this
+            processor=processor,
+            decoder=decoder,
             add_3d_coordinates=add_3d_coordinates,
             hist=hist,
             checkpointing=self.checkpointing,

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -327,7 +327,9 @@ PerceiverImpl = Literal["auto", "naive", "flash"]
 class PerceiverConfig(BaseConfig):
     """A standard config interface to various perceiver implementations.
 
-    The `implementation="auto"` option will guess what is the best implementation given the runtime environment.
+    Builds either a regular Perceiver (for the encoder, via ``build``) or a
+    PerceiverIO (for the decoder, via ``build_io``).  Both respect the shared
+    ``implementation`` setting from ``FOMOConfig.perceiver_implementation``.
     """
 
     depth: int = 6
@@ -336,7 +338,7 @@ class PerceiverConfig(BaseConfig):
         description="The small, latent dimension of the Perceiver. This is the `N` dimension for the Perceiver's `O(M*N)` complexity",
     )
     num_latents: int = Field(
-        default=1024,
+        default=512,
         description="The number of latent vectors in the Perceiver. This is the `M` dimension for the Perceiver's `O(M*N)` complexity",
     )
 
@@ -347,18 +349,15 @@ class PerceiverConfig(BaseConfig):
         max_patch_size: tuple[int, int],
         implementation: PerceiverImpl,
     ) -> nn.Module:
+        """Build a regular Perceiver (used by the encoder)."""
         # This is not really a "frequency" but a maximum of the width appears to be reasonable from looking at the code.
         max_freq = max(*max_patch_size)
 
-        if (
-            implementation == "auto" and torch.cuda.is_available()
-        ) or implementation == "flash":
+        if _use_flash(implementation):
             try:
                 from flash_perceiver import Perceiver as FlashPerceiver  # type: ignore
             except ModuleNotFoundError as e:
-                raise ValueError(
-                    "`implementation==flash` or flash was automatically chosen for `implementation==auto`, but the flash attention dependencies could not be imported. Please run `uv sync --extra cuda` or specify the `naive` attention implementation."
-                ) from e
+                raise _flash_import_error() from e
             perceiver: nn.Module = FlashPerceiver(
                 latent_rotary_emb_dim=max_freq,
                 depth=self.depth,
@@ -368,28 +367,89 @@ class PerceiverConfig(BaseConfig):
                 latent_dim=self.latent_dim,
                 num_latents=self.num_latents,
                 use_flash_attn=True,
-                weight_tie_layers=True,  # share weights of cross-attn blocks during latent iteration
-                self_per_cross_attn=2,  # ratio of self-attention (latent, small) per cross-attn (input, big) blocks
+                weight_tie_layers=True,
+                self_per_cross_attn=2,
             )
-        elif (
-            implementation == "auto" and not torch.cuda.is_available()
-        ) or implementation == "naive":
+        elif _use_naive(implementation):
             perceiver = NaivePerceiver(
                 num_freq_bands=4,
                 max_freq=max_freq,
                 depth=self.depth,
-                input_axis=2,  # Number of positional dims before token dim
+                input_axis=2,
                 input_channels=in_channels,
                 num_classes=out_channels,
                 latent_dim=self.latent_dim,
                 num_latents=self.num_latents,
-                weight_tie_layers=True,  # share weights of cross-attn blocks
-                self_per_cross_attn=2,  # ratio of self-attn (latent, small) and cross-attn (input, big) blocks
+                weight_tie_layers=True,
+                self_per_cross_attn=2,
             )
         else:
             raise ValueError(f"Unknown perceiver implementation: {implementation}.")
 
         return perceiver
+
+    def build_io(
+        self,
+        in_channels: int,
+        queries_dim: int,
+        out_channels: int,
+        implementation: PerceiverImpl,
+    ) -> nn.Module:
+        """Build a PerceiverIO (used by the decoder)."""
+        if _use_flash(implementation):
+            try:
+                from flash_perceiver.perceiver import (  # type: ignore
+                    PerceiverIO as FlashPerceiverIO,  # type: ignore
+                )
+            except ModuleNotFoundError as e:
+                raise _flash_import_error() from e
+            perceiver_io: nn.Module = FlashPerceiverIO(
+                depth=self.depth,
+                input_dim=in_channels,
+                query_dim=queries_dim,
+                proj_dim=out_channels,
+                num_latents=self.num_latents,
+                latent_dim=self.latent_dim,
+                use_flash_attn=True,
+                weight_tie_layers=True,
+            )
+        elif _use_naive(implementation):
+            from perceiver_pytorch.perceiver_io import PerceiverIO as NaivePerceiverIO
+
+            perceiver_io = NaivePerceiverIO(
+                depth=self.depth,
+                dim=in_channels,
+                queries_dim=queries_dim,
+                logits_dim=out_channels,
+                num_latents=self.num_latents,
+                latent_dim=self.latent_dim,
+                weight_tie_layers=True,
+                decoder_ff=True,
+            )
+        else:
+            raise ValueError(f"Unknown perceiver implementation: {implementation}.")
+
+        return perceiver_io
+
+
+def _use_flash(implementation: PerceiverImpl) -> bool:
+    return (
+        implementation == "auto" and torch.cuda.is_available()
+    ) or implementation == "flash"
+
+
+def _use_naive(implementation: PerceiverImpl) -> bool:
+    return (
+        implementation == "auto" and not torch.cuda.is_available()
+    ) or implementation == "naive"
+
+
+def _flash_import_error() -> ValueError:
+    return ValueError(
+        "`implementation==flash` or flash was automatically chosen for `implementation==auto`, "
+        "but the flash attention dependencies could not be imported. "
+        "Please run `uv sync --extra cuda` or specify the `naive` attention implementation."
+    )
 
 
 class EncoderConfig(BaseConfig):
@@ -445,25 +505,16 @@ class DecoderConfig(BaseConfig):
         patch_extent: tuple[float, float],
         max_lat_size: int,
         max_lon_size: int,
+        implementation: PerceiverImpl,
     ) -> PerceiverDecoder:
-        from perceiver_pytorch.perceiver_io import PerceiverIO
-
-        perceiver_io = PerceiverIO(
-            depth=self.perceiver.depth,
-            dim=in_channels,
-            queries_dim=self.queries_dim,
-            logits_dim=out_channels,
-            num_latents=self.perceiver.num_latents,
-            latent_dim=self.perceiver.latent_dim,
-            weight_tie_layers=True,
-            decoder_ff=True,
-        )
         return PerceiverDecoder(
             in_channels=in_channels,
             out_channels=out_channels,
             patch_extent=patch_extent,
             queries_dim=self.queries_dim,
-            perceiver_io=perceiver_io,
+            perceiver_io=self.perceiver.build_io(
+                in_channels, self.queries_dim, out_channels, implementation
+            ),
             window_size=self.window_size,
         )
 
@@ -680,6 +731,7 @@ class FOMOConfig(BaseModelConfig):
             extent,
             max_lat_size,
             max_lon_size,
+            impl,
         )
 
         total_in_channels = in_channels + (3 if self.add_3d_coordinates else 0)

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -325,7 +325,10 @@ PerceiverImpl = Literal["auto", "naive", "flash"]
 
 
 class PerceiverConfig(BaseConfig):
-    """A standard config interface to various perceiver implementations."""
+    """A standard config interface to various perceiver implementations.
+
+    The `implementation="auto"` option will guess what is the best implementation given the runtime environment.
+    """
 
     depth: int = 6
     latent_dim: int = Field(

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -430,10 +430,6 @@ class DecoderConfig(BaseConfig):
         "Should match the encoder's patch_extent for consistent spatial semantics.",
     )
     perceiver: PerceiverConfig = PerceiverConfig()
-    latent_dim: int = Field(
-        default=128,
-        description="Internal latent dimension for decoder queries and attention.",
-    )
 
     def build(
         self,
@@ -445,13 +441,11 @@ class DecoderConfig(BaseConfig):
         assert len(self.patch_extent) == 2, "patch_extent must be a pair of floats."
         extent = self.patch_extent[0], self.patch_extent[1]
         max_patch_size = patch_from(extent, max_lat_size, max_lon_size)
-        perceiver = self.perceiver.build(in_channels, self.latent_dim, max_patch_size)
         return PerceiverDecoder(
             in_channels=in_channels,
             out_channels=out_channels,
             patch_extent=extent,
-            perceiver=perceiver,
-            latent_dim=self.latent_dim,
+            perceiver=self.perceiver.build(in_channels, out_channels, max_patch_size),
         )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -416,19 +416,27 @@ class EncoderConfig(BaseConfig):
 
 
 class DecoderConfig(BaseConfig):
-    """A perceiver-based decoder configuration.
+    """A PerceiverIO-based decoder configuration.
 
-    This consumes a latent representation from the processor and outputs a phyiscal
-    prediction of the Ocean.
+    Uses PerceiverIO (with an explicit query mechanism) rather than a regular
+    Perceiver.  Output pixel positions are encoded as queries, so the output
+    size is determined by the query count — not by ``num_latents``.
 
-    NB: the `num_latents` of the perceiver in the decoder must be greater than
-    the size (patch_h * patch_w) of the biggest patch.
-
-    Futhermore, there could be a benefit to tuning `num_latents` to be somewhat
-    larger than the max patch pixel count, see: https://arxiv.org/pdf/2309.16588.
+    The ``window_size`` parameter caps the number of queries per PerceiverIO
+    call.  At higher resolutions each patch has more pixels (= more queries);
+    windowing keeps per-call cost bounded by splitting them into chunks.
     """
 
     perceiver: PerceiverConfig = PerceiverConfig()
+    queries_dim: int = Field(
+        default=64,
+        description="Embedding dimension for pixel-position queries in the PerceiverIO decoder head.",
+    )
+    window_size: int | None = Field(
+        default=None,
+        description="Max pixel queries per PerceiverIO call.  None = decode all pixels at once.  "
+        "Set this to cap memory/compute at high resolutions.",
+    )
 
     def build(
         self,
@@ -437,26 +445,26 @@ class DecoderConfig(BaseConfig):
         patch_extent: tuple[float, float],
         max_lat_size: int,
         max_lon_size: int,
-        implementation: PerceiverImpl,
     ) -> PerceiverDecoder:
-        max_patch_size = patch_from(patch_extent, max_lat_size, max_lon_size)
-        max_pixels = max_patch_size[0] * max_patch_size[1]
-        if self.perceiver.num_latents < max_pixels:
-            raise ValueError(
-                f"Decoder perceiver num_latents ({self.perceiver.num_latents}) must be "
-                f">= the largest patch pixel count ({max_patch_size[0]} * {max_patch_size[1]} = {max_pixels}). "
-                f"Increase decoder.perceiver.num_latents or reduce patch_extent."
-            )
-        # The perceiver sees (C + 2)-dim tokens: latent channels + 2D pixel query.
-        perceiver_in_channels = in_channels + 2
+        from perceiver_pytorch.perceiver_io import PerceiverIO
+
+        perceiver_io = PerceiverIO(
+            depth=self.perceiver.depth,
+            dim=in_channels,
+            queries_dim=self.queries_dim,
+            logits_dim=out_channels,
+            num_latents=self.perceiver.num_latents,
+            latent_dim=self.perceiver.latent_dim,
+            weight_tie_layers=True,
+            decoder_ff=True,
+        )
         return PerceiverDecoder(
             in_channels=in_channels,
             out_channels=out_channels,
             patch_extent=patch_extent,
-            latent_dim=self.perceiver.latent_dim,
-            perceiver=self.perceiver.build(
-                perceiver_in_channels, out_channels, max_patch_size, implementation
-            ),
+            queries_dim=self.queries_dim,
+            perceiver_io=perceiver_io,
+            window_size=self.window_size,
         )
 
 
@@ -672,7 +680,6 @@ class FOMOConfig(BaseModelConfig):
             extent,
             max_lat_size,
             max_lon_size,
-            impl,
         )
 
         total_in_channels = in_channels + (3 if self.add_3d_coordinates else 0)

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -437,6 +437,13 @@ class DecoderConfig(BaseConfig):
         implementation: PerceiverImpl,
     ) -> PerceiverDecoder:
         max_patch_size = patch_from(patch_extent, max_lat_size, max_lon_size)
+        max_pixels = max_patch_size[0] * max_patch_size[1]
+        if self.perceiver.num_latents < max_pixels:
+            raise ValueError(
+                f"Decoder perceiver num_latents ({self.perceiver.num_latents}) must be "
+                f">= the largest patch pixel count ({max_patch_size[0]} * {max_patch_size[1]} = {max_pixels}). "
+                f"Increase decoder.perceiver.num_latents or reduce patch_extent."
+            )
         # The perceiver sees (C + 2)-dim tokens: latent channels + 2D pixel query.
         perceiver_in_channels = in_channels + 2
         return PerceiverDecoder(

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -414,14 +414,6 @@ class EncoderConfig(BaseConfig):
 
 
 class DecoderConfig(BaseConfig):
-    """Configuration for the PerceiverDecoder.
-
-    The decoder mirrors the encoder: while the encoder compresses per-patch
-    data into latent tokens via perceiver cross-attention, the decoder expands
-    the processor's latent grid back to output channels via perceiver
-    cross-attention from learned output queries.
-    """
-
     perceiver: PerceiverConfig = PerceiverConfig()
 
     def build(

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -412,6 +412,18 @@ class EncoderConfig(BaseConfig):
 
 
 class DecoderConfig(BaseConfig):
+    """A perceiver-based decoder configuration.
+
+    This consumes a latent representation from the processor and outputs a phyiscal
+    prediction of the Ocean.
+
+    NB: the `num_latents` of the perceiver in the decoder must be greater than
+    the size (patch_h * patch_w) of the biggest patch.
+
+    Futhermore, there could be a benefit to tuning `num_latents` to be somewhat
+    larger than the max patch pixel count, see: https://arxiv.org/pdf/2309.16588.
+    """
+
     perceiver: PerceiverConfig = PerceiverConfig()
 
     def build(

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -425,11 +425,15 @@ class DecoderConfig(BaseConfig):
         max_lon_size: int,
     ) -> PerceiverDecoder:
         max_patch_size = patch_from(patch_extent, max_lat_size, max_lon_size)
+        # The perceiver sees (C + 2)-dim tokens: latent channels + 2D pixel query.
+        perceiver_in_channels = in_channels + 2
         return PerceiverDecoder(
             in_channels=in_channels,
             out_channels=out_channels,
             patch_extent=patch_extent,
-            perceiver=self.perceiver.build(in_channels, out_channels, max_patch_size),
+            perceiver=self.perceiver.build(
+                perceiver_in_channels, out_channels, max_patch_size
+            ),
         )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -482,9 +482,11 @@ class DecoderConfig(BaseConfig):
     Perceiver.  Output pixel positions are encoded as queries, so the output
     size is determined by the query count — not by ``num_latents``.
 
-    The ``window_size`` parameter caps the number of queries per PerceiverIO
-    call.  At higher resolutions each patch has more pixels (= more queries);
-    windowing keeps per-call cost bounded by splitting them into chunks.
+    When ``window_patches`` is set, the decoder tiles the output grid into
+    spatial blocks of that many patches per side.  Each block's PerceiverIO
+    call receives only the overlapping latent tokens plus ``context_patches``
+    extra rings of neighbors, keeping cost bounded even when the latent grid
+    is large (i.e. fine ``patch_extent``).
     """
 
     perceiver: PerceiverConfig = PerceiverConfig()
@@ -492,10 +494,16 @@ class DecoderConfig(BaseConfig):
         default=64,
         description="Embedding dimension for pixel-position queries in the PerceiverIO decoder head.",
     )
-    window_size: int | None = Field(
-        default=8192,
-        description="Max pixel queries per PerceiverIO call.  None = decode all pixels at once.  "
-        "Set this to cap memory/compute at high resolutions.",
+    window_patches: int | None = Field(
+        default=None,
+        description="Side length (in patches) of each spatial decode window. "
+        "None = decode all patches at once (global attention). "
+        "E.g. window_patches=8 means each PerceiverIO call covers an 8x8 block of patches.",
+    )
+    context_patches: int | None = Field(
+        default=1,
+        description="Number of extra patch rings around each window to include as data context. "
+        "Only used when window_patches is set. None = full context (every window sees all latent tokens).",
     )
 
     def build(
@@ -513,7 +521,8 @@ class DecoderConfig(BaseConfig):
             perceiver_io=self.perceiver.build_io(
                 in_channels, self.queries_dim, out_channels, implementation
             ),
-            window_size=self.window_size,
+            window_patches=self.window_patches,
+            context_patches=self.context_patches,
         )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -429,37 +429,10 @@ class DecoderConfig(BaseConfig):
         description="Target physical extent of each patch in degrees [height_deg, width_deg]. "
         "Should match the encoder's patch_extent for consistent spatial semantics.",
     )
-    depth: int = Field(
-        default=6,
-        description="Number of cross-attention + self-attention layer blocks.",
-    )
+    perceiver: PerceiverConfig = PerceiverConfig()
     latent_dim: int = Field(
         default=128,
         description="Internal latent dimension for decoder queries and attention.",
-    )
-    cross_heads: int = Field(
-        default=1,
-        description="Number of attention heads for cross-attention (queries to context).",
-    )
-    latent_heads: int = Field(
-        default=8,
-        description="Number of attention heads for self-attention between output queries.",
-    )
-    cross_dim_head: int = Field(
-        default=64,
-        description="Dimension per head for cross-attention.",
-    )
-    latent_dim_head: int = Field(
-        default=64,
-        description="Dimension per head for self-attention.",
-    )
-    self_per_cross_attn: int = Field(
-        default=2,
-        description="Number of self-attention blocks per cross-attention block.",
-    )
-    weight_tie_layers: bool = Field(
-        default=True,
-        description="Share weights across depth layers (reduces parameters).",
     )
 
     def build(
@@ -472,23 +445,13 @@ class DecoderConfig(BaseConfig):
         assert len(self.patch_extent) == 2, "patch_extent must be a pair of floats."
         extent = self.patch_extent[0], self.patch_extent[1]
         max_patch_size = patch_from(extent, max_lat_size, max_lon_size)
-        # Number of spatial positions in the latent grid (same across all resolutions).
-        num_queries = (max_lat_size // max_patch_size[0]) * (
-            max_lon_size // max_patch_size[1]
-        )
+        perceiver = self.perceiver.build(in_channels, out_channels, max_patch_size)
         return PerceiverDecoder(
             in_channels=in_channels,
             out_channels=out_channels,
             patch_extent=extent,
-            num_queries=num_queries,
+            perceiver=perceiver,
             latent_dim=self.latent_dim,
-            depth=self.depth,
-            cross_heads=self.cross_heads,
-            latent_heads=self.latent_heads,
-            cross_dim_head=self.cross_dim_head,
-            latent_dim_head=self.latent_dim_head,
-            self_per_cross_attn=self.self_per_cross_attn,
-            weight_tie_layers=self.weight_tie_layers,
         )
 
 

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -102,13 +102,6 @@ class FOMO(BaseModel):
         # Convert back to float32 for unpatchify operations
         fts = fts.to(torch.float32)
 
-        # Decoder goes from (per patch) latent --> out_channels x ph x pw (ph is the patch height)
-        #
-        # another solution: a shared perciver that works across output res
-        # simplest possible version is the perceiver gets the latent vector + some query verctor  (contact together)
-        # where the query just says (I want the 0x0 pixel), then we run this perceiver for the pixel output space
-        # (patch output space).
-
         # Unpatchify: project to patch area, then reshape back to original spatial dimensions
         patch_size = patch_from(self.encoder.patch_extent, H, W)
         _, _, h, w = fts.shape

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -11,7 +11,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 
 from ocean_emulators.constants import GridSize
 from ocean_emulators.models.base import BaseModel
-from ocean_emulators.models.modules import PerceiverEncoder
+from ocean_emulators.models.modules import PerceiverDecoder, PerceiverEncoder
 from ocean_emulators.models.modules.encoder import patch_from
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
 from ocean_emulators.utils.ctx import GridContext
@@ -37,6 +37,7 @@ class FOMO(BaseModel):
         add_3d_coordinates: nn.Module | None,
         encoder: PerceiverEncoder,
         processor: UNetBackbone,
+        decoder: PerceiverDecoder,
         hist: int,
         checkpointing: "Checkpointing | None",
         gradient_detach_interval: int,
@@ -56,14 +57,8 @@ class FOMO(BaseModel):
         self.maybe_add_3d_coordinates = add_3d_coordinates
         self.encoder = encoder
         self.processor = processor
+        self.decoder = decoder
         self.use_bfloat16 = use_bfloat16
-        # Placeholder decoder is a non-globe aware Conv2d.
-        self.decoder = nn.Conv2d(
-            processor.out_channels,
-            out_channels,
-            last_kernel_size,
-            padding=last_kernel_size // 2,
-        )
         all_patches = [
             patch_from(self.encoder.patch_extent, *grid_size)
             for grid_size in grid_sizes
@@ -87,6 +82,7 @@ class FOMO(BaseModel):
                     | FeedForward
                     | nn.Linear
                     | Perceiver
+                    | PerceiverDecoder
                     | PerceiverEncoder
                     | UNetBackbone
                     | Attention,
@@ -104,7 +100,7 @@ class FOMO(BaseModel):
 
         # Convert back to float32 for decoder and unpatchify operations
         fts = fts.to(torch.float32)
-        fts = self.decoder(fts)
+        fts = self.decoder(fts, ctx.input_resolution_cpu)
 
         # Unpatchify: project to patch area, then reshape back to original spatial dimensions
         patch_size = patch_from(self.encoder.patch_extent, H, W)

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -81,6 +81,7 @@ class FOMO(BaseModel):
             fts = self.decoder(fts, ctx.input_resolution_cpu)
 
         # Convert back to float32
+        # TODO(alxmrs): We actually only support float16 when turned on; this kind of tricks us.
         fts = fts.to(torch.float32)
 
         return torch.where(ctx.label_mask, fts, 0.0)

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -97,10 +97,10 @@ class FOMO(BaseModel):
                 fts = self.maybe_add_3d_coordinates(fts, ctx.input_resolution_cpu)
             fts = self.encoder(fts, ctx.input_resolution_cpu)
             fts = self.processor(fts)
+            fts = self.decoder(fts, ctx.input_resolution_cpu)
 
-        # Convert back to float32 for decoder and unpatchify operations
+        # Convert back to float32 for unpatchify operations
         fts = fts.to(torch.float32)
-        fts = self.decoder(fts, ctx.input_resolution_cpu)
 
         # Unpatchify: project to patch area, then reshape back to original spatial dimensions
         patch_size = patch_from(self.encoder.patch_extent, H, W)

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -102,6 +102,13 @@ class FOMO(BaseModel):
         # Convert back to float32 for unpatchify operations
         fts = fts.to(torch.float32)
 
+        # Decoder goes from (per patch) latent --> out_channels x ph x pw (ph is the patch height)
+        #
+        # another solution: a shared perciver that works across output res
+        # simplest possible version is the perceiver gets the latent vector + some query verctor  (contact together)
+        # where the query just says (I want the 0x0 pixel), then we run this perceiver for the pixel output space
+        # (patch output space).
+
         # Unpatchify: project to patch area, then reshape back to original spatial dimensions
         patch_size = patch_from(self.encoder.patch_extent, H, W)
         _, _, h, w = fts.shape

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
 import torch
-from einops import rearrange
 from perceiver_pytorch import Perceiver
 from perceiver_pytorch.perceiver_pytorch import Attention, FeedForward
 from torch import nn
@@ -9,10 +8,8 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     apply_activation_checkpointing,
 )
 
-from ocean_emulators.constants import GridSize
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import PerceiverDecoder, PerceiverEncoder
-from ocean_emulators.models.modules.encoder import patch_from
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
 from ocean_emulators.utils.ctx import GridContext
 from ocean_emulators.utils.device import autocast
@@ -41,7 +38,6 @@ class FOMO(BaseModel):
         hist: int,
         checkpointing: "Checkpointing | None",
         gradient_detach_interval: int,
-        grid_sizes: list[GridSize],
         use_bfloat16: bool,
     ):
         super().__init__(
@@ -59,19 +55,6 @@ class FOMO(BaseModel):
         self.processor = processor
         self.decoder = decoder
         self.use_bfloat16 = use_bfloat16
-        all_patches = [
-            patch_from(self.encoder.patch_extent, *grid_size)
-            for grid_size in grid_sizes
-        ]
-
-        self.unpatch = nn.ModuleDict(
-            {
-                str(patch_size): nn.Linear(
-                    out_channels, out_channels * patch_size[0] * patch_size[1]
-                )
-                for patch_size in all_patches
-            }
-        )
 
         if checkpointing == "all":
             apply_activation_checkpointing(
@@ -90,8 +73,6 @@ class FOMO(BaseModel):
             )
 
     def forward_once(self, fts: torch.Tensor, ctx: GridContext) -> torch.Tensor:
-        _, _, H, W = fts.shape
-
         with autocast(enabled=self.use_bfloat16, dtype=torch.bfloat16):
             if self.maybe_add_3d_coordinates is not None:
                 fts = self.maybe_add_3d_coordinates(fts, ctx.input_resolution_cpu)
@@ -99,22 +80,7 @@ class FOMO(BaseModel):
             fts = self.processor(fts)
             fts = self.decoder(fts, ctx.input_resolution_cpu)
 
-        # Convert back to float32 for unpatchify operations
+        # Convert back to float32
         fts = fts.to(torch.float32)
-
-        # Unpatchify: project to patch area, then reshape back to original spatial dimensions
-        patch_size = patch_from(self.encoder.patch_extent, H, W)
-        _, _, h, w = fts.shape
-        fts = rearrange(fts, "b l h w -> b h w l")
-        fts = self.unpatch[str(patch_size)](fts)  # (b, h, w, out_channels * ph * pw)
-        fts = rearrange(
-            fts,
-            "b h w (c ph pw) -> b c (h ph) (w pw)",
-            c=self.out_channels,
-            ph=patch_size[0],
-            pw=patch_size[1],
-            h=h,
-            w=w,
-        )
 
         return torch.where(ctx.label_mask, fts, 0.0)

--- a/src/ocean_emulators/models/modules/__init__.py
+++ b/src/ocean_emulators/models/modules/__init__.py
@@ -11,6 +11,7 @@ from .blocks import (
     UpsamplingBlockBuilder,
     ZonallyPeriodicBilinearUpsample,
 )
+from .decoder import PerceiverDecoder
 from .encoder import PerceiverEncoder
 from .unet_backbone import UNetBackbone
 
@@ -25,6 +26,7 @@ __all__ = [
     "CappedGELU",
     "CappedLeakyReLU",
     "MaxPool",
+    "PerceiverDecoder",
     "PerceiverEncoder",
     "ReLU",
     "UNetBackbone",

--- a/src/ocean_emulators/models/modules/augment_input.py
+++ b/src/ocean_emulators/models/modules/augment_input.py
@@ -7,7 +7,11 @@ from ocean_emulators.constants import Lat, Lon
 
 
 def make_3d_coordinate_grid(lat, lon) -> torch.Tensor:
-    """Makes a 3d Cartesian Coordinates on a unit sphere."""
+    """Make 3D Cartesian coordinates on a unit sphere.
+
+    Returns:
+        ``(3, H, W)`` tensor of ``(x, y, z)`` unit-sphere coordinates.
+    """
     lat_lon_grid = lat_lon_meshgrid(lat, lon)  # [2, H, W]
     lat_rad = torch.deg2rad(lat_lon_grid[0])  # [H, W]
     lon_rad = torch.deg2rad(lat_lon_grid[1])  # [H, W]
@@ -16,8 +20,7 @@ def make_3d_coordinate_grid(lat, lon) -> torch.Tensor:
     y = torch.cos(lat_rad) * torch.sin(lon_rad)
     z = torch.sin(lat_rad)
 
-    grid = torch.stack([x, y, z], dim=0)  # [3, H, W]
-    return grid.float().unsqueeze(0)
+    return torch.stack([x, y, z], dim=0).float()  # [3, H, W]
 
 
 class Concat3dCoordinates(nn.Module):
@@ -50,6 +53,7 @@ class Concat3dCoordinates(nn.Module):
     ) -> Float[torch.Tensor, "batch channel+3 height width"]:
         grid = (
             make_3d_coordinate_grid(*resolution)
+            .unsqueeze(0)
             .to(fts.device)
             .expand(fts.shape[0], -1, -1, -1)
         )

--- a/src/ocean_emulators/models/modules/augment_input.py
+++ b/src/ocean_emulators/models/modules/augment_input.py
@@ -6,7 +6,7 @@ from torch import nn
 from ocean_emulators.constants import Lat, Lon
 
 
-def make_3d_coordinate_grid(lat, lon) -> torch.Tensor:
+def make_3d_coordinate_grid(lat: Lat, lon: Lon) -> Float[torch.Tensor, "3 H W"]:
     """Make 3D Cartesian coordinates on a unit sphere.
 
     Returns:

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -81,13 +81,17 @@ class PerceiverDecoder(nn.Module):
         patch_extent: tuple[float, float],
         queries_dim: int,
         perceiver_io: nn.Module,
-        window_patches: int | None = None,
-        context_patches: int | None = 1,
+        window_patches: int | None,
+        context_patches: int | None,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.patch_extent = patch_extent
+        if window_patches is None and context_patches is not None:
+            raise ValueError(
+                "window_patches must be set in order for context_patches to be set."
+            )
         self.window_patches = window_patches
         self.context_patches = context_patches
 

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -8,7 +8,6 @@ from aurora.model.fourier import pos_expansion, scale_expansion
 from aurora.model.posencoding import pos_scale_enc
 from einops import rearrange
 from jaxtyping import Float
-from perceiver_pytorch.perceiver_pytorch import Attention, FeedForward, PreNorm
 from torch import nn
 
 from ocean_emulators.constants import Lat, Lon
@@ -46,18 +45,8 @@ class PerceiverDecoder(nn.Module):
         out_channels: Number of output channels per spatial position.
         patch_extent: Spatial extent of each patch in degrees (lat, lon).
             Used for computing positional and scale encodings.
-        num_queries: Number of learned output queries (should equal h * w of
-            the latent grid, e.g. 30 * 36 = 1080 for default patch extents).
+        perceiver: The underlying perceiver decoder.
         latent_dim: Dimension of the decoder's internal latent space.
-        depth: Number of cross-attention + self-attention layer blocks.
-        cross_heads: Number of attention heads for cross-attention.
-        latent_heads: Number of attention heads for self-attention.
-        cross_dim_head: Dimension per head for cross-attention.
-        latent_dim_head: Dimension per head for self-attention.
-        self_per_cross_attn: Number of self-attention blocks per cross-attention block.
-        weight_tie_layers: Whether to share weights across depth layers.
-        attn_dropout: Dropout rate for attention weights.
-        ff_dropout: Dropout rate for feedforward layers.
 
     References:
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
@@ -68,26 +57,15 @@ class PerceiverDecoder(nn.Module):
         in_channels: int,
         out_channels: int,
         patch_extent: tuple[float, float],
-        num_queries: int,
+        perceiver: nn.Module,
         latent_dim: int = 128,
-        depth: int = 6,
-        cross_heads: int = 1,
-        latent_heads: int = 8,
-        cross_dim_head: int = 64,
-        latent_dim_head: int = 64,
-        self_per_cross_attn: int = 2,
-        weight_tie_layers: bool = True,
-        attn_dropout: float = 0.0,
-        ff_dropout: float = 0.0,
     ) -> None:
         super().__init__()
         self.out_channels = out_channels
         self.patch_extent = patch_extent
 
-        # Learned output queries — one per spatial position in the latent grid.
-        # These learn to represent "what information to extract" for each output position.
-        self.queries = nn.Parameter(torch.randn(num_queries, latent_dim))
-
+        # TODO(claude) I don't think we need to project to a latent space; the output
+        #  of the processor will be a latent space.
         # Project processor output channels to decoder latent dimension
         self.input_proj = nn.Linear(in_channels, latent_dim)
 
@@ -95,63 +73,7 @@ class PerceiverDecoder(nn.Module):
         self.pos_embed = nn.Linear(latent_dim, latent_dim)
         self.scale_embed = nn.Linear(latent_dim, latent_dim)
 
-        # Build cross-attention and self-attention layers, following the
-        # same pattern as perceiver_pytorch.Perceiver.
-        def get_cross_attn():
-            return PreNorm(
-                latent_dim,
-                Attention(
-                    latent_dim,
-                    latent_dim,
-                    heads=cross_heads,
-                    dim_head=cross_dim_head,
-                    dropout=attn_dropout,
-                ),
-                context_dim=latent_dim,
-            )
-
-        def get_cross_ff():
-            return PreNorm(latent_dim, FeedForward(latent_dim, dropout=ff_dropout))
-
-        def get_latent_attn():
-            return PreNorm(
-                latent_dim,
-                Attention(
-                    latent_dim,
-                    heads=latent_heads,
-                    dim_head=latent_dim_head,
-                    dropout=attn_dropout,
-                ),
-            )
-
-        def get_latent_ff():
-            return PreNorm(latent_dim, FeedForward(latent_dim, dropout=ff_dropout))
-
-        # Optionally share weights across depth layers (weight tying)
-        if weight_tie_layers:
-            # Create one set of layers and reuse references
-            cross_attn = get_cross_attn()
-            cross_ff = get_cross_ff()
-            latent_attn = get_latent_attn()
-            latent_ff = get_latent_ff()
-
-            self.layers = nn.ModuleList([])
-            for _ in range(depth):
-                self_attns = nn.ModuleList([])
-                for _ in range(self_per_cross_attn):
-                    self_attns.append(nn.ModuleList([latent_attn, latent_ff]))
-                self.layers.append(nn.ModuleList([cross_attn, cross_ff, self_attns]))
-        else:
-            self.layers = nn.ModuleList([])
-            for _ in range(depth):
-                self_attns = nn.ModuleList([])
-                for _ in range(self_per_cross_attn):
-                    self_attns.append(
-                        nn.ModuleList([get_latent_attn(), get_latent_ff()])
-                    )
-                self.layers.append(
-                    nn.ModuleList([get_cross_attn(), get_cross_ff(), self_attns])
-                )
+        self.perceiver = perceiver
 
         # Final projection from latent_dim to out_channels
         self.to_out = nn.Sequential(
@@ -192,17 +114,20 @@ class PerceiverDecoder(nn.Module):
         ).unsqueeze(0)
         context = context + pos_encoding + scale_encoding
 
-        # Initialize output queries: (B, num_queries, latent_dim)
-        queries = self.queries.unsqueeze(0).expand(B, -1, -1)
+        # # Initialize output queries: (B, num_queries, latent_dim)
+        # queries = self.queries.unsqueeze(0).expand(B, -1, -1)
+        #
+        # # Cross-attention + self-attention layers
+        # for cross_attn, cross_ff, self_attns in self.layers:  # type: ignore
+        #     queries = cross_attn(queries, context=context) + queries  # type: ignore
+        #     queries = cross_ff(queries) + queries  # type: ignore
+        #
+        #     for self_attn, self_ff in self_attns:  # type: ignore
+        #         queries = self_attn(queries) + queries
+        #         queries = self_ff(queries) + queries
+        #
 
-        # Cross-attention + self-attention layers
-        for cross_attn, cross_ff, self_attns in self.layers:  # type: ignore
-            queries = cross_attn(queries, context=context) + queries  # type: ignore
-            queries = cross_ff(queries) + queries  # type: ignore
-
-            for self_attn, self_ff in self_attns:  # type: ignore
-                queries = self_attn(queries) + queries
-                queries = self_ff(queries) + queries
+        queries = self.perceiver(context)
 
         # Project to output channels: (B, h*w, out_channels)
         out = self.to_out(queries)

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -145,8 +145,6 @@ class PerceiverDecoder(nn.Module):
 
         # --- Reassemble into full-resolution output ---
         # num_latents >= patch_h * patch_w; take only the pixels we need.
-        # TODO(alxmrs,Claude): Consider using a learned selection of the latents or pooling over the latents
-        #  (more complex)
         #
         # num_latents should be as large as the biggest patch. For smaller patches,
         # num_latents includes "extra" information beyond the pixel count.
@@ -155,6 +153,9 @@ class PerceiverDecoder(nn.Module):
         # architectures to use even if they aren't used in the output.
         # Transformers can use these as "scratch" space, check out [2]  for more
         # on this topic.
+        #
+        # TODO(alxmrs,Claude): Consider using a learned selection of the latents
+        #  or pooling over the latents (more complex).
         num_pixels = patch_h * patch_w
         out = out[:, :num_pixels, :]  # (B*nh*nw, patch_h*patch_w, out_channels)
 

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -1,7 +1,4 @@
 # Perceiver-based decoder, complementary to encoder.py
-# Sources:
-# - https://ar5iv.labs.arxiv.org/html/2405.13063 (Aurora paper, Appendix B.3: 3D Perceiver Decoder)
-# - https://github.com/lucidrains/perceiver-pytorch
 
 import torch
 from aurora.model.fourier import pos_expansion, scale_expansion
@@ -15,7 +12,7 @@ from ocean_emulators.models.modules.encoder import patch_from
 
 
 class PerceiverDecoder(nn.Module):
-    """A perceiver-based decoder that maps latent patch tokens to full-resolution output.
+    """A perceiver-based[0] decoder that maps latent patch tokens to full-resolution output.
 
     For each patch position on the latent grid, the decoder:
 
@@ -49,6 +46,7 @@ class PerceiverDecoder(nn.Module):
             ``in_channels + 2`` (latent dim + 2D pixel query).
 
     References:
+        [0]: https://github.com/lucidrains/perceiver-pytorch
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
         [2]: https://ar5iv.labs.arxiv.org/html/2309.16588
     """

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -33,12 +33,13 @@ class PerceiverDecoder(nn.Module):
        producing ``(B, H * W, out_channels)``.
     5. Reshape to ``(B, out_channels, H, W)``.
 
-    **Multi-scale windowing**: At higher resolutions ``H * W`` grows, making
-    the full query set expensive.  When ``window_size`` is set, the decoder
-    splits pixel queries into fixed-size chunks and calls the PerceiverIO once
-    per chunk.  Each call re-encodes the same latent data (the ``nh * nw``
-    tokens — cheap for small latent grids) and only decodes its subset of
-    pixel queries, keeping per-call cost bounded.
+    **Spatial windowing**: When ``window_patches`` is set, the decoder tiles
+    the output grid into spatial blocks, each covering ``window_patches``
+    patches along each axis.  For each block, only the overlapping latent
+    tokens — plus ``context_patches`` extra rings of neighbors — are passed
+    as data.  This bounds both query count and data count per PerceiverIO
+    call, keeping cost manageable even when the latent grid is large (i.e.
+    fine ``patch_extent``).
 
     Because pixel queries are normalized to ``[0, 1)``, the same PerceiverIO
     generalizes across resolutions.
@@ -52,9 +53,15 @@ class PerceiverDecoder(nn.Module):
         perceiver_io: A PerceiverIO module.  ``dim`` must equal ``in_channels``,
             ``queries_dim`` must match this decoder's ``queries_dim``, and
             ``logits_dim`` must equal ``out_channels``.
-        window_size: Maximum number of pixel queries per PerceiverIO call.
-            If ``None``, all ``H * W`` pixels are decoded in one call.
-            Set this to cap memory/compute at high resolutions.
+        window_patches: Side length (in patches) of each spatial decode window.
+            If ``None``, all patches are used globally (no windowing).
+            E.g. ``window_patches=8`` means each PerceiverIO call covers an
+            8x8 block of patches.
+        context_patches: Number of extra patch rings around each window to
+            include as data context.  Only used when ``window_patches`` is set.
+            Default 1 gives each window one ring of neighboring patches beyond
+            its own block.  ``None`` means full context — every window sees all
+            latent tokens (windowed queries but global data attention).
 
     References:
         [0]: https://github.com/lucidrains/perceiver-pytorch
@@ -70,13 +77,15 @@ class PerceiverDecoder(nn.Module):
         patch_extent: tuple[float, float],
         queries_dim: int,
         perceiver_io: nn.Module,
-        window_size: int | None = None,
+        window_patches: int | None = None,
+        context_patches: int | None = 1,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.patch_extent = patch_extent
-        self.window_size = window_size
+        self.window_patches = window_patches
+        self.context_patches = context_patches
 
         # TODO(#451): The input to these position and scale linear units could be a hparam.
         # Same pos/scale linear layers as the encoder, but applied *before* the
@@ -123,7 +132,6 @@ class PerceiverDecoder(nn.Module):
             scale_encode.to(dtype=tokens.dtype, device=tokens.device)
         ).unsqueeze(0)
         tokens = tokens + pos_encoding + scale_encoding
-        # tokens: (B, nh*nw, C) — full latent grid as data for PerceiverIO.
 
         # --- Build global pixel-position queries ---
         # Normalized 2D coords in [0, 1) for every output pixel.
@@ -131,33 +139,85 @@ class PerceiverDecoder(nn.Module):
         qw = torch.arange(W, dtype=x.dtype, device=x.device) / W
         grid_h, grid_w = torch.meshgrid(qh, qw, indexing="ij")
         coords = torch.stack([grid_h, grid_w], dim=-1)  # (H, W, 2)
-        coords = rearrange(coords, "h w d -> (h w) d")  # (H*W, 2)
-        queries = self.query_embed(coords)  # (H*W, queries_dim)
+        queries = self.query_embed(
+            rearrange(coords, "h w d -> (h w) d")
+        )  # (H*W, queries_dim)
+        queries = rearrange(
+            queries, "(h w) d -> h w d", h=H, w=W
+        )  # (H, W, queries_dim)
 
-        # --- Decode via PerceiverIO with optional windowing ---
-        out = self._decode(tokens, queries)  # (B, H*W, out_channels)
-
-        # --- Reshape to spatial ---
-        out = rearrange(out, "b (h w) c -> b c h w", h=H, w=W)
+        # --- Decode via PerceiverIO with optional spatial windowing ---
+        data_grid = rearrange(tokens, "b (nh nw) c -> b nh nw c", nh=nh, nw=nw)
+        out = self._decode(data_grid, queries, pos_patch_h, pos_patch_w)
 
         return out
 
     def _decode(
         self,
-        data: Float[torch.Tensor, "batch num_patches channels"],
-        queries: Float[torch.Tensor, "num_pixels queries_dim"],
-    ) -> Float[torch.Tensor, "batch num_pixels {self.out_channels}"]:
-        """Run PerceiverIO, windowing over queries if they exceed window_size."""
-        num_pixels = queries.shape[0]
+        data_grid: Float[torch.Tensor, "batch nh nw channels"],
+        queries_grid: Float[torch.Tensor, "H W queries_dim"],
+        patch_h: int,
+        patch_w: int,
+    ) -> Float[torch.Tensor, "batch {self.out_channels} H W"]:
+        """Run PerceiverIO, optionally tiling into spatial windows.
 
-        if self.window_size is None or num_pixels <= self.window_size:
-            return self.perceiver_io(data, queries=queries)
+        When ``window_patches`` is None, all data and queries are passed in one
+        call (global attention).  Otherwise, the output grid is tiled into
+        spatial blocks and each block attends only to nearby latent tokens.
+        """
+        B, nh, nw, C = data_grid.shape
+        H, W, _ = queries_grid.shape
 
-        # Split queries into fixed-size windows to cap memory at high resolutions.
-        # Each window re-encodes the same latent data and only decodes its
-        # subset of pixel queries.
-        chunks = []
-        for i in range(0, num_pixels, self.window_size):
-            q_window = queries[i : i + self.window_size]
-            chunks.append(self.perceiver_io(data, queries=q_window))
-        return torch.cat(chunks, dim=1)
+        if self.window_patches is None:
+            data = rearrange(data_grid, "b nh nw c -> b (nh nw) c")
+            queries = rearrange(queries_grid, "h w d -> (h w) d")
+            out = self.perceiver_io(data, queries=queries)  # (B, H*W, out_channels)
+            return rearrange(out, "b (h w) c -> b c h w", h=H, w=W)
+
+        wp = self.window_patches
+        cp = self.context_patches
+
+        out = data_grid.new_zeros(B, H, W, self.out_channels)
+
+        # Flatten full data once when context_patches is None (full context).
+        full_data = (
+            rearrange(data_grid, "b nh nw c -> b (nh nw) c") if cp is None else None
+        )
+
+        for pi in range(0, nh, wp):
+            for pj in range(0, nw, wp):
+                pi_end = min(pi + wp, nh)
+                pj_end = min(pj + wp, nw)
+
+                if cp is None:
+                    # Full context: every window sees all latent tokens.
+                    local_data = full_data
+                else:
+                    # Expand data region by context_patches, clamped to grid bounds.
+                    di_start = max(pi - cp, 0)
+                    di_end = min(pi_end + cp, nh)
+                    dj_start = max(pj - cp, 0)
+                    dj_end = min(pj_end + cp, nw)
+
+                    local_data = data_grid[:, di_start:di_end, dj_start:dj_end, :]
+                    local_data = rearrange(local_data, "b h w c -> b (h w) c")
+
+                # Pixel region covered by this patch block.
+                qi_start = pi * patch_h
+                qi_end = pi_end * patch_h
+                qj_start = pj * patch_w
+                qj_end = pj_end * patch_w
+
+                local_queries = queries_grid[qi_start:qi_end, qj_start:qj_end, :]
+                local_queries = rearrange(local_queries, "h w d -> (h w) d")
+
+                local_out = self.perceiver_io(local_data, queries=local_queries)
+                qh_size = qi_end - qi_start
+                qw_size = qj_end - qj_start
+                local_out = rearrange(
+                    local_out, "b (h w) c -> b h w c", h=qh_size, w=qw_size
+                )
+
+                out[:, qi_start:qi_end, qj_start:qj_end, :] = local_out
+
+        return rearrange(out, "b h w c -> b c h w")

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -102,7 +102,7 @@ class PerceiverDecoder(nn.Module):
         # It assumes that `input_axis=2`.
         context = context.unsqueeze(1).unsqueeze(1)
 
-        # (B*h*w, 1, channels) -> (B*h*w, out_channels)
+        # (B*h*w, 1, 1, channels) -> (B*h*w, out_channels)
         out = self.perceiver(context)
 
         # Reshape back to spatial grid

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -1,4 +1,4 @@
-# Mirrors the encoder structure in encoder.py
+# Perceiver-based decoder, complementary to encoder.py
 # Sources:
 # - https://ar5iv.labs.arxiv.org/html/2405.13063 (Aurora paper, Appendix B.3: 3D Perceiver Decoder)
 # - https://github.com/lucidrains/perceiver-pytorch
@@ -67,7 +67,8 @@ class PerceiverDecoder(nn.Module):
         self.patch_extent = patch_extent
 
         # TODO(#451): The input to these position and scale linear units could be a hparam.
-        # Positional and scale encoding (mirrors encoder's post-perceiver encoding)
+        # Same pos/scale linear layers as the encoder, but applied *before* the
+        # perceiver (the encoder applies them after).
         self.pos_embed = nn.Linear(in_channels, in_channels)
         self.scale_embed = nn.Linear(in_channels, in_channels)
 
@@ -96,7 +97,7 @@ class PerceiverDecoder(nn.Module):
         # but in unit tests the input grid may not match, so derive from tensor.
         pos_patch_h, pos_patch_w = H // nh, W // nw
 
-        # --- Add pos/scale encoding to latent tokens (mirrors encoder) ---
+        # --- Add pos/scale encoding to latent tokens (before perceiver, unlike encoder) ---
         tokens = rearrange(x, "b c nh nw -> b (nh nw) c")
 
         pos_encode, scale_encode = pos_scale_enc(
@@ -135,7 +136,8 @@ class PerceiverDecoder(nn.Module):
         perceiver_input = torch.cat([tokens, query], dim=-1)
 
         # --- Run perceiver without mean-pooling ---
-        # return_embeddings=True skips the perceiver's to_logits (which mean-pools).
+        # return_embeddings=True skips the output head (which mean-pools) in both
+        # NaivePerceiver and FlashPerceiver, returning raw latent embeddings.
         # Returns: (B*nh*nw, num_latents, latent_dim)
         embeddings = self.perceiver(perceiver_input, return_embeddings=True)
 

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -8,54 +8,54 @@ from jaxtyping import Float
 from torch import nn
 
 from ocean_emulators.constants import Lat, Lon
-from ocean_emulators.models.modules.encoder import patch_from
 
 
 class PerceiverDecoder(nn.Module):
-    """A PerceiverIO-based[0] decoder that maps latent patch tokens to full-resolution output.
+    """A PerceiverIO-based decoder that maps a latent patch grid to full-resolution output.
 
-    Unlike the encoder's regular Perceiver (which compresses spatial input into
-    a fixed-size latent), the decoder uses **PerceiverIO**[3] — a variant with
-    an explicit query mechanism.  Queries represent output pixel positions, and
-    the PerceiverIO cross-attends from those queries to the encoded latent
-    representation, producing one prediction per query.
+    Unlike the previous per-patch decoder, this operates over the **full latent
+    grid** at once.  All ``nh * nw`` pos/scale-encoded latent tokens are passed
+    as **data** to the PerceiverIO, and every output pixel position is a
+    **query**.  Each query cross-attends to the full latent representation,
+    giving it global spatial context — pixels near patch boundaries can attend
+    to neighboring patches, and the model can learn smooth inter-patch
+    transitions.
 
-    For each patch position on the latent grid, the decoder:
+    Concretely:
 
-    1. Adds Aurora-style pos/scale encoding to the latent vector (telling the
-       model *where on the globe* this patch is).
-    2. Passes the encoded latent as **data** to the PerceiverIO — the single
-       token that the model's internal latents cross-attend to during encoding.
-    3. Builds normalized 2D pixel-position **queries** for every output pixel
-       within the patch, embeds them via a learned linear layer into
-       ``queries_dim``, and feeds them to the PerceiverIO's decoder head.
-    4. The PerceiverIO's decoder cross-attends from the queries to the encoded
-       latents, producing ``(num_pixels, out_channels)`` — one output per pixel.
-    5. The per-pixel outputs are reassembled into ``(B, out_channels, H, W)``.
+    1. Add Aurora-style pos/scale encoding to the ``nh * nw`` latent tokens
+       (telling the model *where on the globe* each patch is).
+    2. Pass all encoded latents as **data** to the PerceiverIO:
+       ``(B, nh * nw, C)``.
+    3. Build normalized 2D **queries** for every output pixel ``(i/H, j/W)``
+       in ``[0, 1)``, embed them via a learned linear layer, and feed them
+       to the PerceiverIO decoder head.
+    4. The PerceiverIO's decoder cross-attends from queries to the internal
+       latents (which themselves cross-attended to all patch tokens),
+       producing ``(B, H * W, out_channels)``.
+    5. Reshape to ``(B, out_channels, H, W)``.
 
-    **Multi-scale windowing**: At higher resolutions, each patch contains more
-    pixels and therefore more queries.  To keep per-call cost bounded, when the
-    number of pixels exceeds ``window_size`` the decoder splits queries into
-    fixed-size windows and calls the PerceiverIO once per window.  Each window
-    re-encodes the same latent data (cheap — it's a single token) but only
-    decodes its subset of pixel queries.
+    **Multi-scale windowing**: At higher resolutions ``H * W`` grows, making
+    the full query set expensive.  When ``window_size`` is set, the decoder
+    splits pixel queries into fixed-size chunks and calls the PerceiverIO once
+    per chunk.  Each call re-encodes the same latent data (the ``nh * nw``
+    tokens — cheap for small latent grids) and only decodes its subset of
+    pixel queries, keeping per-call cost bounded.
 
     Because pixel queries are normalized to ``[0, 1)``, the same PerceiverIO
-    generalizes across resolutions: a 1-degree patch queries a coarse grid
-    while a 0.25-degree patch queries a finer grid over the same coordinate
-    space.
+    generalizes across resolutions.
 
     Args:
         in_channels: Number of input channels from the processor.
         out_channels: Number of output channels per pixel.
         patch_extent: Spatial extent of each patch in degrees (lat, lon).
-            Used for computing positional and scale encodings.
+            Used for computing positional and scale encodings on latent tokens.
         queries_dim: Embedding dimension for pixel-position queries.
         perceiver_io: A PerceiverIO module.  ``dim`` must equal ``in_channels``,
             ``queries_dim`` must match this decoder's ``queries_dim``, and
             ``logits_dim`` must equal ``out_channels``.
         window_size: Maximum number of pixel queries per PerceiverIO call.
-            If ``None``, all pixels in a patch are decoded in one call.
+            If ``None``, all ``H * W`` pixels are decoded in one call.
             Set this to cap memory/compute at high resolutions.
 
     References:
@@ -97,12 +97,10 @@ class PerceiverDecoder(nn.Module):
         resolution: tuple[Lat, Lon],
     ) -> Float[torch.Tensor, "batch {self.out_channels} H W"]:
         # nh, nw: number of patches along height and width (the latent grid dims).
-        # Not to be confused with patch_h, patch_w which are each patch's pixel size.
         B, C, nh, nw = x.shape
         lat, lon = resolution
 
         H, W = len(lat), len(lon)
-        patch_h, patch_w = patch_from(self.patch_extent, H, W)
 
         # For pos/scale encoding we need a patch size that produces exactly
         # nh*nw tokens.  In the full pipeline patch_from gives the same result,
@@ -127,33 +125,22 @@ class PerceiverDecoder(nn.Module):
             scale_encode.to(dtype=tokens.dtype, device=tokens.device)
         ).unsqueeze(0)
         tokens = tokens + pos_encoding + scale_encoding
+        # tokens: (B, nh*nw, C) — full latent grid as data for PerceiverIO.
 
-        # --- Data for PerceiverIO: one latent token per patch ---
-        # (B, nh*nw, C) -> (B*nh*nw, 1, C)
-        data = rearrange(tokens, "b (nh nw) c -> (b nh nw) 1 c", nh=nh, nw=nw)
-
-        # --- Build pixel-position queries ---
-        # Normalized 2D coords in [0, 1), embedded into queries_dim.
-        qh = torch.arange(patch_h, dtype=x.dtype, device=x.device) / patch_h
-        qw = torch.arange(patch_w, dtype=x.dtype, device=x.device) / patch_w
+        # --- Build global pixel-position queries ---
+        # Normalized 2D coords in [0, 1) for every output pixel.
+        qh = torch.arange(H, dtype=x.dtype, device=x.device) / H
+        qw = torch.arange(W, dtype=x.dtype, device=x.device) / W
         grid_h, grid_w = torch.meshgrid(qh, qw, indexing="ij")
-        coords = torch.stack([grid_h, grid_w], dim=-1)  # (patch_h, patch_w, 2)
-        coords = rearrange(coords, "ph pw d -> (ph pw) d")  # (num_pixels, 2)
-        queries = self.query_embed(coords)  # (num_pixels, queries_dim)
+        coords = torch.stack([grid_h, grid_w], dim=-1)  # (H, W, 2)
+        coords = rearrange(coords, "h w d -> (h w) d")  # (H*W, 2)
+        queries = self.query_embed(coords)  # (H*W, queries_dim)
 
         # --- Decode via PerceiverIO with optional windowing ---
-        out = self._decode(data, queries)  # (B*nh*nw, num_pixels, out_channels)
+        out = self._decode(tokens, queries)  # (B, H*W, out_channels)
 
-        # --- Reassemble into full-resolution output ---
-        out = rearrange(
-            out,
-            "(b nh nw) (ph pw) c -> b c (nh ph) (nw pw)",
-            b=B,
-            nh=nh,
-            nw=nw,
-            ph=patch_h,
-            pw=patch_w,
-        )
+        # --- Reshape to spatial ---
+        out = rearrange(out, "b (h w) c -> b c h w", h=H, w=W)
 
         return out
 
@@ -165,12 +152,12 @@ class PerceiverDecoder(nn.Module):
         """Run PerceiverIO, windowing over queries if they exceed window_size.
 
         Args:
-            data: Encoded latent tokens, shape ``(batch, 1, C)``.
-            queries: Embedded pixel queries, shape ``(num_pixels, queries_dim)``.
+            data: Pos/scale-encoded latent tokens, shape ``(B, nh*nw, C)``.
+            queries: Embedded pixel queries, shape ``(H*W, queries_dim)``.
                 Shared across the batch (PerceiverIO broadcasts internally).
 
         Returns:
-            Output predictions, shape ``(batch, num_pixels, out_channels)``.
+            Output predictions, shape ``(B, H*W, out_channels)``.
         """
         num_pixels = queries.shape[0]
 
@@ -178,8 +165,8 @@ class PerceiverDecoder(nn.Module):
             return self.perceiver_io(data, queries=queries)
 
         # Split queries into fixed-size windows to cap memory at high resolutions.
-        # Each window re-encodes the same data (one latent token, cheap) but only
-        # decodes its subset of pixel queries.
+        # Each window re-encodes the same latent data and only decodes its
+        # subset of pixel queries.
         chunks = []
         for i in range(0, num_pixels, self.window_size):
             q_window = queries[i : i + self.window_size]

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -51,8 +51,8 @@ class PerceiverDecoder(nn.Module):
         in_channels: int,
         out_channels: int,
         patch_extent: tuple[float, float],
+        latent_dim: int,
         perceiver: nn.Module,
-        latent_dim: int = 128,
     ) -> None:
         super().__init__()
         self.out_channels = out_channels
@@ -66,7 +66,7 @@ class PerceiverDecoder(nn.Module):
 
         # Final projection from latent_dim to out_channels
         self.to_out = nn.Sequential(
-            nn.LayerNorm(latent_dim),
+            nn.LayerNorm(latent_dim),  # TODO(alxmrs): This norm is probably redundant.
             nn.Linear(latent_dim, out_channels),
         )
 

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -29,9 +29,11 @@ class PerceiverDecoder(nn.Module):
     3. Build 3D unit-sphere **queries** ``(x, y, z)`` for every output pixel
        from its lat/lon, embed them via a learned linear layer, and feed
        them to the PerceiverIO decoder head.
-    4. The PerceiverIO's decoder cross-attends from queries to the internal
-       latents (which themselves cross-attended to all patch tokens),
-       producing ``(B, H * W, out_channels)``.
+    4. Inside the PerceiverIO:
+       a. Internal latents cross-attend to the ``nh * nw`` data tokens.
+       b. The latents refine through several rounds of self-attention.
+       c. A final cross-attention maps from queries to the refined latents,
+          producing ``(B, H * W, out_channels)``.
     5. Reshape to ``(B, out_channels, H, W)``.
 
     **Spatial windowing**: When ``window_patches`` is set, the decoder tiles

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -1,0 +1,213 @@
+# Mirrors the encoder structure in encoder.py
+# Sources:
+# - https://ar5iv.labs.arxiv.org/html/2405.13063 (Aurora paper, Appendix B.3: 3D Perceiver Decoder)
+# - https://github.com/lucidrains/perceiver-pytorch
+
+import torch
+from aurora.model.fourier import pos_expansion, scale_expansion
+from aurora.model.posencoding import pos_scale_enc
+from einops import rearrange
+from jaxtyping import Float
+from perceiver_pytorch.perceiver_pytorch import Attention, FeedForward, PreNorm
+from torch import nn
+
+from ocean_emulators.constants import Lat, Lon
+from ocean_emulators.models.modules.encoder import patch_from
+
+
+class PerceiverDecoder(nn.Module):
+    """A perceiver-based decoder that mirrors the PerceiverEncoder.
+
+    While the encoder compresses per-patch physical data into latent tokens via
+    cross-attention (many input tokens -> few latent queries), this decoder
+    expands the processor's latent grid back to output channels via cross-attention
+    (latent context -> output position queries).
+
+    The decoder operates on the **full latent grid** rather than per-patch because:
+    - Per-patch decoding with a single context token degenerates cross-attention
+      into a linear projection (no attention dynamics).
+    - The latent grid is small (~1080 tokens for all resolutions with default
+      patch extents), making full-grid attention very efficient.
+    - Global attention enables long-range spatial dependencies in the decoder.
+
+    Architecture per forward pass:
+        1. Project processor output to decoder latent dimension
+        2. Add positional + scale encoding to latent context (mirrors encoder)
+        3. Cross-attention: learned output queries attend to latent context
+        4. Self-attention: output queries refine via mutual attention
+        5. Linear projection to output channels
+        6. Reshape to spatial grid (B, out_channels, h, w)
+
+    The output is then passed through the existing ``unpatch`` system in FOMO
+    for pixel-level expansion back to the original spatial resolution.
+
+    Args:
+        in_channels: Number of input channels from the processor.
+        out_channels: Number of output channels per spatial position.
+        patch_extent: Spatial extent of each patch in degrees (lat, lon).
+            Used for computing positional and scale encodings.
+        num_queries: Number of learned output queries (should equal h * w of
+            the latent grid, e.g. 30 * 36 = 1080 for default patch extents).
+        latent_dim: Dimension of the decoder's internal latent space.
+        depth: Number of cross-attention + self-attention layer blocks.
+        cross_heads: Number of attention heads for cross-attention.
+        latent_heads: Number of attention heads for self-attention.
+        cross_dim_head: Dimension per head for cross-attention.
+        latent_dim_head: Dimension per head for self-attention.
+        self_per_cross_attn: Number of self-attention blocks per cross-attention block.
+        weight_tie_layers: Whether to share weights across depth layers.
+        attn_dropout: Dropout rate for attention weights.
+        ff_dropout: Dropout rate for feedforward layers.
+
+    References:
+        [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        patch_extent: tuple[float, float],
+        num_queries: int,
+        latent_dim: int = 128,
+        depth: int = 6,
+        cross_heads: int = 1,
+        latent_heads: int = 8,
+        cross_dim_head: int = 64,
+        latent_dim_head: int = 64,
+        self_per_cross_attn: int = 2,
+        weight_tie_layers: bool = True,
+        attn_dropout: float = 0.0,
+        ff_dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.out_channels = out_channels
+        self.patch_extent = patch_extent
+
+        # Learned output queries — one per spatial position in the latent grid.
+        # These learn to represent "what information to extract" for each output position.
+        self.queries = nn.Parameter(torch.randn(num_queries, latent_dim))
+
+        # Project processor output channels to decoder latent dimension
+        self.input_proj = nn.Linear(in_channels, latent_dim)
+
+        # Positional and scale encoding (mirrors encoder's post-perceiver encoding)
+        self.pos_embed = nn.Linear(latent_dim, latent_dim)
+        self.scale_embed = nn.Linear(latent_dim, latent_dim)
+
+        # Build cross-attention and self-attention layers, following the
+        # same pattern as perceiver_pytorch.Perceiver.
+        def get_cross_attn():
+            return PreNorm(
+                latent_dim,
+                Attention(
+                    latent_dim,
+                    latent_dim,
+                    heads=cross_heads,
+                    dim_head=cross_dim_head,
+                    dropout=attn_dropout,
+                ),
+                context_dim=latent_dim,
+            )
+
+        def get_cross_ff():
+            return PreNorm(latent_dim, FeedForward(latent_dim, dropout=ff_dropout))
+
+        def get_latent_attn():
+            return PreNorm(
+                latent_dim,
+                Attention(
+                    latent_dim,
+                    heads=latent_heads,
+                    dim_head=latent_dim_head,
+                    dropout=attn_dropout,
+                ),
+            )
+
+        def get_latent_ff():
+            return PreNorm(latent_dim, FeedForward(latent_dim, dropout=ff_dropout))
+
+        # Optionally share weights across depth layers (weight tying)
+        if weight_tie_layers:
+            # Create one set of layers and reuse references
+            cross_attn = get_cross_attn()
+            cross_ff = get_cross_ff()
+            latent_attn = get_latent_attn()
+            latent_ff = get_latent_ff()
+
+            self.layers = nn.ModuleList([])
+            for _ in range(depth):
+                self_attns = nn.ModuleList([])
+                for _ in range(self_per_cross_attn):
+                    self_attns.append(nn.ModuleList([latent_attn, latent_ff]))
+                self.layers.append(nn.ModuleList([cross_attn, cross_ff, self_attns]))
+        else:
+            self.layers = nn.ModuleList([])
+            for _ in range(depth):
+                self_attns = nn.ModuleList([])
+                for _ in range(self_per_cross_attn):
+                    self_attns.append(
+                        nn.ModuleList([get_latent_attn(), get_latent_ff()])
+                    )
+                self.layers.append(
+                    nn.ModuleList([get_cross_attn(), get_cross_ff(), self_attns])
+                )
+
+        # Final projection from latent_dim to out_channels
+        self.to_out = nn.Sequential(
+            nn.LayerNorm(latent_dim),
+            nn.Linear(latent_dim, out_channels),
+        )
+
+    def forward(
+        self, x: Float[torch.Tensor, "batch channels h w"], resolution: tuple[Lat, Lon]
+    ) -> Float[torch.Tensor, "batch {self.out_channels} h w"]:
+        B, C, h, w = x.shape
+        lat, lon = resolution
+
+        # Compute patch sizes from the original resolution for pos/scale encoding.
+        H, W = len(lat), len(lon)
+        patch_h, patch_w = patch_from(self.patch_extent, H, W)
+
+        # Reshape processor output to token sequence: (B, h*w, C)
+        context = rearrange(x, "b c h w -> b (h w) c")
+
+        # Project to decoder latent dimension
+        context = self.input_proj(context)  # (B, h*w, latent_dim)
+
+        # Add positional + scale encoding (mirrors encoder's post-perceiver step)
+        pos_encode, scale_encode = pos_scale_enc(
+            context.shape[-1],  # latent_dim
+            lat,
+            lon,
+            (patch_h, patch_w),
+            pos_expansion=pos_expansion,
+            scale_expansion=scale_expansion,
+        )
+        pos_encoding = self.pos_embed(
+            pos_encode.to(dtype=context.dtype, device=context.device)
+        ).unsqueeze(0)
+        scale_encoding = self.scale_embed(
+            scale_encode.to(dtype=context.dtype, device=context.device)
+        ).unsqueeze(0)
+        context = context + pos_encoding + scale_encoding
+
+        # Initialize output queries: (B, num_queries, latent_dim)
+        queries = self.queries.unsqueeze(0).expand(B, -1, -1)
+
+        # Cross-attention + self-attention layers
+        for cross_attn, cross_ff, self_attns in self.layers:  # type: ignore
+            queries = cross_attn(queries, context=context) + queries  # type: ignore
+            queries = cross_ff(queries) + queries  # type: ignore
+
+            for self_attn, self_ff in self_attns:  # type: ignore
+                queries = self_attn(queries) + queries
+                queries = self_ff(queries) + queries
+
+        # Project to output channels: (B, h*w, out_channels)
+        out = self.to_out(queries)
+
+        # Reshape back to spatial grid
+        out = rearrange(out, "b (h w) c -> b c h w", h=h, w=w)
+
+        return out

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -14,7 +14,7 @@ class PerceiverDecoder(nn.Module):
     """A PerceiverIO-based decoder that maps a latent patch grid to full-resolution output.
 
     All ``nh * nw`` pos/scale-encoded latent tokens are passed as **data** to
-    the PerceiverIO[3], and every output pixel position is a **query**.  Each
+    the PerceiverIO[2], and every output pixel position is a **query**.  Each
     query cross-attends to the full latent representation, giving it global
     spatial context — pixels near patch boundaries can attend to neighboring
     patches, and the model can learn smooth inter-patch transitions.
@@ -39,7 +39,8 @@ class PerceiverDecoder(nn.Module):
     tokens — plus ``context_patches`` extra rings of neighbors — are passed
     as data.  This bounds both query count and data count per PerceiverIO
     call, keeping cost manageable even when the latent grid is large (i.e.
-    fine ``patch_extent``).
+    fine ``patch_extent``).  Setting ``context_patches=None`` gives each
+    window full access to all latent tokens (windowed queries, global data).
 
     Because pixel queries are normalized to ``[0, 1)``, the same PerceiverIO
     generalizes across resolutions.
@@ -66,8 +67,7 @@ class PerceiverDecoder(nn.Module):
     References:
         [0]: https://github.com/lucidrains/perceiver-pytorch
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
-        [2]: https://ar5iv.labs.arxiv.org/html/2309.16588
-        [3]: https://ar5iv.labs.arxiv.org/html/2107.14795
+        [2]: https://ar5iv.labs.arxiv.org/html/2107.14795
     """
 
     def __init__(

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -11,7 +11,6 @@ from jaxtyping import Float
 from torch import nn
 
 from ocean_emulators.constants import Lat, Lon
-from ocean_emulators.models.modules.encoder import patch_from
 
 
 class PerceiverDecoder(nn.Module):
@@ -38,9 +37,9 @@ class PerceiverDecoder(nn.Module):
         out_channels: Number of output channels per spatial position.
         patch_extent: Spatial extent of each patch in degrees (lat, lon).
             Used for computing positional and scale encodings.
-        perceiver: The underlying perceiver decoder.
-        latent_dim: Dimension of the decoder's internal latent space. The output
-            channel dimension of the perceiver.
+        perceiver: The underlying perceiver decoder. Must project to
+            ``out_channels`` internally (e.g. via ``num_classes=out_channels``
+            in the NaivePerceiver).
 
     References:
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
@@ -51,7 +50,6 @@ class PerceiverDecoder(nn.Module):
         in_channels: int,
         out_channels: int,
         patch_extent: tuple[float, float],
-        latent_dim: int,
         perceiver: nn.Module,
     ) -> None:
         super().__init__()
@@ -64,21 +62,20 @@ class PerceiverDecoder(nn.Module):
 
         self.perceiver = perceiver
 
-        # Final projection from latent_dim to out_channels
-        self.to_out = nn.Sequential(
-            nn.LayerNorm(latent_dim),  # TODO(alxmrs): This norm is probably redundant.
-            nn.Linear(latent_dim, out_channels),
-        )
-
     def forward(
         self, x: Float[torch.Tensor, "batch channels h w"], resolution: tuple[Lat, Lon]
     ) -> Float[torch.Tensor, "batch {self.out_channels} h w"]:
         B, C, h, w = x.shape  # h = input H // patch_h; w = input W // patch_w
         lat, lon = resolution
 
-        # Compute patch sizes from the original resolution for pos/scale encoding.
-        H, W = len(lat), len(lon)  # Target H and W.
-        patch_h, patch_w = patch_from(self.patch_extent, H, W)
+        # Derive the effective patch size from the original resolution and the
+        # decoder's spatial grid.  In the full FOMO pipeline the processor output
+        # (h, w) equals (H // patch_h, W // patch_w), but we compute the patch
+        # size from the tensor itself so the pos/scale encodings always produce
+        # exactly h*w tokens — even in unit tests where h, w may differ from the
+        # patch-reduced grid.
+        H, W = len(lat), len(lon)  # Original (physical) resolution.
+        patch_h, patch_w = H // h, W // w
 
         # Reshape processor output to token sequence: (B, h*w, C)
         context = rearrange(x, "b c h w -> b (h w) c")
@@ -103,11 +100,8 @@ class PerceiverDecoder(nn.Module):
         context = rearrange(context, "b (h w) c -> (b h w) c", h=h, w=w)
         context = context.unsqueeze(1)
 
-        # (B*h*w, 1, channels) -> (B*h*w, latent_dim)
-        queries = self.perceiver(context)
-
-        # Project to output channels: (B*h*w, out_channels)
-        out = self.to_out(queries)
+        # (B*h*w, 1, channels) -> (B*h*w, out_channels)
+        out = self.perceiver(context)
 
         # Reshape back to spatial grid
         out = rearrange(out, "(b h w) c -> b c h w", h=h, w=w)

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -1,6 +1,7 @@
 # Perceiver-based decoder, complementary to encoder.py
 
 import torch
+import torch.nn.functional as F
 from aurora.model.fourier import pos_expansion, scale_expansion
 from aurora.model.posencoding import pos_scale_enc
 from einops import rearrange
@@ -37,14 +38,15 @@ class PerceiverDecoder(nn.Module):
           producing ``(B, H * W, out_channels)``.
     5. Reshape to ``(B, out_channels, H, W)``.
 
-    **Spatial windowing**: When ``window_patches`` is set, the decoder tiles
-    the output grid into spatial blocks, each covering ``window_patches``
-    patches along each axis.  For each block, only the overlapping latent
-    tokens — plus ``context_patches`` extra rings of neighbors — are passed
-    as data.  This bounds both query count and data count per PerceiverIO
-    call, keeping cost manageable even when the latent grid is large (i.e.
-    fine ``patch_extent``).  Setting ``context_patches=None`` gives each
-    window full access to all latent tokens (windowed queries, global data).
+    **Spatial windowing**: When ``window_patches`` is set, the latent grid
+    must be evenly divisible by ``window_patches``.  The grid is padded —
+    circular along longitude (so windows near lon=0 see context from
+    lon≈360) and constant-zero along latitude (poles are true boundaries)
+    — then ``Tensor.unfold`` extracts fixed-size overlapping windows.
+    Each block's PerceiverIO call receives the local data context plus
+    the corresponding pixel queries.  Setting ``context_patches=None``
+    gives each window full access to all latent tokens (windowed queries,
+    global data).
 
     Because pixel queries are unit-sphere coordinates — continuous values
     determined by lat/lon, not grid indices — the same PerceiverIO
@@ -165,20 +167,12 @@ class PerceiverDecoder(nn.Module):
         patch_h: int,
         patch_w: int,
     ) -> Float[torch.Tensor, "batch {self.out_channels} H W"]:
-        """Run PerceiverIO, optionally tiling into spatial windows.
+        """Decode a latent patch grid into full-resolution pixel output.
 
-        When ``window_patches`` is None, all data and queries are passed in one
-        call (global attention).  Otherwise, the output grid is tiled into
-        spatial blocks and each block attends only to nearby latent tokens.
-
-        Note: the windowed loop below is structurally equivalent to
-        ``nn.Unfold`` / ``im2col`` — strided extraction of overlapping 2D
-        patches.  We use explicit indexing instead because (1) ``unfold``
-        requires pre-padding and produces fixed-size windows, adding edge-
-        handling complexity for grids not evenly divisible by
-        ``window_patches``, and (2) the bottleneck is the PerceiverIO forward
-        pass per window, not the Python index arithmetic, so there is no
-        performance benefit to fusing the extraction.
+        Without windowing, every pixel query attends to every latent token
+        (global attention).  With windowing, the grid is split into spatial
+        blocks so each PerceiverIO call only covers a local neighborhood,
+        keeping cost bounded for large latent grids.
         """
         B, nh, nw, C = data_grid.shape
         H, W, _ = queries_grid.shape
@@ -192,47 +186,63 @@ class PerceiverDecoder(nn.Module):
         wp = self.window_patches
         cp = self.context_patches
 
-        out = data_grid.new_zeros(B, H, W, self.out_channels)
-
-        # Flatten full data once when context_patches is None (full context).
-        full_data = (
-            rearrange(data_grid, "b nh nw c -> b (nh nw) c") if cp is None else None
+        assert nh % wp == 0 and nw % wp == 0, (
+            f"Latent grid ({nh}, {nw}) must be divisible by window_patches={wp}"
         )
 
-        for pi in range(0, nh, wp):
-            for pj in range(0, nw, wp):
-                pi_end = min(pi + wp, nh)
-                pj_end = min(pj + wp, nw)
+        n_blocks_h = nh // wp
+        n_blocks_w = nw // wp
+        block_ph = wp * patch_h  # pixel height per query block
+        block_pw = wp * patch_w  # pixel width per query block
 
+        # --- Prepare data windows ---
+        if cp is None:
+            # Full context: every window sees all latent tokens.
+            full_data = rearrange(data_grid, "b nh nw c -> b (nh nw) c")
+        elif cp == 0:
+            # No context padding — unfold with exact window size.
+            data = rearrange(data_grid, "b nh nw c -> b c nh nw")
+            data_windows = data.unfold(2, wp, wp).unfold(3, wp, wp)
+        else:
+            # Pad: circular along longitude (last dim), zero along latitude.
+            data = rearrange(data_grid, "b nh nw c -> b c nh nw")
+            data = F.pad(data, (cp, cp, 0, 0), mode="circular")
+            data = F.pad(data, (0, 0, cp, cp), mode="constant", value=0)
+            win_size_h = wp + 2 * cp
+            win_size_w = wp + 2 * cp
+            data_windows = data.unfold(2, win_size_h, wp).unfold(3, win_size_w, wp)
+        # data_windows shape (when cp is not None):
+        #   (B, C, n_blocks_h, n_blocks_w, win_h, win_w)
+
+        # --- Decode each spatial block ---
+        out = data_grid.new_zeros(B, H, W, self.out_channels)
+
+        for bi in range(n_blocks_h):
+            for bj in range(n_blocks_w):
                 if cp is None:
-                    # Full context: every window sees all latent tokens.
                     local_data = full_data
                 else:
-                    # Expand data region by context_patches, clamped to grid bounds.
-                    di_start = max(pi - cp, 0)
-                    di_end = min(pi_end + cp, nh)
-                    dj_start = max(pj - cp, 0)
-                    dj_end = min(pj_end + cp, nw)
+                    local_data = rearrange(
+                        data_windows[:, :, bi, bj], "b c h w -> b (h w) c"
+                    )
 
-                    local_data = data_grid[:, di_start:di_end, dj_start:dj_end, :]
-                    local_data = rearrange(local_data, "b h w c -> b (h w) c")
-
-                # Pixel region covered by this patch block.
-                qi_start = pi * patch_h
-                qi_end = pi_end * patch_h
-                qj_start = pj * patch_w
-                qj_end = pj_end * patch_w
-
-                local_queries = queries_grid[qi_start:qi_end, qj_start:qj_end, :]
+                qi_start = bi * block_ph
+                qj_start = bj * block_pw
+                local_queries = queries_grid[
+                    qi_start : qi_start + block_ph,
+                    qj_start : qj_start + block_pw,
+                ]
                 local_queries = rearrange(local_queries, "h w d -> (h w) d")
 
                 local_out = self.perceiver_io(local_data, queries=local_queries)
-                qh_size = qi_end - qi_start
-                qw_size = qj_end - qj_start
                 local_out = rearrange(
-                    local_out, "b (h w) c -> b h w c", h=qh_size, w=qw_size
+                    local_out, "b (h w) c -> b h w c", h=block_ph, w=block_pw
                 )
-
-                out[:, qi_start:qi_end, qj_start:qj_end, :] = local_out
+                out[
+                    :,
+                    qi_start : qi_start + block_ph,
+                    qj_start : qj_start + block_pw,
+                    :,
+                ] = local_out
 
         return rearrange(out, "b h w c -> b c h w")

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -16,30 +16,22 @@ from ocean_emulators.constants import Lat, Lon
 class PerceiverDecoder(nn.Module):
     """A perceiver-based decoder that mirrors the PerceiverEncoder.
 
-    While the encoder compresses per-patch physical data into latent tokens via
-    cross-attention (many input tokens -> few latent queries), this decoder
-    expands the processor's latent grid back to output channels via cross-attention
-    (latent context -> output position queries).
+    The encoder compresses each patch of physical data into a single latent
+    token via perceiver cross-attention. This decoder inverts that: for each
+    latent-grid position it runs a perceiver that maps one token back to
+    ``out_channels``, then FOMO's ``unpatch`` layer expands each position to
+    full patch resolution.
 
-    The decoder operates on the **full latent grid** rather than per-patch because:
-    - Per-patch decoding with a single context token degenerates cross-attention
-      into a linear projection (no attention dynamics).
-    - The latent grid is small (~1080 tokens for all resolutions with default
-      patch extents), making full-grid attention very efficient.
-    - Global attention enables long-range spatial dependencies in the decoder.
-
-    After decoding, the output is then passed through the existing ``unpatch``
-    system in FOMO for pixel-level expansion back to the original spatial
-    resolution.
+    Positional and scale encodings (Aurora-style [1]) are added to the latent
+    tokens before decoding, mirroring the encoder's post-perceiver step.
 
     Args:
         in_channels: Number of input channels from the processor.
         out_channels: Number of output channels per spatial position.
         patch_extent: Spatial extent of each patch in degrees (lat, lon).
             Used for computing positional and scale encodings.
-        perceiver: The underlying perceiver decoder. Must project to
-            ``out_channels`` internally (e.g. via ``num_classes=out_channels``
-            in the NaivePerceiver).
+        perceiver: The underlying perceiver module. Must project to
+            ``out_channels`` internally (e.g. ``num_classes=out_channels``).
 
     References:
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
@@ -63,22 +55,26 @@ class PerceiverDecoder(nn.Module):
         self.perceiver = perceiver
 
     def forward(
-        self, x: Float[torch.Tensor, "batch channels h w"], resolution: tuple[Lat, Lon]
-    ) -> Float[torch.Tensor, "batch {self.out_channels} h w"]:
-        B, C, h, w = x.shape  # h = input H // patch_h; w = input W // patch_w
+        self,
+        x: Float[torch.Tensor, "batch channels nh nw"],
+        resolution: tuple[Lat, Lon],
+    ) -> Float[torch.Tensor, "batch {self.out_channels} nh nw"]:
+        # nh, nw: number of patches along height and width (the latent grid dims).
+        # Not to be confused with patch_h, patch_w which are each patch's pixel size.
+        B, C, nh, nw = x.shape
         lat, lon = resolution
 
         # Derive the effective patch size from the original resolution and the
         # decoder's spatial grid.  In the full FOMO pipeline the processor output
-        # (h, w) equals (H // patch_h, W // patch_w), but we compute the patch
+        # (nh, nw) equals (H // patch_h, W // patch_w), but we compute the patch
         # size from the tensor itself so the pos/scale encodings always produce
-        # exactly h*w tokens — even in unit tests where h, w may differ from the
-        # patch-reduced grid.
+        # exactly nh*nw tokens — even in unit tests where nh, nw may differ from
+        # the patch-reduced grid.
         H, W = len(lat), len(lon)  # Original (physical) resolution.
-        patch_h, patch_w = H // h, W // w
+        patch_h, patch_w = H // nh, W // nw
 
-        # Reshape processor output to token sequence: (B, h*w, C)
-        context = rearrange(x, "b c h w -> b (h w) c")
+        # Reshape processor output to token sequence: (B, nh*nw, C)
+        context = rearrange(x, "b c nh nw -> b (nh nw) c")
 
         # Add positional + scale encoding (mirrors encoder's post-perceiver step)
         pos_encode, scale_encode = pos_scale_enc(
@@ -97,15 +93,15 @@ class PerceiverDecoder(nn.Module):
         ).unsqueeze(0)
         context = context + pos_encoding + scale_encoding
 
-        context = rearrange(context, "b (h w) c -> (b h w) c", h=h, w=w)
+        context = rearrange(context, "b (nh nw) c -> (b nh nw) c", nh=nh, nw=nw)
         # We add these middle singleton dimensions to make this perceiver consistent with the encoder's perceiver.
         # It assumes that `input_axis=2`.
         context = context.unsqueeze(1).unsqueeze(1)
 
-        # (B*h*w, 1, 1, channels) -> (B*h*w, out_channels)
+        # (B*nh*nw, 1, 1, channels) -> (B*nh*nw, out_channels)
         out = self.perceiver(context)
 
         # Reshape back to spatial grid
-        out = rearrange(out, "(b h w) c -> b c h w", h=h, w=w)
+        out = rearrange(out, "(b nh nw) c -> b c nh nw", nh=nh, nw=nw)
 
         return out

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -8,6 +8,7 @@ from jaxtyping import Float
 from torch import nn
 
 from ocean_emulators.constants import Lat, Lon
+from ocean_emulators.models.modules.augment_input import make_3d_coordinate_grid
 
 
 class PerceiverDecoder(nn.Module):
@@ -25,9 +26,9 @@ class PerceiverDecoder(nn.Module):
        (telling the model *where on the globe* each patch is).
     2. Pass all encoded latents as **data** to the PerceiverIO:
        ``(B, nh * nw, C)``.
-    3. Build normalized 2D **queries** for every output pixel ``(i/H, j/W)``
-       in ``[0, 1)``, embed them via a learned linear layer, and feed them
-       to the PerceiverIO decoder head.
+    3. Build 3D unit-sphere **queries** ``(x, y, z)`` for every output pixel
+       from its lat/lon, embed them via a learned linear layer, and feed
+       them to the PerceiverIO decoder head.
     4. The PerceiverIO's decoder cross-attends from queries to the internal
        latents (which themselves cross-attended to all patch tokens),
        producing ``(B, H * W, out_channels)``.
@@ -42,7 +43,8 @@ class PerceiverDecoder(nn.Module):
     fine ``patch_extent``).  Setting ``context_patches=None`` gives each
     window full access to all latent tokens (windowed queries, global data).
 
-    Because pixel queries are normalized to ``[0, 1)``, the same PerceiverIO
+    Because pixel queries are unit-sphere coordinates — continuous values
+    determined by lat/lon, not grid indices — the same PerceiverIO
     generalizes across resolutions.
 
     Args:
@@ -93,8 +95,8 @@ class PerceiverDecoder(nn.Module):
         self.pos_embed = nn.Linear(in_channels, in_channels)
         self.scale_embed = nn.Linear(in_channels, in_channels)
 
-        # Embed 2D pixel coordinates into queries_dim for the PerceiverIO decoder head.
-        self.query_embed = nn.Linear(2, queries_dim)
+        # Embed 3D unit-sphere coordinates into queries_dim for the PerceiverIO decoder head.
+        self.query_embed = nn.Linear(3, queries_dim)
 
         self.perceiver_io = perceiver_io
 
@@ -134,11 +136,11 @@ class PerceiverDecoder(nn.Module):
         tokens = tokens + pos_encoding + scale_encoding
 
         # --- Build global pixel-position queries ---
-        # Normalized 2D coords in [0, 1) for every output pixel.
-        qh = torch.arange(H, dtype=x.dtype, device=x.device) / H
-        qw = torch.arange(W, dtype=x.dtype, device=x.device) / W
-        grid_h, grid_w = torch.meshgrid(qh, qw, indexing="ij")
-        coords = torch.stack([grid_h, grid_w], dim=-1)  # (H, W, 2)
+        # 3D unit-sphere coordinates for every output pixel.
+        coords = make_3d_coordinate_grid(lat, lon)  # (3, H, W)
+        coords = rearrange(coords, "d h w -> h w d").to(
+            dtype=x.dtype, device=x.device
+        )  # (H, W, 3)
         queries = self.query_embed(
             rearrange(coords, "h w d -> (h w) d")
         )  # (H*W, queries_dim)

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -3,7 +3,7 @@
 import torch
 from aurora.model.fourier import pos_expansion, scale_expansion
 from aurora.model.posencoding import pos_scale_enc
-from einops import rearrange, repeat
+from einops import rearrange
 from jaxtyping import Float
 from torch import nn
 
@@ -12,43 +12,57 @@ from ocean_emulators.models.modules.encoder import patch_from
 
 
 class PerceiverDecoder(nn.Module):
-    """A perceiver-based[0] decoder that maps latent patch tokens to full-resolution output.
+    """A PerceiverIO-based[0] decoder that maps latent patch tokens to full-resolution output.
+
+    Unlike the encoder's regular Perceiver (which compresses spatial input into
+    a fixed-size latent), the decoder uses **PerceiverIO**[3] — a variant with
+    an explicit query mechanism.  Queries represent output pixel positions, and
+    the PerceiverIO cross-attends from those queries to the encoded latent
+    representation, producing one prediction per query.
 
     For each patch position on the latent grid, the decoder:
 
     1. Adds Aurora-style pos/scale encoding to the latent vector (telling the
-       perceiver *where on the globe* this patch is).
-    2. Broadcasts the encoded latent vector to every pixel within the patch and
-       concatenates a normalized 2D pixel-position query (telling the perceiver
-       *where within the patch* each output pixel is).
-    3. Feeds the ``(patch_h, patch_w, C + 2)``-dim token grid through a shared
-       perceiver whose ``num_latents`` equals (or exceeds[2]) ``patch_h * patch_w``.
-    4. The decoder calls the perceiver with ``return_embeddings=True`` to skip
-       the default mean-pooling, getting back per-latent embeddings
-       ``(batch, num_latents, latent_dim)``.  It then projects each latent
-       independently via ``LayerNorm + Linear`` to ``out_channels``.
+       model *where on the globe* this patch is).
+    2. Passes the encoded latent as **data** to the PerceiverIO — the single
+       token that the model's internal latents cross-attend to during encoding.
+    3. Builds normalized 2D pixel-position **queries** for every output pixel
+       within the patch, embeds them via a learned linear layer into
+       ``queries_dim``, and feeds them to the PerceiverIO's decoder head.
+    4. The PerceiverIO's decoder cross-attends from the queries to the encoded
+       latents, producing ``(num_pixels, out_channels)`` — one output per pixel.
     5. The per-pixel outputs are reassembled into ``(B, out_channels, H, W)``.
 
-    Because pixel queries are normalized to ``[0, 1)``, the same perceiver
+    **Multi-scale windowing**: At higher resolutions, each patch contains more
+    pixels and therefore more queries.  To keep per-call cost bounded, when the
+    number of pixels exceeds ``window_size`` the decoder splits queries into
+    fixed-size windows and calls the PerceiverIO once per window.  Each window
+    re-encodes the same latent data (cheap — it's a single token) but only
+    decodes its subset of pixel queries.
+
+    Because pixel queries are normalized to ``[0, 1)``, the same PerceiverIO
     generalizes across resolutions: a 1-degree patch queries a coarse grid
     while a 0.25-degree patch queries a finer grid over the same coordinate
-    space.  Higher-resolution grids simply have more pixels per patch, and
-    the perceiver's ``num_latents`` is set to accommodate the largest patch.
+    space.
 
     Args:
         in_channels: Number of input channels from the processor.
         out_channels: Number of output channels per pixel.
         patch_extent: Spatial extent of each patch in degrees (lat, lon).
             Used for computing positional and scale encodings.
-        latent_dim: The perceiver's latent dimension.  Used to build the
-            per-latent ``LayerNorm + Linear`` projection.
-        perceiver: Shared perceiver module.  ``input_channels`` must equal
-            ``in_channels + 2`` (latent dim + 2D pixel query).
+        queries_dim: Embedding dimension for pixel-position queries.
+        perceiver_io: A PerceiverIO module.  ``dim`` must equal ``in_channels``,
+            ``queries_dim`` must match this decoder's ``queries_dim``, and
+            ``logits_dim`` must equal ``out_channels``.
+        window_size: Maximum number of pixel queries per PerceiverIO call.
+            If ``None``, all pixels in a patch are decoded in one call.
+            Set this to cap memory/compute at high resolutions.
 
     References:
         [0]: https://github.com/lucidrains/perceiver-pytorch
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
         [2]: https://ar5iv.labs.arxiv.org/html/2309.16588
+        [3]: https://ar5iv.labs.arxiv.org/html/2107.14795
     """
 
     def __init__(
@@ -56,13 +70,15 @@ class PerceiverDecoder(nn.Module):
         in_channels: int,
         out_channels: int,
         patch_extent: tuple[float, float],
-        latent_dim: int,
-        perceiver: nn.Module,
+        queries_dim: int,
+        perceiver_io: nn.Module,
+        window_size: int | None = None,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.patch_extent = patch_extent
+        self.window_size = window_size
 
         # TODO(#451): The input to these position and scale linear units could be a hparam.
         # Same pos/scale linear layers as the encoder, but applied *before* the
@@ -70,12 +86,10 @@ class PerceiverDecoder(nn.Module):
         self.pos_embed = nn.Linear(in_channels, in_channels)
         self.scale_embed = nn.Linear(in_channels, in_channels)
 
-        self.perceiver = perceiver
+        # Embed 2D pixel coordinates into queries_dim for the PerceiverIO decoder head.
+        self.query_embed = nn.Linear(2, queries_dim)
 
-        # Per-latent projection: replaces the perceiver's default mean-pool + linear.
-        # Each learned latent corresponds to one output pixel.
-        self.norm = nn.LayerNorm(latent_dim)
-        self.proj = nn.Linear(latent_dim, out_channels)
+        self.perceiver_io = perceiver_io
 
     def forward(
         self,
@@ -114,51 +128,23 @@ class PerceiverDecoder(nn.Module):
         ).unsqueeze(0)
         tokens = tokens + pos_encoding + scale_encoding
 
-        # --- Build per-pixel input: broadcast latent + concat pixel query ---
-        # Broadcast each latent vector to every pixel in its patch.
-        # tokens: (B, nh*nw, C) -> (B*nh*nw, patch_h, patch_w, C)
-        tokens = rearrange(tokens, "b (nh nw) c -> (b nh nw) c", nh=nh, nw=nw)
-        tokens = repeat(tokens, "n c -> n ph pw c", ph=patch_h, pw=patch_w)
+        # --- Data for PerceiverIO: one latent token per patch ---
+        # (B, nh*nw, C) -> (B*nh*nw, 1, C)
+        data = rearrange(tokens, "b (nh nw) c -> (b nh nw) 1 c", nh=nh, nw=nw)
 
-        # Build normalized 2D pixel query grid in [0, 1).
-        # Shape: (patch_h, patch_w, 2)
+        # --- Build pixel-position queries ---
+        # Normalized 2D coords in [0, 1), embedded into queries_dim.
         qh = torch.arange(patch_h, dtype=x.dtype, device=x.device) / patch_h
         qw = torch.arange(patch_w, dtype=x.dtype, device=x.device) / patch_w
         grid_h, grid_w = torch.meshgrid(qh, qw, indexing="ij")
-        query = torch.stack([grid_h, grid_w], dim=-1)  # (patch_h, patch_w, 2)
+        coords = torch.stack([grid_h, grid_w], dim=-1)  # (patch_h, patch_w, 2)
+        coords = rearrange(coords, "ph pw d -> (ph pw) d")  # (num_pixels, 2)
+        queries = self.query_embed(coords)  # (num_pixels, queries_dim)
 
-        # Broadcast query to batch: (B*nh*nw, patch_h, patch_w, 2)
-        query = query.unsqueeze(0).expand(tokens.shape[0], -1, -1, -1)
-
-        # Concat: (B*nh*nw, patch_h, patch_w, C+2)
-        perceiver_input = torch.cat([tokens, query], dim=-1)
-
-        # --- Run perceiver without mean-pooling ---
-        # return_embeddings=True skips the output head (which mean-pools) in both
-        # NaivePerceiver and FlashPerceiver, returning raw latent embeddings.
-        # Returns: (B*nh*nw, num_latents, latent_dim)
-        embeddings = self.perceiver(perceiver_input, return_embeddings=True)
-
-        # --- Per-latent projection to out_channels ---
-        # (B*nh*nw, num_latents, latent_dim) -> (B*nh*nw, num_latents, out_channels)
-        out = self.proj(self.norm(embeddings))
+        # --- Decode via PerceiverIO with optional windowing ---
+        out = self._decode(data, queries)  # (B*nh*nw, num_pixels, out_channels)
 
         # --- Reassemble into full-resolution output ---
-        # num_latents >= patch_h * patch_w; take only the pixels we need.
-        #
-        # num_latents should be as large as the biggest patch. For smaller patches,
-        # num_latents includes "extra" information beyond the pixel count.
-        #
-        # The additional output space could actually be useful for transformer
-        # architectures to use even if they aren't used in the output.
-        # Transformers can use these as "scratch" space, check out [2]  for more
-        # on this topic.
-        #
-        # TODO(alxmrs,Claude): Consider using a learned selection of the latents
-        #  or pooling over the latents (more complex).
-        num_pixels = patch_h * patch_w
-        out = out[:, :num_pixels, :]  # (B*nh*nw, patch_h*patch_w, out_channels)
-
         out = rearrange(
             out,
             "(b nh nw) (ph pw) c -> b c (nh ph) (nw pw)",
@@ -170,3 +156,32 @@ class PerceiverDecoder(nn.Module):
         )
 
         return out
+
+    def _decode(
+        self,
+        data: torch.Tensor,
+        queries: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run PerceiverIO, windowing over queries if they exceed window_size.
+
+        Args:
+            data: Encoded latent tokens, shape ``(batch, 1, C)``.
+            queries: Embedded pixel queries, shape ``(num_pixels, queries_dim)``.
+                Shared across the batch (PerceiverIO broadcasts internally).
+
+        Returns:
+            Output predictions, shape ``(batch, num_pixels, out_channels)``.
+        """
+        num_pixels = queries.shape[0]
+
+        if self.window_size is None or num_pixels <= self.window_size:
+            return self.perceiver_io(data, queries=queries)
+
+        # Split queries into fixed-size windows to cap memory at high resolutions.
+        # Each window re-encodes the same data (one latent token, cheap) but only
+        # decodes its subset of pixel queries.
+        chunks = []
+        for i in range(0, num_pixels, self.window_size):
+            q_window = queries[i : i + self.window_size]
+            chunks.append(self.perceiver_io(data, queries=q_window))
+        return torch.cat(chunks, dim=1)

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -9,6 +9,7 @@ from torch import nn
 
 from ocean_emulators.constants import Lat, Lon
 from ocean_emulators.models.modules.augment_input import make_3d_coordinate_grid
+from ocean_emulators.models.modules.encoder import patch_from
 
 
 class PerceiverDecoder(nn.Module):
@@ -117,10 +118,7 @@ class PerceiverDecoder(nn.Module):
 
         H, W = len(lat), len(lon)
 
-        # For pos/scale encoding we need a patch size that produces exactly
-        # nh*nw tokens.  In the full pipeline patch_from gives the same result,
-        # but in unit tests the input grid may not match, so derive from tensor.
-        pos_patch_h, pos_patch_w = H // nh, W // nw
+        pos_patch_h, pos_patch_w = patch_from(self.patch_extent, H, W)
 
         # --- Add pos/scale encoding to latent tokens (before perceiver, unlike encoder) ---
         tokens = rearrange(x, "b c nh nw -> b (nh nw) c")

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -29,16 +29,9 @@ class PerceiverDecoder(nn.Module):
       patch extents), making full-grid attention very efficient.
     - Global attention enables long-range spatial dependencies in the decoder.
 
-    Architecture per forward pass:
-        1. Project processor output to decoder latent dimension
-        2. Add positional + scale encoding to latent context (mirrors encoder)
-        3. Cross-attention: learned output queries attend to latent context
-        4. Self-attention: output queries refine via mutual attention
-        5. Linear projection to output channels
-        6. Reshape to spatial grid (B, out_channels, h, w)
-
-    The output is then passed through the existing ``unpatch`` system in FOMO
-    for pixel-level expansion back to the original spatial resolution.
+    After decoding, the output is then passed through the existing ``unpatch``
+    system in FOMO for pixel-level expansion back to the original spatial
+    resolution.
 
     Args:
         in_channels: Number of input channels from the processor.
@@ -46,7 +39,8 @@ class PerceiverDecoder(nn.Module):
         patch_extent: Spatial extent of each patch in degrees (lat, lon).
             Used for computing positional and scale encodings.
         perceiver: The underlying perceiver decoder.
-        latent_dim: Dimension of the decoder's internal latent space.
+        latent_dim: Dimension of the decoder's internal latent space. The output
+            channel dimension of the perceiver.
 
     References:
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
@@ -64,14 +58,9 @@ class PerceiverDecoder(nn.Module):
         self.out_channels = out_channels
         self.patch_extent = patch_extent
 
-        # TODO(claude) I don't think we need to project to a latent space; the output
-        #  of the processor will be a latent space.
-        # Project processor output channels to decoder latent dimension
-        self.input_proj = nn.Linear(in_channels, latent_dim)
-
         # Positional and scale encoding (mirrors encoder's post-perceiver encoding)
-        self.pos_embed = nn.Linear(latent_dim, latent_dim)
-        self.scale_embed = nn.Linear(latent_dim, latent_dim)
+        self.pos_embed = nn.Linear(in_channels, in_channels)
+        self.scale_embed = nn.Linear(in_channels, in_channels)
 
         self.perceiver = perceiver
 
@@ -84,18 +73,15 @@ class PerceiverDecoder(nn.Module):
     def forward(
         self, x: Float[torch.Tensor, "batch channels h w"], resolution: tuple[Lat, Lon]
     ) -> Float[torch.Tensor, "batch {self.out_channels} h w"]:
-        B, C, h, w = x.shape
+        B, C, h, w = x.shape  # h = input H // patch_h; w = input W // patch_w
         lat, lon = resolution
 
         # Compute patch sizes from the original resolution for pos/scale encoding.
-        H, W = len(lat), len(lon)
+        H, W = len(lat), len(lon)  # Target H and W.
         patch_h, patch_w = patch_from(self.patch_extent, H, W)
 
         # Reshape processor output to token sequence: (B, h*w, C)
         context = rearrange(x, "b c h w -> b (h w) c")
-
-        # Project to decoder latent dimension
-        context = self.input_proj(context)  # (B, h*w, latent_dim)
 
         # Add positional + scale encoding (mirrors encoder's post-perceiver step)
         pos_encode, scale_encode = pos_scale_enc(
@@ -114,25 +100,16 @@ class PerceiverDecoder(nn.Module):
         ).unsqueeze(0)
         context = context + pos_encoding + scale_encoding
 
-        # # Initialize output queries: (B, num_queries, latent_dim)
-        # queries = self.queries.unsqueeze(0).expand(B, -1, -1)
-        #
-        # # Cross-attention + self-attention layers
-        # for cross_attn, cross_ff, self_attns in self.layers:  # type: ignore
-        #     queries = cross_attn(queries, context=context) + queries  # type: ignore
-        #     queries = cross_ff(queries) + queries  # type: ignore
-        #
-        #     for self_attn, self_ff in self_attns:  # type: ignore
-        #         queries = self_attn(queries) + queries
-        #         queries = self_ff(queries) + queries
-        #
+        context = rearrange(context, "b (h w) c -> (b h w) c", h=h, w=w)
+        context = context.unsqueeze(1)
 
+        # (B*h*w, 1, channels) -> (B*h*w, latent_dim)
         queries = self.perceiver(context)
 
-        # Project to output channels: (B, h*w, out_channels)
+        # Project to output channels: (B*h*w, out_channels)
         out = self.to_out(queries)
 
         # Reshape back to spatial grid
-        out = rearrange(out, "b (h w) c -> b c h w", h=h, w=w)
+        out = rearrange(out, "(b h w) c -> b c h w", h=h, w=w)
 
         return out

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -17,29 +17,36 @@ from ocean_emulators.models.modules.encoder import patch_from
 class PerceiverDecoder(nn.Module):
     """A perceiver-based decoder that maps latent patch tokens to full-resolution output.
 
-    For each patch position on the latent grid, the decoder broadcasts the
-    pos/scale-encoded latent vector to every output pixel within the patch,
-    concatenates a normalized 2D pixel-position query, and runs a shared
-    perceiver over the ``(patch_h, patch_w)`` grid of ``(C + 2)``-dim tokens.
+    For each patch position on the latent grid, the decoder:
 
-    The perceiver's learned latents cross-attend to these pixel tokens and
-    the output is mean-pooled to ``out_channels`` — producing one prediction
-    per patch.  This is then reassembled into ``(B, out_channels, nh, nw)``.
-    FOMO's ``unpatch`` linear handles the final expansion to full resolution.
+    1. Adds Aurora-style pos/scale encoding to the latent vector (telling the
+       perceiver *where on the globe* this patch is).
+    2. Broadcasts the encoded latent vector to every pixel within the patch and
+       concatenates a normalized 2D pixel-position query (telling the perceiver
+       *where within the patch* each output pixel is).
+    3. Feeds the ``(patch_h, patch_w, C + 2)``-dim token grid through a shared
+       perceiver whose ``num_latents`` equals ``patch_h * patch_w``.
+    4. The decoder calls the perceiver with ``return_embeddings=True`` to skip
+       the default mean-pooling, getting back per-latent embeddings
+       ``(batch, num_latents, latent_dim)``.  It then projects each latent
+       independently via ``LayerNorm + Linear`` to ``out_channels``.
+    5. The per-pixel outputs are reassembled into ``(B, out_channels, H, W)``.
 
     Because pixel queries are normalized to ``[0, 1)``, the same perceiver
     generalizes across resolutions: a 1-degree patch queries a coarse grid
     while a 0.25-degree patch queries a finer grid over the same coordinate
-    space.
+    space.  Higher-resolution grids simply have more pixels per patch, and
+    the perceiver's ``num_latents`` is set to accommodate the largest patch.
 
     Args:
         in_channels: Number of input channels from the processor.
-        out_channels: Number of output channels per patch position.
+        out_channels: Number of output channels per pixel.
         patch_extent: Spatial extent of each patch in degrees (lat, lon).
             Used for computing positional and scale encodings.
+        latent_dim: The perceiver's latent dimension.  Used to build the
+            per-latent ``LayerNorm + Linear`` projection.
         perceiver: Shared perceiver module.  ``input_channels`` must equal
             ``in_channels + 2`` (latent dim + 2D pixel query).
-            ``num_classes`` must equal ``out_channels``.
 
     References:
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
@@ -50,6 +57,7 @@ class PerceiverDecoder(nn.Module):
         in_channels: int,
         out_channels: int,
         patch_extent: tuple[float, float],
+        latent_dim: int,
         perceiver: nn.Module,
     ) -> None:
         super().__init__()
@@ -63,11 +71,16 @@ class PerceiverDecoder(nn.Module):
 
         self.perceiver = perceiver
 
+        # Per-latent projection: replaces the perceiver's default mean-pool + linear.
+        # Each learned latent corresponds to one output pixel.
+        self.norm = nn.LayerNorm(latent_dim)
+        self.proj = nn.Linear(latent_dim, out_channels)
+
     def forward(
         self,
         x: Float[torch.Tensor, "batch channels nh nw"],
         resolution: tuple[Lat, Lon],
-    ) -> Float[torch.Tensor, "batch {self.out_channels} nh nw"]:
+    ) -> Float[torch.Tensor, "batch {self.out_channels} H W"]:
         # nh, nw: number of patches along height and width (the latent grid dims).
         # Not to be confused with patch_h, patch_w which are each patch's pixel size.
         B, C, nh, nw = x.shape
@@ -119,13 +132,28 @@ class PerceiverDecoder(nn.Module):
         # Concat: (B*nh*nw, patch_h, patch_w, C+2)
         perceiver_input = torch.cat([tokens, query], dim=-1)
 
-        # --- Run shared perceiver ---
-        # The perceiver cross-attends its learned latents to the (patch_h, patch_w)
-        # grid of (C+2)-dim tokens, then mean-pools to (out_channels,).
-        # (B*nh*nw, patch_h, patch_w, C+2) -> (B*nh*nw, out_channels)
-        out = self.perceiver(perceiver_input)
+        # --- Run perceiver without mean-pooling ---
+        # return_embeddings=True skips the perceiver's to_logits (which mean-pools).
+        # Returns: (B*nh*nw, num_latents, latent_dim)
+        embeddings = self.perceiver(perceiver_input, return_embeddings=True)
 
-        # --- Reshape back to latent grid ---
-        out = rearrange(out, "(b nh nw) c -> b c nh nw", b=B, nh=nh, nw=nw)
+        # --- Per-latent projection to out_channels ---
+        # (B*nh*nw, num_latents, latent_dim) -> (B*nh*nw, num_latents, out_channels)
+        out = self.proj(self.norm(embeddings))
+
+        # --- Reassemble into full-resolution output ---
+        # num_latents >= patch_h * patch_w; take only the pixels we need.
+        num_pixels = patch_h * patch_w
+        out = out[:, :num_pixels, :]  # (B*nh*nw, patch_h*patch_w, out_channels)
+
+        out = rearrange(
+            out,
+            "(b nh nw) (ph pw) c -> b c (nh ph) (nw pw)",
+            b=B,
+            nh=nh,
+            nw=nw,
+            ph=patch_h,
+            pw=patch_w,
+        )
 
         return out

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -6,32 +6,40 @@
 import torch
 from aurora.model.fourier import pos_expansion, scale_expansion
 from aurora.model.posencoding import pos_scale_enc
-from einops import rearrange
+from einops import rearrange, repeat
 from jaxtyping import Float
 from torch import nn
 
 from ocean_emulators.constants import Lat, Lon
+from ocean_emulators.models.modules.encoder import patch_from
 
 
 class PerceiverDecoder(nn.Module):
-    """A perceiver-based decoder that mirrors the PerceiverEncoder.
+    """A perceiver-based decoder that maps latent patch tokens to full-resolution output.
 
-    The encoder compresses each patch of physical data into a single latent
-    token via perceiver cross-attention. This decoder inverts that: for each
-    latent-grid position it runs a perceiver that maps one token back to
-    ``out_channels``, then FOMO's ``unpatch`` layer expands each position to
-    full patch resolution.
+    For each patch position on the latent grid, the decoder broadcasts the
+    pos/scale-encoded latent vector to every output pixel within the patch,
+    concatenates a normalized 2D pixel-position query, and runs a shared
+    perceiver over the ``(patch_h, patch_w)`` grid of ``(C + 2)``-dim tokens.
 
-    Positional and scale encodings (Aurora-style [1]) are added to the latent
-    tokens before decoding, mirroring the encoder's post-perceiver step.
+    The perceiver's learned latents cross-attend to these pixel tokens and
+    the output is mean-pooled to ``out_channels`` — producing one prediction
+    per patch.  This is then reassembled into ``(B, out_channels, nh, nw)``.
+    FOMO's ``unpatch`` linear handles the final expansion to full resolution.
+
+    Because pixel queries are normalized to ``[0, 1)``, the same perceiver
+    generalizes across resolutions: a 1-degree patch queries a coarse grid
+    while a 0.25-degree patch queries a finer grid over the same coordinate
+    space.
 
     Args:
         in_channels: Number of input channels from the processor.
-        out_channels: Number of output channels per spatial position.
+        out_channels: Number of output channels per patch position.
         patch_extent: Spatial extent of each patch in degrees (lat, lon).
             Used for computing positional and scale encodings.
-        perceiver: The underlying perceiver module. Must project to
-            ``out_channels`` internally (e.g. ``num_classes=out_channels``).
+        perceiver: Shared perceiver module.  ``input_channels`` must equal
+            ``in_channels + 2`` (latent dim + 2D pixel query).
+            ``num_classes`` must equal ``out_channels``.
 
     References:
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
@@ -45,6 +53,7 @@ class PerceiverDecoder(nn.Module):
         perceiver: nn.Module,
     ) -> None:
         super().__init__()
+        self.in_channels = in_channels
         self.out_channels = out_channels
         self.patch_extent = patch_extent
 
@@ -64,44 +73,59 @@ class PerceiverDecoder(nn.Module):
         B, C, nh, nw = x.shape
         lat, lon = resolution
 
-        # Derive the effective patch size from the original resolution and the
-        # decoder's spatial grid.  In the full FOMO pipeline the processor output
-        # (nh, nw) equals (H // patch_h, W // patch_w), but we compute the patch
-        # size from the tensor itself so the pos/scale encodings always produce
-        # exactly nh*nw tokens — even in unit tests where nh, nw may differ from
-        # the patch-reduced grid.
-        H, W = len(lat), len(lon)  # Original (physical) resolution.
-        patch_h, patch_w = H // nh, W // nw
+        H, W = len(lat), len(lon)
+        patch_h, patch_w = patch_from(self.patch_extent, H, W)
 
-        # Reshape processor output to token sequence: (B, nh*nw, C)
-        context = rearrange(x, "b c nh nw -> b (nh nw) c")
+        # For pos/scale encoding we need a patch size that produces exactly
+        # nh*nw tokens.  In the full pipeline patch_from gives the same result,
+        # but in unit tests the input grid may not match, so derive from tensor.
+        pos_patch_h, pos_patch_w = H // nh, W // nw
 
-        # Add positional + scale encoding (mirrors encoder's post-perceiver step)
+        # --- Add pos/scale encoding to latent tokens (mirrors encoder) ---
+        tokens = rearrange(x, "b c nh nw -> b (nh nw) c")
+
         pos_encode, scale_encode = pos_scale_enc(
-            context.shape[-1],  # latent_dim
+            C,
             lat,
             lon,
-            (patch_h, patch_w),
+            (pos_patch_h, pos_patch_w),
             pos_expansion=pos_expansion,
             scale_expansion=scale_expansion,
         )
         pos_encoding = self.pos_embed(
-            pos_encode.to(dtype=context.dtype, device=context.device)
+            pos_encode.to(dtype=tokens.dtype, device=tokens.device)
         ).unsqueeze(0)
         scale_encoding = self.scale_embed(
-            scale_encode.to(dtype=context.dtype, device=context.device)
+            scale_encode.to(dtype=tokens.dtype, device=tokens.device)
         ).unsqueeze(0)
-        context = context + pos_encoding + scale_encoding
+        tokens = tokens + pos_encoding + scale_encoding
 
-        context = rearrange(context, "b (nh nw) c -> (b nh nw) c", nh=nh, nw=nw)
-        # We add these middle singleton dimensions to make this perceiver consistent with the encoder's perceiver.
-        # It assumes that `input_axis=2`.
-        context = context.unsqueeze(1).unsqueeze(1)
+        # --- Build per-pixel input: broadcast latent + concat pixel query ---
+        # Broadcast each latent vector to every pixel in its patch.
+        # tokens: (B, nh*nw, C) -> (B*nh*nw, patch_h, patch_w, C)
+        tokens = rearrange(tokens, "b (nh nw) c -> (b nh nw) c", nh=nh, nw=nw)
+        tokens = repeat(tokens, "n c -> n ph pw c", ph=patch_h, pw=patch_w)
 
-        # (B*nh*nw, 1, 1, channels) -> (B*nh*nw, out_channels)
-        out = self.perceiver(context)
+        # Build normalized 2D pixel query grid in [0, 1).
+        # Shape: (patch_h, patch_w, 2)
+        qh = torch.arange(patch_h, dtype=x.dtype, device=x.device) / patch_h
+        qw = torch.arange(patch_w, dtype=x.dtype, device=x.device) / patch_w
+        grid_h, grid_w = torch.meshgrid(qh, qw, indexing="ij")
+        query = torch.stack([grid_h, grid_w], dim=-1)  # (patch_h, patch_w, 2)
 
-        # Reshape back to spatial grid
-        out = rearrange(out, "(b nh nw) c -> b c nh nw", nh=nh, nw=nw)
+        # Broadcast query to batch: (B*nh*nw, patch_h, patch_w, 2)
+        query = query.unsqueeze(0).expand(tokens.shape[0], -1, -1, -1)
+
+        # Concat: (B*nh*nw, patch_h, patch_w, C+2)
+        perceiver_input = torch.cat([tokens, query], dim=-1)
+
+        # --- Run shared perceiver ---
+        # The perceiver cross-attends its learned latents to the (patch_h, patch_w)
+        # grid of (C+2)-dim tokens, then mean-pools to (out_channels,).
+        # (B*nh*nw, patch_h, patch_w, C+2) -> (B*nh*nw, out_channels)
+        out = self.perceiver(perceiver_input)
+
+        # --- Reshape back to latent grid ---
+        out = rearrange(out, "(b nh nw) c -> b c nh nw", b=B, nh=nh, nw=nw)
 
         return out

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -144,19 +144,10 @@ class PerceiverDecoder(nn.Module):
 
     def _decode(
         self,
-        data: torch.Tensor,
-        queries: torch.Tensor,
-    ) -> torch.Tensor:
-        """Run PerceiverIO, windowing over queries if they exceed window_size.
-
-        Args:
-            data: Pos/scale-encoded latent tokens, shape ``(B, nh*nw, C)``.
-            queries: Embedded pixel queries, shape ``(H*W, queries_dim)``.
-                Shared across the batch (PerceiverIO broadcasts internally).
-
-        Returns:
-            Output predictions, shape ``(B, H*W, out_channels)``.
-        """
+        data: Float[torch.Tensor, "batch num_patches channels"],
+        queries: Float[torch.Tensor, "num_pixels queries_dim"],
+    ) -> Float[torch.Tensor, "batch num_pixels {self.out_channels}"]:
+        """Run PerceiverIO, windowing over queries if they exceed window_size."""
         num_pixels = queries.shape[0]
 
         if self.window_size is None or num_pixels <= self.window_size:

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -98,7 +98,9 @@ class PerceiverDecoder(nn.Module):
         context = context + pos_encoding + scale_encoding
 
         context = rearrange(context, "b (h w) c -> (b h w) c", h=h, w=w)
-        context = context.unsqueeze(1)
+        # We add these middle singleton dimensions to make this perceiver consistent with the encoder's perceiver.
+        # It assumes that `input_axis=2`.
+        context = context.unsqueeze(1).unsqueeze(1)
 
         # (B*h*w, 1, channels) -> (B*h*w, out_channels)
         out = self.perceiver(context)

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -13,13 +13,11 @@ from ocean_emulators.constants import Lat, Lon
 class PerceiverDecoder(nn.Module):
     """A PerceiverIO-based decoder that maps a latent patch grid to full-resolution output.
 
-    Unlike the previous per-patch decoder, this operates over the **full latent
-    grid** at once.  All ``nh * nw`` pos/scale-encoded latent tokens are passed
-    as **data** to the PerceiverIO, and every output pixel position is a
-    **query**.  Each query cross-attends to the full latent representation,
-    giving it global spatial context — pixels near patch boundaries can attend
-    to neighboring patches, and the model can learn smooth inter-patch
-    transitions.
+    All ``nh * nw`` pos/scale-encoded latent tokens are passed as **data** to
+    the PerceiverIO[3], and every output pixel position is a **query**.  Each
+    query cross-attends to the full latent representation, giving it global
+    spatial context — pixels near patch boundaries can attend to neighboring
+    patches, and the model can learn smooth inter-patch transitions.
 
     Concretely:
 

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -164,6 +164,15 @@ class PerceiverDecoder(nn.Module):
         When ``window_patches`` is None, all data and queries are passed in one
         call (global attention).  Otherwise, the output grid is tiled into
         spatial blocks and each block attends only to nearby latent tokens.
+
+        Note: the windowed loop below is structurally equivalent to
+        ``nn.Unfold`` / ``im2col`` — strided extraction of overlapping 2D
+        patches.  We use explicit indexing instead because (1) ``unfold``
+        requires pre-padding and produces fixed-size windows, adding edge-
+        handling complexity for grids not evenly divisible by
+        ``window_patches``, and (2) the bottleneck is the PerceiverIO forward
+        pass per window, not the Python index arithmetic, so there is no
+        performance benefit to fusing the extraction.
         """
         B, nh, nw, C = data_grid.shape
         H, W, _ = queries_grid.shape

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -25,7 +25,7 @@ class PerceiverDecoder(nn.Module):
        concatenates a normalized 2D pixel-position query (telling the perceiver
        *where within the patch* each output pixel is).
     3. Feeds the ``(patch_h, patch_w, C + 2)``-dim token grid through a shared
-       perceiver whose ``num_latents`` equals ``patch_h * patch_w``.
+       perceiver whose ``num_latents`` equals (or exceeds[2]) ``patch_h * patch_w``.
     4. The decoder calls the perceiver with ``return_embeddings=True`` to skip
        the default mean-pooling, getting back per-latent embeddings
        ``(batch, num_latents, latent_dim)``.  It then projects each latent
@@ -50,6 +50,7 @@ class PerceiverDecoder(nn.Module):
 
     References:
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
+        [2]: https://ar5iv.labs.arxiv.org/html/2309.16588
     """
 
     def __init__(
@@ -143,17 +144,17 @@ class PerceiverDecoder(nn.Module):
         out = self.proj(self.norm(embeddings))
 
         # --- Reassemble into full-resolution output ---
+        # num_latents >= patch_h * patch_w; take only the pixels we need.
+        # TODO(alxmrs,Claude): Consider using a learned selection of the latents or pooling over the latents
+        #  (more complex)
+        #
         # num_latents should be as large as the biggest patch. For smaller patches,
         # num_latents includes "extra" information beyond the pixel count.
         #
         # The additional output space could actually be useful for transformer
         # architectures to use even if they aren't used in the output.
-        # Transformers can use these as "scratch" space, check out this paper
-        # for more on this topic: https://arxiv.org/pdf/2309.16588.
-        #
-        # num_latents >= patch_h * patch_w; take only the pixels we need.
-        # TODO(alxmrs,Claude): Consider using a learned selection of the latents or pooling over the latents
-        #  (more complex)
+        # Transformers can use these as "scratch" space, check out [2]  for more
+        # on this topic.
         num_pixels = patch_h * patch_w
         out = out[:, :num_pixels, :]  # (B*nh*nw, patch_h*patch_w, out_channels)
 

--- a/src/ocean_emulators/models/modules/decoder.py
+++ b/src/ocean_emulators/models/modules/decoder.py
@@ -65,6 +65,7 @@ class PerceiverDecoder(nn.Module):
         self.out_channels = out_channels
         self.patch_extent = patch_extent
 
+        # TODO(#451): The input to these position and scale linear units could be a hparam.
         # Positional and scale encoding (mirrors encoder's post-perceiver encoding)
         self.pos_embed = nn.Linear(in_channels, in_channels)
         self.scale_embed = nn.Linear(in_channels, in_channels)
@@ -142,7 +143,17 @@ class PerceiverDecoder(nn.Module):
         out = self.proj(self.norm(embeddings))
 
         # --- Reassemble into full-resolution output ---
+        # num_latents should be as large as the biggest patch. For smaller patches,
+        # num_latents includes "extra" information beyond the pixel count.
+        #
+        # The additional output space could actually be useful for transformer
+        # architectures to use even if they aren't used in the output.
+        # Transformers can use these as "scratch" space, check out this paper
+        # for more on this topic: https://arxiv.org/pdf/2309.16588.
+        #
         # num_latents >= patch_h * patch_w; take only the pixels we need.
+        # TODO(alxmrs,Claude): Consider using a learned selection of the latents or pooling over the latents
+        #  (more complex)
         num_pixels = patch_h * patch_w
         out = out[:, :num_pixels, :]  # (B*nh*nw, patch_h*patch_w, out_channels)
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -10,6 +10,16 @@ LATENT_DIM = 8
 QUERIES_DIM = 16
 NUM_LATENTS = 4
 
+IN_CHANNELS = 12
+OUT_CHANNELS = 24
+PATCH_EXTENT = (90.0, 90.0)
+BATCH = 2
+
+# With patch_extent=(90, 90) and H=8, W=16:
+#   patch_h=4, patch_w=4  →  nh=2, nw=4
+NH, NW = 2, 4
+H, W = 8, 16
+
 
 def make_perceiver_encoder(in_channels, out_channels, *, num_latents=2):
     """Build a regular Perceiver for the encoder (uses mean-pooling)."""
@@ -29,7 +39,7 @@ def make_perceiver_encoder(in_channels, out_channels, *, num_latents=2):
     )
 
 
-def make_decoder_perceiver_io(in_channels, out_channels):
+def make_decoder_perceiver_io(in_channels=IN_CHANNELS, out_channels=OUT_CHANNELS):
     """Build a PerceiverIO for the decoder."""
     return PerceiverIO(
         depth=2,
@@ -43,9 +53,73 @@ def make_decoder_perceiver_io(in_channels, out_channels):
     )
 
 
+@pytest.fixture()
+def resolution():
+    """Standard (H, W) = (8, 16) resolution grid."""
+    return (
+        torch.linspace(-90, 90, steps=H),
+        torch.linspace(0, 360, steps=W),
+    )
+
+
+@pytest.fixture()
+def latent_input():
+    """Latent grid tensor with shape (BATCH, IN_CHANNELS, NH, NW)."""
+    return torch.randn(BATCH, IN_CHANNELS, NH, NW)
+
+
+@pytest.fixture()
+def decoder_kwargs():
+    """Common kwargs for building a PerceiverDecoder (without windowing args).
+
+    Uses a single shared PerceiverIO so weight-sharing tests can rely on
+    identical parameters across decoders built from the same fixture.
+    """
+    return dict(
+        in_channels=IN_CHANNELS,
+        out_channels=OUT_CHANNELS,
+        patch_extent=PATCH_EXTENT,
+        queries_dim=QUERIES_DIM,
+        perceiver_io=make_decoder_perceiver_io(),
+    )
+
+
+def make_decoder_with_shared_weights(
+    reference: PerceiverDecoder,
+    **overrides,
+) -> PerceiverDecoder:
+    """Clone a decoder with different windowing params but shared weights.
+
+    Builds a new PerceiverDecoder from *reference*'s config, applies
+    *overrides* (e.g. ``window_patches``, ``context_patches``), copies
+    weights, and sets eval mode on both.
+    """
+    kwargs = dict(
+        in_channels=reference.in_channels,
+        out_channels=reference.out_channels,
+        patch_extent=reference.patch_extent,
+        queries_dim=reference.query_embed.out_features,
+        perceiver_io=reference.perceiver_io,
+        window_patches=reference.window_patches,
+        context_patches=reference.context_patches,
+    )
+    kwargs.update(overrides)
+    other = PerceiverDecoder(**kwargs)  # type: ignore
+
+    reference.eval()
+    other.eval()
+    other.load_state_dict(reference.state_dict())
+    return other
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
 def test_roundtrip():
-    H, W = 4, 8
-    x = torch.randn(3, 10, H, W)
+    H_rt, W_rt = 4, 8
+    x = torch.randn(3, 10, H_rt, W_rt)
 
     patch_embed = PerceiverEncoder(
         in_channels=10,
@@ -55,7 +129,7 @@ def test_roundtrip():
     )
 
     patches = patch_embed(x, make_resolution(x))
-    resolution = make_resolution(x)
+    res = make_resolution(x)
 
     decode = PerceiverDecoder(
         in_channels=4,
@@ -67,180 +141,78 @@ def test_roundtrip():
         context_patches=None,
     )
 
-    y_hat = decode(patches, resolution)
+    y_hat = decode(patches, res)
 
-    assert y_hat.shape == (3, 10, H, W), (
+    assert y_hat.shape == (3, 10, H_rt, W_rt), (
         f"Decoder should produce full-resolution output, got {y_hat.shape}."
     )
 
 
-def test_decode():
-    H, W = 8, 16
-    # Resolution represents the original (pre-encoder) physical grid, which is
-    # larger than the decoder's latent input — mirroring the real pipeline where
-    # the encoder reduces spatial dimensions.
-    resolution = (
-        torch.linspace(-90, 90, steps=H),
-        torch.linspace(0, 360, steps=W),
-    )
-
-    # patch_from((90, 90), 8, 16) -> patch_h=4, patch_w=4
-    # So nh=8/4=2, nw=16/4=4.  Input x has shape (3, 12, 2, 4).
-    x = torch.randn(3, 12, 2, 4)
-
+def test_decode(resolution, latent_input, decoder_kwargs):
     decode = PerceiverDecoder(
-        in_channels=12,
-        out_channels=24,
-        patch_extent=(90, 90),
-        queries_dim=QUERIES_DIM,
-        perceiver_io=make_decoder_perceiver_io(12, 24),
-        window_patches=None,
-        context_patches=None,
+        **decoder_kwargs, window_patches=None, context_patches=None
     )
+    y_hat = decode(latent_input, resolution)
 
-    y_hat = decode(x, resolution)
-
-    assert y_hat.shape == (3, 24, H, W), (
+    assert y_hat.shape == (BATCH, OUT_CHANNELS, H, W), (
         f"Decoder should produce full-resolution output, got {y_hat.shape}."
     )
 
 
-def test_windowed_decode():
+def test_windowed_decode(resolution, latent_input, decoder_kwargs):
     """At high resolution, windowing splits queries into fixed-size chunks."""
-    H, W = 8, 16
-    resolution = (
-        torch.linspace(-90, 90, steps=H),
-        torch.linspace(0, 360, steps=W),
-    )
+    decode = PerceiverDecoder(**decoder_kwargs, window_patches=1, context_patches=None)
+    y_hat = decode(latent_input, resolution)
 
-    # nh=2, nw=4 latent grid, window_patches=1 -> 2*4=8 PerceiverIO calls.
-    x = torch.randn(2, 12, 2, 4)
-
-    decode = PerceiverDecoder(
-        in_channels=12,
-        out_channels=24,
-        patch_extent=(90, 90),
-        queries_dim=QUERIES_DIM,
-        perceiver_io=make_decoder_perceiver_io(12, 24),
-        window_patches=1,  # 1 patch per window side → 1x1 blocks of patches
-        context_patches=None,
-    )
-
-    y_hat = decode(x, resolution)
-
-    assert y_hat.shape == (2, 24, H, W), (
+    assert y_hat.shape == (BATCH, OUT_CHANNELS, H, W), (
         f"Windowed decoder should produce full-resolution output, got {y_hat.shape}."
     )
 
 
-def test_windowed_matches_non_windowed():
+def test_windowed_matches_non_windowed(resolution, latent_input, decoder_kwargs):
     """Windowed and non-windowed decoding should produce identical results."""
-    H, W = 4, 8
-    resolution = (
-        torch.linspace(-90, 90, steps=H),
-        torch.linspace(0, 360, steps=W),
-    )
-
-    x = torch.randn(2, 12, 2, 4)
-    pio = make_decoder_perceiver_io(12, 24)
-
-    kwargs = dict(
-        in_channels=12,
-        out_channels=24,
-        patch_extent=(90, 90),
-        queries_dim=QUERIES_DIM,
-        perceiver_io=pio,
-    )
-
-    full = PerceiverDecoder(**kwargs, window_patches=None, context_patches=None)
+    full = PerceiverDecoder(**decoder_kwargs, window_patches=None, context_patches=None)
     # window_patches=4 covers the full 2x4 latent grid in one call,
     # so the windowed path should produce identical results to global.
-    windowed = PerceiverDecoder(**kwargs, window_patches=4, context_patches=0)
-
-    full.eval()
-    windowed.eval()
-
-    # Share the same parameters (same pio and same query_embed/pos/scale).
-    windowed.load_state_dict(full.state_dict())
+    windowed = make_decoder_with_shared_weights(
+        full, window_patches=4, context_patches=0
+    )
 
     with torch.no_grad():
-        y_full = full(x, resolution)
-        y_windowed = windowed(x, resolution)
+        y_full = full(latent_input, resolution)
+        y_windowed = windowed(latent_input, resolution)
 
     assert torch.allclose(y_full, y_windowed, atol=1e-5), (
         "Windowed and non-windowed results should match."
     )
 
 
-def test_full_context_matches_non_windowed():
+def test_full_context_matches_non_windowed(resolution, latent_input, decoder_kwargs):
     """context_patches=None (full context) with windowed queries matches global."""
-    H, W = 4, 8
-    resolution = (
-        torch.linspace(-90, 90, steps=H),
-        torch.linspace(0, 360, steps=W),
-    )
-
-    x = torch.randn(2, 12, 2, 4)
-    pio = make_decoder_perceiver_io(12, 24)
-
-    kwargs = dict(
-        in_channels=12,
-        out_channels=24,
-        patch_extent=(90, 90),
-        queries_dim=QUERIES_DIM,
-        perceiver_io=pio,
-    )
-
-    full = PerceiverDecoder(**kwargs, window_patches=None, context_patches=None)
+    full = PerceiverDecoder(**decoder_kwargs, window_patches=None, context_patches=None)
     # window_patches=1 with context_patches=None: windowed queries but every
     # window sees the full latent grid as data.
-    windowed_full_ctx = PerceiverDecoder(
-        **kwargs, window_patches=1, context_patches=None
+    windowed_full_ctx = make_decoder_with_shared_weights(
+        full, window_patches=1, context_patches=None
     )
 
-    full.eval()
-    windowed_full_ctx.eval()
-    windowed_full_ctx.load_state_dict(full.state_dict())
-
     with torch.no_grad():
-        y_full = full(x, resolution)
-        y_windowed = windowed_full_ctx(x, resolution)
+        y_full = full(latent_input, resolution)
+        y_windowed = windowed_full_ctx(latent_input, resolution)
 
     assert torch.allclose(y_full, y_windowed, atol=1e-5), (
         "Full-context windowed and non-windowed results should match."
     )
 
 
-def test_context_patches_affects_output():
+def test_context_patches_affects_output(resolution, latent_input, decoder_kwargs):
     """Different context_patches values should produce different outputs."""
-    H, W = 8, 16
-    resolution = (
-        torch.linspace(-90, 90, steps=H),
-        torch.linspace(0, 360, steps=W),
-    )
-
-    # nh=2, nw=4 latent grid with window_patches=1.
-    x = torch.randn(2, 12, 2, 4)
-    pio = make_decoder_perceiver_io(12, 24)
-
-    kwargs = dict(
-        in_channels=12,
-        out_channels=24,
-        patch_extent=(90, 90),
-        queries_dim=QUERIES_DIM,
-        perceiver_io=pio,
-    )
-
-    cp0 = PerceiverDecoder(**kwargs, window_patches=1, context_patches=0)
-    cp1 = PerceiverDecoder(**kwargs, window_patches=1, context_patches=1)
-
-    cp0.eval()
-    cp1.eval()
-    cp1.load_state_dict(cp0.state_dict())
+    cp0 = PerceiverDecoder(**decoder_kwargs, window_patches=1, context_patches=0)
+    cp1 = make_decoder_with_shared_weights(cp0, context_patches=1)
 
     with torch.no_grad():
-        y_cp0 = cp0(x, resolution)
-        y_cp1 = cp1(x, resolution)
+        y_cp0 = cp0(latent_input, resolution)
+        y_cp1 = cp1(latent_input, resolution)
 
     # context_patches=0 sees only the local 1x1 patch per window,
     # context_patches=1 sees a 3x3 neighborhood — different data means
@@ -250,40 +222,22 @@ def test_context_patches_affects_output():
     )
 
 
-def test_more_context_closer_to_global():
+def test_more_context_closer_to_global(resolution, latent_input, decoder_kwargs):
     """Increasing context_patches should converge toward the global result."""
-    H, W = 8, 16
-    resolution = (
-        torch.linspace(-90, 90, steps=H),
-        torch.linspace(0, 360, steps=W),
+    global_dec = PerceiverDecoder(
+        **decoder_kwargs, window_patches=None, context_patches=None
     )
-
-    # nh=2, nw=4 latent grid with window_patches=1.
-    x = torch.randn(2, 12, 2, 4)
-    pio = make_decoder_perceiver_io(12, 24)
-
-    kwargs = dict(
-        in_channels=12,
-        out_channels=24,
-        patch_extent=(90, 90),
-        queries_dim=QUERIES_DIM,
-        perceiver_io=pio,
+    cp0 = make_decoder_with_shared_weights(
+        global_dec, window_patches=1, context_patches=0
     )
-
-    global_dec = PerceiverDecoder(**kwargs, window_patches=None, context_patches=None)
-    cp0 = PerceiverDecoder(**kwargs, window_patches=1, context_patches=0)
-    cp1 = PerceiverDecoder(**kwargs, window_patches=1, context_patches=1)
-
-    global_dec.eval()
-    cp0.eval()
-    cp1.eval()
-    cp0.load_state_dict(global_dec.state_dict())
-    cp1.load_state_dict(global_dec.state_dict())
+    cp1 = make_decoder_with_shared_weights(
+        global_dec, window_patches=1, context_patches=1
+    )
 
     with torch.no_grad():
-        y_global = global_dec(x, resolution)
-        y_cp0 = cp0(x, resolution)
-        y_cp1 = cp1(x, resolution)
+        y_global = global_dec(latent_input, resolution)
+        y_cp0 = cp0(latent_input, resolution)
+        y_cp1 = cp1(latent_input, resolution)
 
     err_cp0 = (y_global - y_cp0).abs().mean().item()
     err_cp1 = (y_global - y_cp1).abs().mean().item()
@@ -297,14 +251,13 @@ def test_more_context_closer_to_global():
 
 def test_context_patches_without_window_patches_raises():
     """Setting context_patches without window_patches should raise."""
-
     with pytest.raises(ValueError, match="window_patches must be set"):
         PerceiverDecoder(
-            in_channels=12,
-            out_channels=24,
-            patch_extent=(90, 90),
+            in_channels=IN_CHANNELS,
+            out_channels=OUT_CHANNELS,
+            patch_extent=PATCH_EXTENT,
             queries_dim=QUERIES_DIM,
-            perceiver_io=make_decoder_perceiver_io(12, 24),
+            perceiver_io=make_decoder_perceiver_io(),
             window_patches=None,
             context_patches=1,
         )

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,10 +1,45 @@
 import torch
-from test_encoder import make_perceiver, make_resolution  # type: ignore
+from perceiver_pytorch.perceiver_io import PerceiverIO
+from test_encoder import make_resolution  # type: ignore
 
 from ocean_emulators.models.modules import PerceiverDecoder, PerceiverEncoder
-from ocean_emulators.models.modules.encoder import patch_from
 
-LATENT_DIM = 3
+# Small values for fast tests.
+LATENT_DIM = 8
+QUERIES_DIM = 16
+NUM_LATENTS = 4
+
+
+def make_perceiver_encoder(in_channels, out_channels, *, num_latents=2):
+    """Build a regular Perceiver for the encoder (uses mean-pooling)."""
+    from perceiver_pytorch import Perceiver
+
+    return Perceiver(
+        num_freq_bands=4,
+        max_freq=1.0,
+        depth=2,
+        input_axis=2,
+        input_channels=in_channels,
+        latent_dim=3,
+        num_latents=num_latents,
+        num_classes=out_channels,
+        weight_tie_layers=True,
+        self_per_cross_attn=2,
+    )
+
+
+def make_decoder_perceiver_io(in_channels, out_channels):
+    """Build a PerceiverIO for the decoder."""
+    return PerceiverIO(
+        depth=2,
+        dim=in_channels,
+        queries_dim=QUERIES_DIM,
+        logits_dim=out_channels,
+        num_latents=NUM_LATENTS,
+        latent_dim=LATENT_DIM,
+        weight_tie_layers=True,
+        decoder_ff=True,
+    )
 
 
 def test_roundtrip():
@@ -15,23 +50,18 @@ def test_roundtrip():
         in_channels=10,
         out_channels=4,
         patch_extent=(180, 180),
-        perceiver=make_perceiver(10, 4),
+        perceiver=make_perceiver_encoder(10, 4),
     )
 
     patches = patch_embed(x, make_resolution(x))
-
     resolution = make_resolution(x)
-    _, _, nh, nw = patches.shape
-    patch_h, patch_w = H // nh, W // nw
-    num_latents = patch_h * patch_w
 
-    # Perceiver input_channels = in_channels + 2 (latent + 2D pixel query)
     decode = PerceiverDecoder(
         in_channels=4,
         out_channels=10,
         patch_extent=(180, 180),
-        latent_dim=LATENT_DIM,
-        perceiver=make_perceiver(4 + 2, 10, num_latents=num_latents),
+        queries_dim=QUERIES_DIM,
+        perceiver_io=make_decoder_perceiver_io(4, 10),
     )
 
     y_hat = decode(patches, resolution)
@@ -54,20 +84,44 @@ def test_decode():
     # patch_from((90, 90), 8, 16) -> patch_h=4, patch_w=4
     # So nh=8/4=2, nw=16/4=4.  Input x has shape (3, 12, 2, 4).
     x = torch.randn(3, 12, 2, 4)
-    patch_h, patch_w = patch_from((90, 90), H, W)
-    num_latents = patch_h * patch_w
 
-    # Perceiver input_channels = in_channels + 2 (latent + 2D pixel query)
     decode = PerceiverDecoder(
         in_channels=12,
         out_channels=24,
         patch_extent=(90, 90),
-        latent_dim=LATENT_DIM,
-        perceiver=make_perceiver(12 + 2, 24, num_latents=num_latents),
+        queries_dim=QUERIES_DIM,
+        perceiver_io=make_decoder_perceiver_io(12, 24),
     )
 
     y_hat = decode(x, resolution)
 
     assert y_hat.shape == (3, 24, H, W), (
         f"Decoder should produce full-resolution output, got {y_hat.shape}."
+    )
+
+
+def test_windowed_decode():
+    """At high resolution, windowing splits queries into fixed-size chunks."""
+    H, W = 8, 16
+    resolution = (
+        torch.linspace(-90, 90, steps=H),
+        torch.linspace(0, 360, steps=W),
+    )
+
+    # patch_from((90, 90), 8, 16) -> patch_h=4, patch_w=4 -> 16 pixels per patch
+    x = torch.randn(2, 12, 2, 4)
+
+    decode = PerceiverDecoder(
+        in_channels=12,
+        out_channels=24,
+        patch_extent=(90, 90),
+        queries_dim=QUERIES_DIM,
+        perceiver_io=make_decoder_perceiver_io(12, 24),
+        window_size=4,  # 16 pixels split into 4 windows of 4
+    )
+
+    y_hat = decode(x, resolution)
+
+    assert y_hat.shape == (2, 24, H, W), (
+        f"Windowed decoder should produce full-resolution output, got {y_hat.shape}."
     )

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -170,12 +170,13 @@ def test_windowed_decode(resolution, latent_input, decoder_kwargs):
 
 
 def test_windowed_matches_non_windowed(resolution, latent_input, decoder_kwargs):
-    """Windowed and non-windowed decoding should produce identical results."""
+    """Windowed with full context should match non-windowed decoding."""
     full = PerceiverDecoder(**decoder_kwargs, window_patches=None, context_patches=None)
-    # window_patches=4 covers the full 2x4 latent grid in one call,
-    # so the windowed path should produce identical results to global.
+    # window_patches=2 divides nh=2 and nw=4; context_patches=None gives
+    # every window the full latent grid as data, so the only difference
+    # from global is that queries are tiled into blocks.
     windowed = make_decoder_with_shared_weights(
-        full, window_patches=4, context_patches=0
+        full, window_patches=2, context_patches=None
     )
 
     with torch.no_grad():

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,0 +1,29 @@
+import torch
+from test_encoder import make_perceiver, make_resolution  # type: ignore
+
+from ocean_emulators.models.modules import PerceiverDecoder, PerceiverEncoder
+
+
+def test_roundtrip():
+    x = torch.randn(3, 10, 4, 8)
+
+    patch_embed = PerceiverEncoder(
+        in_channels=10,
+        out_channels=4,
+        patch_extent=(180, 180),
+        perceiver=make_perceiver(10, 4),
+    )
+
+    patches = patch_embed(x, make_resolution(x))
+
+    decode = PerceiverDecoder(
+        in_channels=4,
+        out_channels=10,
+        latent_dim=12,
+        patch_extent=(180, 180),
+        perceiver=make_perceiver(4, 12, num_latents=6, input_axis=1),
+    )
+
+    y_hat = decode(patches, make_resolution(x))
+
+    assert y_hat.shape == x.shape

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -2,10 +2,14 @@ import torch
 from test_encoder import make_perceiver, make_resolution  # type: ignore
 
 from ocean_emulators.models.modules import PerceiverDecoder, PerceiverEncoder
+from ocean_emulators.models.modules.encoder import patch_from
+
+LATENT_DIM = 3
 
 
 def test_roundtrip():
-    x = torch.randn(3, 10, 4, 8)
+    H, W = 4, 8
+    x = torch.randn(3, 10, H, W)
 
     patch_embed = PerceiverEncoder(
         in_channels=10,
@@ -16,46 +20,54 @@ def test_roundtrip():
 
     patches = patch_embed(x, make_resolution(x))
 
+    resolution = make_resolution(x)
+    _, _, nh, nw = patches.shape
+    patch_h, patch_w = H // nh, W // nw
+    num_latents = patch_h * patch_w
+
     # Perceiver input_channels = in_channels + 2 (latent + 2D pixel query)
     decode = PerceiverDecoder(
         in_channels=4,
         out_channels=10,
         patch_extent=(180, 180),
-        perceiver=make_perceiver(4 + 2, 10, num_latents=6),
+        latent_dim=LATENT_DIM,
+        perceiver=make_perceiver(4 + 2, 10, num_latents=num_latents),
     )
 
-    y_hat = decode(patches, make_resolution(x))
+    y_hat = decode(patches, resolution)
 
-    assert y_hat.shape[-2:] == patches.shape[-2:], (
-        "The decoder preserves the input grid."
-    )
-    assert y_hat.shape[1] == 10, (
-        "The decoder outputs the desired number of output channels."
+    assert y_hat.shape == (3, 10, H, W), (
+        f"Decoder should produce full-resolution output, got {y_hat.shape}."
     )
 
 
 def test_decode():
-    x = torch.randn(3, 12, 4, 8)
-
+    H, W = 8, 16
     # Resolution represents the original (pre-encoder) physical grid, which is
     # larger than the decoder's latent input — mirroring the real pipeline where
     # the encoder reduces spatial dimensions.
     resolution = (
-        torch.linspace(-90, 90, steps=8),
-        torch.linspace(0, 360, steps=16),
+        torch.linspace(-90, 90, steps=H),
+        torch.linspace(0, 360, steps=W),
     )
+
+    # patch_from((90, 90), 8, 16) -> patch_h=4, patch_w=4
+    # So nh=8/4=2, nw=16/4=4.  Input x has shape (3, 12, 2, 4).
+    x = torch.randn(3, 12, 2, 4)
+    patch_h, patch_w = patch_from((90, 90), H, W)
+    num_latents = patch_h * patch_w
 
     # Perceiver input_channels = in_channels + 2 (latent + 2D pixel query)
     decode = PerceiverDecoder(
         in_channels=12,
         out_channels=24,
         patch_extent=(90, 90),
-        perceiver=make_perceiver(12 + 2, 24, num_latents=6),
+        latent_dim=LATENT_DIM,
+        perceiver=make_perceiver(12 + 2, 24, num_latents=num_latents),
     )
 
     y_hat = decode(x, resolution)
 
-    assert y_hat.shape[-2:] == x.shape[-2:], "The decoder preserves the input grid."
-    assert y_hat.shape[1] == 24, (
-        "The decoder outputs the desired number of output channels."
+    assert y_hat.shape == (3, 24, H, W), (
+        f"Decoder should produce full-resolution output, got {y_hat.shape}."
     )

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -108,7 +108,7 @@ def test_windowed_decode():
         torch.linspace(0, 360, steps=W),
     )
 
-    # H*W = 128 pixels total, window_size=32 -> 4 PerceiverIO calls.
+    # nh=2, nw=4 latent grid, window_patches=1 -> 2*4=8 PerceiverIO calls.
     x = torch.randn(2, 12, 2, 4)
 
     decode = PerceiverDecoder(
@@ -117,7 +117,7 @@ def test_windowed_decode():
         patch_extent=(90, 90),
         queries_dim=QUERIES_DIM,
         perceiver_io=make_decoder_perceiver_io(12, 24),
-        window_size=32,
+        window_patches=1,  # 1 patch per window side → 1x1 blocks of patches
     )
 
     y_hat = decode(x, resolution)
@@ -147,7 +147,9 @@ def test_windowed_matches_non_windowed():
     )
 
     full = PerceiverDecoder(**kwargs)
-    windowed = PerceiverDecoder(**kwargs, window_size=8)
+    # window_patches=4 covers the full 2x4 latent grid in one call,
+    # so the windowed path should produce identical results to global.
+    windowed = PerceiverDecoder(**kwargs, window_patches=4, context_patches=0)
 
     full.eval()
     windowed.eval()
@@ -161,4 +163,43 @@ def test_windowed_matches_non_windowed():
 
     assert torch.allclose(y_full, y_windowed, atol=1e-5), (
         "Windowed and non-windowed results should match."
+    )
+
+
+def test_full_context_matches_non_windowed():
+    """context_patches=None (full context) with windowed queries matches global."""
+    H, W = 4, 8
+    resolution = (
+        torch.linspace(-90, 90, steps=H),
+        torch.linspace(0, 360, steps=W),
+    )
+
+    x = torch.randn(2, 12, 2, 4)
+    pio = make_decoder_perceiver_io(12, 24)
+
+    kwargs = dict(
+        in_channels=12,
+        out_channels=24,
+        patch_extent=(90, 90),
+        queries_dim=QUERIES_DIM,
+        perceiver_io=pio,
+    )
+
+    full = PerceiverDecoder(**kwargs)
+    # window_patches=1 with context_patches=None: windowed queries but every
+    # window sees the full latent grid as data.
+    windowed_full_ctx = PerceiverDecoder(
+        **kwargs, window_patches=1, context_patches=None
+    )
+
+    full.eval()
+    windowed_full_ctx.eval()
+    windowed_full_ctx.load_state_dict(full.state_dict())
+
+    with torch.no_grad():
+        y_full = full(x, resolution)
+        y_windowed = windowed_full_ctx(x, resolution)
+
+    assert torch.allclose(y_full, y_windowed, atol=1e-5), (
+        "Full-context windowed and non-windowed results should match."
     )

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -108,7 +108,7 @@ def test_windowed_decode():
         torch.linspace(0, 360, steps=W),
     )
 
-    # patch_from((90, 90), 8, 16) -> patch_h=4, patch_w=4 -> 16 pixels per patch
+    # H*W = 128 pixels total, window_size=32 -> 4 PerceiverIO calls.
     x = torch.randn(2, 12, 2, 4)
 
     decode = PerceiverDecoder(
@@ -117,11 +117,48 @@ def test_windowed_decode():
         patch_extent=(90, 90),
         queries_dim=QUERIES_DIM,
         perceiver_io=make_decoder_perceiver_io(12, 24),
-        window_size=4,  # 16 pixels split into 4 windows of 4
+        window_size=32,
     )
 
     y_hat = decode(x, resolution)
 
     assert y_hat.shape == (2, 24, H, W), (
         f"Windowed decoder should produce full-resolution output, got {y_hat.shape}."
+    )
+
+
+def test_windowed_matches_non_windowed():
+    """Windowed and non-windowed decoding should produce identical results."""
+    H, W = 4, 8
+    resolution = (
+        torch.linspace(-90, 90, steps=H),
+        torch.linspace(0, 360, steps=W),
+    )
+
+    x = torch.randn(2, 12, 2, 4)
+    pio = make_decoder_perceiver_io(12, 24)
+
+    kwargs = dict(
+        in_channels=12,
+        out_channels=24,
+        patch_extent=(90, 90),
+        queries_dim=QUERIES_DIM,
+        perceiver_io=pio,
+    )
+
+    full = PerceiverDecoder(**kwargs)
+    windowed = PerceiverDecoder(**kwargs, window_size=8)
+
+    full.eval()
+    windowed.eval()
+
+    # Share the same parameters (same pio and same query_embed/pos/scale).
+    windowed.load_state_dict(full.state_dict())
+
+    with torch.no_grad():
+        y_full = full(x, resolution)
+        y_windowed = windowed(x, resolution)
+
+    assert torch.allclose(y_full, y_windowed, atol=1e-5), (
+        "Windowed and non-windowed results should match."
     )

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -19,11 +19,41 @@ def test_roundtrip():
     decode = PerceiverDecoder(
         in_channels=4,
         out_channels=10,
-        latent_dim=12,
         patch_extent=(180, 180),
-        perceiver=make_perceiver(4, 12, num_latents=6, input_axis=1),
+        perceiver=make_perceiver(4, 10, num_latents=6, input_axis=1),
     )
 
     y_hat = decode(patches, make_resolution(x))
 
-    assert y_hat.shape == x.shape
+    assert y_hat.shape[-2:] == patches.shape[-2:], (
+        "The decoder preservers the input grid."
+    )
+    assert y_hat.shape[1] == 10, (
+        "The decoder outputs the desired number of output channels."
+    )
+
+
+def test_decode():
+    x = torch.randn(3, 12, 4, 8)
+
+    # Resolution represents the original (pre-encoder) physical grid, which is
+    # larger than the decoder's latent input — mirroring the real pipeline where
+    # the encoder reduces spatial dimensions.
+    resolution = (
+        torch.linspace(-90, 90, steps=8),
+        torch.linspace(0, 360, steps=16),
+    )
+
+    decode = PerceiverDecoder(
+        in_channels=12,
+        out_channels=24,
+        patch_extent=(90, 90),
+        perceiver=make_perceiver(12, 24, num_latents=6, input_axis=1),
+    )
+
+    y_hat = decode(x, resolution)
+
+    assert y_hat.shape[-2:] == x.shape[-2:], "The decoder preservers the input grid."
+    assert y_hat.shape[1] == 24, (
+        "The decoder outputs the desired number of output channels."
+    )

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -20,7 +20,7 @@ def test_roundtrip():
         in_channels=4,
         out_channels=10,
         patch_extent=(180, 180),
-        perceiver=make_perceiver(4, 10, num_latents=6, input_axis=1),
+        perceiver=make_perceiver(4, 10, num_latents=6),
     )
 
     y_hat = decode(patches, make_resolution(x))
@@ -48,7 +48,7 @@ def test_decode():
         in_channels=12,
         out_channels=24,
         patch_extent=(90, 90),
-        perceiver=make_perceiver(12, 24, num_latents=6, input_axis=1),
+        perceiver=make_perceiver(12, 24, num_latents=6),
     )
 
     y_hat = decode(x, resolution)

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from perceiver_pytorch.perceiver_io import PerceiverIO
 from test_encoder import make_resolution  # type: ignore
@@ -208,3 +209,102 @@ def test_full_context_matches_non_windowed():
     assert torch.allclose(y_full, y_windowed, atol=1e-5), (
         "Full-context windowed and non-windowed results should match."
     )
+
+
+def test_context_patches_affects_output():
+    """Different context_patches values should produce different outputs."""
+    H, W = 8, 16
+    resolution = (
+        torch.linspace(-90, 90, steps=H),
+        torch.linspace(0, 360, steps=W),
+    )
+
+    # nh=2, nw=4 latent grid with window_patches=1.
+    x = torch.randn(2, 12, 2, 4)
+    pio = make_decoder_perceiver_io(12, 24)
+
+    kwargs = dict(
+        in_channels=12,
+        out_channels=24,
+        patch_extent=(90, 90),
+        queries_dim=QUERIES_DIM,
+        perceiver_io=pio,
+    )
+
+    cp0 = PerceiverDecoder(**kwargs, window_patches=1, context_patches=0)
+    cp1 = PerceiverDecoder(**kwargs, window_patches=1, context_patches=1)
+
+    cp0.eval()
+    cp1.eval()
+    cp1.load_state_dict(cp0.state_dict())
+
+    with torch.no_grad():
+        y_cp0 = cp0(x, resolution)
+        y_cp1 = cp1(x, resolution)
+
+    # context_patches=0 sees only the local 1x1 patch per window,
+    # context_patches=1 sees a 3x3 neighborhood — different data means
+    # different cross-attention, so outputs must differ.
+    assert not torch.allclose(y_cp0, y_cp1, atol=1e-5), (
+        "context_patches=0 and context_patches=1 should produce different outputs."
+    )
+
+
+def test_more_context_closer_to_global():
+    """Increasing context_patches should converge toward the global result."""
+    H, W = 8, 16
+    resolution = (
+        torch.linspace(-90, 90, steps=H),
+        torch.linspace(0, 360, steps=W),
+    )
+
+    # nh=2, nw=4 latent grid with window_patches=1.
+    x = torch.randn(2, 12, 2, 4)
+    pio = make_decoder_perceiver_io(12, 24)
+
+    kwargs = dict(
+        in_channels=12,
+        out_channels=24,
+        patch_extent=(90, 90),
+        queries_dim=QUERIES_DIM,
+        perceiver_io=pio,
+    )
+
+    global_dec = PerceiverDecoder(**kwargs, window_patches=None, context_patches=None)
+    cp0 = PerceiverDecoder(**kwargs, window_patches=1, context_patches=0)
+    cp1 = PerceiverDecoder(**kwargs, window_patches=1, context_patches=1)
+
+    global_dec.eval()
+    cp0.eval()
+    cp1.eval()
+    cp0.load_state_dict(global_dec.state_dict())
+    cp1.load_state_dict(global_dec.state_dict())
+
+    with torch.no_grad():
+        y_global = global_dec(x, resolution)
+        y_cp0 = cp0(x, resolution)
+        y_cp1 = cp1(x, resolution)
+
+    err_cp0 = (y_global - y_cp0).abs().mean().item()
+    err_cp1 = (y_global - y_cp1).abs().mean().item()
+
+    # More context should bring the windowed result closer to global.
+    assert err_cp1 < err_cp0, (
+        f"context_patches=1 (err={err_cp1:.6f}) should be closer to global "
+        f"than context_patches=0 (err={err_cp0:.6f})."
+    )
+
+
+def test_context_patches_without_window_patches_raises():
+    """Setting context_patches without window_patches should raise."""
+
+    with pytest.raises(ValueError, match="window_patches must be set"):
+        PerceiverDecoder(
+            in_channels=12,
+            out_channels=24,
+            patch_extent=(90, 90),
+            queries_dim=QUERIES_DIM,
+            perceiver_io=make_decoder_perceiver_io(12, 24),
+            window_patches=None,
+            context_patches=1,
+        )

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -62,6 +62,8 @@ def test_roundtrip():
         patch_extent=(180, 180),
         queries_dim=QUERIES_DIM,
         perceiver_io=make_decoder_perceiver_io(4, 10),
+        window_patches=None,
+        context_patches=None,
     )
 
     y_hat = decode(patches, resolution)
@@ -91,6 +93,8 @@ def test_decode():
         patch_extent=(90, 90),
         queries_dim=QUERIES_DIM,
         perceiver_io=make_decoder_perceiver_io(12, 24),
+        window_patches=None,
+        context_patches=None,
     )
 
     y_hat = decode(x, resolution)
@@ -118,6 +122,7 @@ def test_windowed_decode():
         queries_dim=QUERIES_DIM,
         perceiver_io=make_decoder_perceiver_io(12, 24),
         window_patches=1,  # 1 patch per window side → 1x1 blocks of patches
+        context_patches=None,
     )
 
     y_hat = decode(x, resolution)
@@ -146,7 +151,7 @@ def test_windowed_matches_non_windowed():
         perceiver_io=pio,
     )
 
-    full = PerceiverDecoder(**kwargs)
+    full = PerceiverDecoder(**kwargs, window_patches=None, context_patches=None)
     # window_patches=4 covers the full 2x4 latent grid in one call,
     # so the windowed path should produce identical results to global.
     windowed = PerceiverDecoder(**kwargs, window_patches=4, context_patches=0)
@@ -185,7 +190,7 @@ def test_full_context_matches_non_windowed():
         perceiver_io=pio,
     )
 
-    full = PerceiverDecoder(**kwargs)
+    full = PerceiverDecoder(**kwargs, window_patches=None, context_patches=None)
     # window_patches=1 with context_patches=None: windowed queries but every
     # window sees the full latent grid as data.
     windowed_full_ctx = PerceiverDecoder(

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -16,17 +16,18 @@ def test_roundtrip():
 
     patches = patch_embed(x, make_resolution(x))
 
+    # Perceiver input_channels = in_channels + 2 (latent + 2D pixel query)
     decode = PerceiverDecoder(
         in_channels=4,
         out_channels=10,
         patch_extent=(180, 180),
-        perceiver=make_perceiver(4, 10, num_latents=6),
+        perceiver=make_perceiver(4 + 2, 10, num_latents=6),
     )
 
     y_hat = decode(patches, make_resolution(x))
 
     assert y_hat.shape[-2:] == patches.shape[-2:], (
-        "The decoder preservers the input grid."
+        "The decoder preserves the input grid."
     )
     assert y_hat.shape[1] == 10, (
         "The decoder outputs the desired number of output channels."
@@ -44,16 +45,17 @@ def test_decode():
         torch.linspace(0, 360, steps=16),
     )
 
+    # Perceiver input_channels = in_channels + 2 (latent + 2D pixel query)
     decode = PerceiverDecoder(
         in_channels=12,
         out_channels=24,
         patch_extent=(90, 90),
-        perceiver=make_perceiver(12, 24, num_latents=6),
+        perceiver=make_perceiver(12 + 2, 24, num_latents=6),
     )
 
     y_hat = decode(x, resolution)
 
-    assert y_hat.shape[-2:] == x.shape[-2:], "The decoder preservers the input grid."
+    assert y_hat.shape[-2:] == x.shape[-2:], "The decoder preserves the input grid."
     assert y_hat.shape[1] == 24, (
         "The decoder outputs the desired number of output channels."
     )

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -5,15 +5,15 @@ from ocean_emulators.constants import Lat, Lon
 from ocean_emulators.models.modules.encoder import PerceiverEncoder, patch_from
 
 
-def make_perceiver(in_channels, out_channels):
+def make_perceiver(in_channels, out_channels, *, num_latents=2, input_axis=2):
     return Perceiver(
         num_freq_bands=4,
         max_freq=1.0,
         depth=2,
-        input_axis=2,
+        input_axis=input_axis,
         input_channels=in_channels,
         latent_dim=3,
-        num_latents=2,
+        num_latents=num_latents,
         num_classes=out_channels,
         weight_tie_layers=True,
         self_per_cross_attn=2,


### PR DESCRIPTION
Here is a PerceiverIO-based decoder. It consumes latent information and produces the physical output grid with a single perceiver-transformer. It accomplishes this by arranging tensors to take in the latent input tokens and "query" channels, which are points on a 3D unit sphere that correspond to the area on Earth. Because the output dimension is large and involves expensive cross attentions, we provide a `window_size` argument to the decoder that will only process a chunk of output information at a time. This should bound peak memory during decoding.

When the input patch extent is fine grained, attending over the whole input -- even when composed of latent information -- will likely explode memory during decoding. To address this, we provide the decoder with a `context_patches` that builds off the `window_size` argument: it adds a number of patches of `window_size` around the target patch as the only context (i.e. a local context) for the PerceiverIO call.

Fixes #395.