### PR TITLE
Each worker should have its own ThreadPoolExecutor. 

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -453,7 +453,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
     def _get_executor(cls) -> ThreadPoolExecutor:
         if cls._shared_executor is None:
             cls._shared_executor = ThreadPoolExecutor(
-                thread_name_prefix="concurrent_compute"
+                max_workers=None, thread_name_prefix="concurrent_compute"
             )
         return cls._shared_executor
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -2,7 +2,7 @@ import logging
 import time
 from concurrent.futures import wait
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import final
+from typing import ClassVar, final
 
 import numpy as np
 import torch
@@ -444,6 +444,19 @@ class TorchTrainDataset(Dataset[RawTrainData]):
 
     FLAG = LoaderVersion.OM4_TORCH
 
+    # Shared across all instances within a process. Created lazily on first
+    # __getitem__ call so that each forked DataLoader worker gets its own
+    # clean executor — avoids inheriting fork-corrupted locks from the parent.
+    _shared_executor: ClassVar[ThreadPoolExecutor | None] = None
+
+    @classmethod
+    def _get_executor(cls) -> ThreadPoolExecutor:
+        if cls._shared_executor is None:
+            cls._shared_executor = ThreadPoolExecutor(
+                thread_name_prefix="concurrent_compute"
+            )
+        return cls._shared_executor
+
     @elapsed
     def __init__(
         self,
@@ -456,7 +469,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         normalize_before_mask: bool,
         masked_fill_value: float,
         stride: int = 1,
-        executor: ThreadPoolExecutor | None = None,
+        concurrent_compute: bool = False,
     ):
         super().__init__()
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
@@ -468,7 +481,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.stride: int = stride
         self.normalize_before_mask: bool = normalize_before_mask
         self.masked_fill_value: float = masked_fill_value
-        self._executor = executor
+        self._concurrent_compute = concurrent_compute
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
         assert np.array_equal(srcs[0].data.time, srcs[-1].data.time), (
@@ -537,11 +550,11 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             )  # forecasted data
             prognostic_selected = [input_selected, label_selected]
 
-            if self._executor is not None:
+            if self._concurrent_compute:
                 datasets = prognostic_selected + [boundary_selected]
                 concurrent_compute(
                     *datasets,
-                    executor=self._executor,
+                    executor=self._get_executor(),
                 )
 
             if "lev" in prognostic_selected[0].dims:
@@ -667,7 +680,7 @@ def concurrent_compute(
 
     futures = []
     for ds in datasets:
-        for var in ds.variables.values():
+        for var in ds.data_vars.variables.values():
             futures.append(executor.submit(load_variable_data, var))
 
     wait(futures)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -469,7 +469,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         normalize_before_mask: bool,
         masked_fill_value: float,
         stride: int = 1,
-        concurrent_compute: bool = False,
+        concurrent_compute_: bool = False,
     ):
         super().__init__()
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
@@ -481,7 +481,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.stride: int = stride
         self.normalize_before_mask: bool = normalize_before_mask
         self.masked_fill_value: float = masked_fill_value
-        self._concurrent_compute = concurrent_compute
+        self._concurrent_compute = concurrent_compute_
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
         assert np.array_equal(srcs[0].data.time, srcs[-1].data.time), (

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -9,7 +9,6 @@ import time
 import warnings
 from collections import OrderedDict
 from collections.abc import Iterable
-from concurrent.futures import ThreadPoolExecutor
 from multiprocessing.context import BaseContext
 from pathlib import Path
 from typing import Any, assert_never
@@ -187,11 +186,7 @@ class Trainer:
                 f"with validation time range {cfg.val_time}"
             )
 
-        self.executor: ThreadPoolExecutor | None = None
-        if cfg.data.concurrent_compute:
-            self.executor = ThreadPoolExecutor(
-                max_workers=None, thread_name_prefix="concurrent_compute"
-            )
+        self.concurrent_compute = cfg.data.concurrent_compute
 
         self.primary_src = self.data_container.primary_source
 
@@ -792,7 +787,7 @@ class Trainer:
                 normalize_before_mask=self.normalize_before_mask,
                 masked_fill_value=self.normalize_fill_value,
                 stride=stride,
-                executor=self.executor,
+                concurrent_compute=self.concurrent_compute,
             )
             for stride in self.data_stride
             for src, dst in srcs
@@ -809,7 +804,7 @@ class Trainer:
                 normalize_before_mask=self.normalize_before_mask,
                 masked_fill_value=self.normalize_fill_value,
                 stride=stride,
-                executor=self.executor,
+                concurrent_compute=self.concurrent_compute,
             )
             for stride in self.data_stride
             for src, dst in srcs
@@ -1087,8 +1082,6 @@ class Trainer:
             self._ema.restore(parameters=self.model.parameters())
 
     def finish(self):
-        if self.executor is not None:
-            self.executor.shutdown()
         self.wandb_logger.finish()
 
 

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -787,7 +787,7 @@ class Trainer:
                 normalize_before_mask=self.normalize_before_mask,
                 masked_fill_value=self.normalize_fill_value,
                 stride=stride,
-                concurrent_compute=self.concurrent_compute,
+                concurrent_compute_=self.concurrent_compute,
             )
             for stride in self.data_stride
             for src, dst in srcs
@@ -804,7 +804,7 @@ class Trainer:
                 normalize_before_mask=self.normalize_before_mask,
                 masked_fill_value=self.normalize_fill_value,
                 stride=stride,
-                concurrent_compute=self.concurrent_compute,
+                concurrent_compute_=self.concurrent_compute,
             )
             for stride in self.data_stride
             for src, dst in srcs


### PR DESCRIPTION
This PR creates the ThreadPoolExecutors late when enabled. We add a private, static `_get_executor()` method to the DataLoader class. This means that there will be one thread pool created per worker (we create multiple dataloaders per zarr dataset; this only makes 1 pool per scale of data).