### PR TITLE
Attention positional embeddings

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -269,24 +269,42 @@ class AttentionBlockConfig(BaseConfig):
         default=0.0,
         description="Dropout rate applied to the output projection.",
     )
+    positional_embedding: Literal["sinusoidal_1d", "sinusoidal_2d"] | None = Field(
+        default=None,
+        description=(
+            "Optional positional encoding added inside the attention block before "
+            "QKV projection. Use `sinusoidal_1d` with axial attention and "
+            "`sinusoidal_2d` with full attention."
+        ),
+    )
 
     def build(self, channels: int) -> nn.Module:
         assert channels % self.num_heads == 0, (
             f"channels {channels} must be divisible by num_heads {self.num_heads}"
         )
         if self.attention_type == "axial":
+            if self.positional_embedding not in (None, "sinusoidal_1d"):
+                raise ValueError(
+                    "Axial attention only supports positional_embedding='sinusoidal_1d'."
+                )
             return AxialAttentionBlock(
                 channels=channels,
                 num_heads=self.num_heads,
                 attn_drop=self.attn_drop,
                 proj_drop=self.proj_drop,
+                positional_embedding=self.positional_embedding,
             )
         if self.attention_type == "full":
+            if self.positional_embedding not in (None, "sinusoidal_2d"):
+                raise ValueError(
+                    "Full attention only supports positional_embedding='sinusoidal_2d'."
+                )
             return FullAttentionBlock(
                 channels=channels,
                 num_heads=self.num_heads,
                 attn_drop=self.attn_drop,
                 proj_drop=self.proj_drop,
+                positional_embedding=self.positional_embedding,
             )
         assert_never(self.attention_type)
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -1,7 +1,7 @@
 import abc
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated, Literal, Self, assert_never
+from typing import Annotated, Literal, Self, assert_never, cast
 
 import cftime
 import pydantic
@@ -287,24 +287,32 @@ class AttentionBlockConfig(BaseConfig):
                 raise ValueError(
                     "Axial attention only supports positional_embedding='sinusoidal_1d'."
                 )
+            axial_positional_embedding = cast(
+                Literal["sinusoidal_1d"] | None,
+                self.positional_embedding,
+            )
             return AxialAttentionBlock(
                 channels=channels,
                 num_heads=self.num_heads,
                 attn_drop=self.attn_drop,
                 proj_drop=self.proj_drop,
-                positional_embedding=self.positional_embedding,
+                positional_embedding=axial_positional_embedding,
             )
         if self.attention_type == "full":
             if self.positional_embedding not in (None, "sinusoidal_2d"):
                 raise ValueError(
                     "Full attention only supports positional_embedding='sinusoidal_2d'."
                 )
+            full_positional_embedding = cast(
+                Literal["sinusoidal_2d"] | None,
+                self.positional_embedding,
+            )
             return FullAttentionBlock(
                 channels=channels,
                 num_heads=self.num_heads,
                 attn_drop=self.attn_drop,
                 proj_drop=self.proj_drop,
-                positional_embedding=self.positional_embedding,
+                positional_embedding=full_positional_embedding,
             )
         assert_never(self.attention_type)
 

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -52,7 +52,7 @@ def sinusoidal_2d_position_embedding(
         ],
         dim=-1,
     )
-    return embedding.permute(2, 0, 1).unsqueeze(0).to(dtype=dtype)
+    return rearrange(embedding, "h w c -> 1 c h w").to(dtype=dtype)
 
 
 class PointwiseLinear(torch.nn.Module):
@@ -422,24 +422,18 @@ class AxialAttention(nn.Module):
                     C,
                     device=x.device,
                 )
-                positional_embedding = (
-                    positional_embedding.transpose(0, 1)
-                    .unsqueeze(0)
-                    .unsqueeze(-1)
-                    .to(dtype=x.dtype)
-                )
+                positional_embedding = rearrange(
+                    positional_embedding, "h c -> 1 c h 1"
+                ).to(dtype=x.dtype)
             else:
                 positional_embedding = sinusoidal_1d_position_embedding(
                     W,
                     C,
                     device=x.device,
                 )
