### PR TITLE
NCCL timeouts: Stick some Gloo on it

### DIFF
--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -693,9 +693,6 @@ class Trainer:
                 if self.debug and (data_iter_step + 1) % 5 == 0:
                     break
 
-                if self._cpu_group is not None:
-                    dist.barrier(group=self._cpu_group)
-
                 VO: ValBatchOutput = Stepper.validate_batch(
                     self.model, data, self.loss_fn
                 )

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -16,6 +16,7 @@ from typing import Any, assert_never
 
 import dask
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch.utils.data import (
     ConcatDataset,
@@ -290,6 +291,13 @@ class Trainer:
                 nn.SyncBatchNorm.convert_sync_batchnorm(self.model),
                 device_ids=[self.distributed.gpu],
             )
+            # Create a CPU-side (Gloo) process group for data-loading barriers.
+            # This lets all ranks synchronize after loading a batch without
+            # consuming the NCCL timeout budget, preventing NCCL timeouts when
+            # the networked filesystem stalls on some ranks.
+            self._cpu_group = dist.new_group(backend="gloo")
+        else:
+            self._cpu_group = None
 
         # EMA (must come after DDP setup so parameter names match final self.model)
         if not loaded_checkpoint:
@@ -507,6 +515,12 @@ class Trainer:
             else:
                 r = self.gradient_accumulation_steps
 
+            # Synchronize all ranks after data loading so that no rank
+            # starts GPU work (and hits NCCL collectives) while another is
+            # still blocked on a slow networked filesystem read.
+            if self._cpu_group is not None:
+                dist.barrier(group=self._cpu_group)
+
             if self.num_batches_seen == 0:
                 get_model_summary(self.model, data, self.debug)
 
@@ -675,6 +689,9 @@ class Trainer:
             ):
                 if self.debug and (data_iter_step + 1) % 5 == 0:
                     break
+
+                if self._cpu_group is not None:
+                    dist.barrier(group=self._cpu_group)
 
                 VO: ValBatchOutput = Stepper.validate_batch(
                     self.model, data, self.loss_fn

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -1123,9 +1123,11 @@ def main():
 
     try:
         trainer.run()
-    except Exception as e:
+    except Exception:
         logger.exception("Training failed with an exception")
-        raise e
+        raise
+    finally:
+        trainer.finish()
 
 
 if __name__ == "__main__":

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -295,7 +295,10 @@ class Trainer:
             # This lets all ranks synchronize after loading a batch without
             # consuming the NCCL timeout budget, preventing NCCL timeouts when
             # the networked filesystem stalls on some ranks.
-            self._cpu_group = dist.new_group(backend="gloo")
+            self._cpu_group = dist.new_group(
+                backend="gloo",
+                timeout=datetime.timedelta(hours=2),
+            )
         else:
             self._cpu_group = None
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -902,7 +902,13 @@ class Trainer:
         self.val_sampler = val_batch_sampler
 
         # Create data loaders (same for both distributed and non-distributed)
-        # When using batch_sampler, don't specify batch_size or sampler
+        # When using batch_sampler, don't specify batch_size or sampler.
+        # timeout (seconds): if a DataLoader worker doesn't produce a batch
+        # within this window, raise an error instead of hanging the whole
+        # training run.  A stuck worker would otherwise block all DDP ranks
+        # at the next collective.
+        worker_timeout = 1800 if self.num_workers > 0 else 0  # 30 minutes or 0.
+
         train_dataloader = DataLoader(
             train_data,
             batch_sampler=train_batch_sampler,
@@ -910,6 +916,7 @@ class Trainer:
             pin_memory=self.pin_mem,
             collate_fn=collate_fn,
             multiprocessing_context=self.mp_context,
+            timeout=worker_timeout,
         )
 
         val_dataloader = DataLoader(
@@ -919,6 +926,7 @@ class Trainer:
             pin_memory=self.pin_mem,
             collate_fn=collate_fn,
             multiprocessing_context=self.mp_context,
+            timeout=worker_timeout,
         )
 
         # Wrap dataloaders to handle GPU post-processing

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -285,6 +285,7 @@ class Trainer:
         else:
             self.start_epoch = 1
 
+        self._cpu_group = None
         # Modify DDP setup based on device
         if self.distributed is not None:
             self.model = nn.parallel.DistributedDataParallel(
@@ -297,10 +298,8 @@ class Trainer:
             # the networked filesystem stalls on some ranks.
             self._cpu_group = dist.new_group(
                 backend="gloo",
-                timeout=datetime.timedelta(hours=2),
+                timeout=datetime.timedelta(minutes=30),
             )
-        else:
-            self._cpu_group = None
 
         # EMA (must come after DDP setup so parameter names match final self.model)
         if not loaded_checkpoint:

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -1098,6 +1098,9 @@ class Trainer:
     def finish(self):
         if self.executor is not None:
             self.executor.shutdown()
+        if self._cpu_group is not None:
+            dist.destroy_process_group(self._cpu_group)
+            self._cpu_group = None
         self.wandb_logger.finish()
 
 


### PR DESCRIPTION
We use Pytorch's build in library for distributed communication primitives ([Gloo](https://github.com/pytorch/gloo)) to synchronize example data loading across DDP replicas on the CPU side. If and when the networked filesystem on SLURM gets throttled and has a slow down, this change means we'll wait only using CPU resources. This prevents the scenario where the slowdown happens during either the forward or backward pass, causing NCCL timeouts which ultimately crash the training job.