### PR TITLE
fix-video-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,14 @@
 [![Benchmark CPU](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/benchmarks.yml/badge.svg)](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/benchmarks.yml)
 [Benchmark Results](https://open-athena.github.io/Ocean_Emulator/dev/bench/)
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.
 
+## Sea Surface Temperature (SST) Emulation
+
+<p align="center">
+  <img src="docs/assets/sst_tropical_pacific_fivedays.gif" alt="Comparison of ground truth and Ocean Emulator SST predictions in the tropical Pacific over a 5-day rollout" width="800">
+</p>
+
+> Ground truth (left) vs. Ocean Emulator prediction (right) for sea surface temperature in the tropical Pacific.
+
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) to get started.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![Benchmark CPU](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/benchmarks.yml/badge.svg)](https://github.com/LaureZanna/Ocean_Emulator/actions/workflows/benchmarks.yml)
 [Benchmark Results](https://open-athena.github.io/Ocean_Emulator/dev/bench/)
 
-
 ## Sea Surface Temperature (SST) Emulation
 
 <p align="center">
-  <video width="800" autoplay loop muted playsinline>
-    <source src="docs/assets/sst_tropical_pacific_ultra.mp4" type="video/mp4">
+  <video width="800" controls autoplay loop muted playsinline>
+    <source src="https://raw.githubusercontent.com/Open-Athena/Ocean_Emulator/main/docs/assets/sst_tropical_pacific_ultra.mp4" type="video/mp4">
+    Your browser does not support the video tag. You can view the video directly <a href="https://github.com/Open-Athena/Ocean_Emulator/blob/main/docs/assets/sst_tropical_pacific_ultra.mp4">here</a>.
   </video>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 ## Sea Surface Temperature (SST) Emulation
 
 <p align="center">
-  <img src="docs/assets/sst_tropical_pacific_fivedays.gif" alt="Comparison of ground truth and Ocean Emulator SST predictions in the tropical Pacific over a 5-day rollout" width="800">
+  <video width="800" autoplay loop muted playsinline>
+    <source src="docs/assets/sst_tropical_pacific_ultra.mp4" type="video/mp4">
+  </video>
 </p>
 
 > Ground truth (left) vs. Ocean Emulator prediction (right) for sea surface temperature in the tropical Pacific.


### PR DESCRIPTION
I identified an issue where the Sea Surface Temperature (SST) comparison video failed to render in the README preview. This was caused by the use of a relative path that GitHub's renderer couldn't resolve.