-                positional_embedding = (
-                    positional_embedding.transpose(0, 1)
-                    .unsqueeze(0)
-                    .unsqueeze(2)
-                    .to(dtype=x.dtype)
-                )
+                positional_embedding = rearrange(
+                    positional_embedding, "w c -> 1 c 1 w"
+                ).to(dtype=x.dtype)
             x = x + positional_embedding
 
         if self.axis == "height":

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -1,16 +1,58 @@
+import math
 from collections.abc import Callable
 from typing import Literal, Protocol
 
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint
-<<<<<<< HEAD
 from einops import rearrange
-=======
->>>>>>> 386e3796 (Added jax typing)
 from jaxtyping import Float
 
 from ocean_emulators.models.modules.activations import CappedGELU
+
+
+def sinusoidal_1d_position_embedding(
+    length: int,
+    dim: int,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    if dim <= 0:
+        return torch.empty(length, 0, device=device, dtype=torch.float32)
+
+    position = torch.arange(length, device=device, dtype=torch.float32).unsqueeze(1)
+    div_term = torch.exp(
+        torch.arange(0, dim, 2, device=device, dtype=torch.float32)
+        * (-(math.log(10000.0) / max(dim, 1)))
+    )
+
+    embedding = torch.zeros(length, dim, device=device, dtype=torch.float32)
+    embedding[:, 0::2] = torch.sin(position * div_term)
+    embedding[:, 1::2] = torch.cos(position * div_term[: embedding[:, 1::2].shape[1]])
+    return embedding
+
+
+def sinusoidal_2d_position_embedding(
+    height: int,
+    width: int,
+    dim: int,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    row_dim = dim // 2
+    col_dim = dim - row_dim
+    row_embedding = sinusoidal_1d_position_embedding(height, row_dim, device=device)
+    col_embedding = sinusoidal_1d_position_embedding(width, col_dim, device=device)
+
+    embedding = torch.cat(
+        [
+            row_embedding.unsqueeze(1).expand(-1, width, -1),
+            col_embedding.unsqueeze(0).expand(height, -1, -1),
+        ],
+        dim=-1,
+    )
+    return embedding.permute(2, 0, 1).unsqueeze(0).to(dtype=dtype)
 
 
 class PointwiseLinear(torch.nn.Module):
@@ -342,6 +384,7 @@ class AxialAttention(nn.Module):
     def __init__(
         self,
         dim: int,
+        positional_embedding: Literal["sinusoidal_1d"] | None,
         num_heads: int,
         qkv_bias: bool,
         attn_drop: float,
@@ -355,6 +398,7 @@ class AxialAttention(nn.Module):
         self.head_dim = dim // num_heads
         self.axis = axis
         self.attn_drop_p = attn_drop
+        self.positional_embedding = positional_embedding
 
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
         self.proj = nn.Linear(dim, dim)
@@ -370,6 +414,33 @@ class AxialAttention(nn.Module):
         x: Float[torch.Tensor, "batch channels height width"],
     ) -> Float[torch.Tensor, "batch channels height width"]:
         B, C, H, W = x.shape
+
+        if self.positional_embedding is not None:
+            if self.axis == "height":
+                positional_embedding = sinusoidal_1d_position_embedding(
+                    H,
+                    C,
+                    device=x.device,
+                )
+                positional_embedding = (
+                    positional_embedding.transpose(0, 1)
+                    .unsqueeze(0)
+                    .unsqueeze(-1)
+                    .to(dtype=x.dtype)
+                )
+            else:
+                positional_embedding = sinusoidal_1d_position_embedding(
+                    W,
+                    C,
+                    device=x.device,
+                )
+                positional_embedding = (
+                    positional_embedding.transpose(0, 1)
+                    .unsqueeze(0)
+                    .unsqueeze(2)
+                    .to(dtype=x.dtype)
+                )
+            x = x + positional_embedding
 
         if self.axis == "height":
             x = rearrange(x, "b c h w -> (b w) h c")
@@ -438,6 +509,7 @@ class AxialAttentionBlock(nn.Module):
     def __init__(
         self,
         channels: int,
+        positional_embedding: Literal["sinusoidal_1d"] | None = None,
         num_heads: int = 8,
         attn_drop: float = 0.0,
         proj_drop: float = 0.0,
@@ -446,6 +518,7 @@ class AxialAttentionBlock(nn.Module):
         self.norm_h = nn.GroupNorm(1, channels)
         self.attn_h = AxialAttention(
             channels,
+            positional_embedding,
             num_heads,
             qkv_bias=True,
             axis="height",
@@ -455,6 +528,7 @@ class AxialAttentionBlock(nn.Module):
         self.norm_w = nn.GroupNorm(1, channels)
         self.attn_w = AxialAttention(
             channels,
+            positional_embedding,
             num_heads,
             qkv_bias=True,
             axis="width",
@@ -494,6 +568,7 @@ class FullAttention(nn.Module):
     def __init__(
         self,
         dim: int,
+        positional_embedding: Literal["sinusoidal_2d"] | None,
         num_heads: int,
         qkv_bias: bool,
         attn_drop: float,
@@ -505,8 +580,11 @@ class FullAttention(nn.Module):
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
         self.attn_drop_p = attn_drop
+        self.positional_embedding = positional_embedding
 
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.q_norm = nn.LayerNorm(self.head_dim)
+        self.k_norm = nn.LayerNorm(self.head_dim)
         self.proj = nn.Linear(dim, dim)
         self.proj_drop = nn.Dropout(proj_drop)
 
@@ -521,6 +599,15 @@ class FullAttention(nn.Module):
         B, C, H, W = x.shape
         seq_len = H * W
 
+        if self.positional_embedding is not None:
+            x = x + sinusoidal_2d_position_embedding(
+                H,
+                W,
+                C,
+                device=x.device,
+                dtype=x.dtype,
+            )
+
         x = rearrange(x, "b c h w -> b (h w) c")
 
         qkv = self.qkv(x).reshape(B, seq_len, 3, self.num_heads, self.head_dim)
@@ -528,6 +615,8 @@ class FullAttention(nn.Module):
             qkv, "batch seq three heads head_dim -> three batch heads seq head_dim"
         )
         q, k, v = qkv.unbind(0)
+        q = self.q_norm(q)
+        k = self.k_norm(k)
 
         out = torch.nn.functional.scaled_dot_product_attention(
             q,
@@ -568,6 +657,7 @@ class FullAttentionBlock(nn.Module):
     def __init__(
         self,
         channels: int,
+        positional_embedding: Literal["sinusoidal_2d"] | None = None,
         num_heads: int = 8,
         attn_drop: float = 0.0,
         proj_drop: float = 0.0,
@@ -576,6 +666,7 @@ class FullAttentionBlock(nn.Module):
         self.norm = nn.GroupNorm(1, channels)
         self.attn = FullAttention(
             channels,
+            positional_embedding,
             num_heads,
             qkv_bias=True,
             attn_drop=attn_drop,

--- a/src/ocean_emulators/models/modules/blocks.py
+++ b/src/ocean_emulators/models/modules/blocks.py
@@ -4,7 +4,10 @@ from typing import Literal, Protocol
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint
+<<<<<<< HEAD
 from einops import rearrange
+=======
+>>>>>>> 386e3796 (Added jax typing)
 from jaxtyping import Float
 
 from ocean_emulators.models.modules.activations import CappedGELU


### PR DESCRIPTION
This PR adds optional sinusoidal positional embeddings to the attention blocks on top of the axial_attention branch. It extends AttentionBlockConfig with a positional_embedding option and adds helper functions for building 1D and 2D sinusoidal embeddings, which are applied before QKV projection. It also adds per-head q/k layer norm in full attention, which helps stabilize training by making the attention weights more evenly distributed across tokens.

