### PR TITLE
Remove partition specification from sbatch script

### DIFF
--- a/scripts/slurm_apptainer_eval.sbatch
+++ b/scripts/slurm_apptainer_eval.sbatch
@@ -25,7 +25,6 @@
 #SBATCH --job-name=oe-eval
 #SBATCH --output=slurm-%j.out
 #SBATCH --account=torch_pr_347_courant
-#SBATCH --partition=rtx6000_lzanna
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=8


### PR DESCRIPTION
NYU HPC recommends account and GPU requirements and not specify partitions.