### PR TITLE
Stack 1/2: Initial configuration of skip connection drop path drop out.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -590,6 +590,10 @@ class UNetBackboneConfig(BaseConfig):
     core_block: BlockConfig = BlockConfig()
     down_sampling_block: DownSamplingBlocks = "avg_pool"
     up_sampling_block: UpSamplingBlocks = "zonally_periodic_upsample"
+    drop_path_rate: float = Field(
+        default=0.0,
+        description="Stochastic depth dropout rate. The chance we turn off residual connections in the UNet. Reasonable values are 0.1-0.3. Use 0.0 to disable.",
+    )
 
     def build(
         self,
@@ -634,6 +638,7 @@ class UNetBackboneConfig(BaseConfig):
             downsampling_block=downsampling_block,
             create_upsampling_block=create_upsampling_block,
             checkpointing=checkpointing,
+            drop_path_rate=self.drop_path_rate,
         )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -592,7 +592,7 @@ class UNetBackboneConfig(BaseConfig):
     up_sampling_block: UpSamplingBlocks = "zonally_periodic_upsample"
     drop_path_rate: float = Field(
         default=0.0,
-        description="Stochastic depth dropout rate. The chance we turn off residual connections in the UNet. Reasonable values are 0.1-0.3. Use 0.0 to disable.",
+        description="Shortcut dropout rate. The chance we turn off skip connections in the UNet. Reasonable values are 0.1-0.3. Use 0.0 to disable.",
     )
 
     def build(

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -100,7 +100,7 @@ class ZonallyPeriodicBilinearUpsample(torch.nn.Module):
 
 
 class DropPath(torch.nn.Module):
-    """Shortcut dropout (drop path) for skip connections.
+    """Drop path dropout (for skip connections).
 
     During training, randomly drops entire samples' skip connections
     with probability ``drop_prob``, scaling survivors by 1/(1-p) to preserve
@@ -110,7 +110,6 @@ class DropPath(torch.nn.Module):
     References:
         [0]: Rethinking U-net Skip Connections for Biomedical Image Segmentation (https://arxiv.org/abs/2402.08276)
         [1]: Dropout Reduces Underfitting (https://arxiv.org/abs/2303.01500)
-
     """
 
     def __init__(self, drop_prob: float = 0.0):
@@ -118,22 +117,22 @@ class DropPath(torch.nn.Module):
         self.dropout = torch.nn.Dropout(p=drop_prob)
 
     def forward(
-        self, residual: Float[torch.Tensor, "B C H W"]
+        self, skip_conn: Float[torch.Tensor, "B C H W"]
     ) -> Float[torch.Tensor, "B C H W"]:
         if not self.training or self.dropout.p == 0.0:
-            return residual
+            return skip_conn
         # Per-sample mask: (B, 1, 1, 1) broadcasts over C, H, W.
         mask = self.dropout(
             torch.ones(
-                residual.shape[0],
+                skip_conn.shape[0],
                 1,
                 1,
                 1,
-                device=residual.device,
-                dtype=residual.dtype,
+                device=skip_conn.device,
+                dtype=skip_conn.dtype,
             )
         )
-        return residual * mask
+        return skip_conn * mask
 
 
 class AvgPool(torch.nn.Module):

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -99,6 +99,42 @@ class ZonallyPeriodicBilinearUpsample(torch.nn.Module):
         return upsampled[..., start:end]
 
 
+class DropPath(torch.nn.Module):
+    """Stochastic depth (drop path) for residual connections.
+
+    During training, randomly drops entire samples' residual contributions
+    with probability ``drop_prob``, scaling survivors by 1/(1-p) to preserve
+    expected values. Implemented via ``nn.Dropout`` applied to a per-sample
+    mask of ones.
+
+    References:
+        [0]: Deep Networks with Stochastic Depth (https://arxiv.org/abs/1603.09382)
+        [1]: Dropout Reduces Underfitting (https://arxiv.org/abs/2303.01500)
+    """
+
+    def __init__(self, drop_prob: float = 0.0):
+        super().__init__()
+        self.dropout = torch.nn.Dropout(p=drop_prob)
+
+    def forward(
+        self, residual: Float[torch.Tensor, "B C H W"]
+    ) -> Float[torch.Tensor, "B C H W"]:
+        if not self.training or self.dropout.p == 0.0:
+            return residual
+        # Per-sample mask: (B, 1, 1, 1) broadcasts over C, H, W.
+        mask = self.dropout(
+            torch.ones(
+                residual.shape[0],
+                1,
+                1,
+                1,
+                device=residual.device,
+                dtype=residual.dtype,
+            )
+        )
+        return residual * mask
+
+
 class AvgPool(torch.nn.Module):
     def __init__(
         self,

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -100,16 +100,17 @@ class ZonallyPeriodicBilinearUpsample(torch.nn.Module):
 
 
 class DropPath(torch.nn.Module):
-    """Stochastic depth (drop path) for residual connections.
+    """Shortcut dropout (drop path) for skip connections.
 
-    During training, randomly drops entire samples' residual contributions
+    During training, randomly drops entire samples' skip connections
     with probability ``drop_prob``, scaling survivors by 1/(1-p) to preserve
     expected values. Implemented via ``nn.Dropout`` applied to a per-sample
     mask of ones.
 
     References:
-        [0]: Deep Networks with Stochastic Depth (https://arxiv.org/abs/1603.09382)
+        [0]: Rethinking U-net Skip Connections for Biomedical Image Segmentation (https://arxiv.org/abs/2402.08276)
         [1]: Dropout Reduces Underfitting (https://arxiv.org/abs/2303.01500)
+
     """
 
     def __init__(self, drop_prob: float = 0.0):

--- a/src/ocean_emulators/models/modules/unet_backbone.py
+++ b/src/ocean_emulators/models/modules/unet_backbone.py
@@ -8,6 +8,7 @@ from ocean_emulators.models.modules.blocks import (
     BilinearUpsample,
     CoreBlock,
     CoreBlockBuilder,
+    DropPath,
     TransposedConvUpsample,
     UpsamplingBlockBuilder,
     ZonallyPeriodicBilinearUpsample,
@@ -53,6 +54,7 @@ class UNetBackbone(nn.Module):
         downsampling_block: nn.Module,
         create_upsampling_block: UpsamplingBlockBuilder,
         checkpointing: "Checkpointing | None",
+        drop_path_rate: float = 0.0,
     ):
         super().__init__()
         self.in_channels = in_channels
@@ -145,6 +147,7 @@ class UNetBackbone(nn.Module):
         self.N_pad = first_block.N_pad
         self.layers = nn.ModuleList(layers)
         self.num_steps = int(len(ch_width) - 1)
+        self.drop_path = DropPath(drop_path_rate)
 
     def forward(self, fts: torch.Tensor) -> torch.Tensor:
         skip_inputs: list[torch.Tensor] = []
@@ -190,7 +193,9 @@ class UNetBackbone(nn.Module):
                         pads[0] - pads[0] // 2,
                     ]
                     fts = nn.functional.pad(fts, pads)
-                    fts += skip_inputs[int(2 * self.num_steps - count - 1)]
+                    fts += self.drop_path(
+                        skip_inputs[int(2 * self.num_steps - count - 1)]
+                    )
                     count += 1
 
         return fts

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -4,7 +4,11 @@ import torch.nn as nn
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from ocean_emulators.models.modules.blocks import ConvNeXtBlock, PointwiseLinear
+from ocean_emulators.models.modules.blocks import (
+    ConvNeXtBlock,
+    DropPath,
+    PointwiseLinear,
+)
 
 
 @given(
@@ -48,3 +52,43 @@ def test_convnext_block_backward_pass(pointwise_linear: bool):
     y.sum().backward()
     assert x.grad is not None
     assert x.grad.shape == x.shape
+
+
+class TestDropPath:
+    def test_no_op_during_eval(self):
+        """During eval, skip connections always pass through regardless of drop_prob."""
+        drop_path = DropPath(drop_prob=1.0)
+        drop_path.eval()
+        skip = torch.randn(4, 16, 8, 8)
+        torch.testing.assert_close(drop_path(skip), skip)
+
+    def test_drop_prob_one_zeros_all_skip_connections(self):
+        """With drop_prob=1.0, all skip connections are zeroed out,
+        forcing the model to rely entirely on the trunk (deep path)."""
+        drop_path = DropPath(drop_prob=1.0)
+        drop_path.train()
+
+        trunk = torch.randn(4, 16, 8, 8)
+        skip = torch.randn(4, 16, 8, 8)
+
+        output = trunk + drop_path(skip)
+        torch.testing.assert_close(output, trunk)
+
+    def test_gradient_flows_through_trunk_when_skip_dropped(self):
+        """When skip connections are dropped, gradients must still flow
+        through the trunk (the deep/bottleneck path)."""
+        drop_path = DropPath(drop_prob=1.0)
+        drop_path.train()
+
+        trunk = torch.randn(2, 16, 8, 8, requires_grad=True)
+        skip = torch.randn(2, 16, 8, 8, requires_grad=True)
+
+        output = trunk + drop_path(skip)
+        output.sum().backward()
+
+        assert trunk.grad is not None, "Gradient must flow through the trunk."
+        assert skip.grad is not None, "Skip should still get a (zero) gradient."
+        # Trunk gradient should be all ones (d/d(trunk) of sum(trunk + 0))
+        torch.testing.assert_close(trunk.grad, torch.ones_like(trunk))
+        # Skip gradient should be all zeros (dropped)
+        torch.testing.assert_close(skip.grad, torch.zeros_like(skip))


### PR DESCRIPTION
This PR introduces a form of drop path dropout on skip connections. This is put behind a flag we call "shortcut dropout rate", to refer to this stochastic form of "pruning" the skip connections from the encoder to decoder of the U-Net. 

We've internally conducted a few experiments (I'll put a link to a doc about this later) that provides some evidence that the standard U-Net structure without drop-out under-exercised the deeper layers of the U-Net, including the bottleneck. Further experiments using a variant of this feature (see part 2 of the stack; [early results](https://docs.google.com/presentation/d/1Wq4BLDJ3ptUhnhgIPSTG1MtCa3LcOM1Q0kvV2IJ3-O8/edit?slide=id.g397559857dc_1_22#slide=id.g397559857dc_1_22), [more recent results](https://docs.google.com/presentation/d/1HClqaXEiKd7l8b4Eold6meJai4I7lCg7xX24D7mDd2A/edit?slide=id.g397a5bf5ead_2_7#slide=id.g397a5bf5ead_2_7)) show improvements to the base samudra model when dropping these connections. Drop out is even more effective than [pruning the shallow connections](https://wandb.ai/ocean_emulators/default/runs/9jafz191?nw=nwuseralxmrs) or [pruning  the shallow connections with axial attenion at the bottleneck](https://wandb.ai/ocean_emulators/default/runs/6apycyv8?nw=nwuseramoghgulati).

We believe this method works similar to the intuition for why wide residual connections improve ResNets: the residual identity path in ResNets provides a liability for deeper networks where more depth means there's a greater of information flowing through the identity connections, not added parameters. Similarly, we believe that penalizing/regularizing skip connections during the encoders of the U-Net will incentivize the network from making more use of the encoder/decoder pathways. 

As mentioned below in this PR's conversation, this is different from the literature around "stochastic depth", which uses drop out in the opposite connection path -- here, drop path is applied to the non-skip connection channels. 