### PR TITLE
Split data loading config from worker settings

### DIFF
--- a/configs/data/om4.yaml
+++ b/configs/data/om4.yaml
@@ -8,4 +8,3 @@ static_data_vars: []
 concurrent_compute: true
 loading:
   type: cpu
-  num_workers: 4

--- a/configs/data/om4.yaml
+++ b/configs/data/om4.yaml
@@ -6,3 +6,6 @@ sources:
     data_stds_location: OM4_stds.zarr
 static_data_vars: []
 concurrent_compute: true
+loading:
+  type: cpu
+  num_workers: 4

--- a/configs/fomo_om4/train_multiscale.yaml
+++ b/configs/fomo_om4/train_multiscale.yaml
@@ -50,6 +50,9 @@ experiment:
 data:
   static_data_vars: []
   concurrent_compute: true
+  loading:
+    type: cpu
+    num_workers: 4
   sources:
     - data_location: OM4.zarr
       data_means_location: OM4_means.zarr

--- a/configs/test/train_default.yaml
+++ b/configs/test/train_default.yaml
@@ -47,7 +47,9 @@ data:
     - data_location: data.zarr
       data_means_location: means.nc
       data_stds_location: stds.nc
-  num_workers: 4
+  loading:
+    type: cpu
+    num_workers: 4
   hist: 0
 
 model:

--- a/configs/test/train_default_2step.yaml
+++ b/configs/test/train_default_2step.yaml
@@ -47,7 +47,9 @@ data:
     - data_location: data.zarr
       data_means_location: means.nc
       data_stds_location: stds.nc
-  num_workers: 4
+  loading:
+    type: cpu
+    num_workers: 4
   hist: 0
 
 model:

--- a/configs/test/train_fomini.yaml
+++ b/configs/test/train_fomini.yaml
@@ -46,7 +46,9 @@ data:
     - data_location: data.zarr
       data_means_location: means.nc
       data_stds_location: stds.nc
-  num_workers: 4
+  loading:
+    type: cpu
+    num_workers: 4
   hist: 0
 
 model:

--- a/configs/test/train_fomo.yaml
+++ b/configs/test/train_fomo.yaml
@@ -47,7 +47,9 @@ data:
     - data_location: data.zarr
       data_means_location: means.nc
       data_stds_location: stds.nc
-  num_workers: 4
+  loading:
+    type: cpu
+    num_workers: 4
   hist: 0
 
 model:

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -146,15 +146,26 @@ class DataSourceConfig(BaseConfig):
     )
 
 
-class CpuDataLoadingConfig(BaseConfig):
+class BaseDataLoadingConfig(BaseConfig):
+    def num_pytorch_workers(self) -> int:
+        raise NotImplementedError
+
+
+class CpuDataLoadingConfig(BaseDataLoadingConfig):
     type: Literal["cpu"] = "cpu"
     num_workers: int = Field(default=4, ge=0)
 
+    def num_pytorch_workers(self) -> int:
+        return self.num_workers
 
-class GpuDataLoadingConfig(BaseConfig):
+
+class GpuDataLoadingConfig(BaseDataLoadingConfig):
     type: Literal["gpu"] = "gpu"
     kvikio_task_size: int = Field(default=64 * 1024 * 1024, gt=0)
     kvikio_num_threads: int = Field(default=8, gt=0)
+
+    def num_pytorch_workers(self) -> int:
+        return 0
 
 
 DataLoadingConfig = Annotated[

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -146,6 +146,23 @@ class DataSourceConfig(BaseConfig):
     )
 
 
