### PR TITLE
Enable LLC training configs

### DIFF
--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -519,7 +519,7 @@ class DataConfig(BaseConfig):
 
 BlockType = Literal["conv_next_block", "conv_block"]
 ActivationType = Literal["relu", "gelu", "capped_gelu"]
-NormType = Literal["batch", "instance", "layer"]
+NormType = Literal["batch", "instance", "group", "nonorm", "layer"]
 
 
 class BlockConfig(BaseConfig):
@@ -528,6 +528,7 @@ class BlockConfig(BaseConfig):
     activation: ActivationType = "capped_gelu"
     upscale_factor: int = 4
     norm: NormType = "batch"
+    group_norm_groups: int = Field(default=32, ge=1)
     pointwise_linear: bool = False
 
     def build(self) -> CoreBlockBuilder:
@@ -572,6 +573,7 @@ class BlockConfig(BaseConfig):
                         kernel_size=self.kernel_size,
                         upscale_factor=self.upscale_factor,
                         norm=self.norm,
+                        group_norm_groups=self.group_norm_groups,
                         activation=activation,
                         pointwise_linear=self.pointwise_linear,
                     )
@@ -1286,6 +1288,7 @@ class TrainConfig(TopLevelConfig):
 
     # Data parameters at root level
     data_stride: list[int] = [1]
+    temporal_stride: int = Field(default=1, ge=1)
     steps: list[int] = [4]
     step_transition: list[int] = []
     inference_epochs: list[int] = [-1]

--- a/src/samudra/configs/data/llc.yaml
+++ b/src/samudra/configs/data/llc.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Ocean Emulator Authors
+# SPDX-FileCopyrightText: 2026 Samudra Authors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,6 +6,8 @@
 
 sources:
   - type: llc
+    prognostic_vars_key: single_1
+    boundary_vars_key: single_1
     face: 1
     i_start: 0
     i_end: 720
@@ -17,6 +19,9 @@ sources:
     val_time:
       start: "2012-09-01T12:00:00Z"
       end: "2012-11-15T12:00:00Z"
+    inference_times:
+      - start: "2012-10-16T12:00:00Z"
+        end: "2012-11-14T12:00:00Z"
     data_location: LLC.zarr
     data_means_location: LLC_means.zarr
     data_stds_location: LLC_stds.zarr

--- a/src/samudra/configs/samudra_llc/eval.yaml
+++ b/src/samudra/configs/samudra_llc/eval.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=../schemas/EvalConfig.json
+
+debug: false
+save_zarr: false
+disk_mode: true
+num_model_steps_forward: 25
+
+experiment:
+  name: samudra_llc_eval
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+data: !include ../data/llc.yaml
+model: !include model.yaml

--- a/src/samudra/configs/samudra_llc/model.yaml
+++ b/src/samudra/configs/samudra_llc/model.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=../schemas/SamudraConfig.json
+
+checkpointing: all
+pred_residuals: false
+last_kernel_size: 3
+pad: "constant"
+use_bfloat16: false
+
+unet:
+  ch_width: [256, 384, 512, 512]
+  dilation: [1, 2, 4, 8]
+  n_layers: [1, 1, 1, 1]
+
+  core_block:
+    block_type: "conv_next_block"
+    kernel_size: 3
+    activation: "capped_gelu"
+    upscale_factor: 2
+    norm: "group"
+    group_norm_groups: 32
+
+  down_sampling_block: "avg_pool"
+  up_sampling_block: "bilinear_upsample"

--- a/src/samudra/configs/samudra_llc/train.yaml
+++ b/src/samudra/configs/samudra_llc/train.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# yaml-language-server: $schema=../schemas/TrainConfig.json
+
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 70
+batch_size: 1
+learning_rate: 0.0006
+gradient_accumulation_steps: 4
+scheduler: { type: cosine }
+loss:
+  type: dynamic
+  metric: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: []
+data_stride: [1]
+temporal_stride: 24
+steps: [1]
+step_transition: []
+preemptible: false
+
+backend: auto
+
+experiment:
+  name: samudra_llc
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+data: !include ../data/llc.yaml
+model: !include model.yaml

--- a/src/samudra/datasets.py
+++ b/src/samudra/datasets.py
@@ -376,6 +376,7 @@ class TorchTrainDataset(Dataset[HostBatch]):
         masked_fill_value: float,
         stride: int = 1,
         concurrent_compute_: bool = False,
