### PR TITLE
Multi-scale models need to allow unused parameters in DDP training.

### DIFF
--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -279,7 +279,15 @@ class Trainer:
             # per-resolution unpatch layers.  Under a "match" or "mix" schedule
             # only one resolution's unpatch layer participates in each batch,
             # so the others have no gradients.  DDP must be told about this.
-            has_unused = self.train_schedule != "standard"
+            match self.train_schedule:
+                case "standard":
+                    has_unused = False
+                case "mix":
+                    has_unused = True
+                case "match":
+                    has_unused = True
+                case _:
+                    assert_never(self.train_schedule)
             self.model = nn.parallel.DistributedDataParallel(
                 nn.SyncBatchNorm.convert_sync_batchnorm(self.model),
                 device_ids=[self.distributed.gpu],

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -275,9 +275,15 @@ class Trainer:
 
         # Modify DDP setup based on device
         if self.distributed is not None:
+            # Multiscale models (e.g. FOMO with multiple grid sizes) have
+            # per-resolution unpatch layers.  Under a "match" or "mix" schedule
+            # only one resolution's unpatch layer participates in each batch,
+            # so the others have no gradients.  DDP must be told about this.
+            has_unused = self.train_schedule != "standard"
             self.model = nn.parallel.DistributedDataParallel(
                 nn.SyncBatchNorm.convert_sync_batchnorm(self.model),
                 device_ids=[self.distributed.gpu],
+                find_unused_parameters=has_unused,
             )
 
         # EMA (must come after DDP setup so parameter names match final self.model)


### PR DESCRIPTION
In Multi-scale FOMO, we now include a ModuleDict of linear projections after decoding. These are treated as unused parameters during DDP training. It's expected that they should be unused since we only want to project for the current scale the batch is training on. Thus, to get multi-scale training to work, we need to conditionally pass a flag to turn this check off.