### PR TITLE
GridContext also needs an output resolution.

### DIFF
--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -110,7 +110,7 @@ class InferenceDataset(Dataset):
             self.wet_surface = self.wet_surface.pin_memory()
             self.wet_label = self.wet_label.pin_memory()
 
-        self.ctx = GridContext(self.wet_label, self.input_res)
+        self.ctx = GridContext(self.wet_label, self.input_res, self.input_res)
 
     def __len__(self):
         return self.size
@@ -503,8 +503,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.wet_surface: GridMask = src.masks.boundary
 
         self.ctx = GridContext(
-            self.prognostic_srcs[-1].masks.prognostic_with_hist(self.hist),
-            self.prognostic_srcs[0].resolution,
+            label_mask=self.prognostic_srcs[-1].masks.prognostic_with_hist(self.hist),
+            input_resolution_cpu=self.prognostic_srcs[0].resolution,
+            output_resolution_cpu=self.prognostic_srcs[-1].resolution,
         )
 
         self.size: int = (

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -110,6 +110,8 @@ class InferenceDataset(Dataset):
             self.wet_surface = self.wet_surface.pin_memory()
             self.wet_label = self.wet_label.pin_memory()
 
+        # Inference only currently supports the same output resolution as the input
+        # resolution.
         self.ctx = GridContext(self.wet_label, self.input_res, self.input_res)
 
     def __len__(self):

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -48,6 +48,10 @@ class BaseModel(torch.nn.Module):
             if step == 0:
                 input_tensor = train_data.get_initial_input()
             else:
+                # TODO(alxmrs): With cross-resolution training (e.g. "mix" schedule where
+                #  input and output grids differ), the previous prediction lives on the
+                #  output grid but merge_prognostic_and_boundary expects the input grid.
+                #  Multi-step rollouts (steps > 1) will need regridding here.
                 prev_output = outputs[-1]
                 if (
                     self.gradient_detach_interval > 0

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -91,6 +91,9 @@ class FOMO(BaseModel):
                 fts = self.maybe_add_3d_coordinates(fts, ctx.input_resolution_cpu)
             fts = self.encoder(fts, ctx.input_resolution_cpu)
             fts = self.processor(fts)
+
+            # TODO(alxmrs): When the output resolution differs from the input (i.e. in a "mix" schedule), we cannot use
+            #  residual predictions (`self.pred_residuals` must be `False`).
             fts = self.decoder(fts, ctx.output_resolution_cpu)
 
         # Convert back to float32

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -91,7 +91,7 @@ class FOMO(BaseModel):
                 fts = self.maybe_add_3d_coordinates(fts, ctx.input_resolution_cpu)
             fts = self.encoder(fts, ctx.input_resolution_cpu)
             fts = self.processor(fts)
-            fts = self.decoder(fts, ctx.input_resolution_cpu)
+            fts = self.decoder(fts, ctx.output_resolution_cpu)
 
         # Convert back to float32
         # TODO(alxmrs): We actually only support float16 when turned on; this kind of tricks us.

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -150,6 +150,10 @@ class Trainer:
             raise ValueError(
                 "Residual predictions on a mixed multiscale training schedule is not currently supported."
             )
+        if self.train_schedule == "mix" and cfg.steps[0] > 1:
+            raise ValueError(
+                "Step predictions on a mixed multiscale training schedule is not currently supported."
+            )
 
         self.mp_context: BaseContext | None = None
         if cfg.data.num_workers > 0:

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -150,7 +150,7 @@ class Trainer:
             raise ValueError(
                 "Residual predictions on a mixed multiscale training schedule is not currently supported."
             )
-        if self.train_schedule == "mix" and cfg.steps[0] > 1:
+        if self.train_schedule == "mix" and any(step > 1 for step in cfg.steps):
             raise ValueError(
                 "Step predictions on a mixed multiscale training schedule is not currently supported."
             )

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -146,6 +146,10 @@ class Trainer:
             boundary_var_names=self.boundary_var_names,
         )
         self.train_schedule: TrainSchedule = cfg.experiment.train_schedule
+        if self.train_schedule == "mix" and cfg.model.pred_residuals:
+            raise ValueError(
+                "Residual predictions on a mixed multiscale training schedule is not currently supported."
+            )
 
         self.mp_context: BaseContext | None = None
         if cfg.data.num_workers > 0:

--- a/src/ocean_emulators/utils/ctx.py
+++ b/src/ocean_emulators/utils/ctx.py
@@ -18,11 +18,15 @@ class GridContext:
         label_mask: Boolean mask indicating valid ocean cells for each prognostic
             variable. Shape: (num_prognostic_vars, lat, lon). Land cells are False.
         input_resolution_cpu: Tuple of (latitude, longitude) coordinate tensors defining
-            the spatial grid. Used for cosine-latitude weighting in loss functions.
+            the input spatial grid. Used by encoders for positional encoding.
+        output_resolution_cpu: Tuple of (latitude, longitude) coordinate tensors defining
+            the output spatial grid. Used by decoders to determine output shape and
+            pixel-query positions. Defaults to input_resolution_cpu for single-scale use.
     """
 
     label_mask: PrognosticMask
     input_resolution_cpu: tuple[Lat, Lon]
+    output_resolution_cpu: tuple[Lat, Lon]
 
     def to(self, device: torch.device) -> Self:
         """Move the label mask to the specified device."""

--- a/tests/test_fomini.py
+++ b/tests/test_fomini.py
@@ -25,7 +25,8 @@ def make_perceiver_io(
 def make_ctx(out_channels: int, H: int, W: int) -> GridContext:
     mask = torch.ones(out_channels, H, W, dtype=torch.bool)
     dummy = torch.randn(1, 1, H, W)
-    return GridContext(mask, make_resolution(dummy))
+    res = make_resolution(dummy)
+    return GridContext(mask, res, res)
 
 
 def make_model(query_chunk_size: int | None) -> FOMini:

--- a/tests/test_gradient_detaching.py
+++ b/tests/test_gradient_detaching.py
@@ -77,7 +77,7 @@ def create_samudra_model():
             # Create TrainData compatible with model dimensions
             train_data = TrainData(
                 num_prognostic_channels=1,
-                ctx=GridContext(masks.prognostic, src.resolution),
+                ctx=GridContext(masks.prognostic, src.resolution, src.resolution),
             )
             for step in range(4):
                 input_tensor = torch.randn(1, 2, h, w, requires_grad=True)

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -40,7 +40,9 @@ def test_positional_parameters_update(dummy_src: DataSource):
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
     x = torch.randn(1, 2, h, w)
     optimizer.zero_grad()
-    out = model.forward_once(x, GridContext(masks.prognostic, src.resolution))
+    out = model.forward_once(
+        x, GridContext(masks.prognostic, src.resolution, src.resolution)
+    )
     loss = out.sum()
     loss.backward()
     before = model.positional_params.detach().clone()

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -221,7 +221,8 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     assert torch.equal(input_tensor.flatten(), expected_input)
 
     pred = model.forward_once(
-        input_tensor, GridContext(wet, inference_dataset.input_res)
+        input_tensor,
+        GridContext(wet, inference_dataset.input_res, inference_dataset.input_res),
     )
     assert pred.shape == (1, num_prognostic_channels, 1, 1)
     expected_pred = torch.tensor(

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -116,7 +116,7 @@ def test_checkpoint_inference(trainer_pair: TrainPair, caplog):
     hist = trainer.hist
     resolution = trainer.inference_src.resolution
     wet = trainer.inference_src.masks.prognostic_with_hist(hist)
-    ctx = GridContext(wet, resolution).to(trainer.device)
+    ctx = GridContext(wet, resolution, resolution).to(trainer.device)
     data = trainer.inference_loader.dataset[0]
     X, y = data
     trainer.best_val_loss = 10

--- a/tests/test_validate_aggregator.py
+++ b/tests/test_validate_aggregator.py
@@ -40,6 +40,10 @@ def val_batch_of(
                 torch.linspace(-90, 90, steps=h),
                 torch.linspace(-180, 180, steps=w),
             ),
+            output_resolution_cpu=(
+                torch.linspace(-90, 90, steps=h),
+                torch.linspace(-180, 180, steps=w),
+            ),
         ),
     )
     return batch


### PR DESCRIPTION
This is a small fix that enables "mix" resolution training. Currently, only "standard" and "match" training schedules are supported, with "match" being multi-resolution. To enable "mix" schedule, where the input and output resolution commonly differ, we need to give the GridContext access to the output resolution to be used inside the FOMO model. Once this exists, it's a trivial update to fix the FOMO model to allow for mixed resolutions.

Fixes #663.