+        temporal_stride: int = 1,
     ):
         super().__init__()
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
@@ -390,6 +391,9 @@ class TorchTrainDataset(Dataset[HostBatch]):
             )
         self.steps: int = steps
         self.stride: int = stride
+        if temporal_stride < 1:
+            raise ValueError("temporal_stride must be >= 1")
+        self.temporal_stride: int = temporal_stride
         self._concurrent_compute = concurrent_compute_
 
         assert np.array_equal(sources[0].time, sources[-1].time), (
@@ -438,10 +442,14 @@ class TorchTrainDataset(Dataset[HostBatch]):
             output_resolution_cpu=self.sources[-1].resolution,
         )
 
-        self.size: int = (
+        base_size = (
             time_.size
             - self.steps * self.output_steps * self.stride
             - (self.input_steps - 1) * self.stride
+        )
+        self.size: int = max(
+            0,
+            (base_size + self.temporal_stride - 1) // self.temporal_stride,
         )
 
     def __len__(self) -> int:
@@ -518,7 +526,9 @@ class TorchTrainDataset(Dataset[HostBatch]):
         if idx >= len(self):
             raise IndexError("Index out of range")
 
-        window_index = idx + step * self.output_steps * self.stride
+        window_index = (
+            idx * self.temporal_stride + step * self.output_steps * self.stride
+        )
         return self.rolling_indices.isel(window=window_index, drop=True)
 
 

--- a/src/samudra/models/modules/blocks.py
+++ b/src/samudra/models/modules/blocks.py
@@ -280,6 +280,7 @@ class ConvNeXtBlock(CoreBlock):
         pad="circular",
         upscale_factor: int = 4,
         norm="batch",
+        group_norm_groups: int = 32,
         checkpoint_simple: bool = False,
         pointwise_linear: bool = False,
     ):
@@ -302,16 +303,13 @@ class ConvNeXtBlock(CoreBlock):
                 dilation=dilation,
             )
         )
-        # BatchNorm
-        if norm == "batch":
-            convblock.append(torch.nn.BatchNorm2d(in_channels * upscale_factor))
-        # Instance Norm
-        elif norm == "instance":
-            convblock.append(torch.nn.InstanceNorm2d(in_channels * upscale_factor))
-        elif norm == "nonorm":
-            pass
-        else:
-            raise NotImplementedError
+        norm_layer = self._build_norm_layer(
+            norm=norm,
+            channels=int(in_channels * upscale_factor),
+            group_norm_groups=group_norm_groups,
+        )
+        if norm_layer is not None:
+            convblock.append(norm_layer)
         if activation is not None:
             convblock.append(activation())
         convblock.append(
@@ -322,16 +320,13 @@ class ConvNeXtBlock(CoreBlock):
                 dilation=dilation,
             )
         )
-        # BatchNorm
-        if norm == "batch":
-            convblock.append(torch.nn.BatchNorm2d(in_channels * upscale_factor))
-        # Instance Norm
-        elif norm == "instance":
-            convblock.append(torch.nn.InstanceNorm2d(in_channels * upscale_factor))
-        elif norm == "nonorm":
-            pass
-        else:
-            raise NotImplementedError
+        norm_layer = self._build_norm_layer(
+            norm=norm,
+            channels=int(in_channels * upscale_factor),
+            group_norm_groups=group_norm_groups,
+        )
+        if norm_layer is not None:
+            convblock.append(norm_layer)
         if activation is not None:
             convblock.append(activation())
         # Linear postprocessing
@@ -342,6 +337,29 @@ class ConvNeXtBlock(CoreBlock):
         )
         self.convblock = torch.nn.Sequential(*convblock)
         self.checkpoint_simple = checkpoint_simple
+
+    @staticmethod
+    def _build_norm_layer(
+        norm: str,
+        channels: int,
+        group_norm_groups: int,
+    ) -> torch.nn.Module | None:
+        if norm == "batch":
+            return torch.nn.BatchNorm2d(channels)
+        if norm == "instance":
+            return torch.nn.InstanceNorm2d(channels)
+        if norm == "group":
+            if group_norm_groups < 1:
+                raise ValueError("group_norm_groups must be >= 1")
+            num_groups = min(group_norm_groups, channels)
+            while channels % num_groups != 0:
+                num_groups -= 1
+            return torch.nn.GroupNorm(num_groups=num_groups, num_channels=channels)
+        if norm == "layer":
+            return torch.nn.GroupNorm(num_groups=1, num_channels=channels)
+        if norm == "nonorm":
+            return None
+        raise NotImplementedError(f"Unsupported normalization mode {norm!r}")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # return self.skip_module(x) + self.convblock(x)

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -323,6 +323,7 @@ class Trainer:
         self.search_run = cfg.experiment.search
         self.debug = cfg.debug
         self.data_stride: list[int] = cfg.data_stride
