### PR TITLE
eval.py script supports single scale evaluations of mulit-scale FOMO models.

### DIFF
--- a/configs/fomo_om4/eval_multiscale.yaml
+++ b/configs/fomo_om4/eval_multiscale.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=../schemas/EvalConfig.json
+#
+# Eval config for the multi-scale FOMO model.
+#
+# The eval code runs inference on the *first* data source only.
+# To evaluate all three scales, run three separate eval jobs and
+# reorder the sources list so the target resolution is first.
+# All three sources must always be present so the model builds
+# with the correct max grid size for the encoder patch grid.
+# Setting multiple data sources lets us use checkpoints for
+# FOMO models that use multiple scales.
+
+debug: false
+save_zarr: true
+disk_mode: true
+inference_time:
+  start: "2014-10-05"
+  end: "2015-10-05"
+num_model_steps_forward: 25
+
+experiment:
+  name: fomo_om4_eval
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+  prognostic_vars_key: thermo_dynamic_all
+  boundary_vars_key: tau_hfds_hfds_anom
+
+data:
+  static_data_vars: []
+  concurrent_compute: true
+  sources:
+    # First source is used for inference. Reorder to eval a different scale.
+    - data_location: om4_onedeg_v3/OM4.zarr
+      data_means_location: om4_onedeg_v3/OM4_means.zarr
+      data_stds_location: om4_onedeg_v3/OM4_stds.zarr
+    - data_location: om4_halfdeg_v4/OM4.zarr
+      data_means_location: om4_halfdeg_v4/OM4_means.zarr
+      data_stds_location: om4_halfdeg_v4/OM4_stds.zarr
+    - data_location: om4_quarterdeg_v2/OM4.zarr
+      data_means_location: om4_quarterdeg_v2/OM4_means.zarr
+      data_stds_location: om4_quarterdeg_v2/OM4_stds.zarr
+
+model: !include model.yaml

--- a/configs/fomo_om4/eval_multiscale.yaml
+++ b/configs/fomo_om4/eval_multiscale.yaml
@@ -7,6 +7,9 @@
 # reorder the sources list so the target resolution is first.
 # All three sources must always be present so the model builds
 # with the correct max grid size for the encoder patch grid.
+# The max grid size affects the rotary positional embedding
+# dimension for the encoder's Perceiver. If it is set wrong,
+# it would likely cause hard-to-debug model level errors.
 # Setting multiple data sources lets us use checkpoints for
 # FOMO models that use multiple scales.
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -1040,7 +1040,7 @@ class EvalConfig(TopLevelConfig):
     )
     experiment: ExperimentConfig
     data: DataConfig
-    model: AnyModelConfig = SamudraConfig()
+    model: AnyModelConfig
 
     def prepare_output_dirs(self) -> None:
         self.experiment.output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Added multiscale eval config + fixed config.py

Fixes #651.