+class CpuDataLoadingConfig(BaseConfig):
+    type: Literal["cpu"] = "cpu"
+    num_workers: int = Field(default=4, ge=0)
+
+
+class GpuDataLoadingConfig(BaseConfig):
+    type: Literal["gpu"] = "gpu"
+    kvikio_task_size: int = Field(default=64 * 1024 * 1024, gt=0)
+    kvikio_num_threads: int = Field(default=8, gt=0)
+
+
+DataLoadingConfig = Annotated[
+    CpuDataLoadingConfig | GpuDataLoadingConfig,
+    Field(discriminator="type"),
+]
+
+
 class DataConfig(BaseConfig):
     sources: list[DataSourceConfig] = Field(
         description=(
@@ -155,7 +172,7 @@ class DataConfig(BaseConfig):
         min_length=1,
     )
     static_data_vars: list[str] | None = None
-    num_workers: int = 4
+    loading: DataLoadingConfig = Field(default_factory=CpuDataLoadingConfig)
     hist: int = 1
     loader_version: str = str(LoaderVersion.OM4_TORCH.value)
     normalize_before_mask: bool = True

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -165,6 +165,8 @@ class GpuDataLoadingConfig(BaseDataLoadingConfig):
     kvikio_num_threads: int = Field(default=8, gt=0)
 
     def num_pytorch_workers(self) -> int:
+        # When loading data direct to GPU, we don't want worker processes.
+        # 0 means "load in the main process"
         return 0
 
 

--- a/src/ocean_emulators/config_schema.py
+++ b/src/ocean_emulators/config_schema.py
@@ -52,6 +52,8 @@ def _collect_pydantic_models(
             _collect_pydantic_models(field.annotation, models, seen)
         return
 
+    # We check if this is a parameterized type and recurse if so (eg Union[int, str])
+    # (Union is the origin in that case.)
     origin = get_origin(annotation)
     if origin is None:
         return

--- a/src/ocean_emulators/config_schema.py
+++ b/src/ocean_emulators/config_schema.py
@@ -3,8 +3,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from types import UnionType
-from typing import get_args
+from typing import get_args, get_origin
 
 import pydantic
 import yaml
@@ -36,15 +35,25 @@ def get_pydantic_models(
     seen[model_name] = model
 
     for field in model.model_fields.values():
-        field_type = field.annotation
-        if isinstance(field_type, type) and issubclass(field_type, pydantic.BaseModel):
-            get_pydantic_models(field_type, seen)
-        elif isinstance(field_type, UnionType):
-            for type_ in get_args(field_type):
-                if isinstance(type_, type) and issubclass(type_, pydantic.BaseModel):
-                    get_pydantic_models(type_, seen)
+        _collect_pydantic_models(field.annotation, seen)
 
     return seen
+
+
+def _collect_pydantic_models(
+    annotation: object,
+    seen: dict[str, type[pydantic.BaseModel]],
+) -> None:
+    if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
+        get_pydantic_models(annotation, seen)
+        return
+
+    origin = get_origin(annotation)
+    if origin is None:
+        return
+
+    for arg in get_args(annotation):
+        _collect_pydantic_models(arg, seen)
 
 
 def generate_schemas(

--- a/src/ocean_emulators/config_schema.py
+++ b/src/ocean_emulators/config_schema.py
@@ -14,38 +14,42 @@ from ocean_emulators.viz import VizConfig
 
 def get_pydantic_models(
     model: type[pydantic.BaseModel],
-    seen: dict[str, type[pydantic.BaseModel]] | None = None,
+    models: dict[str, type[pydantic.BaseModel]] | None = None,
+    seen: set[int] | None = None,
 ) -> dict[str, type[pydantic.BaseModel]]:
     """Recursively find all Pydantic models in a model's fields.
 
     Args:
         model: The Pydantic model to start from
-        seen: Dictionary of already seen models (keyed by model name)
+        models: Collected models keyed by model name
+        seen: Visited annotation objects keyed by identity
 
     Returns:
         Dictionary of model names to model classes
     """
+    if models is None:
+        models = {}
     if seen is None:
-        seen = {}
+        seen = set()
 
-    model_name = model.__name__
-    if model_name in seen:
-        return seen
-
-    seen[model_name] = model
-
-    for field in model.model_fields.values():
-        _collect_pydantic_models(field.annotation, seen)
-
-    return seen
+    _collect_pydantic_models(model, models, seen)
+    return models
 
 
 def _collect_pydantic_models(
     annotation: object,
-    seen: dict[str, type[pydantic.BaseModel]],
+    models: dict[str, type[pydantic.BaseModel]],
+    seen: set[int],
 ) -> None:
+    annotation_id = id(annotation)
+    if annotation_id in seen:
+        return
+    seen.add(annotation_id)
+
     if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
-        get_pydantic_models(annotation, seen)
+        models[annotation.__name__] = annotation
+        for field in annotation.model_fields.values():
+            _collect_pydantic_models(field.annotation, models, seen)
         return
 
     origin = get_origin(annotation)
@@ -53,7 +57,7 @@ def _collect_pydantic_models(
         return
 
     for arg in get_args(annotation):
-        _collect_pydantic_models(arg, seen)
+        _collect_pydantic_models(arg, models, seen)
 
 
 def generate_schemas(

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -7,7 +7,7 @@ import torch
 
 from ocean_emulators.aggregator import Aggregator
 from ocean_emulators.backend import init_eval_backend
-from ocean_emulators.config import EvalConfig
+from ocean_emulators.config import CpuDataLoadingConfig, EvalConfig
 from ocean_emulators.constants import (
     BOUNDARY_VARS,
     PROGNOSTIC_VARS,
@@ -43,10 +43,16 @@ class Eval:
         self.device = init_eval_backend(cfg.backend)
 
         # Adjust workers and memory pinning based on device
+        cpu_loading = (
+            cfg.data.loading
+            if isinstance(cfg.data.loading, CpuDataLoadingConfig)
+            else None
+        )
+        data_num_workers = cpu_loading.num_workers if cpu_loading is not None else 0
         if not using_gpu():
-            cfg.data.num_workers = 0  # Disable multi-processing on CPU
-        elif cfg.disk_mode:
-            cfg.data.num_workers = torch.cuda.device_count() * cfg.data.num_workers
+            data_num_workers = 0  # Disable multi-processing on CPU
+        elif cfg.disk_mode and cpu_loading is not None:
+            data_num_workers = torch.cuda.device_count() * cpu_loading.num_workers
 
         # Set seeds
         set_seed(cfg.experiment.rand_seed)
@@ -141,7 +147,7 @@ class Eval:
         self.hist = cfg.data.hist
         self.output_dir = cfg.experiment.output_dir
         self.debug = cfg.debug
-        self.num_workers = cfg.data.num_workers
+        self.num_workers = data_num_workers
         self.inference_time = cfg.inference_time
         self.num_model_steps_forward = cfg.num_model_steps_forward
         self.save_zarr = cfg.save_zarr

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -7,7 +7,7 @@ import torch
 
 from ocean_emulators.aggregator import Aggregator
 from ocean_emulators.backend import init_eval_backend
-from ocean_emulators.config import CpuDataLoadingConfig, EvalConfig
+from ocean_emulators.config import EvalConfig
 from ocean_emulators.constants import (
     BOUNDARY_VARS,
     PROGNOSTIC_VARS,
@@ -43,16 +43,11 @@ class Eval:
         self.device = init_eval_backend(cfg.backend)
 
         # Adjust workers and memory pinning based on device
-        cpu_loading = (
-            cfg.data.loading
-            if isinstance(cfg.data.loading, CpuDataLoadingConfig)
-            else None
-        )
-        data_num_workers = cpu_loading.num_workers if cpu_loading is not None else 0
+        data_num_workers = cfg.data.loading.num_pytorch_workers()
         if not using_gpu():
             data_num_workers = 0  # Disable multi-processing on CPU
-        elif cfg.disk_mode and cpu_loading is not None:
-            data_num_workers = torch.cuda.device_count() * cpu_loading.num_workers
+        elif cfg.disk_mode:
+            data_num_workers = torch.cuda.device_count() * data_num_workers
 
         # Set seeds
         set_seed(cfg.experiment.rand_seed)

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -154,8 +154,15 @@ class Trainer:
                 "Step predictions on a mixed multiscale training schedule is not currently supported."
             )
 
+        cpu_loading = (
+            cfg.data.loading
+            if isinstance(cfg.data.loading, config.CpuDataLoadingConfig)
+            else None
+        )
+        data_num_workers = cpu_loading.num_workers if cpu_loading is not None else 0
+
         self.mp_context: BaseContext | None = None
-        if cfg.data.num_workers > 0:
+        if data_num_workers > 0:
             if self.data_container.supports_fork:
                 self.mp_context = multiprocessing.get_context("fork")
             else:
@@ -315,7 +322,7 @@ class Trainer:
         self.data_stride: list[int] = cfg.data_stride
         self.batch_size: int = cfg.batch_size
         self.gradient_accumulation_steps: int = cfg.gradient_accumulation_steps
-        self.num_workers: int = cfg.data.num_workers
+        self.num_workers: int = data_num_workers
         self.pin_mem: bool = cfg.pin_mem
         self.train_time: config.TimeConfig = cfg.train_time
         self.val_time = cfg.val_time

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -154,12 +154,7 @@ class Trainer:
                 "Step predictions on a mixed multiscale training schedule is not currently supported."
             )
 
-        cpu_loading = (
-            cfg.data.loading
-            if isinstance(cfg.data.loading, config.CpuDataLoadingConfig)
-            else None
-        )
-        data_num_workers = cpu_loading.num_workers if cpu_loading is not None else 0
+        data_num_workers = cfg.data.loading.num_pytorch_workers()
 
         self.mp_context: BaseContext | None = None
         if data_num_workers > 0:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from ocean_emulators.config import (
+    CpuDataLoadingConfig,
+    DataConfig,
+    DataSourceConfig,
+    GpuDataLoadingConfig,
+    TrainConfig,
+)
+from ocean_emulators.utils.location import UnresolvedLocation
+
+
+def test_data_config_rejects_legacy_num_workers_field():
+    with pytest.raises(ValidationError, match="num_workers"):
+        DataConfig.model_validate(
+            {
+                "sources": [
+                    {
+                        "data_location": "data.zarr",
+                        "data_means_location": "means.zarr",
+                        "data_stds_location": "stds.zarr",
+                    }
+                ],
+                "num_workers": 4,
+            }
+        )
+
+
+def test_data_config_defaults_to_cpu_loading():
+    cfg = DataConfig(
+        sources=[
+            DataSourceConfig(
+                data_location=UnresolvedLocation(path="data.zarr"),
+                data_means_location=UnresolvedLocation(path="means.zarr"),
+                data_stds_location=UnresolvedLocation(path="stds.zarr"),
+            )
+        ]
+    )
+
+    assert isinstance(cfg.loading, CpuDataLoadingConfig)
+    assert cfg.loading.num_workers == 4
+
+
+def test_data_config_accepts_gpu_loading():
+    cfg = DataConfig.model_validate(
+        {
+            "sources": [
+                {
+                    "data_location": "data.zarr",
+                    "data_means_location": "means.zarr",
+                    "data_stds_location": "stds.zarr",
+                }
+            ],
+            "loading": {
+                "type": "gpu",
+                "kvikio_task_size": 32 * 1024 * 1024,
+                "kvikio_num_threads": 4,
+            },
+        }
+    )
+
+    assert isinstance(cfg.loading, GpuDataLoadingConfig)
+    assert cfg.loading.kvikio_task_size == 32 * 1024 * 1024
+    assert cfg.loading.kvikio_num_threads == 4
+
+
+def test_train_config_allows_cli_override_for_cpu_num_workers(tmp_path):
+    config_path = (
+        Path(__file__).resolve().parents[1] / "configs" / "test" / "train_default.yaml"
+    )
+
+    cfg = TrainConfig.from_yaml_and_cli(
+        [
+            str(config_path),
+            "--experiment.data_root",
+            str(tmp_path),
+            "--experiment.base_output_dir",
+            str(tmp_path / "outputs"),
+            "--data.loading.num_workers",
+            "2",
+        ]
+    )
+
+    assert isinstance(cfg.data.loading, CpuDataLoadingConfig)
+    assert cfg.data.loading.num_workers == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ from ocean_emulators.config import (
     GpuDataLoadingConfig,
     TrainConfig,
 )
+from ocean_emulators.config_schema import get_pydantic_models
 from ocean_emulators.utils.location import UnresolvedLocation
 
 
@@ -42,6 +43,7 @@ def test_data_config_defaults_to_cpu_loading():
 
     assert isinstance(cfg.loading, CpuDataLoadingConfig)
     assert cfg.loading.num_workers == 4
+    assert cfg.loading.num_pytorch_workers() == 4
 
 
 def test_data_config_accepts_gpu_loading():
@@ -65,6 +67,7 @@ def test_data_config_accepts_gpu_loading():
     assert isinstance(cfg.loading, GpuDataLoadingConfig)
     assert cfg.loading.kvikio_task_size == 32 * 1024 * 1024
     assert cfg.loading.kvikio_num_threads == 4
+    assert cfg.loading.num_pytorch_workers() == 0
 
 
 def test_train_config_allows_cli_override_for_cpu_num_workers(tmp_path):
@@ -86,3 +89,10 @@ def test_train_config_allows_cli_override_for_cpu_num_workers(tmp_path):
 
     assert isinstance(cfg.data.loading, CpuDataLoadingConfig)
     assert cfg.data.loading.num_workers == 2
+
+
+def test_get_pydantic_models_collects_loading_variants():
+    models = get_pydantic_models(TrainConfig)
+
+    assert models["CpuDataLoadingConfig"] is CpuDataLoadingConfig
+    assert models["GpuDataLoadingConfig"] is GpuDataLoadingConfig


### PR DESCRIPTION
## Summary
This is the first PR in the LLC stack.

It separates `data.loading` from generic worker and DataLoader settings so CPU vs GPU loading can be configured explicitly without overloading one config object.

## Why
Later LLC and GPU-decode changes need an explicit loading mode. Pulling that distinction forward keeps the rest of the stack smaller and should preserve OM4 CPU behavior.

## Notes
This is intended as a draft stacked base PR for the rest of the LLC stack.
