### PR TITLE
Updating our BatchSamplers to use the same scale across all replicas.

### DIFF
--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -434,9 +434,9 @@ class Trainer:
                 cur_step = self.get_current_step(epoch)
                 self.init_data_loaders(cur_step)
 
-            if isinstance(self.train_sampler, DistributedSampler):
+            if hasattr(self.train_sampler, "set_epoch"):
                 self.train_sampler.set_epoch(epoch)
-            if isinstance(self.val_sampler, DistributedSampler):
+            if hasattr(self.val_sampler, "set_epoch"):
                 self.val_sampler.set_epoch(epoch)
 
             start_epoch_train_time = time.perf_counter()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -888,6 +888,7 @@ class Trainer:
                 datasets=train_datasets,
                 group_key=group_key,
                 batch_size=self.batch_size,
+                num_replicas=1,
                 shuffle=True,
                 drop_last=True,
             )
@@ -896,6 +897,7 @@ class Trainer:
                 datasets=val_datasets,
                 group_key=group_key,
                 batch_size=self.batch_size,
+                num_replicas=1,
                 shuffle=True,
                 drop_last=False,
             )

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -112,7 +112,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             group_key: Callable that extracts grouping key from a dataset.
             batch_size: Number of samples per batch
             num_replicas: Coordinate batches across workers to prevent loading asymmetry.
-                This should prevent NCCL timeouts. Use -1 to turn worker coordination off.
+                This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
 

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -286,7 +286,10 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
                 # the same examples every epoch.
                 all_group_batches = list(itertools.chain.from_iterable(group_chunks))
                 while len(last) < self.num_replicas:
-                    last.append(rng.choice(all_group_batches))
+                    if self.shuffle:
+                        last.append(rng.choice(all_group_batches))
+                    else:
+                        last.append(all_group_batches[-1])
                 group_chunks[-1] = tuple(last)
             if self.shuffle:
                 rng.shuffle(group_chunks)

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -36,7 +36,6 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
         shuffle: Whether to shuffle indices within groups and shuffle batches globally
         drop_last: Whether to drop incomplete batches at the end of each group
-        rng: Random number generator (optional): Use to seed shuffles.
     """
 
     def __init__(
@@ -46,7 +45,6 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         num_replicas: int = 1,
         shuffle: bool = True,
         drop_last: bool = False,
-        rng: random.Random | None = None,
     ):
         super().__init__()
         self.groups = groups
@@ -54,7 +52,6 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         self.num_replicas = num_replicas
         self.shuffle = shuffle
         self.drop_last = drop_last
-        self.rng = rng
 
         # Choose sampler based on shuffle setting
         SubsetSampler = SubsetRandomSampler if self.shuffle else _SimpleSubsetSampler
@@ -76,7 +73,6 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         num_replicas: int = 1,
         shuffle: bool = True,
         drop_last: bool = False,
-        rng: random.Random | None = None,
     ) -> Self:
         """Create sampler from dataset sizes, treating each as a contiguous group.
 
@@ -88,14 +84,13 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
                 This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
-            rng: Random number generator (optional): Use to seed shuffles.
         """
         cumsum = 0
         groups = []
         for size in dataset_sizes:
             groups.append(list(range(cumsum, cumsum + size)))
             cumsum += size
-        return cls(groups, batch_size, num_replicas, shuffle, drop_last, rng)
+        return cls(groups, batch_size, num_replicas, shuffle, drop_last)
 
     @classmethod
     def from_datasets(
@@ -106,7 +101,6 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         num_replicas: int,
         shuffle: bool,
         drop_last: bool,
-        rng: random.Random | None = None,
     ) -> Self:
         """Create sampler by grouping datasets using a key function.
 
@@ -121,7 +115,6 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
                 This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
-            rng: Random number generator (optional): Use to seed shuffles.
 
         Examples:
                 - lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon'])  # group by resolution
@@ -156,48 +149,38 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         sorted_groups = sorted(groups.items(), key=lambda x: x[0])  # type: ignore
         group_indices = [indices for _, indices in sorted_groups]
 
-        return cls(group_indices, batch_size, num_replicas, shuffle, drop_last, rng)
-
-    def _apply_shuffle(self, items: list) -> None:
-        if self.rng:
-            self.rng.shuffle(items)
-        else:
-            random.shuffle(items)
+        return cls(group_indices, batch_size, num_replicas, shuffle, drop_last)
 
     def __iter__(self):
-        # Create batch samplers for each group
-        batch_sampler = itertools.chain(*self._samplers)
+        # Batch within each group and align to num_replicas boundaries so that
+        # consecutive num_replicas batches always belong to the same group.
+        # This prevents different DDP ranks from receiving different-resolution
+        # data in the same training step, which causes load-time asymmetry and
+        # Gloo/NCCL timeouts.
+        per_replica = []
+        move_to_end = []
+        for sampler in self._samplers:
+            pre_replica_per_sample = list(itertools.batched(sampler, self.num_replicas))
+            if (
+                pre_replica_per_sample
+                and len(pre_replica_per_sample[-1]) < self.num_replicas
+            ):
+                move_to_end.append(pre_replica_per_sample.pop())
+            if self.shuffle:
+                random.shuffle(pre_replica_per_sample)
+            per_replica.append(pre_replica_per_sample)
 
-        if not self.shuffle:
-            # No global shuffle: return batches in sequential group order
-            yield from batch_sampler
+        whole_replica_batches = list(itertools.chain.from_iterable(per_replica))
+        if self.shuffle:
+            random.shuffle(whole_replica_batches)
+
+        if self.drop_last:
+            all_replica_batches = whole_replica_batches
         else:
-            # Shuffle batches in a replica-aware way. When num_replicas=1, it behaves
-            # like a global shuffle. When num_replicas>1 and drop_last=False, we move
-            # the "remainder" batch to the very end. This makes timeouts a lot less
-            # likely to occur. In general, we shuffle within replica samples and globally
-            # for replica chunked batches.
-            per_replica = []
-            move_to_end = []
-            for sampler in self._samplers:
-                pre_replica_per_sample = list(
-                    itertools.batched(sampler, self.num_replicas)
-                )
-                if (
-                    pre_replica_per_sample
-                    and len(pre_replica_per_sample[-1]) < self.num_replicas
-                ):
-                    move_to_end.append(pre_replica_per_sample.pop())
-                self._apply_shuffle(pre_replica_per_sample)
-                per_replica.append(pre_replica_per_sample)
-            whole_replica_batches = list(itertools.chain.from_iterable(per_replica))
-            self._apply_shuffle(whole_replica_batches)
-            if self.drop_last:
-                all_replica_batches = whole_replica_batches
-            else:
-                self._apply_shuffle(move_to_end)
-                all_replica_batches = whole_replica_batches + move_to_end
-            yield from itertools.chain.from_iterable(all_replica_batches)
+            if self.shuffle:
+                random.shuffle(move_to_end)
+            all_replica_batches = whole_replica_batches + move_to_end
+        yield from itertools.chain.from_iterable(all_replica_batches)
 
     def __len__(self):
         """Calculate total number of batches across all groups."""
