### PR TITLE
Initial FOMO model hyperparamter configuration.

### DIFF
--- a/configs/fomo_om4/model.yaml
+++ b/configs/fomo_om4/model.yaml
@@ -5,13 +5,24 @@ last_kernel_size: 3
 pad: "circular"
 checkpointing: "all"
 embedding_dim: 128  # Reduced from 280
-perceiver_implementation: "naive"
+perceiver_implementation: "flash"
+# TODO(alxmrs): How fine of a resolution should each patch be? This produces a 60x72 latent grid.
+patch_extent: [3.0, 5.0]
 
 encoder:
   perceiver:
     depth: 2  # Reduced from 3
     latent_dim: 48  # Reduced from 64
     num_latents: 128  # Reduced from 256
+
+decoder:
+  perceiver:
+    depth: 2  # Match encoder depth
+    latent_dim: 48  # Match encoder latent_dim
+    num_latents: 128  # Match encoder num_latents
+  queries_dim: 64  # on the small end, but typical for PercieverIO models (usually in the ~100s-1000s).
+  window_patches: 12  # Must evenly divide latent grid (60x72). Enables real spatial windowing.
+  context_patches: 1  # Look at this many window_patches around the target patch.
 
 processor:
   ch_width: [200, 256, 320]  # Reduced from [380, 480, 520]


### PR DESCRIPTION
Turns on flash perceiver implementation. Configures the decoder to match the encoder in terms of depth and width. In addition, this configures the decode strategy for the decoder (window patch size, query dim, number of context patches for the memory-bound decode). Last, but not least, this sets a slightly higher spatial extent for patches to produce a 60 x 72 latent grid.

This was the configuration used in this run: https://wandb.ai/ocean_emulators/default/runs/0zeuoacu