### PR TITLE
Adding pointwise linear block as an alternative to 1x1 Conv.

### DIFF
--- a/configs/fomo_om4/model.yaml
+++ b/configs/fomo_om4/model.yaml
@@ -35,6 +35,7 @@ processor:
     activation: "capped_gelu"
     upscale_factor: 2
     norm: "batch"
+    pointwise_linear: true
 
   down_sampling_block: "avg_pool"
   up_sampling_block: "zonally_periodic_upsample"

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -251,7 +251,7 @@ class BlockConfig(BaseConfig):
     activation: ActivationType = "capped_gelu"
     upscale_factor: int = 4
     norm: NormType = "batch"
-    pointwise_linear: bool = True
+    pointwise_linear: bool = False
 
     def build(self) -> CoreBlockBuilder:
         match self.activation:

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -251,6 +251,7 @@ class BlockConfig(BaseConfig):
     activation: ActivationType = "capped_gelu"
     upscale_factor: int = 4
     norm: NormType = "batch"
+    pointwise_linear: bool = True
 
     def build(self) -> CoreBlockBuilder:
         match self.activation:
@@ -295,6 +296,7 @@ class BlockConfig(BaseConfig):
                         upscale_factor=self.upscale_factor,
                         norm=self.norm,
                         activation=activation,
+                        pointwise_linear=self.pointwise_linear,
                     )
                 case _:
                     assert_never(self.block_type)

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -239,7 +239,7 @@ class ConvNeXtBlock(CoreBlock):
         upscale_factor: int = 4,
         norm="batch",
         checkpoint_simple: bool = False,
-        pointwise_linear: bool = True,
+        pointwise_linear: bool = False,
     ):
         super().__init__(in_channels, out_channels, kernel_size, dilation, pad)
         assert n_layers == 1, "Can only use a single layer here!"

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -4,6 +4,7 @@ from typing import Protocol
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint
+from jaxtyping import Float
 
 from ocean_emulators.models.modules.activations import CappedGELU
 
@@ -24,8 +25,9 @@ class PointwiseLinear(torch.nn.Module):
         super().__init__()
         self.linear = torch.nn.Linear(in_channels, out_channels)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        # x: [B, C_in, H, W] -> permute to [B, H, W, C_in] -> linear -> permute back
+    def forward(
+        self, x: Float[torch.Tensor, "B C_in H W"]
+    ) -> Float[torch.Tensor, "B C_out H W"]:
         return self.linear(x.permute(0, 2, 3, 1)).permute(0, 3, 1, 2)
 
 

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -8,6 +8,27 @@ import torch.utils.checkpoint
 from ocean_emulators.models.modules.activations import CappedGELU
 
 