@@ -270,34 +253,53 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
             group_key=group_key,
             batch_size=batch_size,
             num_replicas=num_replicas,
-            shuffle=self.shuffle,
+            shuffle=False,  # We handle shuffling with seeded RNG
             drop_last=drop_last,
-            rng=random.Random(self.seed + self.epoch),
         )
 
     def set_epoch(self, epoch: int) -> None:
         """Set the epoch for deterministic shuffling across workers."""
         self.epoch = epoch
-        self._inner.rng = random.Random(self.seed + self.epoch)
 
     def __iter__(self):
-        # Get all batches from inner sampler (deterministic order)
-        all_batches = list(self._inner)
+        rng = random.Random(self.seed + self.epoch)
+
+        # Chunk each group's batches by num_replicas so that consecutive
+        # num_replicas batches always come from the same resolution group.
+        # This prevents different DDP ranks from receiving different-resolution
+        # data in the same training step, which causes load-time asymmetry and
+        # Gloo/NCCL timeouts.
+        chunks: list[tuple] = []
+        for sampler in self._inner._samplers:
+            group_chunks = list(itertools.batched(sampler, self.num_replicas))
+            if group_chunks and len(group_chunks[-1]) < self.num_replicas:
+                if self.drop_last:
+                    group_chunks.pop()
+                else:
+                    # Pad the incomplete chunk with duplicates from the same
+                    # group so every chunk is homogeneous and full-sized.
+                    last = list(group_chunks[-1])
+                    while len(last) < self.num_replicas:
+                        last.append(last[-1])
+                    group_chunks[-1] = tuple(last)
+            if self.shuffle:
+                rng.shuffle(group_chunks)
+            chunks.extend(group_chunks)
+
+        if self.shuffle:
+            rng.shuffle(chunks)
+
+        # Flatten chunks back to a list of batches. Every consecutive
+        # num_replicas batches now belong to the same resolution group.
+        all_batches = list(itertools.chain.from_iterable(chunks))
 
         # Ensure uniform batch count across all ranks to prevent DDP hangs.
-        # When shuffle=True, the inner sampler's replica-aware batching already
-        # trims for drop_last. When shuffle=False, it doesn't, so we must trim
-        # here. The trim is a no-op when already divisible, so it's always safe.
         total = len(all_batches)
         if self.drop_last:
             num_batches_per_rank = total // self.num_replicas
             all_batches = all_batches[: num_batches_per_rank * self.num_replicas]
-            total = len(all_batches)
-        if not self.drop_last:
-            # Pad to ensure divisibility (ceiling division)
+        else:
             num_batches_per_rank = (total + self.num_replicas - 1) // self.num_replicas
