### PR TITLE
Stack 2/2: Adding early dropout to drop path feature using linear decay.

### DIFF
--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -666,7 +666,7 @@ class UNetBackboneConfig(BaseConfig):
     )
     drop_path_epochs: int = Field(
         default=0,
-        description="Number of epochs over which to linearly decay the drop path rate to 0 (early stochastic depth). "
+        description="Number of epochs over which to linearly decay the drop path rate to 0 (early shortcut dropout). "
         "0 means drop path is applied at a constant rate for the entire training run.",
     )
 

--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -664,6 +664,11 @@ class UNetBackboneConfig(BaseConfig):
         default=0.0,
         description="Shortcut dropout rate. The chance we turn off skip connections in the UNet. Reasonable values are 0.1-0.3. Use 0.0 to disable.",
     )
+    drop_path_epochs: int = Field(
+        default=0,
+        description="Number of epochs over which to linearly decay the drop path rate to 0 (early stochastic depth). "
+        "0 means drop path is applied at a constant rate for the entire training run.",
+    )
 
     def build(
         self,
@@ -709,6 +714,7 @@ class UNetBackboneConfig(BaseConfig):
             create_upsampling_block=create_upsampling_block,
             checkpointing=checkpointing,
             drop_path_rate=self.drop_path_rate,
+            drop_path_epochs=self.drop_path_epochs,
         )
 
 

--- a/src/samudra/models/base.py
+++ b/src/samudra/models/base.py
@@ -46,6 +46,12 @@ class BaseModel(torch.nn.Module):
         self.hist = hist
         self.gradient_detach_interval = gradient_detach_interval
 
+    def set_epoch(self, epoch: int) -> None:
+        """Per-epoch hook for scheduling (e.g. early stochastic depth).
+
+        Subclasses should override to delegate to child modules.
+        """
+
     def forward_once(
         self, prognostic: Prognostic, boundary: Boundary, ctx: GridContext
     ) -> Prognostic:

--- a/src/samudra/models/base.py
+++ b/src/samudra/models/base.py
@@ -47,7 +47,7 @@ class BaseModel(torch.nn.Module):
         self.gradient_detach_interval = gradient_detach_interval
 
     def set_epoch(self, epoch: int) -> None:
