### PR TITLE
vertical conv stem

### DIFF
--- a/configs/samudra_om4_v1_vertical_stem/README.md
+++ b/configs/samudra_om4_v1_vertical_stem/README.md
@@ -3,6 +3,12 @@
 These configurations mirror `samudra_om4_v1` but enable the vertical convolution
 stem before the U-Net backbone.
 
+The current stem uses a two-stage residual design:
+
+- a local depth convolution to encode nearby-level locality
+- a residual MLP mixer over the full 19-level depth vector to add cheap
+	column-wise expressivity without a large conv bottleneck
+
 The `vertical_conv_stem` block in `model.yaml` is derived from the experiment
 variable definitions in `train.yaml`:
 
@@ -36,9 +42,17 @@ So the stem parameters are set as:
 - `num_3d_vars: 4` from `uo`, `vo`, `thetao`, `so`
 - `num_depths: 19` because `thermo_dynamic_all` uses all 19 OM4 depth levels
 - `num_2d_vars: 1` from `zos`
-- `kernel_size: 3` as the chosen depthwise Conv1d kernel
-- `mid_channels: null` meaning it defaults to `num_depths`, so `19`
-- `shared_weights: true` meaning the same depthwise stem is shared across all 3D variables
+- `kernel_size: 5` to keep a local vertical neighborhood bias
+- `mid_channels: 16` to keep the conv activations small at OM4 resolution
+- `depth_mlp_hidden: 32` to add a cheap residual mixer over the full depth vector
+- `shared_weights: false` so each of `uo`, `vo`, `thetao`, and `so` gets its own depth-conv stack
+
+With these settings, each variable-specific stem has:
+
+- local Conv1d block: `(1 * 16 * 5 + 16) + (16 * 1 * 5 + 1) = 177` parameters
+- residual depth MLP: `(19 * 32 + 32) + (32 * 19 + 19) = 1,267` parameters
+- total per variable: `1,444` parameters
+- total across 4 variables: `5,776` parameters
 
 `boundary_vars_key: tau_hfds_hfds_anom` contributes 4 boundary variables
 (`tauuo`, `tauvo`, `hfds`, `hfds_anomalies`), but that count is inferred by the

--- a/configs/samudra_om4_v1_vertical_stem/README.md
+++ b/configs/samudra_om4_v1_vertical_stem/README.md
@@ -1,0 +1,45 @@
+# Samudra OM4 V1 Vertical Stem
+
+These configurations mirror `samudra_om4_v1` but enable the vertical convolution
+stem before the U-Net backbone.
+
+The `vertical_conv_stem` block in `model.yaml` is derived from the experiment
+variable definitions in `train.yaml`:
+
+- `prognostic_vars_key: thermo_dynamic_all`
+- `boundary_vars_key: tau_hfds_hfds_anom`
+
+The source of truth for these variable groups is:
+
+- `PROGNOSTIC_VARS` in `src/ocean_emulators/constants.py`
+- `BOUNDARY_VARS` in `src/ocean_emulators/constants.py`
+- the `TensorMap` logic in `src/ocean_emulators/constants.py`, which splits the
+	selected prognostic variables into 3D variable families, depth levels, and 2D
+	variables
+
+For `thermo_dynamic_all`, the prognostic variables are:
+
+- 4 three-dimensional variables: `uo`, `vo`, `thetao`, `so`
+- 19 depth levels for each 3D variable
+- 1 two-dimensional prognostic variable: `zos`
+
+This comes from the definition:
+
+- `thermo_dynamic_all = [uo_*, vo_*, thetao_*, so_* over DEPTH_I_LEVELS] + [zos]`
+
+and from the `TensorMap` rules that treat names with a depth suffix like
+`thetao_0`, `thetao_1`, ... as 3D channels and names without that suffix like
+`zos` as 2D channels.
+
+So the stem parameters are set as:
+
+- `num_3d_vars: 4` from `uo`, `vo`, `thetao`, `so`
+- `num_depths: 19` because `thermo_dynamic_all` uses all 19 OM4 depth levels
+- `num_2d_vars: 1` from `zos`
+- `kernel_size: 3` as the chosen depthwise Conv1d kernel
+- `mid_channels: null` meaning it defaults to `num_depths`, so `19`
+- `shared_weights: true` meaning the same depthwise stem is shared across all 3D variables
+
+`boundary_vars_key: tau_hfds_hfds_anom` contributes 4 boundary variables
+(`tauuo`, `tauvo`, `hfds`, `hfds_anomalies`), but that count is inferred by the
+model build path rather than set explicitly in the YAML.

--- a/configs/samudra_om4_v1_vertical_stem/eval.yaml
+++ b/configs/samudra_om4_v1_vertical_stem/eval.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../schemas/EvalConfig.json
+
+debug: false
+save_zarr: true
+disk_mode: true
+inference_time:
+  start: "2014-10-10"
+  end: "2022-12-24"
+num_model_steps_forward: 25
+
+experiment:
+  name: samudra_om4_v1_vertical_stem_eval
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+  prognostic_vars_key: thermo_dynamic_all
+  boundary_vars_key: tau_hfds_hfds_anom
+
+data: !include ../data/om4.yaml
+model: !include model.yaml

