### PR TITLE
Immediately move TensorMap to GPU to reduce high AllReduce times during multiscale training.

### DIFF
--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -1,5 +1,6 @@
 import enum
 import logging
+from typing import Self
 
 logger = logging.getLogger(__name__)
 
@@ -321,7 +322,7 @@ class TensorMap(Multiton):
         for i, k in enumerate(self.boundary_var_names):
             self.INPT_BOUNDARY_IDX[k] = torch.tensor([i])
 
-    def to(self, device: torch.device) -> "TensorMap":
+    def to(self, device: torch.device) -> Self:
         """Move all index tensors to the given device.
 
         Call this once after model initialization so that indexing a GPU tensor

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -320,3 +320,18 @@ class TensorMap(Multiton):
         """
         for i, k in enumerate(self.boundary_var_names):
             self.INPT_BOUNDARY_IDX[k] = torch.tensor([i])
+
+    def to(self, device: torch.device) -> "TensorMap":
+        """Move all index tensors to the given device.
+
+        Call this once after model initialization so that indexing a GPU tensor
+        with these indices stays on-device and avoids implicit CUDA syncs.
+        """
+        for k in self.VAR_3D_IDX:
+            self.VAR_3D_IDX[k] = self.VAR_3D_IDX[k].to(device)
+        for k in self.DP_3D_IDX:
+            self.DP_3D_IDX[k] = self.DP_3D_IDX[k].to(device)
+        for k in self.INPT_BOUNDARY_IDX:
+            self.INPT_BOUNDARY_IDX[k] = self.INPT_BOUNDARY_IDX[k].to(device)
+        self.dz = self.dz.to(device)
+        return self

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -80,7 +80,7 @@ class Eval:
 
         self.tensor_map = TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
-        )
+        ).to(self.device)
 
         logger.info(f"Number of inputs (prognostic + boundary): {self.num_in}")
         logger.info(f"Number of outputs (prognostic): {self.num_out}")

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -159,7 +159,7 @@ class Trainer:
 
         self.tensor_map = TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
-        )
+        ).to(self.device)
 
         logger.info(f"Number of inputs (prognostic + boundary): {self.num_in}")
         logger.info(f"Number of outputs (prognostic): {self.num_out}")


### PR DESCRIPTION
This doesn't totally fix the underlying issue with deploying our multi-scale model on torch, but it does significantly improve performance. It does so by reducing the CPU/GPU transfer overhead in one of the "chattiest" parts of the training loop.