-        """Per-epoch hook for scheduling (e.g. early stochastic depth).
+        """Per-epoch hook for scheduling.
 
         Subclasses should override to delegate to child modules.
         """

--- a/src/samudra/models/modules/blocks.py
+++ b/src/samudra/models/modules/blocks.py
@@ -113,7 +113,7 @@ class DropPath(torch.nn.Module):
     expected values. Implemented via ``nn.Dropout`` applied to a per-sample
     mask of ones.
 
-    Supports "early stochastic depth" scheduling [1]: call
+    Supports "early dropout" scheduling [1]: call
     :meth:`set_progress` each epoch with ``progress = epoch / drop_path_epochs``
     to linearly decay the drop rate to 0, then keep it off for the rest of
     training.

--- a/src/samudra/models/modules/blocks.py
+++ b/src/samudra/models/modules/blocks.py
@@ -113,6 +113,11 @@ class DropPath(torch.nn.Module):
     expected values. Implemented via ``nn.Dropout`` applied to a per-sample
     mask of ones.
 
+    Supports "early stochastic depth" scheduling [1]: call
+    :meth:`set_progress` each epoch with ``progress = epoch / drop_path_epochs``
+    to linearly decay the drop rate to 0, then keep it off for the rest of
+    training.
+
     References:
         [0]: Rethinking U-net Skip Connections for Biomedical Image Segmentation (https://arxiv.org/abs/2402.08276)
         [1]: Dropout Reduces Underfitting (https://arxiv.org/abs/2303.01500)
@@ -120,7 +125,18 @@ class DropPath(torch.nn.Module):
 
     def __init__(self, drop_prob: float = 0.0):
         super().__init__()
+        self.max_drop_prob = drop_prob
         self.dropout = torch.nn.Dropout(p=drop_prob)
+
+    def set_progress(self, progress: float) -> None:
+        """Update the drop probability based on training progress.
+
+        Args:
+            progress: Fraction of the drop-path phase elapsed, in [0, inf).
+                At 0 the full ``max_drop_prob`` is used; at 1 and beyond
+                the rate is 0 (drop path disabled).
+        """
+        self.dropout.p = self.max_drop_prob * max(1.0 - progress, 0.0)
 
     def forward(
         self, skip_conn: Float[torch.Tensor, "B C H W"]

--- a/src/samudra/models/modules/unet_backbone.py
+++ b/src/samudra/models/modules/unet_backbone.py
@@ -59,6 +59,7 @@ class UNetBackbone(nn.Module):
         create_upsampling_block: UpsamplingBlockBuilder,
         checkpointing: "Checkpointing | None",
         drop_path_rate: float = 0.0,
+        drop_path_epochs: int = 0,
     ):
         super().__init__()
         self.in_channels = in_channels
@@ -152,6 +153,16 @@ class UNetBackbone(nn.Module):
         self.layers = nn.ModuleList(layers)
         self.num_steps = int(len(ch_width) - 1)
         self.drop_path = DropPath(drop_path_rate)
+        self.drop_path_epochs = drop_path_epochs
+
+    def set_epoch(self, epoch: int) -> None:
+        """Update the drop path rate based on the current epoch.
+
+        When ``drop_path_epochs > 0``, linearly decays the rate to 0 over
+        that many epochs (early stochastic depth). Otherwise, no-ops.
+        """
+        if self.drop_path_epochs > 0:
+            self.drop_path.set_progress(epoch / self.drop_path_epochs)
 
     def forward(self, fts: torch.Tensor) -> torch.Tensor:
         skip_inputs: list[torch.Tensor] = []

--- a/src/samudra/models/samudra.py
+++ b/src/samudra/models/samudra.py
@@ -59,6 +59,9 @@ class Samudra(BaseModel):
         self.corrector = corrector
         self.use_bfloat16 = use_bfloat16
 
+    def set_epoch(self, epoch: int) -> None:
+        self.unet.set_epoch(epoch)
+
     def forward_once(
         self, prognostic: Prognostic, boundary: Boundary, ctx: GridContext
     ) -> Prognostic:

--- a/src/samudra/models/samudra_multi.py
+++ b/src/samudra/models/samudra_multi.py
@@ -90,6 +90,9 @@ class SamudraMulti(BaseModel):
                 check_fn=lambda m: isinstance(m, _checkpoint_types),
             )
 
+    def set_epoch(self, epoch: int) -> None:
+        self.processor.set_epoch(epoch)
+
     def forward_once(
         self, prognostic: Prognostic, boundary: Boundary, ctx: GridContext
     ) -> Prognostic:

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -442,9 +442,9 @@ class Trainer:
 
             # Early stochastic depth: decay drop path rate over training.
             if isinstance(self.model, BaseModel):
-                self.model.set_epoch(epoch)
+                self.model.set_epoch(epoch - 1)
             elif isinstance(self.model, nn.parallel.DistributedDataParallel):
-                self.model.module.set_epoch(epoch)  # type: ignore[union-attr]
+                self.model.module.set_epoch(epoch - 1)  # type: ignore[union-attr]
 
             start_epoch_train_time = time.perf_counter()
             train_stats = self.train_one_epoch(epoch)

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -52,6 +52,7 @@ from samudra.datasets import (
     TrainDataLoader,
 )
 from samudra.models.base import BaseModel
+from samudra.models.modules.unet_backbone import UNetBackbone
 from samudra.stepper import (
     TrainBatchOutput,
     ValBatchOutput,
@@ -439,6 +440,11 @@ class Trainer:
                 self.train_sampler.set_epoch(epoch)
             if hasattr(self.val_sampler, "set_epoch"):
                 self.val_sampler.set_epoch(epoch)
+
+            # Early stochastic depth: decay drop path rate over training.
+            for module in self.model.modules():
+                if isinstance(module, UNetBackbone):
+                    module.set_epoch(epoch)
 
             start_epoch_train_time = time.perf_counter()
             train_stats = self.train_one_epoch(epoch)

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -52,7 +52,6 @@ from samudra.datasets import (
     TrainDataLoader,
 )
 from samudra.models.base import BaseModel
-from samudra.models.modules.unet_backbone import UNetBackbone
 from samudra.stepper import (
     TrainBatchOutput,
     ValBatchOutput,
@@ -442,9 +441,10 @@ class Trainer:
                 self.val_sampler.set_epoch(epoch)
 
             # Early stochastic depth: decay drop path rate over training.
-            for module in self.model.modules():
-                if isinstance(module, UNetBackbone):
-                    module.set_epoch(epoch)
+            if isinstance(self.model, BaseModel):
+                self.model.set_epoch(epoch)
+            elif isinstance(self.model, nn.parallel.DistributedDataParallel):
+                self.model.module.set_epoch(epoch)  # type: ignore[union-attr]
 
             start_epoch_train_time = time.perf_counter()
             train_stats = self.train_one_epoch(epoch)

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -92,3 +92,28 @@ class TestDropPath:
         torch.testing.assert_close(trunk.grad, torch.ones_like(trunk))
         # Skip gradient should be all zeros (dropped)
         torch.testing.assert_close(skip.grad, torch.zeros_like(skip))
+
+    def test_set_progress_linearly_decays_rate(self):
+        """set_progress linearly interpolates dropout.p from max_drop_prob to 0."""
+        drop_path = DropPath(drop_prob=0.6)
+
+        drop_path.set_progress(0.0)
+        assert drop_path.dropout.p == pytest.approx(0.6)
+
+        drop_path.set_progress(0.5)
+        assert drop_path.dropout.p == pytest.approx(0.3)
+
+        drop_path.set_progress(1.0)
+        assert drop_path.dropout.p == pytest.approx(0.0)
+
+    def test_set_progress_beyond_one_keeps_drop_path_off(self):
+        """Once the early phase is over (progress >= 1), drop path stays disabled."""
+        drop_path = DropPath(drop_prob=0.5)
+        drop_path.train()
+
+        drop_path.set_progress(2.0)
+        assert drop_path.dropout.p == pytest.approx(0.0)
+
+        # Confirm it actually passes through (not just p==0 but forward is identity)
+        skip = torch.randn(4, 16, 8, 8)
+        torch.testing.assert_close(drop_path(skip), skip)


### PR DESCRIPTION
This paper[1] and corresponding repo[2] suggest that dropout is even more effective when it is only used early during training. The paper reports that early dropout in ConvNext UNets works better than both using (s.d.) dropout or not using dropout at all:

<img width="561" height="340" alt="Screenshot 2026-03-10 at 3 48 51 PM" src="https://github.com/user-attachments/assets/28dad2bc-a4c4-4db2-a1a2-fc52aeafb9b0" />

Thus, this PR adds an enhancement to #641 that lets users define a number of epochs to linearly decay the dropout rate until it hits zero. This provides a really simple means of specifying early dropout in our experiments. According to [2], this provides just as much benefit as more complex schemes of implementing early drop out while minimizing the number of things we need to configure.

[1]: https://ar5iv.labs.arxiv.org/html/2303.01500
[2]: https://github.com/facebookresearch/dropout