### PR TITLE
Turn off in memory cache when opening Xarray dataset (default is having it on)

### DIFF
--- a/src/ocean_emulators/utils/location.py
+++ b/src/ocean_emulators/utils/location.py
@@ -82,10 +82,8 @@ class S3Location(ResolvedLocation, BaseModel):
             backend_kwargs={"storage_options": {"endpoint_url": self.endpoint_url}},
             engine="zarr",
             chunks=chunks,
-            # Disable xarray's MemoryCachedArray when not using dask.
-            # Without this, the first .isel().to_numpy() on any variable
-            # caches the ENTIRE array in application memory (not just the
-            # requested slice), causing OOM with forked DataLoader workers.
+            # Disable Xarray's MemoryCachedArray regardless of whether
+            # we're using dask (normally it is enabled when dask is disabled).
             # The OS file cache handles repeated reads efficiently.
             cache=False,
         )
@@ -138,10 +136,8 @@ class LocalLocation(ResolvedLocation, BaseModel):
 
     def open(self, chunks: dict[str, int] | None = None) -> xr.Dataset:
         engine = "netcdf4" if self.path.suffix == ".nc" else "zarr"
-        # Disable xarray's MemoryCachedArray when not using dask.
-        # Without this, the first .isel().to_numpy() on any variable
-        # caches the ENTIRE array in application memory (not just the
-        # requested slice), causing OOM with forked DataLoader workers.
+        # Disable Xarray's MemoryCachedArray regardless of whether
+        # we're using dask (normally it is enabled when dask is disabled).
         # The OS file cache handles repeated reads efficiently.
         return xr.open_dataset(self.path, engine=engine, chunks=chunks, cache=False)
 

--- a/src/ocean_emulators/utils/location.py
+++ b/src/ocean_emulators/utils/location.py
@@ -82,6 +82,12 @@ class S3Location(ResolvedLocation, BaseModel):
             backend_kwargs={"storage_options": {"endpoint_url": self.endpoint_url}},
             engine="zarr",
             chunks=chunks,
+            # Disable xarray's MemoryCachedArray when not using dask.
+            # Without this, the first .isel().to_numpy() on any variable
+            # caches the ENTIRE array in application memory (not just the
+            # requested slice), causing OOM with forked DataLoader workers.
+            # The OS file cache handles repeated reads efficiently.
+            cache=False,
         )
 
     def url(self) -> str:
@@ -132,7 +138,12 @@ class LocalLocation(ResolvedLocation, BaseModel):
 
     def open(self, chunks: dict[str, int] | None = None) -> xr.Dataset:
         engine = "netcdf4" if self.path.suffix == ".nc" else "zarr"
-        return xr.open_dataset(self.path, engine=engine, chunks=chunks)
+        # Disable xarray's MemoryCachedArray when not using dask.
+        # Without this, the first .isel().to_numpy() on any variable
+        # caches the ENTIRE array in application memory (not just the
+        # requested slice), causing OOM with forked DataLoader workers.
+        # The OS file cache handles repeated reads efficiently.
+        return xr.open_dataset(self.path, engine=engine, chunks=chunks, cache=False)
 
     def resolve(self, location: "Location") -> "ResolvedLocation":
         if isinstance(location, UnresolvedLocation):


### PR DESCRIPTION
Claude found a simple, but potentially high ROI CPU memory optimization. Since Xarray targets analytics workloads, it turns on an in memory cache by default. This flag turns this off, since we only ever access a `sel` of data once. 

This should help address the OOM memory issue I faced when trying to load three Zarr datasets (1, 1/2, 1/4 degree versions of OM4) in a multi-scale training run on our SLURM cluster.