--- a/configs/samudra_om4_v1_vertical_stem/model.yaml
+++ b/configs/samudra_om4_v1_vertical_stem/model.yaml
@@ -9,9 +9,10 @@ vertical_conv_stem:
   num_3d_vars: 4
   num_depths: 19
   num_2d_vars: 1
-  kernel_size: 3
-  mid_channels: null
-  shared_weights: true
+  kernel_size: 5
+  mid_channels: 16
+  depth_mlp_hidden: 32
+  shared_weights: false
 
 unet:
   ch_width: [200, 250, 300, 400]

--- a/configs/samudra_om4_v1_vertical_stem/model.yaml
+++ b/configs/samudra_om4_v1_vertical_stem/model.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=../schemas/SamudraConfig.json
+
+pred_residuals: false
+last_kernel_size: 3
+pad: "circular"
+checkpointing: "all"
+
+vertical_conv_stem:
+  num_3d_vars: 4
+  num_depths: 19
+  num_2d_vars: 1
+  kernel_size: 3
+  mid_channels: null
+  shared_weights: true
+
+unet:
+  ch_width: [200, 250, 300, 400]
+  dilation: [1, 2, 4, 8]
+  n_layers: [1, 1, 1, 1]
+
+  core_block:
+    block_type: "conv_next_block"
+    kernel_size: 3
+    activation: "capped_gelu"
+    upscale_factor: 4
+    norm: "batch"
+
+  down_sampling_block: "avg_pool"
+  up_sampling_block: "bilinear_upsample"
+
+corrector:
+  non_negative_corrector_names: null
+  ocean_heat_corrector: false

--- a/configs/samudra_om4_v1_vertical_stem/train.yaml
+++ b/configs/samudra_om4_v1_vertical_stem/train.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=../schemas/TrainConfig.json
+
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 70
+batch_size: 4
+learning_rate: 0.0006
+scheduler: { type: cosine }
+loss: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: []
+data_percent: 1.0
+train_time:
+  start: "1975-01-03"
+  end: "2013-10-05"
+val_time:
+  start: "2013-10-05"
+  end: "2014-10-05"
+inference_times:
+  - start: "1975-01-03"
+    end: "1980-01-03"
+  - start: "1980-01-03"
+    end: "1985-01-03"
+  - start: "1985-01-03"
+    end: "1990-01-03"
+  - start: "1990-01-03"
+    end: "1995-01-03"
+  - start: "1995-01-03"
+    end: "2000-01-03"
+  - start: "2000-01-03"
+    end: "2005-01-03"
+  - start: "2005-01-03"
+    end: "2010-01-03"
+  - start: "2010-01-03"
+    end: "2014-10-05"
+data_stride: [1]
+steps: [4]
+step_transition: []
+preemptible: false
+
+backend: auto
+
+experiment:
+  name: samudra_om4_v1_vertical_stem
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+  prognostic_vars_key: thermo_dynamic_all
+  boundary_vars_key: tau_hfds_hfds_anom
+
+data: !include ../data/om4.yaml
+model: !include model.yaml

--- a/configs/samudra_om4_v1_vertical_stem/train.yaml
+++ b/configs/samudra_om4_v1_vertical_stem/train.yaml
@@ -5,7 +5,7 @@ disk_mode: true
 pin_mem: true
 save_freq: 5
 epochs: 70
-batch_size: 4
+batch_size: 2
 learning_rate: 0.0006
 scheduler: { type: cosine }
 loss: mse
@@ -44,11 +44,11 @@ preemptible: false
 backend: auto
 
 experiment:
-  name: samudra_om4_v1_vertical_stem
+  name: samudra_om4_v1_vertical_stem_mixer
   rand_seed: 15
   base_output_dir: .LOCAL
   wandb:
-    mode: disabled
+    mode: online
     project: default
   prognostic_vars_key: thermo_dynamic_all
   boundary_vars_key: tau_hfds_hfds_anom

--- a/configs/samudra_om4_v1_vertical_stem/viz.yaml
+++ b/configs/samudra_om4_v1_vertical_stem/viz.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../schemas/VizConfig.json
+
+base_output_dir: ".LOCAL"
+name: "samudra_om4_v1_vertical_stem_viz"
+dataset_name: "OM4"
+groundtruth_location: "OM4.zarr"
+basins_location:
+  type: s3
+  bucket: "emulators"
+  path: "jr7309/basins/basin_masks_original.zarr"
+  endpoint_url: "https://nyu1.osn.mghpcc.org"
+groundtruth_time_range:
+  start: "2014-10-20"
+  end: "2022-12-24"
+runs:
+  - name: "samudra_om4_v1_vertical_stem_eval"
+    location: ".LOCAL/samudra_om4_v1_vertical_stem_eval/predictions.zarr"

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -35,6 +35,7 @@ from ocean_emulators.models.modules import (
     ReLU,
     TransposedConvUpsample,
     UNetBackbone,
+    VerticalConvStem,
 )
 from ocean_emulators.models.modules.augment_input import Concat3dCoordinates
 from ocean_emulators.models.modules.blocks import ZonallyPeriodicBilinearUpsample