+        self.temporal_stride: int = cfg.temporal_stride
         self.batch_size: int = cfg.batch_size
         self.gradient_accumulation_steps: int = cfg.gradient_accumulation_steps
         self.num_workers: int = data_num_workers
@@ -1099,6 +1100,7 @@ class Trainer:
                 masked_fill_value=self.masked_fill_value,
                 stride=stride,
                 concurrent_compute_=self.concurrent_compute,
+                temporal_stride=self.temporal_stride,
             )
             for stride in self.data_stride
             for source in self.data_bundle.train_sources
@@ -1120,6 +1122,7 @@ class Trainer:
                 masked_fill_value=self.masked_fill_value,
                 stride=stride,
                 concurrent_compute_=self.concurrent_compute,
+                temporal_stride=self.temporal_stride,
             )
             for stride in self.data_stride
         ]

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -92,3 +92,70 @@ class TestDropPath:
         torch.testing.assert_close(trunk.grad, torch.ones_like(trunk))
         # Skip gradient should be all zeros (dropped)
         torch.testing.assert_close(skip.grad, torch.zeros_like(skip))
+
+
+def test_convnext_block_group_norm_uses_divisible_group_count():
+    block = ConvNeXtBlock(
+        in_channels=10,
+        out_channels=10,
+        kernel_size=3,
+        dilation=1,
+        n_layers=1,
+        norm="group",
+        group_norm_groups=6,
+    )
+
+    norm_layers = [
+        layer for layer in block.convblock if isinstance(layer, nn.GroupNorm)
+    ]
+
+    assert len(norm_layers) == 2
+    assert all(layer.num_channels == 40 for layer in norm_layers)
+    assert all(layer.num_groups == 5 for layer in norm_layers)
+
+
+def test_convnext_block_layer_norm_uses_single_group():
+    block = ConvNeXtBlock(
+        in_channels=8,
+        out_channels=8,
+        kernel_size=3,
+        dilation=1,
+        n_layers=1,
+        norm="layer",
+    )
+
+    norm_layers = [
+        layer for layer in block.convblock if isinstance(layer, nn.GroupNorm)
+    ]
+
+    assert len(norm_layers) == 2
+    assert all(layer.num_groups == 1 for layer in norm_layers)
+
+
+def test_convnext_block_nonorm_inserts_no_normalization_layers():
+    block = ConvNeXtBlock(
+        in_channels=8,
+        out_channels=8,
+        kernel_size=3,
+        dilation=1,
+        n_layers=1,
+        norm="nonorm",
+    )
+
+    assert not any(
+        isinstance(layer, (nn.BatchNorm2d, nn.InstanceNorm2d, nn.GroupNorm))
+        for layer in block.convblock
+    )
+
+
+def test_convnext_block_group_norm_rejects_nonpositive_group_count():
+    with pytest.raises(ValueError, match="group_norm_groups must be >= 1"):
+        ConvNeXtBlock(
+            in_channels=8,
+            out_channels=8,
+            kernel_size=3,
+            dilation=1,
+            n_layers=1,
+            norm="group",
+            group_norm_groups=0,
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,9 +22,11 @@ from samudra.config import (
     Om4DataSourceConfig,
     Om4TimeConfig,
     RolloutValidationConfig,
+    SamudraConfig,
     TrainConfig,
 )
 from samudra.config_schema import get_pydantic_models
+from samudra.models.modules.blocks import ConvNeXtBlock
 from samudra.utils.location import LocalLocation, UnresolvedLocation
 from tests.conftest import DEFAULT_CONFIG, TEST_CONFIGS_DIR
 from tests.llc_fixtures import write_raw_llc_datasets
@@ -449,6 +451,40 @@ def test_get_pydantic_models_collects_loading_variants():
 
     assert models["CpuDataLoadingConfig"] is CpuDataLoadingConfig
     assert models["GpuDataLoadingConfig"] is GpuDataLoadingConfig
+
+
+def test_llc_train_config_uses_group_norm_and_temporal_stride(tmp_path):
+    cfg = TrainConfig.from_yaml_and_cli(
+        [
+            "samudra_llc/train.yaml",
+            "--experiment.base_output_dir",
+            str(tmp_path / "outputs"),
+        ]
+    )
+
+    assert cfg.temporal_stride == 24
+    assert cfg.data.sources[0].type == "llc"
+    assert cfg.data.sources[0].prognostic_vars_key == "single_1"
+    assert cfg.data.sources[0].boundary_vars_key == "single_1"
+    assert isinstance(cfg.model, SamudraConfig)
+    assert cfg.model.unet.core_block.norm == "group"
+    assert cfg.model.unet.core_block.group_norm_groups == 32
+    block = cfg.model.unet.core_block.build()(1, 1, 1, 1, "constant", False)
+    assert isinstance(block, ConvNeXtBlock)
+
+
+def test_llc_train_config_allows_cli_override_for_temporal_stride(tmp_path):
+    cfg = TrainConfig.from_yaml_and_cli(
+        [
+            "samudra_llc/train.yaml",
+            "--experiment.base_output_dir",
+            str(tmp_path / "outputs"),
+            "--temporal_stride",
+            "12",
+        ]
+    )
+
+    assert cfg.temporal_stride == 12
 
 
 @pytest.mark.parametrize(

--- a/tests/test_temporal_stride.py
+++ b/tests/test_temporal_stride.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import torch
+import xarray as xr
+
+from samudra.constants import build_om4_layout
+from samudra.datasets import TorchTrainDataset
+from samudra.utils.data import CanonicalSource, Masks
+
+
+def test_torch_train_dataset_temporal_stride_subsamples_windows():
+    coords = {"time": range(10), "lat": range(1), "lon": range(1)}
+    data = xr.Dataset(
+        {
+            "thetao_0": xr.DataArray(
+                np.arange(10, dtype=np.float32).reshape(10, 1, 1),
+                dims=["time", "lat", "lon"],
+                coords=coords,
+            ),
+            "hfds": xr.DataArray(
+                (100 + np.arange(10, dtype=np.float32)).reshape(10, 1, 1),
+                dims=["time", "lat", "lon"],
+                coords=coords,
+            ),
+        }
+    )
+    means = xr.Dataset({"thetao_0": 0.0, "hfds": 0.0})
+    stds = xr.Dataset({"thetao_0": 1.0, "hfds": 1.0})
+    masks = Masks(
+        prognostic=torch.ones((1, 1, 1), dtype=torch.bool),
+        boundary=torch.ones((1, 1), dtype=torch.bool),
+    )
+    data_layout = build_om4_layout(
+        prognostic_vars_key="thetao_1", boundary_vars_key="hfds"
+    )
+    source = CanonicalSource.from_canonical_datasets(
+        name="test",
+        data=data,
+        means=means,
+        stds=stds,
+        masks=masks,
+        data_layout=data_layout,
+    )
+
+    dataset = TorchTrainDataset(
+        input_source=source,
+        label_source=None,
+        prognostic_var_names=["thetao_0"],
+        boundary_var_names=["hfds"],
+        input_steps=2,
+        output_steps=2,
+        steps=2,
+        normalize_before_mask=True,
+        masked_fill_value=0.0,
+        stride=1,
+        temporal_stride=2,
+    )
+
+    assert len(dataset) == 3
+    assert dataset[0].steps[0].prognostic[:, 0, 0, 0].tolist() == [0.0, 1.0]
+    assert dataset[1].steps[0].prognostic[:, 0, 0, 0].tolist() == [2.0, 3.0]
+    assert dataset[2].steps[0].prognostic[:, 0, 0, 0].tolist() == [4.0, 5.0]


### PR DESCRIPTION
## Summary
This is PR 4 in the LLC stack, based on #670.

It lands the minimal model and config changes needed to make the initial LLC training configs valid on the standard training path. The intent is to support the initial LLC experiment shape without mixing in GPU decode or cluster-local launcher logic.

## Why
Once the LLC CPU loader exists, the next step is making LLC runs representable in the training config and model code. Keeping that separate from GPU decode keeps the review surface smaller.

## Notes
This remains a draft stacked PR.