+class PointwiseLinear(torch.nn.Module):
+    """A 1×1 convolution implemented as nn.Linear.
+
+    Mathematically equivalent to Conv2d(kernel_size=1), but avoids the
+    non-contiguous gradient strides that 1×1 convs produce, which cause
+    DDP to copy gradients instead of using zero-copy views.
+
+    This optimization is use in the official ConvNext implementation[0].
+
+    [0]: https://github.com/facebookresearch/ConvNeXt/blob/main/models/convnext.py#L18
+    """
+
+    def __init__(self, in_channels: int, out_channels: int):
+        super().__init__()
+        self.linear = torch.nn.Linear(in_channels, out_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: [B, C_in, H, W] -> permute to [B, H, W, C_in] -> linear -> permute back
+        return self.linear(x.permute(0, 2, 3, 1)).permute(0, 3, 1, 2)
+
+
 class TransposedConvUpsample(torch.nn.Module):
     def __init__(
         self,
@@ -176,6 +197,25 @@ class ConvBlock(CoreBlock):
         return fts
 
 
+def _pointwise(use_linear: bool, in_ch: int, out_ch: int) -> torch.nn.Module:
+    """Create a pointwise (1×1) channel-mixing layer.
+
+    When ``use_linear`` is True, returns a :class:`PointwiseLinear` backed by
+    ``nn.Linear``, which produces 2-D weight tensors and avoids the
+    non-contiguous gradient strides that ``Conv2d(kernel_size=1)`` introduces
+    for degenerate spatial dimensions.  This matters for DDP, which otherwise
+    falls back to copying gradients instead of using zero-copy views.
+
+    The ``nn.Linear`` approach is also used in the official ConvNeXt
+    implementation, where it is noted to be "slightly faster in PyTorch" [0].
+
+    [0]: https://github.com/facebookresearch/ConvNeXt/blob/main/models/convnext.py
+    """
+    if use_linear:
+        return PointwiseLinear(in_ch, out_ch)
+    return torch.nn.Conv2d(in_ch, out_ch, kernel_size=1, padding="same")
+
+
 class ConvNeXtBlock(CoreBlock):
     """
     A convolution block as reported in https://github.com/CognitiveModeling/dlwp-hpx/blob/main/src/dlwp-hpx/dlwp/model/modules/blocks.py.
@@ -197,20 +237,16 @@ class ConvNeXtBlock(CoreBlock):
         upscale_factor: int = 4,
         norm="batch",
         checkpoint_simple: bool = False,
+        pointwise_linear: bool = True,
     ):
         super().__init__(in_channels, out_channels, kernel_size, dilation, pad)
         assert n_layers == 1, "Can only use a single layer here!"
 
-        # Instantiate 1x1 conv to increase/decrease channel depth if necessary
+        # Instantiate pointwise linear to increase/decrease channel depth if necessary
         if in_channels == out_channels:
             self.skip_module = lambda x: x  # Identity-function required in forward pass
         else:
-            self.skip_module = torch.nn.Conv2d(
-                in_channels=in_channels,
-                out_channels=out_channels,
-                kernel_size=1,
-                padding="same",
-            )
+            self.skip_module = _pointwise(pointwise_linear, in_channels, out_channels)
 
         # Convolution block
         convblock: list[torch.nn.Module] = []
@@ -256,11 +292,8 @@ class ConvNeXtBlock(CoreBlock):
             convblock.append(activation())
         # Linear postprocessing
         convblock.append(
-            torch.nn.Conv2d(
-                in_channels=int(in_channels * upscale_factor),
-                out_channels=out_channels,
-                kernel_size=1,
-                padding="same",
+            _pointwise(
+                pointwise_linear, int(in_channels * upscale_factor), out_channels
             )
         )
         self.convblock = torch.nn.Sequential(*convblock)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,0 +1,55 @@
+"""Tests for blocks.py, focusing on PointwiseLinear equivalence to Conv2d(kernel_size=1)."""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from ocean_emulators.models.modules.blocks import ConvNeXtBlock, PointwiseLinear
+
+
+def test_pointwise_linear_equivalent_to_conv1x1():
+    """PointwiseLinear produces the same output as Conv2d(kernel_size=1)
+    when initialized with the same weights."""
+    pw = PointwiseLinear(16, 32)
+    conv = nn.Conv2d(16, 32, kernel_size=1)
+
+    with torch.no_grad():
+        conv.weight.copy_(pw.linear.weight.unsqueeze(-1).unsqueeze(-1))
+        assert conv.bias is not None and pw.linear.bias is not None
+        conv.bias.copy_(pw.linear.bias)
+
+    x = torch.randn(2, 16, 8, 10)
+    torch.testing.assert_close(pw(x), conv(x))
+
+
+def test_conv1x1_equivalent_to_pointwise_linear():
+    """Conv2d(kernel_size=1) produces the same output as PointwiseLinear
+    when initialized with the same weights (reverse direction)."""
+    conv = nn.Conv2d(16, 32, kernel_size=1)
+    pw = PointwiseLinear(16, 32)
+
+    with torch.no_grad():
+        pw.linear.weight.copy_(conv.weight.squeeze(-1).squeeze(-1))
+        assert pw.linear.bias is not None and conv.bias is not None
+        pw.linear.bias.copy_(conv.bias)
+
+    x = torch.randn(2, 16, 8, 10)
+    torch.testing.assert_close(conv(x), pw(x))
+
+
+@pytest.mark.parametrize("pointwise_linear", [True, False])
+def test_convnext_block_backward_pass(pointwise_linear: bool):
+    """Both modes support backward pass without errors."""
+    block = ConvNeXtBlock(
+        in_channels=16,
+        out_channels=32,
+        kernel_size=3,
+        dilation=1,
+        n_layers=1,
+        pointwise_linear=pointwise_linear,
+    )
+    x = torch.randn(2, 16, 8, 10, requires_grad=True)
+    y = block(x)
+    y.sum().backward()
+    assert x.grad is not None
+    assert x.grad.shape == x.shape

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -20,21 +20,6 @@ def test_pointwise_linear_equivalent_to_conv1x1():
     torch.testing.assert_close(pw(x), conv(x))
 
 
-def test_conv1x1_equivalent_to_pointwise_linear():
-    """Conv2d(kernel_size=1) produces the same output as PointwiseLinear
-    when initialized with the same weights (reverse direction)."""
-    conv = nn.Conv2d(16, 32, kernel_size=1)
-    pw = PointwiseLinear(16, 32)
-
-    with torch.no_grad():
-        pw.linear.weight.copy_(conv.weight.squeeze(-1).squeeze(-1))
-        assert pw.linear.bias is not None and conv.bias is not None
-        pw.linear.bias.copy_(conv.bias)
-
-    x = torch.randn(2, 16, 8, 10)
-    torch.testing.assert_close(conv(x), pw(x))
-
-
 @pytest.mark.parametrize("pointwise_linear", [True, False])
 def test_convnext_block_backward_pass(pointwise_linear: bool):
     """Both modes support backward pass without errors."""

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,22 +1,34 @@
 import pytest
 import torch
 import torch.nn as nn
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from ocean_emulators.models.modules.blocks import ConvNeXtBlock, PointwiseLinear
 
 
-def test_pointwise_linear_equivalent_to_conv1x1():
+@given(
+    in_ch=st.integers(min_value=1, max_value=64),
+    out_ch=st.integers(min_value=1, max_value=64),
+    batch=st.integers(min_value=1, max_value=4),
+    height=st.integers(min_value=1, max_value=16),
+    width=st.integers(min_value=1, max_value=16),
+)
+@settings(max_examples=20)
+def test_pointwise_linear_equivalent_to_conv1x1(
+    in_ch: int, out_ch: int, batch: int, height: int, width: int
+):
     """PointwiseLinear produces the same output as Conv2d(kernel_size=1)
-    when initialized with the same weights."""
-    pw = PointwiseLinear(16, 32)
-    conv = nn.Conv2d(16, 32, kernel_size=1)
+    for arbitrary channel counts and spatial dimensions."""
+    pw = PointwiseLinear(in_ch, out_ch)
+    conv = nn.Conv2d(in_ch, out_ch, kernel_size=1)
 
     with torch.no_grad():
         conv.weight.copy_(pw.linear.weight.unsqueeze(-1).unsqueeze(-1))
         assert conv.bias is not None and pw.linear.bias is not None
         conv.bias.copy_(pw.linear.bias)
 
-    x = torch.randn(2, 16, 8, 10)
+    x = torch.randn(batch, in_ch, height, width)
     torch.testing.assert_close(pw(x), conv(x))
 
 

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -1,5 +1,3 @@
-"""Tests for blocks.py, focusing on PointwiseLinear equivalence to Conv2d(kernel_size=1)."""
-
 import pytest
 import torch
 import torch.nn as nn


### PR DESCRIPTION
Fixes #631. Also, this more closely mimics the official implementation of ConvNext: https://github.com/facebookresearch/ConvNeXt/blob/main/models/convnext.py#L18.