@@ -634,6 +635,56 @@ class BaseModelConfig(BaseConfig, abc.ABC):
         pass
 
 
+class VerticalConvStemConfig(BaseConfig):
+    """Configuration for the vertical convolution stem.
+
+    This stem applies 1D convolutions along the depth axis for 3D ocean
+    variables, encoding an inductive bias that adjacent depth levels are
+    related. It is channel-preserving (same input and output channel count).
+    """
+
+    num_3d_vars: int = Field(
+        default=4,
+        description="Number of distinct 3D variable types (e.g. 4 for uo, vo, thetao, so).",
+    )
+    num_depths: int = Field(
+        default=19,
+        description="Number of depth levels per 3D variable.",
+    )
+    num_2d_vars: int = Field(
+        default=1,
+        description="Number of 2D prognostic variables (e.g. 1 for zos).",
+    )
+    kernel_size: int = Field(
+        default=3,
+        description="Kernel size for the 1D depth convolution. Must be odd.",
+    )
+    mid_channels: int | None = Field(
+        default=None,
+        description="Hidden channels in the depth conv. Defaults to num_depths.",
+    )
+    shared_weights: bool = Field(
+        default=True,
+        description="Share depth conv weights across all 3D variable types.",
+    )
+
+    def build(
+        self,
+        num_boundary_vars: int,
+        hist: int,
+    ) -> VerticalConvStem:
+        return VerticalConvStem(
+            num_3d_vars=self.num_3d_vars,
+            num_depths=self.num_depths,
+            num_2d_vars=self.num_2d_vars,
+            num_boundary_vars=num_boundary_vars,
+            hist=hist,
+            kernel_size=self.kernel_size,
+            mid_channels=self.mid_channels,
+            shared_weights=self.shared_weights,
+        )
+
+
 class SamudraConfig(BaseModelConfig):
     unet: UNetBackboneConfig = UNetBackboneConfig()
     corrector: CorrectorConfig | None = None  # None turns all correctors off.
@@ -644,6 +695,11 @@ class SamudraConfig(BaseModelConfig):
     use_bfloat16: bool = Field(
         default=False,
         description="Use bfloat16 for most layers rather than float32.",
+    )
+    vertical_conv_stem: VerticalConvStemConfig | None = Field(
+        default=None,
+        description="Optional vertical convolution stem that applies 1D convolutions "
+        "along the depth axis for 3D ocean variables. Set to null/None to disable.",
     )
 
     def build(
@@ -668,6 +724,28 @@ class SamudraConfig(BaseModelConfig):
             in_channels + self.pos_channels + (3 if self.add_3d_coordinates else 0)
         )
         add_3d_coordinates = Concat3dCoordinates() if self.add_3d_coordinates else None
+
+        # Build optional vertical conv stem
+        vertical_conv_stem_module = None
+        if self.vertical_conv_stem is not None:
+            if in_channels % (hist + 1) != 0 or out_channels % (hist + 1) != 0:
+                raise ValueError(
+                    "Samudra vertical_conv_stem requires time-major channel counts "
+                    "that are divisible by hist + 1."
+                )
+            # Derive num_boundary_vars from in/out channels and hist
+            channels_per_ts = out_channels // (hist + 1)
+            num_boundary_per_ts = (in_channels // (hist + 1)) - channels_per_ts
+            if num_boundary_per_ts < 0:
+                raise ValueError(
+                    "Samudra vertical_conv_stem inferred a negative number of "
+                    "boundary channels per timestep."
+                )
+            vertical_conv_stem_module = self.vertical_conv_stem.build(
+                num_boundary_vars=num_boundary_per_ts,
+                hist=hist,
+            )
+
         return Samudra(
             in_channels=total_in_channels,
             out_channels=out_channels,
@@ -682,6 +760,7 @@ class SamudraConfig(BaseModelConfig):
             corrector=corrector,
             pos_channels=self.pos_channels,
             add_3d_coordinates=add_3d_coordinates,
+            vertical_conv_stem=vertical_conv_stem_module,
             hist=hist,
             grid_size=src.grid_size,
             gradient_detach_interval=self.gradient_detach_interval,

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -656,15 +656,19 @@ class VerticalConvStemConfig(BaseConfig):
         description="Number of 2D prognostic variables (e.g. 1 for zos).",
     )
     kernel_size: int = Field(
-        default=3,
+        default=7,
         description="Kernel size for the 1D depth convolution. Must be odd.",
     )
     mid_channels: int | None = Field(
+        default=256,
+        description="Hidden channels in the depth conv. Defaults to 256 for a lean per-variable stem.",
+    )
+    depth_mlp_hidden: int | None = Field(
         default=None,
-        description="Hidden channels in the depth conv. Defaults to num_depths.",
+        description="Optional hidden width for a residual depth-vector mixer applied after the local depth convolution.",
     )
     shared_weights: bool = Field(
-        default=True,
+        default=False,
         description="Share depth conv weights across all 3D variable types.",
     )
 
@@ -681,6 +685,7 @@ class VerticalConvStemConfig(BaseConfig):
             hist=hist,
             kernel_size=self.kernel_size,
             mid_channels=self.mid_channels,
+            depth_mlp_hidden=self.depth_mlp_hidden,
             shared_weights=self.shared_weights,
         )
 