-            # Pad by wrapping around from the beginning (may wrap multiple times
-            # if total < num_replicas)
             padding_size = num_batches_per_rank * self.num_replicas - total
             if padding_size > 0:
                 all_batches = all_batches + [

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -190,7 +190,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         """Calculate total number of batches across all groups."""
         total_batches = 0
         for sampler in self._samplers:
-            if self.num_replicas != -1 and self.drop_last:
+            if self.num_replicas > 0 and self.drop_last:
                 total_batches += (len(sampler) // self.num_replicas) * self.num_replicas
             else:
                 total_batches += len(sampler)

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -291,7 +291,7 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
                             last.append(rng.choice(all_group_batches))
                         else:
                             last.append(all_group_batches[-1])
-                        group_chunks[-1] = tuple(last)
+                    group_chunks[-1] = tuple(last)
             if self.shuffle:
                 rng.shuffle(group_chunks)
             chunks.extend(group_chunks)
@@ -325,9 +325,11 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
         n = self.num_replicas
         total = 0
         for sampler in self._inner._samplers:
-            # Per-group chunks are always padded to num_replicas (never
-            # dropped), so use ceil here regardless of drop_last.
-            total += math.ceil(len(sampler) / n) * n
+            group_len = len(sampler)
+            if self.drop_last:
+                total += (group_len // n) * n
+            else:
+                total += math.ceil(group_len / n) * n
         if self.drop_last:
             return total // n
         else:

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -281,8 +281,12 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
                 # batches than num_replicas; global trimming below handles
                 # drop_last instead.
                 last = list(group_chunks[-1])
+                # Sample from all of this group's batches (not just the
+                # tail) so padding doesn't systematically over-weight
+                # the same examples every epoch.
+                all_group_batches = list(itertools.chain.from_iterable(group_chunks))
                 while len(last) < self.num_replicas:
-                    last.append(last[-1])
+                    last.append(rng.choice(all_group_batches))
                 group_chunks[-1] = tuple(last)
             if self.shuffle:
                 rng.shuffle(group_chunks)

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -274,15 +274,16 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
         for sampler in self._inner._samplers:
             group_chunks = list(itertools.batched(sampler, self.num_replicas))
             if group_chunks and len(group_chunks[-1]) < self.num_replicas:
-                if self.drop_last:
-                    group_chunks.pop()
-                else:
-                    # Pad the incomplete chunk with duplicates from the same
-                    # group so every chunk is homogeneous and full-sized.
-                    last = list(group_chunks[-1])
-                    while len(last) < self.num_replicas:
-                        last.append(last[-1])
-                    group_chunks[-1] = tuple(last)
+                # Always pad incomplete chunks so every chunk is homogeneous
+                # and full-sized. Without padding, an incomplete chunk would
+                # break the stride alignment for all subsequent chunks.
+                # Dropping here would erase entire groups that have fewer
+                # batches than num_replicas; global trimming below handles
+                # drop_last instead.
+                last = list(group_chunks[-1])
+                while len(last) < self.num_replicas:
+                    last.append(last[-1])
+                group_chunks[-1] = tuple(last)
             if self.shuffle:
                 rng.shuffle(group_chunks)
             chunks.extend(group_chunks)
@@ -316,11 +317,9 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
         n = self.num_replicas
         total = 0
         for sampler in self._inner._samplers:
-            group_len = len(sampler)
-            if self.drop_last:
-                total += (group_len // n) * n
-            else:
-                total += math.ceil(group_len / n) * n
+            # Per-group chunks are always padded to num_replicas (never
+            # dropped), so use ceil here regardless of drop_last.
+            total += math.ceil(len(sampler) / n) * n
         if self.drop_last:
             return total // n
         else:

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -32,8 +32,8 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         groups: List of index lists, where each inner list contains indices belonging to
             the same equivalence group.
         batch_size: Number of samples per batch
-        n_workers: Coordinate batches across workers to prevent loading asymmetry.
-            This should prevent NCCL timeouts. Use -1 to turn worker coordination off.
+        num_replicas: Coordinate batches across workers to prevent loading asymmetry.
+            This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
         shuffle: Whether to shuffle indices within groups and shuffle batches globally
         drop_last: Whether to drop incomplete batches at the end of each group
     """
@@ -42,14 +42,14 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         self,
         groups: list[list[int]],
         batch_size: int,
-        n_workers: int = -1,
+        num_replicas: int = 1,
         shuffle: bool = True,
         drop_last: bool = False,
     ):
         super().__init__()
         self.groups = groups
         self.batch_size = batch_size
-        self.n_workers = n_workers
+        self.num_replicas = num_replicas
         self.shuffle = shuffle
         self.drop_last = drop_last
 
@@ -70,7 +70,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         cls,
         dataset_sizes: list[int],
         batch_size: int,
-        n_workers: int = -1,
+        num_replicas: int = 1,
         shuffle: bool = True,
         drop_last: bool = False,
     ) -> Self:
@@ -80,8 +80,8 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             dataset_sizes: List of individual dataset sizes. Groups are created based on
                 cumulative boundaries, where each dataset forms its own equivalence group.
             batch_size: Number of samples per batch
-            n_workers: Coordinate batches across workers to prevent loading asymmetry.
-                This should prevent NCCL timeouts. Use -1 to turn worker coordination off.
+            num_replicas: Coordinate batches across workers to prevent loading asymmetry.
+                This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
         """
@@ -90,7 +90,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         for size in dataset_sizes:
             groups.append(list(range(cumsum, cumsum + size)))
             cumsum += size
-        return cls(groups, batch_size, n_workers, shuffle, drop_last)
+        return cls(groups, batch_size, num_replicas, shuffle, drop_last)
 
     @classmethod
     def from_datasets(
@@ -98,7 +98,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         datasets: list["TorchTrainDataset"],
         group_key: Callable[["TorchTrainDataset"], Hashable],
         batch_size: int,
-        n_workers: int,
+        num_replicas: int,
         shuffle: bool,
         drop_last: bool,
     ) -> Self:
@@ -111,7 +111,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             datasets: List of TorchTrainDataset instances to group
             group_key: Callable that extracts grouping key from a dataset.
             batch_size: Number of samples per batch
-            n_workers: Coordinate batches across workers to prevent loading asymmetry.
+            num_replicas: Coordinate batches across workers to prevent loading asymmetry.
                 This should prevent NCCL timeouts. Use -1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
@@ -152,7 +152,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         sorted_groups = sorted(groups.items(), key=lambda x: x[0])  # type: ignore
         group_indices = [indices for _, indices in sorted_groups]
 
-        return cls(group_indices, batch_size, n_workers, shuffle, drop_last)
+        return cls(group_indices, batch_size, num_replicas, shuffle, drop_last)
 
     def __iter__(self):
         # Create batch samplers for each group
@@ -161,38 +161,37 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         if not self.shuffle:
             # No global shuffle: return batches in sequential group order
             yield from batch_sampler
-        elif self.n_workers != -1:
-            per_worker = []
+        else:
+            # Shuffle batches in a replica-aware way. When num_replicas=1, it behaves
+            # like a global shuffle. When num_replicas>1 and drop_last=False, we move
+            # the "remainder" batch to the very end. This makes timeouts a lot less
+            # likely to occur. In general, we shuffle within replica samples and globally
+            # for replica chunked batches.
+            per_replica = []
             move_to_end = []
             for sampler in self._samplers:
-                per_worker_per_sampler = list(
-                    itertools.batched(sampler, self.n_workers)
+                pre_replica_per_sample = list(
+                    itertools.batched(sampler, self.num_replicas)
                 )
-                if len(per_worker_per_sampler[-1]) < self.n_workers:
-                    move_to_end.append(per_worker_per_sampler.pop())
-                random.shuffle(per_worker_per_sampler)
-                per_worker.append(per_worker_per_sampler)
-            whole_worker_batches = list(itertools.chain(*per_worker))
-            random.shuffle(whole_worker_batches)
+                if len(pre_replica_per_sample[-1]) < self.num_replicas:
+                    move_to_end.append(pre_replica_per_sample.pop())
+                random.shuffle(pre_replica_per_sample)
+                per_replica.append(pre_replica_per_sample)
+            whole_replica_batches = list(itertools.chain.from_iterable(per_replica))
+            random.shuffle(whole_replica_batches)
             if self.drop_last:
-                all_worker_batches = whole_worker_batches
+                all_replica_batches = whole_replica_batches
             else:
                 random.shuffle(move_to_end)
-                all_worker_batches = whole_worker_batches + move_to_end
-            yield from itertools.chain.from_iterable(all_worker_batches)
-        else:
-            # Shuffle batches globally to avoid sequential group processing
-            # This is regenerated each epoch, giving different orderings
-            all_batches = list(batch_sampler)
-            random.shuffle(all_batches)
-            yield from all_batches
+                all_replica_batches = whole_replica_batches + move_to_end
+            yield from itertools.chain.from_iterable(all_replica_batches)
 
     def __len__(self):
         """Calculate total number of batches across all groups."""
         total_batches = 0
         for sampler in self._samplers:
-            if self.n_workers != -1 and self.drop_last:
-                total_batches += (len(sampler) // self.n_workers) * self.n_workers
+            if self.num_replicas != -1 and self.drop_last:
+                total_batches += (len(sampler) // self.num_replicas) * self.num_replicas
             else:
                 total_batches += len(sampler)
 
@@ -257,7 +256,7 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
             datasets=datasets,
             group_key=group_key,
             batch_size=batch_size,
-            n_workers=-1,
+            num_replicas=num_replicas,
             shuffle=False,  # We handle shuffling with seeded RNG
             drop_last=drop_last,
         )
@@ -272,8 +271,17 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
 
         # Shuffle with seeded RNG so all workers get identical ordering
         if self.shuffle:
+            per_replica = list(itertools.batched(all_batches, self.num_replicas))
+            last_replica = []
+            if len(per_replica[-1]) % self.num_replicas != 0:
+                if self.drop_last:
+                    per_replica = per_replica[:-1]
+                else:
+                    last_replica = [per_replica.pop()]
             rng = random.Random(self.seed + self.epoch)
-            rng.shuffle(all_batches)
+            rng.shuffle(per_replica)
+            per_replica = per_replica + last_replica
+            all_batches = list(itertools.chain.from_iterable(per_replica))
 
         # Ensure uniform batch count across all ranks to prevent DDP hangs.
         # Similar to torch.utils.data.DistributedSampler behavior:

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -274,23 +274,24 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
         for sampler in self._inner._samplers:
             group_chunks = list(itertools.batched(sampler, self.num_replicas))
             if group_chunks and len(group_chunks[-1]) < self.num_replicas:
-                # Always pad incomplete chunks so every chunk is homogeneous
-                # and full-sized. Without padding, an incomplete chunk would
-                # break the stride alignment for all subsequent chunks.
-                # Dropping here would erase entire groups that have fewer
-                # batches than num_replicas; global trimming below handles
-                # drop_last instead.
-                last = list(group_chunks[-1])
-                # Sample from all of this group's batches (not just the
-                # tail) so padding doesn't systematically over-weight
-                # the same examples every epoch.
-                all_group_batches = list(itertools.chain.from_iterable(group_chunks))
-                while len(last) < self.num_replicas:
-                    if self.shuffle:
-                        last.append(rng.choice(all_group_batches))
-                    else:
-                        last.append(all_group_batches[-1])
-                group_chunks[-1] = tuple(last)
+                if self.drop_last:
+                    group_chunks.pop()
+                else:
+                    # Pad the incomplete chunk with duplicates from the same
+                    # group so every chunk is homogeneous and full-sized.
+                    last = list(group_chunks[-1])
+                    # Sample from all of this group's batches (not just the
+                    # tail) so padding doesn't systematically over-weight
+                    # the same examples every epoch.
+                    all_group_batches = list(
+                        itertools.chain.from_iterable(group_chunks)
+                    )
+                    while len(last) < self.num_replicas:
+                        if self.shuffle:
+                            last.append(rng.choice(all_group_batches))
+                        else:
+                            last.append(all_group_batches[-1])
+                        group_chunks[-1] = tuple(last)
             if self.shuffle:
                 rng.shuffle(group_chunks)
             chunks.extend(group_chunks)

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -32,6 +32,8 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         groups: List of index lists, where each inner list contains indices belonging to
             the same equivalence group.
         batch_size: Number of samples per batch
+        n_workers: Coordinate batches across workers to prevent loading asymmetry.
+            This should prevent NCCL timeouts. Use -1 to turn worker coordination off.
         shuffle: Whether to shuffle indices within groups and shuffle batches globally
         drop_last: Whether to drop incomplete batches at the end of each group
     """
@@ -40,12 +42,14 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         self,
         groups: list[list[int]],
         batch_size: int,
+        n_workers: int = -1,
         shuffle: bool = True,
         drop_last: bool = False,
     ):
         super().__init__()
         self.groups = groups
         self.batch_size = batch_size
+        self.n_workers = n_workers
         self.shuffle = shuffle
         self.drop_last = drop_last
 
@@ -66,6 +70,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         cls,
         dataset_sizes: list[int],
         batch_size: int,
+        n_workers: int = -1,
         shuffle: bool = True,
         drop_last: bool = False,
     ) -> Self:
@@ -75,6 +80,8 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             dataset_sizes: List of individual dataset sizes. Groups are created based on
                 cumulative boundaries, where each dataset forms its own equivalence group.
             batch_size: Number of samples per batch
+            n_workers: Coordinate batches across workers to prevent loading asymmetry.
+                This should prevent NCCL timeouts. Use -1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
         """
@@ -83,7 +90,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         for size in dataset_sizes:
             groups.append(list(range(cumsum, cumsum + size)))
             cumsum += size
-        return cls(groups, batch_size, shuffle, drop_last)
+        return cls(groups, batch_size, n_workers, shuffle, drop_last)
 
     @classmethod
     def from_datasets(
@@ -91,6 +98,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         datasets: list["TorchTrainDataset"],
         group_key: Callable[["TorchTrainDataset"], Hashable],
         batch_size: int,
+        n_workers: int,
         shuffle: bool,
         drop_last: bool,
     ) -> Self:
@@ -103,6 +111,8 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             datasets: List of TorchTrainDataset instances to group
             group_key: Callable that extracts grouping key from a dataset.
             batch_size: Number of samples per batch
+            n_workers: Coordinate batches across workers to prevent loading asymmetry.
+                This should prevent NCCL timeouts. Use -1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
 
@@ -142,7 +152,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         sorted_groups = sorted(groups.items(), key=lambda x: x[0])  # type: ignore
         group_indices = [indices for _, indices in sorted_groups]
 
-        return cls(group_indices, batch_size, shuffle, drop_last)
+        return cls(group_indices, batch_size, n_workers, shuffle, drop_last)
 
     def __iter__(self):
         # Create batch samplers for each group
@@ -151,6 +161,25 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         if not self.shuffle:
             # No global shuffle: return batches in sequential group order
             yield from batch_sampler
+        elif self.n_workers != -1:
+            per_worker = []
+            move_to_end = []
+            for sampler in self._samplers:
+                per_worker_per_sampler = list(
+                    itertools.batched(sampler, self.n_workers)
+                )
+                if len(per_worker_per_sampler[-1]) < self.n_workers:
+                    move_to_end.append(per_worker_per_sampler.pop())
+                random.shuffle(per_worker_per_sampler)
+                per_worker.append(per_worker_per_sampler)
+            whole_worker_batches = list(itertools.chain(*per_worker))
+            random.shuffle(whole_worker_batches)
+            if self.drop_last:
+                all_worker_batches = whole_worker_batches
+            else:
+                random.shuffle(move_to_end)
+                all_worker_batches = whole_worker_batches + move_to_end
+            yield from itertools.chain.from_iterable(all_worker_batches)
         else:
             # Shuffle batches globally to avoid sequential group processing
             # This is regenerated each epoch, giving different orderings
@@ -162,7 +191,10 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         """Calculate total number of batches across all groups."""
         total_batches = 0
         for sampler in self._samplers:
-            total_batches += len(sampler)
+            if self.n_workers != -1 and self.drop_last:
+                total_batches += (len(sampler) // self.n_workers) * self.n_workers
+            else:
+                total_batches += len(sampler)
 
         return total_batches
 
@@ -225,6 +257,7 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
             datasets=datasets,
             group_key=group_key,
             batch_size=batch_size,
+            n_workers=-1,
             shuffle=False,  # We handle shuffling with seeded RNG
             drop_last=drop_last,
         )

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -273,12 +273,13 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
         if self.shuffle:
             per_replica = list(itertools.batched(all_batches, self.num_replicas))
             last_replica = []
+            rng = random.Random(self.seed + self.epoch)
             if len(per_replica[-1]) % self.num_replicas != 0:
                 if self.drop_last:
                     per_replica = per_replica[:-1]
                 else:
                     last_replica = [per_replica.pop()]
-            rng = random.Random(self.seed + self.epoch)
+                    rng.shuffle(last_replica)
             rng.shuffle(per_replica)
             per_replica = per_replica + last_replica
             all_batches = list(itertools.chain.from_iterable(per_replica))

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -173,7 +173,10 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
                 pre_replica_per_sample = list(
                     itertools.batched(sampler, self.num_replicas)
                 )
-                if len(pre_replica_per_sample[-1]) < self.num_replicas:
+                if (
+                    pre_replica_per_sample
+                    and len(pre_replica_per_sample[-1]) < self.num_replicas
+                ):
                     move_to_end.append(pre_replica_per_sample.pop())
                 random.shuffle(pre_replica_per_sample)
                 per_replica.append(pre_replica_per_sample)

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -299,22 +299,10 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
         if self.shuffle:
             rng.shuffle(chunks)
 
-        # Flatten chunks back to a list of batches. Every consecutive
-        # num_replicas batches now belong to the same resolution group.
+        # Per-group chunking above already ensures len is a multiple of num_replicas,
+        # so every consecutive num_replicas batches belong to the same group.
         all_batches = list(itertools.chain.from_iterable(chunks))
-
-        # Ensure uniform batch count across all ranks to prevent DDP hangs.
-        total = len(all_batches)
-        if self.drop_last:
-            num_batches_per_rank = total // self.num_replicas
-            all_batches = all_batches[: num_batches_per_rank * self.num_replicas]
-        else:
-            num_batches_per_rank = (total + self.num_replicas - 1) // self.num_replicas
-            padding_size = num_batches_per_rank * self.num_replicas - total
-            if padding_size > 0:
-                all_batches = all_batches + [
-                    all_batches[i % total] for i in range(padding_size)
-                ]
+        assert len(all_batches) % self.num_replicas == 0
 
         # Each worker takes every num_replicas'th batch starting at rank
         for i in range(self.rank, len(all_batches), self.num_replicas):

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -36,6 +36,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
             This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
         shuffle: Whether to shuffle indices within groups and shuffle batches globally
         drop_last: Whether to drop incomplete batches at the end of each group
+        rng: Random number generator (optional): Use to seed shuffles.
     """
 
     def __init__(
@@ -45,6 +46,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         num_replicas: int = 1,
         shuffle: bool = True,
         drop_last: bool = False,
+        rng: random.Random | None = None,
     ):
         super().__init__()
         self.groups = groups
@@ -52,6 +54,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         self.num_replicas = num_replicas
         self.shuffle = shuffle
         self.drop_last = drop_last
+        self.rng = rng
 
         # Choose sampler based on shuffle setting
         SubsetSampler = SubsetRandomSampler if self.shuffle else _SimpleSubsetSampler
@@ -73,6 +76,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         num_replicas: int = 1,
         shuffle: bool = True,
         drop_last: bool = False,
+        rng: random.Random | None = None,
     ) -> Self:
         """Create sampler from dataset sizes, treating each as a contiguous group.
 
@@ -84,13 +88,14 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
                 This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
+            rng: Random number generator (optional): Use to seed shuffles.
         """
         cumsum = 0
         groups = []
         for size in dataset_sizes:
             groups.append(list(range(cumsum, cumsum + size)))
             cumsum += size
-        return cls(groups, batch_size, num_replicas, shuffle, drop_last)
+        return cls(groups, batch_size, num_replicas, shuffle, drop_last, rng)
 
     @classmethod
     def from_datasets(
@@ -101,6 +106,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         num_replicas: int,
         shuffle: bool,
         drop_last: bool,
+        rng: random.Random | None = None,
     ) -> Self:
         """Create sampler by grouping datasets using a key function.
 
@@ -115,13 +121,11 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
                 This should prevent NCCL timeouts. Use 1 to turn worker coordination off.
             shuffle: Whether to shuffle indices within groups and shuffle batches globally
             drop_last: Whether to drop incomplete batches at the end of each group
+            rng: Random number generator (optional): Use to seed shuffles.
 
         Examples:
                 - lambda ds: (ds._input_src.data.sizes['lat'], ds._input_src.data.sizes['lon'])  # group by resolution
                 - lambda ds: ds._input_src.data.sizes['lat']  # group by latitude size only
-            batch_size: Number of samples per batch
-            shuffle: Whether to shuffle indices within groups and shuffle batches globally
-            drop_last: Whether to drop incomplete batches at the end of each group
 
         Returns:
             EquivalenceGroupBatchSampler configured to group by the provided key
@@ -152,7 +156,13 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         sorted_groups = sorted(groups.items(), key=lambda x: x[0])  # type: ignore
         group_indices = [indices for _, indices in sorted_groups]
 
-        return cls(group_indices, batch_size, num_replicas, shuffle, drop_last)
+        return cls(group_indices, batch_size, num_replicas, shuffle, drop_last, rng)
+
+    def _apply_shuffle(self, items: list) -> None:
+        if self.rng:
+            self.rng.shuffle(items)
+        else:
+            random.shuffle(items)
 
     def __iter__(self):
         # Create batch samplers for each group
@@ -178,14 +188,14 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
                     and len(pre_replica_per_sample[-1]) < self.num_replicas
                 ):
                     move_to_end.append(pre_replica_per_sample.pop())
-                random.shuffle(pre_replica_per_sample)
+                self._apply_shuffle(pre_replica_per_sample)
                 per_replica.append(pre_replica_per_sample)
             whole_replica_batches = list(itertools.chain.from_iterable(per_replica))
-            random.shuffle(whole_replica_batches)
+            self._apply_shuffle(whole_replica_batches)
             if self.drop_last:
                 all_replica_batches = whole_replica_batches
             else:
-                random.shuffle(move_to_end)
+                self._apply_shuffle(move_to_end)
                 all_replica_batches = whole_replica_batches + move_to_end
             yield from itertools.chain.from_iterable(all_replica_batches)
 
@@ -193,7 +203,7 @@ class EquivalenceGroupBatchSampler(Sampler[list[int]]):
         """Calculate total number of batches across all groups."""
         total_batches = 0
         for sampler in self._samplers:
-            if self.num_replicas > 0 and self.drop_last:
+            if self.num_replicas > 1 and self.drop_last:
                 total_batches += (len(sampler) // self.num_replicas) * self.num_replicas
             else:
                 total_batches += len(sampler)
@@ -260,44 +270,30 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
             group_key=group_key,
             batch_size=batch_size,
             num_replicas=num_replicas,
-            shuffle=False,  # We handle shuffling with seeded RNG
+            shuffle=self.shuffle,
             drop_last=drop_last,
+            rng=random.Random(self.seed + self.epoch),
         )
 
     def set_epoch(self, epoch: int) -> None:
         """Set the epoch for deterministic shuffling across workers."""
         self.epoch = epoch
+        self._inner.rng = random.Random(self.seed + self.epoch)
 
     def __iter__(self):
         # Get all batches from inner sampler (deterministic order)
         all_batches = list(self._inner)
 
-        # Shuffle with seeded RNG so all workers get identical ordering
-        if self.shuffle:
-            per_replica = list(itertools.batched(all_batches, self.num_replicas))
-            last_replica = []
-            rng = random.Random(self.seed + self.epoch)
-            if len(per_replica[-1]) % self.num_replicas != 0:
-                if self.drop_last:
-                    per_replica = per_replica[:-1]
-                else:
-                    last_replica = [per_replica.pop()]
-                    rng.shuffle(last_replica)
-            rng.shuffle(per_replica)
-            per_replica = per_replica + last_replica
-            all_batches = list(itertools.chain.from_iterable(per_replica))
-
         # Ensure uniform batch count across all ranks to prevent DDP hangs.
-        # Similar to torch.utils.data.DistributedSampler behavior:
-        # - drop_last=True: trim to largest multiple of num_replicas
-        # - drop_last=False: pad by duplicating batches to reach next multiple
+        # When shuffle=True, the inner sampler's replica-aware batching already
+        # trims for drop_last. When shuffle=False, it doesn't, so we must trim
+        # here. The trim is a no-op when already divisible, so it's always safe.
         total = len(all_batches)
         if self.drop_last:
-            # Trim to ensure divisibility
             num_batches_per_rank = total // self.num_replicas
-            total_batches_to_use = num_batches_per_rank * self.num_replicas
-            all_batches = all_batches[:total_batches_to_use]
-        else:
+            all_batches = all_batches[: num_batches_per_rank * self.num_replicas]
+            total = len(all_batches)
+        if not self.drop_last:
             # Pad to ensure divisibility (ceiling division)
             num_batches_per_rank = (total + self.num_replicas - 1) // self.num_replicas
             # Pad by wrapping around from the beginning (may wrap multiple times

--- a/src/ocean_emulators/utils/samplers.py
+++ b/src/ocean_emulators/utils/samplers.py
@@ -1,4 +1,5 @@
 import itertools
+import math
 import random
 from collections.abc import Callable, Hashable
 from typing import TYPE_CHECKING, Self
@@ -312,8 +313,15 @@ class DistributedEquivalenceGroupBatchSampler(Sampler[list[int]]):
 
     def __len__(self):
         """Number of batches for this worker (same for all ranks)."""
-        total_batches = len(self._inner)
+        n = self.num_replicas
+        total = 0
+        for sampler in self._inner._samplers:
+            group_len = len(sampler)
+            if self.drop_last:
+                total += (group_len // n) * n
+            else:
+                total += math.ceil(group_len / n) * n
         if self.drop_last:
-            return total_batches // self.num_replicas
+            return total // n
         else:
-            return (total_batches + self.num_replicas - 1) // self.num_replicas
+            return math.ceil(total / n)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -153,6 +153,7 @@ def make_loader(
                     group_key=lambda ds: tuple(
                         prog.grid_size for prog in ds.prognostic_srcs
                     ),
+                    num_replicas=1,
                     batch_size=cfg.batch_size,
                     drop_last=drop_last,
                     shuffle=shuffle,

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,3 +1,4 @@
+import itertools
 import random
 
 import pytest
@@ -32,6 +33,7 @@ def sampler_from_datasets(request):
                 datasets=datasets,
                 group_key=group_key,
                 batch_size=batch_size,
+                n_workers=-1,
                 shuffle=shuffle,
                 drop_last=drop_last,
             )
@@ -384,3 +386,61 @@ class TestDistributedBatchSamplerDistribution:
                 shuffle=False,
                 drop_last=False,
             )
+
+
+def test_group_batch_sampler__n_workers__splits_into_worker_batches():
+    ds_size = 20
+    n_workers = 8
+    datasets = [
+        MockDataset(ds_size, grid_size=(10, 20)),
+        MockDataset(ds_size, grid_size=(5, 10)),
+    ]
+    batch_sampler = EquivalenceGroupBatchSampler.from_datasets(
+        datasets,  # type: ignore[arg-type]
+        group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
+        batch_size=2,
+        n_workers=n_workers,
+        shuffle=True,
+        drop_last=True,
+    )
+    assert len(batch_sampler) % n_workers == 0, (
+        "when both n_workers and drop_last are set, we drop batches that don't fit into the n_workers."
+    )
+
+    batches = list(batch_sampler)
+
+    worker_batches = list(itertools.batched(batches, n_workers))
+    for w_batch in worker_batches:
+        batch = list(itertools.chain.from_iterable(w_batch))
+        assert all(b >= ds_size for b in batch) or all(b < ds_size for b in batch), (
+            "Cannot mix dataset batches within grouping of workers."
+        )
+
+
+def test_group_batch_sampler__n_workers_no_drop_last__moves_awkward_batches_to_the_end():
+    ds_size = 20
+    n_workers = 8
+    datasets = [
+        MockDataset(ds_size, grid_size=(10, 20)),
+        MockDataset(ds_size, grid_size=(5, 10)),
+    ]
+    batch_sampler = EquivalenceGroupBatchSampler.from_datasets(
+        datasets,  # type: ignore[arg-type]
+        group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
+        batch_size=2,
+        n_workers=n_workers,
+        shuffle=True,
+        drop_last=False,
+    )
+    assert len(batch_sampler) % n_workers != 0, (
+        "We don't neatly divide the number of workers"
+    )
+
+    batches = list(batch_sampler)
+
+    worker_batches = list(itertools.batched(batches, n_workers))
+    for w_batch in worker_batches[:-1]:
+        batch = list(itertools.chain.from_iterable(w_batch))
+        assert all(b >= ds_size for b in batch) or all(b < ds_size for b in batch), (
+            "Cannot mix dataset batches within grouping of workers."
+        )

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -44,7 +44,7 @@ def sampler_from_datasets(request):
                 datasets=datasets,
                 group_key=group_key,
                 batch_size=batch_size,
-                num_replicas=num_replicas,  # Single worker to match standard behavior
+                num_replicas=num_replicas,
                 rank=0,
                 shuffle=shuffle,
                 drop_last=drop_last,

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -298,10 +298,11 @@ class TestDistributedBatchSamplerDistribution:
             )
             all_batches.extend(list(sampler))
 
-        # With 10 batches and 3 replicas, trimming gives 9 batches (3 per worker)
-        # So we should have 9 batches * 2 samples = 18 indices (not all 20)
+        # With 10 batches and 3 replicas, per-group chunks are padded to 12
+        # (not dropped) to avoid erasing small groups. 12 / 3 = 4 per rank.
+        # 4 batches * 3 ranks * 2 samples = 24 indices.
         all_indices = [idx for batch in all_batches for idx in batch]
-        assert len(all_indices) == 18
+        assert len(all_indices) == 24
 
     def test_set_epoch_changes_ordering(self):
         """Different epochs should produce different batch orderings."""

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -390,56 +390,105 @@ class TestDistributedBatchSamplerDistribution:
             )
 
 
-def test_group_batch_sampler__n_workers__splits_into_worker_batches(
-    sampler_from_datasets,
-):
+def test_group_batch_sampler__standard__replica_chunks_are_homogeneous():
+    """For the non-distributed sampler, consecutive num_replicas batches are from the same group."""
     ds_size = 20
     n_workers = 8
     datasets = [
         MockDataset(ds_size, grid_size=(10, 20)),
         MockDataset(ds_size, grid_size=(5, 10)),
     ]
-    batch_sampler = sampler_from_datasets(
-        datasets,  # type: ignore[arg-type]
+    sampler = EquivalenceGroupBatchSampler.from_datasets(
+        datasets=datasets,  # type: ignore[arg-type]
         group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
         batch_size=2,
         num_replicas=n_workers,
         shuffle=True,
         drop_last=True,
     )
-    batches = list(batch_sampler)
-
-    worker_batches = list(itertools.batched(batches, n_workers))
-    for w_batch in worker_batches:
-        batch = list(itertools.chain.from_iterable(w_batch))
-        assert all(b >= ds_size for b in batch) or all(b < ds_size for b in batch), (
-            "Cannot mix dataset batches within grouping of workers."
-        )
+    batches = list(sampler)
+    for chunk in itertools.batched(batches, n_workers):
+        indices = list(itertools.chain.from_iterable(chunk))
+        assert all(b >= ds_size for b in indices) or all(
+            b < ds_size for b in indices
+        ), "Cannot mix dataset batches within a replica chunk."
 
 
-def test_group_batch_sampler__n_workers_no_drop_last__moves_awkward_batches_to_the_end(
-    sampler_from_datasets,
-):
+def test_group_batch_sampler__distributed__replica_chunks_are_homogeneous():
+    """All DDP ranks at the same step must process batches from the same group."""
     ds_size = 20
     n_workers = 8
     datasets = [
         MockDataset(ds_size, grid_size=(10, 20)),
         MockDataset(ds_size, grid_size=(5, 10)),
     ]
-    batch_sampler = sampler_from_datasets(
-        datasets,  # type: ignore[arg-type]
-        group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
-        batch_size=2,
-        num_replicas=n_workers,
-        shuffle=True,
-        drop_last=False,
-    )
 
-    batches = list(batch_sampler)
-
-    worker_batches = list(itertools.batched(batches, n_workers))
-    for w_batch in worker_batches[:-1]:
-        batch = list(itertools.chain.from_iterable(w_batch))
-        assert all(b >= ds_size for b in batch) or all(b < ds_size for b in batch), (
-            "Cannot mix dataset batches within grouping of workers."
+    # Collect each rank's batches
+    rank_batches = []
+    for rank in range(n_workers):
+        sampler = DistributedEquivalenceGroupBatchSampler(
+            datasets=datasets,  # type: ignore[arg-type]
+            group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
+            batch_size=2,
+            num_replicas=n_workers,
+            rank=rank,
+            shuffle=True,
+            drop_last=True,
         )
+        rank_batches.append(list(sampler))
+
+    # All ranks must have the same number of batches
+    counts = [len(rb) for rb in rank_batches]
+    assert len(set(counts)) == 1, f"Ranks have different batch counts: {counts}"
+
+    # At each step, all ranks should process the same group
+    batches_per_rank = counts[0]
+    for step in range(batches_per_rank):
+        step_indices = list(
+            itertools.chain.from_iterable(
+                rank_batches[r][step] for r in range(n_workers)
+            )
+        )
+        assert all(b >= ds_size for b in step_indices) or all(
+            b < ds_size for b in step_indices
+        ), f"Step {step}: ranks process mixed groups. Indices: {step_indices}"
+
+
+def test_group_batch_sampler__n_workers_no_drop_last__moves_awkward_batches_to_the_end():
+    """Without drop_last, all steps except possibly the last should be homogeneous across ranks."""
+    ds_size = 20
+    n_workers = 8
+    datasets = [
+        MockDataset(ds_size, grid_size=(10, 20)),
+        MockDataset(ds_size, grid_size=(5, 10)),
+    ]
+
+    # Collect each rank's batches
+    rank_batches = []
+    for rank in range(n_workers):
+        sampler = DistributedEquivalenceGroupBatchSampler(
+            datasets=datasets,  # type: ignore[arg-type]
+            group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
+            batch_size=2,
+            num_replicas=n_workers,
+            rank=rank,
+            shuffle=True,
+            drop_last=False,
+        )
+        rank_batches.append(list(sampler))
+
+    # All ranks must have the same number of batches
+    counts = [len(rb) for rb in rank_batches]
+    assert len(set(counts)) == 1, f"Ranks have different batch counts: {counts}"
+
+    # All steps except possibly the last should be homogeneous across ranks
+    batches_per_rank = counts[0]
+    for step in range(batches_per_rank - 1):
+        step_indices = list(
+            itertools.chain.from_iterable(
+                rank_batches[r][step] for r in range(n_workers)
+            )
+        )
+        assert all(b >= ds_size for b in step_indices) or all(
+            b < ds_size for b in step_indices
+        ), f"Step {step}: ranks process mixed groups. Indices: {step_indices}"

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -454,8 +454,8 @@ def test_group_batch_sampler__distributed__replica_chunks_are_homogeneous():
         ), f"Step {step}: ranks process mixed groups. Indices: {step_indices}"
 
 
-def test_group_batch_sampler__n_workers_no_drop_last__moves_awkward_batches_to_the_end():
-    """Without drop_last, all steps except possibly the last should be homogeneous across ranks."""
+def test_group_batch_sampler__n_workers_no_drop_last__all_steps_homogeneous():
+    """With per-group padding, every step should be homogeneous across ranks."""
     ds_size = 20
     n_workers = 8
     datasets = [
@@ -481,9 +481,8 @@ def test_group_batch_sampler__n_workers_no_drop_last__moves_awkward_batches_to_t
     counts = [len(rb) for rb in rank_batches]
     assert len(set(counts)) == 1, f"Ranks have different batch counts: {counts}"
 
-    # All steps except possibly the last should be homogeneous across ranks
     batches_per_rank = counts[0]
-    for step in range(batches_per_rank - 1):
+    for step in range(batches_per_rank):
         step_indices = list(
             itertools.chain.from_iterable(
                 rank_batches[r][step] for r in range(n_workers)
@@ -492,3 +491,75 @@ def test_group_batch_sampler__n_workers_no_drop_last__moves_awkward_batches_to_t
         assert all(b >= ds_size for b in step_indices) or all(
             b < ds_size for b in step_indices
         ), f"Step {step}: ranks process mixed groups. Indices: {step_indices}"
+
+
+def test_group_batch_sampler__distributed__small_group_is_padded_when_not_dropping():
+    """A group with fewer batches than num_replicas is padded (not dropped) with drop_last=False."""
+    # Group 0: 10 batches (1 full chunk of 8 + 2 remainder -> padded to 8)
+    # Group 1: 2 batches (0 full chunks -> padded to 8 entirely from duplicates)
+    n_workers = 8
+    datasets = [
+        MockDataset(20, grid_size=(10, 20)),  # 10 batches
+        MockDataset(4, grid_size=(5, 10)),  # 2 batches (smaller than n_workers)
+    ]
+
+    rank_batches = []
+    for rank in range(n_workers):
+        sampler = DistributedEquivalenceGroupBatchSampler(
+            datasets=datasets,  # type: ignore[arg-type]
+            group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
+            batch_size=2,
+            num_replicas=n_workers,
+            rank=rank,
+            shuffle=True,
+            drop_last=False,
+        )
+        rank_batches.append(list(sampler))
+
+    counts = [len(rb) for rb in rank_batches]
+    assert len(set(counts)) == 1, f"Ranks have different batch counts: {counts}"
+
+    # Every step must be homogeneous across ranks (small group is padded, not mixed).
+    batches_per_rank = counts[0]
+    for step in range(batches_per_rank):
+        step_indices = list(
+            itertools.chain.from_iterable(
+                rank_batches[r][step] for r in range(n_workers)
+            )
+        )
+        assert all(idx < 20 for idx in step_indices) or all(
+            idx >= 20 for idx in step_indices
+        ), f"Step {step} mixes groups: {step_indices}"
+
+    # The small group's samples must appear at least once across all ranks
+    # (otherwise it was silently dropped).
+    all_indices = {idx for rb in rank_batches for batch in rb for idx in batch}
+    assert any(idx >= 20 for idx in all_indices), (
+        "Small group was dropped instead of padded"
+    )
+
+
+def test_group_batch_sampler__distributed__shuffle_false_is_deterministic_across_epochs():
+    """With shuffle=False, batch order (incl. padding) must not change across epochs."""
+    # Choose a size that triggers padding so we exercise the padding path.
+    n_workers = 3
+    datasets = [MockDataset(10), MockDataset(10)]  # 10 batches total, not divisible
+
+    sampler = DistributedEquivalenceGroupBatchSampler(
+        datasets=datasets,  # type: ignore[arg-type]
+        group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
+        batch_size=2,
+        num_replicas=n_workers,
+        rank=0,
+        shuffle=False,
+        drop_last=False,
+    )
+
+    sampler.set_epoch(0)
+    batches_epoch_0 = [tuple(b) for b in sampler]
+    sampler.set_epoch(5)
+    batches_epoch_5 = [tuple(b) for b in sampler]
+
+    assert batches_epoch_0 == batches_epoch_5, (
+        "shuffle=False sampler should be deterministic across epochs"
+    )

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -298,11 +298,10 @@ class TestDistributedBatchSamplerDistribution:
             )
             all_batches.extend(list(sampler))
 
-        # With 10 batches and 3 replicas, per-group chunks are padded to 12
-        # (not dropped) to avoid erasing small groups. 12 / 3 = 4 per rank.
-        # 4 batches * 3 ranks * 2 samples = 24 indices.
+        # With 10 batches and 3 replicas, trimming gives 9 batches (3 per worker)
+        # So we should have 9 batches * 2 samples = 18 indices (not all 20)
         all_indices = [idx for batch in all_batches for idx in batch]
-        assert len(all_indices) == 24
+        assert len(all_indices) == 18
 
     def test_set_epoch_changes_ordering(self):
         """Different epochs should produce different batch orderings."""

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -27,13 +27,15 @@ class MockDataset:
 def sampler_from_datasets(request):
     """Factory fixture that creates either standard or distributed sampler."""
 
-    def _make_sampler(datasets, group_key, batch_size, shuffle, drop_last):
+    def _make_sampler(
+        datasets, group_key, batch_size, shuffle, drop_last, num_replicas=1
+    ):
         if request.param == "standard":
             return EquivalenceGroupBatchSampler.from_datasets(
                 datasets=datasets,
                 group_key=group_key,
                 batch_size=batch_size,
-                n_workers=-1,
+                num_replicas=num_replicas,
                 shuffle=shuffle,
                 drop_last=drop_last,
             )
@@ -42,7 +44,7 @@ def sampler_from_datasets(request):
                 datasets=datasets,
                 group_key=group_key,
                 batch_size=batch_size,
-                num_replicas=1,  # Single worker to match standard behavior
+                num_replicas=num_replicas,  # Single worker to match standard behavior
                 rank=0,
                 shuffle=shuffle,
                 drop_last=drop_last,
@@ -388,25 +390,23 @@ class TestDistributedBatchSamplerDistribution:
             )
 
 
-def test_group_batch_sampler__n_workers__splits_into_worker_batches():
+def test_group_batch_sampler__n_workers__splits_into_worker_batches(
+    sampler_from_datasets,
+):
     ds_size = 20
     n_workers = 8
     datasets = [
         MockDataset(ds_size, grid_size=(10, 20)),
         MockDataset(ds_size, grid_size=(5, 10)),
     ]
-    batch_sampler = EquivalenceGroupBatchSampler.from_datasets(
+    batch_sampler = sampler_from_datasets(
         datasets,  # type: ignore[arg-type]
         group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
         batch_size=2,
-        n_workers=n_workers,
+        num_replicas=n_workers,
         shuffle=True,
         drop_last=True,
     )
-    assert len(batch_sampler) % n_workers == 0, (
-        "when both n_workers and drop_last are set, we drop batches that don't fit into the n_workers."
-    )
-
     batches = list(batch_sampler)
 
     worker_batches = list(itertools.batched(batches, n_workers))
@@ -417,23 +417,22 @@ def test_group_batch_sampler__n_workers__splits_into_worker_batches():
         )
 
 
-def test_group_batch_sampler__n_workers_no_drop_last__moves_awkward_batches_to_the_end():
+def test_group_batch_sampler__n_workers_no_drop_last__moves_awkward_batches_to_the_end(
+    sampler_from_datasets,
+):
     ds_size = 20
     n_workers = 8
     datasets = [
         MockDataset(ds_size, grid_size=(10, 20)),
         MockDataset(ds_size, grid_size=(5, 10)),
     ]
-    batch_sampler = EquivalenceGroupBatchSampler.from_datasets(
+    batch_sampler = sampler_from_datasets(
         datasets,  # type: ignore[arg-type]
         group_key=lambda ds: ds.grid_size,  # type: ignore[attr-defined]
         batch_size=2,
-        n_workers=n_workers,
+        num_replicas=n_workers,
         shuffle=True,
         drop_last=False,
-    )
-    assert len(batch_sampler) % n_workers != 0, (
-        "We don't neatly divide the number of workers"
     )
 
     batches = list(batch_sampler)


### PR DESCRIPTION
This updates both our equivalence batch samplers to make it that all n_workers / num_replicas have batches with the same scale of data. This is needed because in DDP training across n_workers, when we mix scales, we're liable to NCCL timeouts. These timeouts are stochastic; they're caused by the scenario where we load 1/4 scale on at least one worker, but 1 or 1/2 scale on many of the other workers. When batch norm is turned on, and thus we need to synchronize between all workers, we have a high likelihood of facing GPU level timeouts, since data loading can take so much longer for larger datasets. 

This also fixes a small, but significant, bug where we didn't actually set epochs properly!