--- a/src/ocean_emulators/models/modules/__init__.py
+++ b/src/ocean_emulators/models/modules/__init__.py
@@ -14,6 +14,7 @@ from .blocks import (
 from .decoder import PerceiverDecoder
 from .encoder import PerceiverEncoder
 from .unet_backbone import UNetBackbone
+from .vertical_conv_stem import VerticalConvStem
 
 __all__ = [
     "AvgPool",
@@ -30,4 +31,5 @@ __all__ = [
     "PerceiverEncoder",
     "ReLU",
     "UNetBackbone",
+    "VerticalConvStem",
 ]

--- a/src/ocean_emulators/models/modules/vertical_conv_stem.py
+++ b/src/ocean_emulators/models/modules/vertical_conv_stem.py
@@ -4,7 +4,8 @@ This module introduces an inductive bias that treats depth levels as an ordered,
 adjacent dimension rather than independent channels. For each 3D variable group
 (e.g., thetao, so, uo, vo), a 1D convolution is applied along the depth
 axis before the features are flattened back into the channel dimension for the
-main U-Net backbone.
+main U-Net backbone. An optional residual depth mixer can then cheaply mix the
+full depth vector after the local convolution has injected a neighborhood bias.
 
 This is motivated by the observation that Samudra's flat-channel design treats
 thetao_0 (2.5m) and thetao_18 (6000m) as no more related than thetao_0 and vo_17.
@@ -12,9 +13,10 @@ A vertical conv explicitly encodes that adjacent depths are neighbors, giving th
 model a structured prior on vertical locality.
 
 Design decisions:
-- The 1D conv is shared across all 3D variable types by default. This keeps
-  parameters low and encodes the assumption that vertical locality is a universal
-  physical prior. A per-variable option is available via ``shared_weights=False``.
+- By default each 3D variable type gets its own depth-conv stack. This keeps
+    the stem cheap relative to the backbone while avoiding an overly constrained
+    shared filter across uo, vo, thetao, and so. Shared weights remain available
+    via ``shared_weights=True``.
 - A residual connection is used (depth dimension is always preserved).
 - 2D surface variables and boundary variables pass through unchanged.
 """
@@ -32,9 +34,12 @@ class VerticalConvStem(nn.Module):
 
     1. Splits channels into 3D variable groups, 2D variables, and boundary variables
        based on the known channel layout.
-    2. For each 3D group, reshapes to ``(batch, num_3d_vars, num_depths, lat, lon)``
-       and applies a small 1D convolution along the depth dimension.
-    3. Adds a residual connection and recombines all channels.
+     2. Reshapes the 3D channels to
+         ``(batch, total_timesteps * num_3d_vars, num_depths, lat, lon)`` so each
+         timestep-variable pair becomes its own depth profile group, then applies
+         a small 1D convolution along the depth dimension.
+     3. Adds a residual connection, optionally applies a residual depth mixer,
+         and recombines all channels.
 
     The output has the **same** channel count as the input (channel-preserving).
 
@@ -47,9 +52,12 @@ class VerticalConvStem(nn.Module):
         hist: History length (number of past timesteps included, e.g., 1).
         kernel_size: Kernel size for the depth convolution. Must be odd.
         mid_channels: Number of intermediate channels in the depth conv block.
-            Defaults to ``num_depths`` if not set.
-        shared_weights: If True (default), all 3D variable types share the same
-            depth conv weights. If False, each variable type gets its own conv.
+            Defaults to ``256`` if not set.
+        depth_mlp_hidden: Hidden width of an optional residual MLP mixer applied
+            to the full depth vector after the local depth convolution. When
+            ``None``, the residual mixer is disabled.
+        shared_weights: If True, all 3D variable types share the same depth
+            conv weights. If False (default), each variable type gets its own conv.
     """
 
     def __init__(
@@ -59,9 +67,10 @@ class VerticalConvStem(nn.Module):
         num_2d_vars: int,
         num_boundary_vars: int,
         hist: int,
-        kernel_size: int = 3,
-        mid_channels: int | None = None,
-        shared_weights: bool = True,
+        kernel_size: int = 7,
+        mid_channels: int | None = 256,
+        depth_mlp_hidden: int | None = None,
+        shared_weights: bool = False,
     ):
         super().__init__()
         assert kernel_size % 2 == 1, "kernel_size must be odd for symmetric padding"
@@ -71,9 +80,10 @@ class VerticalConvStem(nn.Module):
         self.num_2d_vars = num_2d_vars
         self.num_boundary_vars = num_boundary_vars
         self.hist = hist
+        self.depth_mlp_hidden = depth_mlp_hidden
         self.shared_weights = shared_weights
 
-        mid = mid_channels if mid_channels is not None else num_depths
+        mid = mid_channels if mid_channels is not None else 256
         pad = (kernel_size - 1) // 2
 
         def _make_depth_conv() -> nn.Sequential:
@@ -83,12 +93,27 @@ class VerticalConvStem(nn.Module):
                 nn.Conv1d(mid, 1, kernel_size=kernel_size, padding=pad),
             )
 
+        def _make_depth_mixer() -> nn.Sequential:
+            if depth_mlp_hidden is None:
+                raise ValueError("depth_mlp_hidden must be set to build a depth mixer")
+            return nn.Sequential(
+                nn.Linear(num_depths, depth_mlp_hidden),
+                nn.GELU(),
+                nn.Linear(depth_mlp_hidden, num_depths),
+            )
+
         if shared_weights:
             self.depth_conv = _make_depth_conv()
+            if depth_mlp_hidden is not None:
+                self.depth_mixer = _make_depth_mixer()
         else:
             self.depth_convs = nn.ModuleList(
                 [_make_depth_conv() for _ in range(num_3d_vars)]
             )
+            if depth_mlp_hidden is not None:
+                self.depth_mixers = nn.ModuleList(
+                    [_make_depth_mixer() for _ in range(num_3d_vars)]
+                )
 
         # Pre-compute the channel layout metadata.
         self._channels_per_ts = num_3d_vars * num_depths + num_2d_vars
@@ -151,6 +176,25 @@ class VerticalConvStem(nn.Module):
             y_3d_perm[:, g] = group_out.reshape(B, H, W, self.num_depths)
         return y_3d_perm.reshape(-1, 1, self.num_depths)
 
+    def _apply_depth_mixer(self, x_3d_perm: torch.Tensor) -> torch.Tensor:
+        """Apply an optional residual MLP mixer to (B, G, H, W, D) input."""
+        B, total_groups, H, W, _ = x_3d_perm.shape
+
+        if self.depth_mlp_hidden is None:
+            return torch.zeros_like(x_3d_perm)
+
+        if self.shared_weights:
+            x_flat = x_3d_perm.reshape(-1, self.num_depths)
+            return self.depth_mixer(x_flat).reshape(B, total_groups, H, W, self.num_depths)
+
+        y_3d_perm = torch.empty_like(x_3d_perm)
+        for g in range(total_groups):
+            depth_mixer = self.depth_mixers[g % self.num_3d_vars]
+            group = x_3d_perm[:, g].reshape(-1, self.num_depths)
+            group_out = depth_mixer(group)
+            y_3d_perm[:, g] = group_out.reshape(B, H, W, self.num_depths)
+        return y_3d_perm
+
     # ------------------------------------------------------------------
     # Forward
     # ------------------------------------------------------------------
@@ -182,13 +226,15 @@ class VerticalConvStem(nn.Module):
         x_3d_perm = x_3d.permute(0, 1, 3, 4, 2).contiguous()  # (B, G, H, W, D)
         y_flat = self._apply_depth_conv(x_3d_perm)
 
-        # Reshape back: (N, 1, D) -> (B, G, H, W, D) -> (B, G, D, H, W) -> (B, G*D, H, W)
-        y = y_flat.reshape(B, total_groups, H, W, self.num_depths)
-        y = y.permute(0, 1, 4, 2, 3)  # (B, G, D, H, W)
-        y = y.reshape(B, total_groups * self.num_depths, H, W)
+        # Reshape back to grouped depth profiles, then apply residual depth processing.
+        y_3d_perm = y_flat.reshape(B, total_groups, H, W, self.num_depths)
+        y_3d_perm = y_3d_perm + x_3d_perm
+        if self.depth_mlp_hidden is not None:
+            y_3d_perm = y_3d_perm + self._apply_depth_mixer(y_3d_perm)
 
-        # Residual connection on 3D channels
-        y = y + x[:, idx_3d]
+        # Convert back to the original flattened channel layout.
+        y = y_3d_perm.permute(0, 1, 4, 2, 3)  # (B, G, D, H, W)
+        y = y.reshape(B, total_groups * self.num_depths, H, W)
 
         # Write processed 3D channels back into their original positions,
         # preserving 2D and boundary channels in place.

--- a/src/ocean_emulators/models/modules/vertical_conv_stem.py
+++ b/src/ocean_emulators/models/modules/vertical_conv_stem.py
@@ -1,0 +1,190 @@
+"""Vertical convolution stem for depth-aware processing of 3D ocean variables.
+
+This module introduces an inductive bias that treats depth levels as an ordered,
+adjacent dimension rather than independent channels. For each 3D variable group
+(e.g., thetao, so, uo, vo), a 1D convolution is applied along the depth
+axis before the features are flattened back into the channel dimension for the
+main U-Net backbone.
+
+This is motivated by the observation that Samudra's flat-channel design treats
+thetao_0 (2.5m) and thetao_18 (6000m) as no more related than thetao_0 and vo_17.
+A vertical conv explicitly encodes that adjacent depths are neighbors, giving the
+model a structured prior on vertical locality.
+
+Design decisions:
+- The 1D conv is shared across all 3D variable types by default. This keeps
+  parameters low and encodes the assumption that vertical locality is a universal
+  physical prior. A per-variable option is available via ``shared_weights=False``.
+- A residual connection is used (depth dimension is always preserved).
+- 2D surface variables and boundary variables pass through unchanged.
+"""
+
+from typing import cast
+
+import torch
+import torch.nn as nn
+
+
+class VerticalConvStem(nn.Module):
+    """Applies 1D convolutions along the depth axis for 3D ocean variables.
+
+    Given an input tensor of shape ``(batch, channels, lat, lon)`` this module:
+
+    1. Splits channels into 3D variable groups, 2D variables, and boundary variables
+       based on the known channel layout.
+    2. For each 3D group, reshapes to ``(batch, num_3d_vars, num_depths, lat, lon)``
+       and applies a small 1D convolution along the depth dimension.
+    3. Adds a residual connection and recombines all channels.
+
+    The output has the **same** channel count as the input (channel-preserving).
+
+    Args:
+        num_3d_vars: Number of distinct 3D variable types (e.g., 4 for uo, vo,
+            thetao, so).
+        num_depths: Number of depth levels per 3D variable (e.g., 19).
+        num_2d_vars: Number of 2D prognostic variables (e.g., 1 for zos).
+        num_boundary_vars: Number of boundary forcing variables per timestep.
+        hist: History length (number of past timesteps included, e.g., 1).
+        kernel_size: Kernel size for the depth convolution. Must be odd.
+        mid_channels: Number of intermediate channels in the depth conv block.
+            Defaults to ``num_depths`` if not set.
+        shared_weights: If True (default), all 3D variable types share the same
+            depth conv weights. If False, each variable type gets its own conv.
+    """
+
+    def __init__(
+        self,
+        num_3d_vars: int,
+        num_depths: int,
+        num_2d_vars: int,
+        num_boundary_vars: int,
+        hist: int,
+        kernel_size: int = 3,
+        mid_channels: int | None = None,
+        shared_weights: bool = True,
+    ):
+        super().__init__()
+        assert kernel_size % 2 == 1, "kernel_size must be odd for symmetric padding"
+
+        self.num_3d_vars = num_3d_vars
+        self.num_depths = num_depths
+        self.num_2d_vars = num_2d_vars
+        self.num_boundary_vars = num_boundary_vars
+        self.hist = hist
+        self.shared_weights = shared_weights
+
+        mid = mid_channels if mid_channels is not None else num_depths
+        pad = (kernel_size - 1) // 2
+
+        def _make_depth_conv() -> nn.Sequential:
+            return nn.Sequential(
+                nn.Conv1d(1, mid, kernel_size=kernel_size, padding=pad),
+                nn.GELU(),
+                nn.Conv1d(mid, 1, kernel_size=kernel_size, padding=pad),
+            )
+
+        if shared_weights:
+            self.depth_conv = _make_depth_conv()
+        else:
+            self.depth_convs = nn.ModuleList(
+                [_make_depth_conv() for _ in range(num_3d_vars)]
+            )
+
+        # Pre-compute the channel layout metadata.
+        self._channels_per_ts = num_3d_vars * num_depths + num_2d_vars
+        self._total_ts = hist + 1
+        self._num_prog_channels = self._total_ts * self._channels_per_ts
+        self._num_3d_per_ts = num_3d_vars * num_depths
+        self._expected_channels = self._num_prog_channels + (
+            self._total_ts * num_boundary_vars
+        )
+
+        # Pre-compute and register index tensors so they move with .to(device).
+        self.register_buffer(
+            "_idx_3d", torch.tensor(self._compute_3d_indices(), dtype=torch.long)
+        )
+        self.register_buffer(
+            "_idx_2d", torch.tensor(self._compute_2d_indices(), dtype=torch.long)
+        )
+
+    # ------------------------------------------------------------------
+    # Index helpers
+    # ------------------------------------------------------------------
+    def _compute_3d_indices(self) -> list[int]:
+        """Flat indices of all 3D variable channels across all timesteps."""
+        out: list[int] = []
+        for t in range(self._total_ts):
+            base = t * self._channels_per_ts
+            out.extend(range(base, base + self._num_3d_per_ts))
+        return out
+
+    def _compute_2d_indices(self) -> list[int]:
+        """Flat indices of all 2D variable channels across all timesteps."""
+        out: list[int] = []
+        for t in range(self._total_ts):
+            base = t * self._channels_per_ts + self._num_3d_per_ts
+            out.extend(range(base, base + self.num_2d_vars))
+        return out
+
+    def _boundary_slice(self, total_channels: int) -> slice:
+        """Slice for boundary channels (everything after prognostic)."""
+        return slice(self._num_prog_channels, total_channels)
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply vertical convolution stem.
+
+        Args:
+            x: Input tensor of shape ``(batch, channels, lat, lon)``.
+
+        Returns:
+            Tensor of shape ``(batch, channels, lat, lon)`` (same shape as input).
+            Channel ordering is preserved; only 3D variable channels are modified.
+        """
+        B, C, H, W = x.shape
+        idx_3d = cast(torch.Tensor, self._idx_3d)
+        if C != self._expected_channels:
+            raise ValueError(
+                f"Expected {self._expected_channels} channels for stem with "
+                f"hist={self.hist}, got {C}."
+            )
+
+        # Extract 3D channels and reshape into (B, T*V, D, H, W)
+        x_3d = x[:, idx_3d]  # (B, T*V*D, H, W)
+        total_groups = self._total_ts * self.num_3d_vars
+        x_3d = x_3d.view(B, total_groups, self.num_depths, H, W)
+
+        # Depth conv expects (N, 1, D).
+        # Flatten spatial + batch + groups: (B * G * H * W, 1, D)
+        x_3d_perm = x_3d.permute(0, 1, 3, 4, 2).contiguous()  # (B, G, H, W, D)
+        x_3d_flat = x_3d_perm.view(-1, 1, self.num_depths)  # (N, 1, D)
+
+        if self.shared_weights:
+            y_flat = self.depth_conv(x_3d_flat)  # (N, 1, D)
+        else:
+            # Per-variable convolutions.
+            per_var = B * H * W
+            chunks: list[torch.Tensor] = []
+            for t in range(self._total_ts):
+                for v in range(self.num_3d_vars):
+                    g = t * self.num_3d_vars + v
+                    start = g * per_var
+                    end = start + per_var
+                    chunks.append(self.depth_convs[v](x_3d_flat[start:end]))
+            y_flat = torch.cat(chunks, dim=0)  # (N, 1, D)
+
+        # Reshape back: (N, 1, D) -> (B, G, H, W, D) -> (B, G, D, H, W) -> (B, G*D, H, W)
+        y = y_flat.view(B, total_groups, H, W, self.num_depths)
+        y = y.permute(0, 1, 4, 2, 3)  # (B, G, D, H, W)
+        y = y.reshape(B, total_groups * self.num_depths, H, W)
+
+        # Residual connection on 3D channels
+        y = y + x[:, idx_3d]
+
+        # Write processed 3D channels back into their original positions,
+        # preserving 2D and boundary channels in place.
+        out = x.clone()
+        out[:, idx_3d] = y
+        return out

--- a/src/ocean_emulators/models/modules/vertical_conv_stem.py
+++ b/src/ocean_emulators/models/modules/vertical_conv_stem.py
@@ -110,25 +110,46 @@ class VerticalConvStem(nn.Module):
     # ------------------------------------------------------------------
     # Index helpers
     # ------------------------------------------------------------------
-    def _compute_3d_indices(self) -> list[int]:
-        """Flat indices of all 3D variable channels across all timesteps."""
+    def _compute_indices(self, start: int, length: int) -> list[int]:
+        """Flat indices for a fixed-size channel block across all timesteps."""
         out: list[int] = []
         for t in range(self._total_ts):
-            base = t * self._channels_per_ts
-            out.extend(range(base, base + self._num_3d_per_ts))
+            base = t * self._channels_per_ts + start
+            out.extend(range(base, base + length))
         return out
+
+    def _compute_3d_indices(self) -> list[int]:
+        """Flat indices of all 3D variable channels across all timesteps."""
+        return self._compute_indices(start=0, length=self._num_3d_per_ts)
 
     def _compute_2d_indices(self) -> list[int]:
         """Flat indices of all 2D variable channels across all timesteps."""
-        out: list[int] = []
-        for t in range(self._total_ts):
-            base = t * self._channels_per_ts + self._num_3d_per_ts
-            out.extend(range(base, base + self.num_2d_vars))
-        return out
+        return self._compute_indices(
+            start=self._num_3d_per_ts,
+            length=self.num_2d_vars,
+        )
 
     def _boundary_slice(self, total_channels: int) -> slice:
         """Slice for boundary channels (everything after prognostic)."""
         return slice(self._num_prog_channels, total_channels)
+
+    def _apply_depth_conv(self, x_3d_perm: torch.Tensor) -> torch.Tensor:
+        """Apply shared or per-variable depth convs to (B, G, H, W, D) input."""
+        B, total_groups, H, W, _ = x_3d_perm.shape
+
+        if self.shared_weights:
+            x_3d_flat = x_3d_perm.reshape(-1, 1, self.num_depths)
+            return self.depth_conv(x_3d_flat)
+
+        y_3d_perm = torch.empty_like(x_3d_perm)
+        for g in range(total_groups):
+            # Groups are ordered time-major as [t0v0, t0v1, ..., t1v0, t1v1, ...],
+            # so modulo num_3d_vars recovers the variable-specific conv to use.
+            depth_conv = self.depth_convs[g % self.num_3d_vars]
+            group = x_3d_perm[:, g].reshape(-1, 1, self.num_depths)
+            group_out = depth_conv(group)
+            y_3d_perm[:, g] = group_out.reshape(B, H, W, self.num_depths)
+        return y_3d_perm.reshape(-1, 1, self.num_depths)
 
     # ------------------------------------------------------------------
     # Forward
@@ -154,29 +175,15 @@ class VerticalConvStem(nn.Module):
         # Extract 3D channels and reshape into (B, T*V, D, H, W)
         x_3d = x[:, idx_3d]  # (B, T*V*D, H, W)
         total_groups = self._total_ts * self.num_3d_vars
-        x_3d = x_3d.view(B, total_groups, self.num_depths, H, W)
+        x_3d = x_3d.reshape(B, total_groups, self.num_depths, H, W)
 
         # Depth conv expects (N, 1, D).
         # Flatten spatial + batch + groups: (B * G * H * W, 1, D)
         x_3d_perm = x_3d.permute(0, 1, 3, 4, 2).contiguous()  # (B, G, H, W, D)
-        x_3d_flat = x_3d_perm.view(-1, 1, self.num_depths)  # (N, 1, D)
-
-        if self.shared_weights:
-            y_flat = self.depth_conv(x_3d_flat)  # (N, 1, D)
-        else:
-            # Per-variable convolutions.
-            per_var = B * H * W
-            chunks: list[torch.Tensor] = []
-            for t in range(self._total_ts):
-                for v in range(self.num_3d_vars):
-                    g = t * self.num_3d_vars + v
-                    start = g * per_var
-                    end = start + per_var
-                    chunks.append(self.depth_convs[v](x_3d_flat[start:end]))
-            y_flat = torch.cat(chunks, dim=0)  # (N, 1, D)
+        y_flat = self._apply_depth_conv(x_3d_perm)
 
         # Reshape back: (N, 1, D) -> (B, G, H, W, D) -> (B, G, D, H, W) -> (B, G*D, H, W)
-        y = y_flat.view(B, total_groups, H, W, self.num_depths)
+        y = y_flat.reshape(B, total_groups, H, W, self.num_depths)
         y = y.permute(0, 1, 4, 2, 3)  # (B, G, D, H, W)
         y = y.reshape(B, total_groups * self.num_depths, H, W)
 

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -5,6 +5,7 @@ import torch.utils.checkpoint
 from ocean_emulators.constants import GridSize
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
+from ocean_emulators.models.modules.vertical_conv_stem import VerticalConvStem
 from ocean_emulators.utils.ctx import GridContext
 from ocean_emulators.utils.device import autocast
 
@@ -21,6 +22,7 @@ class Samudra(BaseModel):
         corrector: nn.Module | None,
         pos_channels: int,
         add_3d_coordinates: nn.Module | None,
+        vertical_conv_stem: VerticalConvStem | None,
         hist: int,
         grid_size: GridSize,
         gradient_detach_interval: int,
@@ -43,6 +45,7 @@ class Samudra(BaseModel):
             self.register_parameter("positional_params", None)
 
         self.add_3d_coordinates = add_3d_coordinates
+        self.vertical_conv_stem = vertical_conv_stem
         self.unet = unet
         self.decoder = nn.Conv2d(unet.out_channels, out_channels, last_kernel_size)
 
@@ -54,6 +57,9 @@ class Samudra(BaseModel):
             fts_input = fts.clone().detach()
 
         with autocast(enabled=self.use_bfloat16, dtype=torch.bfloat16):
+            if self.vertical_conv_stem is not None:
+                fts = self.vertical_conv_stem(fts)
+
             if self.positional_params is not None:
                 pos = self.positional_params.unsqueeze(0).expand(
                     fts.shape[0], -1, -1, -1

--- a/tests/test_vertical_conv_stem.py
+++ b/tests/test_vertical_conv_stem.py
@@ -1,0 +1,28 @@
+import torch
+
+from ocean_emulators.models.modules.vertical_conv_stem import VerticalConvStem
+
+
+def test_vertical_conv_stem_with_depth_mixer_preserves_layout():
+    stem = VerticalConvStem(
+        num_3d_vars=2,
+        num_depths=3,
+        num_2d_vars=1,
+        num_boundary_vars=2,
+        hist=1,
+        kernel_size=3,
+        mid_channels=4,
+        depth_mlp_hidden=5,
+        shared_weights=False,
+    )
+
+    total_channels = (stem.hist + 1) * (
+        stem.num_3d_vars * stem.num_depths + stem.num_2d_vars + stem.num_boundary_vars
+    )
+    x = torch.randn(2, total_channels, 4, 5)
+
+    out = stem(x)
+
+    assert out.shape == x.shape
+    assert torch.equal(out[:, stem._idx_2d], x[:, stem._idx_2d])
+    assert torch.equal(out[:, stem._boundary_slice(x.shape[1])], x[:, stem._boundary_slice(x.shape[1])])


### PR DESCRIPTION
Vertical structure is currently not modeled explicitly. The UNet treats depth as stacked channels, so it has no inherent notion of verticality.

this change attempts encoder stem with 1D convolutions along the depth axis

test run here :  https://wandb.ai/ocean_emulators/default/runs/ao1wahl3 