### PR TITLE
Harden distributed training runtime

### DIFF
--- a/src/ocean_emulators/backend.py
+++ b/src/ocean_emulators/backend.py
@@ -30,6 +30,7 @@ def _cuda_diagnostics() -> str:
 
 def init_train_backend(
     backend: TrainBackendConfig,
+    ddp_timeout_minutes: int = 60,
 ) -> tuple[torch.device, DistributedConfig | None]:
     """Given backend config, get the device and (if any) distributed configuration."""
     match backend:
@@ -51,12 +52,12 @@ def init_train_backend(
                     + _cuda_diagnostics()
                 )
             device = torch.device("cuda")
-            dist_cfg = init_distributed_mode()
+            dist_cfg = init_distributed_mode(timeout_minutes=ddp_timeout_minutes)
         case "auto" if torch.cuda.is_available():
             logger.info("auto backend detected CUDA")
             device = torch.device("cuda")
             try:
-                dist_cfg = init_distributed_mode()
+                dist_cfg = init_distributed_mode(timeout_minutes=ddp_timeout_minutes)
                 logger.info("succeeded in initializing distributed mode")
             except RuntimeError as e:
                 logger.info(

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -1162,6 +1162,43 @@ class TrainConfig(TopLevelConfig):
     faster_decay_at_start: bool = True
     delayed_loss_estimate: bool = False
     backend: TrainBackendConfig = "auto"
+    ddp_bucket_cap_mb: int | None = Field(
+        default=50,
+        ge=1,
+        description=(
+            "DDP communication bucket size in MB. Larger values reduce collective "
+            "count but increase burst memory pressure."
+        ),
+    )
+    ddp_gradient_as_bucket_view: bool = True
+    ddp_static_graph: bool = False
+    ddp_find_unused_parameters: bool = False
+    ddp_broadcast_buffers: bool = True
+    ddp_use_no_sync_for_accumulation: bool = True
+    ddp_max_data_workers_per_rank: int = Field(
+        default=2,
+        ge=1,
+        description=(
+            "Upper bound on DataLoader workers per rank during distributed training. "
+            "Caps worker fan-out to reduce straggler-induced collective timeouts."
+        ),
+    )
+    ddp_timeout_minutes: int = Field(
+        default=60,
+        ge=1,
+        description=(
+            "Distributed process-group timeout in minutes. Increase this to "
+            "avoid aborting runs when one rank occasionally stalls."
+        ),
+    )
+    slow_batch_log_threshold_seconds: float = Field(
+        default=300.0,
+        ge=0.0,
+        description=(
+            "Emit a warning when a batch's recorded data load time exceeds this "
+            "threshold."
+        ),
+    )
 
     # Profiling parameters
     profiler: ProfilerConfig = ProfilerConfig()

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -111,7 +111,9 @@ class Trainer:
         cfg.save_yaml(cfg.experiment.output_dir / "config.yaml")
 
         # Backend
-        self.device, self.distributed = init_train_backend(cfg.backend)
+        self.device, self.distributed = init_train_backend(
+            cfg.backend, ddp_timeout_minutes=cfg.ddp_timeout_minutes
+        )
 
         # Adjust workers and memory pinning based on device
         if not using_gpu():
@@ -156,8 +158,41 @@ class Trainer:
                 "Step predictions on a mixed multiscale training schedule is not currently supported."
             )
 
+        cpu_loading = (
+            cfg.data.loading
+            if isinstance(cfg.data.loading, config.CpuDataLoadingConfig)
+            else None
+        )
         data_num_workers = cfg.data.loading.num_pytorch_workers()
         persistent_workers = cfg.data.loading.persistent_pytorch_workers()
+
+        if (
+            self.distributed is not None
+            and cpu_loading is not None
+            and data_num_workers > 0
+        ):
+            world_size = get_world_size()
+            scaled_workers = max(1, data_num_workers // world_size)
+            capped_workers = (
+                min(scaled_workers, cfg.ddp_max_data_workers_per_rank)
+                if world_size > 1
+                else scaled_workers
+            )
+            if scaled_workers != data_num_workers:
+                logger.info(
+                    "Scaling data.loading.num_workers from "
+                    f"{data_num_workers} to {scaled_workers} per rank "
+                    f"for world_size={world_size}."
+                )
+            if capped_workers != scaled_workers:
+                logger.info(
+                    "Capping data.loading.num_workers per rank from "
+                    f"{scaled_workers} to {capped_workers} "
+                    f"(ddp_max_data_workers_per_rank="
+                    f"{cfg.ddp_max_data_workers_per_rank})."
+                )
+            cpu_loading.num_workers = capped_workers
+            data_num_workers = capped_workers
 
         self.mp_context: BaseContext | None = None
         if data_num_workers > 0:
@@ -298,9 +333,24 @@ class Trainer:
 
         # Modify DDP setup based on device
         if self.distributed is not None:
+            assert self.distributed.gpu is not None
+            ddp_options = {
+                "device_ids": [self.distributed.gpu],
+                "bucket_cap_mb": cfg.ddp_bucket_cap_mb,
+                "gradient_as_bucket_view": cfg.ddp_gradient_as_bucket_view,
+                "static_graph": cfg.ddp_static_graph,
+                "find_unused_parameters": cfg.ddp_find_unused_parameters,
+                "broadcast_buffers": cfg.ddp_broadcast_buffers,
+            }
+            logger.info(f"Initializing DDP with options: {ddp_options}")
             self.model = nn.parallel.DistributedDataParallel(
                 nn.SyncBatchNorm.convert_sync_batchnorm(self.model),
                 device_ids=[self.distributed.gpu],
+                bucket_cap_mb=cfg.ddp_bucket_cap_mb,
+                gradient_as_bucket_view=cfg.ddp_gradient_as_bucket_view,
+                static_graph=cfg.ddp_static_graph,
+                find_unused_parameters=cfg.ddp_find_unused_parameters,
+                broadcast_buffers=cfg.ddp_broadcast_buffers,
             )
 
         # EMA (must come after DDP setup so parameter names match final self.model)
@@ -325,6 +375,18 @@ class Trainer:
         self.temporal_stride: int = cfg.temporal_stride
         self.batch_size: int = cfg.batch_size
         self.gradient_accumulation_steps: int = cfg.gradient_accumulation_steps
+        self.ddp_use_no_sync_for_accumulation = cfg.ddp_use_no_sync_for_accumulation
+        self.ddp_static_graph: bool = cfg.ddp_static_graph
+        if (
+            self.ddp_static_graph
+            and self.ddp_use_no_sync_for_accumulation
+            and self.gradient_accumulation_steps > 1
+        ):
+            logger.warning(
+                "Disabling DDP no_sync accumulation because ddp_static_graph=true. "
+                "This avoids known DDP reducer assertions in this PyTorch setup."
+            )
+            self.ddp_use_no_sync_for_accumulation = False
         self.num_workers: int = data_num_workers
         self.persistent_workers: bool = persistent_workers
         self.pin_mem: bool = cfg.pin_mem
@@ -338,6 +400,9 @@ class Trainer:
         self.normalize_before_mask: bool = cfg.data.normalize_before_mask
         self.normalize_fill_value: float = cfg.data.masked_fill_value
         self.delayed_loss_estimate: bool = cfg.delayed_loss_estimate
+        self.slow_batch_log_threshold_seconds: float = (
+            cfg.slow_batch_log_threshold_seconds
+        )
 
         self.profiler = cfg.profiler.build(self.output_dir, self.device)
         self.validation_images_enabled = self._sync_flag_from_main(
@@ -507,6 +572,17 @@ class Trainer:
             if remaining_batches > 0
             else total_batches
         )
+        ddp_model = (
+            self.model
+            if isinstance(self.model, torch.nn.parallel.DistributedDataParallel)
+            else None
+        )
+        use_no_sync = (
+            ddp_model is not None
+            and self.ddp_use_no_sync_for_accumulation
+            and self.gradient_accumulation_steps > 1
+            and not self.ddp_static_graph
+        )
 
         for data_iter_step, data in enumerate(
             metric_logger.log_every(self.train_loader, 1, header)
@@ -526,19 +602,28 @@ class Trainer:
 
             if self.num_batches_seen == 0:
                 get_model_summary(self.model, data, self.debug)
+            is_last = data_iter_step + 1 == total_batches
+            should_step = (data_iter_step + 1) % self.gradient_accumulation_steps == 0
+            sync_gradients = should_step or is_last
 
-            TO: TrainBatchOutput = train_batch(self.model, data, self.loss_fn)
+            sync_context: contextlib.AbstractContextManager[None]
+            if use_no_sync and not sync_gradients:
+                assert ddp_model is not None
+                sync_context = ddp_model.no_sync()
+            else:
+                sync_context = contextlib.nullcontext()
 
-            # Scale loss by the actual number of microbatches that will be accumulated
-            scaled_loss = TO.loss / r
-            scaled_loss.backward()
+            with sync_context:
+                TO: TrainBatchOutput = train_batch(self.model, data, self.loss_fn)
+
+                # Scale loss by the actual number of microbatches that will be accumulated
+                scaled_loss = TO.loss / r
+                scaled_loss.backward()
 
             train_aggregator.record_batch(TO)
 
             self.num_batches_seen += 1
 
-            is_last = data_iter_step + 1 == total_batches
-            should_step = (data_iter_step + 1) % self.gradient_accumulation_steps == 0
             # Step optimizer after accumulating enough batches or at the end
             if should_step or is_last:
                 torch.nn.utils.clip_grad_norm_(self.model.parameters(), 1.0)
@@ -554,8 +639,14 @@ class Trainer:
 
             with torch.no_grad():
                 # Reduce losses
-                loss_value_reduce = all_reduce_mean(TO.loss.detach())
-                loss_per_channel_reduce = all_reduce_mean(TO.loss_per_channel.detach())
+                if sync_gradients:
+                    loss_value_reduce = all_reduce_mean(TO.loss.detach())
+                    loss_per_channel_reduce = all_reduce_mean(
+                        TO.loss_per_channel.detach()
+                    )
+                else:
+                    loss_value_reduce = TO.loss.detach()
+                    loss_per_channel_reduce = TO.loss_per_channel.detach()
                 metrics = {
                     "train/batch/loss": loss_value_reduce,
                     "train/batch/lr": lr,
@@ -614,6 +705,17 @@ class Trainer:
                             "train/batch/loss_unscaled": unscaled_loss,
                         }
                     )
+
+            data_load_time = metric_logger.meters["data_load_time"].value
+            if data_load_time > self.slow_batch_log_threshold_seconds:
+                logger.warning(
+                    "Slow batch load time %.1fs exceeded threshold %.1fs "
+                    "at epoch %s batch %s.",
+                    data_load_time,
+                    self.slow_batch_log_threshold_seconds,
+                    epoch,
+                    data_iter_step,
+                )
 
             if (it_time := metric_logger.meters["iter_time"]).count > 0:
                 metrics["train/batch/iter_time"] = it_time.value

--- a/src/ocean_emulators/utils/distributed.py
+++ b/src/ocean_emulators/utils/distributed.py
@@ -81,7 +81,7 @@ def is_main_process():
     return get_rank() == 0
 
 
-def init_distributed_mode() -> DistributedConfig:
+def init_distributed_mode(timeout_minutes: int = 60) -> DistributedConfig:
     cfg = DistributedConfig()
 
     if "RANK" in os.environ:
@@ -123,11 +123,13 @@ def init_distributed_mode() -> DistributedConfig:
         world_size=cfg.world_size,
         rank=cfg.rank,
         device_id=cfg.gpu,
+        timeout=datetime.timedelta(minutes=timeout_minutes),
     )
     torch.cuda.set_device(cfg.gpu)
     logger.info(
         f"| distributed init (rank {cfg.rank}), gpu {cfg.gpu}, "
-        f"world_size {cfg.world_size}, dist_url {cfg.dist_url}"
+        f"world_size {cfg.world_size}, dist_url {cfg.dist_url}, "
+        f"timeout {timeout_minutes} min"
     )
     torch.distributed.barrier()
     suppress_prints(cfg.rank == 0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -329,3 +329,32 @@ def test_llc_train_config_allows_cli_override_for_temporal_stride(tmp_path):
     )
 
     assert cfg.temporal_stride == 12
+
+
+def test_train_config_allows_cli_override_for_ddp_runtime_fields(tmp_path):
+    config_path = (
+        Path(__file__).resolve().parents[1] / "configs" / "test" / "train_default.yaml"
+    )
+
+    cfg = TrainConfig.from_yaml_and_cli(
+        [
+            str(config_path),
+            "--experiment.data_root",
+            str(tmp_path),
+            "--experiment.base_output_dir",
+            str(tmp_path / "outputs"),
+            "--ddp_bucket_cap_mb",
+            "64",
+            "--ddp_max_data_workers_per_rank",
+            "3",
+            "--ddp_timeout_minutes",
+            "15",
+            "--slow_batch_log_threshold_seconds",
+            "12.5",
+        ]
+    )
+
+    assert cfg.ddp_bucket_cap_mb == 64
+    assert cfg.ddp_max_data_workers_per_rank == 3
+    assert cfg.ddp_timeout_minutes == 15
+    assert cfg.slow_batch_log_threshold_seconds == 12.5

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -354,7 +354,7 @@ def test_train_one_epoch_uses_no_sync_for_intermediate_microbatches(
         _FakeDDP(trainer.model),
     )
     monkeypatch.setattr(
-        "ocean_emulators.train.Stepper.train_batch",
+        "ocean_emulators.train.train_batch",
         lambda model, data, loss_fn: TrainBatchOutput(
             loss=torch.tensor(1.0, requires_grad=True),
             loss_per_channel=torch.ones(trainer.num_out),
@@ -391,7 +391,7 @@ def test_train_one_epoch_warns_for_slow_batches(
     trainer.slow_batch_log_threshold_seconds = -1.0
 
     monkeypatch.setattr(
-        "ocean_emulators.train.Stepper.train_batch",
+        "ocean_emulators.train.train_batch",
         lambda model, data, loss_fn: TrainBatchOutput(
             loss=torch.tensor(1.0, requires_grad=True),
             loss_per_channel=torch.ones(trainer.num_out),

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,14 +1,22 @@
 import logging
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
+from typing import cast
 
 import pytest
 import torch
 
-from ocean_emulators.config import CpuDataLoadingConfig, DynamicLossConfig
+from ocean_emulators.config import (
+    CpuDataLoadingConfig,
+    DistributedConfig,
+    DynamicLossConfig,
+)
 from ocean_emulators.models.base import BaseModel
+from ocean_emulators.stepper import TrainBatchOutput
 from ocean_emulators.train import Trainer, should_log_validation_images
 from ocean_emulators.utils.ctx import GridContext
+from ocean_emulators.utils.device import set_device
 from ocean_emulators.utils.loss import DynamicLoss
 from ocean_emulators.utils.multiton import MultitonScope
 from tests.conftest import DEFAULT_CONFIG, TrainPair
@@ -27,7 +35,6 @@ def test_trainer__mini_benchmark(trainer_pair: TrainPair, caplog, benchmark):
         trainer.run()
 
 
-@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
 @pytest.mark.parametrize(
     "data_source,config_name",
     [("mock-om4", "test/train_default_2step.yaml")],
@@ -221,6 +228,185 @@ def test_data_loaders_disable_persistent_workers_when_num_workers_is_zero(
     assert trainer.val_loader._dataloader.persistent_workers is False
 
 
+class _FakeDDP(torch.nn.Module):
+    def __init__(self, module: torch.nn.Module, **kwargs):
+        super().__init__()
+        self.module = module
+        self.kwargs = kwargs
+        self.no_sync_calls = 0
+
+    @contextmanager
+    def no_sync(self):
+        self.no_sync_calls += 1
+        yield
+
+
+@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("mock-om4", "test/train_default_2step.yaml")],
+    indirect=True,
+)
+def test_trainer_scales_cpu_loader_workers_per_rank(train_config, monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+    train_config.data.loading = CpuDataLoadingConfig(num_workers=8)
+    train_config.ddp_max_data_workers_per_rank = 2
+    train_config.ddp_timeout_minutes = 17
+    train_config.inference_epochs = []
+    captured_timeout: dict[str, int] = {}
+
+    def fake_init_train_backend(backend, ddp_timeout_minutes=60):
+        captured_timeout["value"] = ddp_timeout_minutes
+        set_device(torch.device("cpu"))
+        return torch.device("cpu"), DistributedConfig(world_size=4, rank=0, gpu=0)
+
+    monkeypatch.setattr(
+        "ocean_emulators.train.init_train_backend", fake_init_train_backend
+    )
+    monkeypatch.setattr("ocean_emulators.train.get_world_size", lambda: 4)
+    monkeypatch.setattr(
+        "ocean_emulators.train.nn.SyncBatchNorm.convert_sync_batchnorm",
+        lambda model: model,
+    )
+    monkeypatch.setattr(
+        "ocean_emulators.train.nn.parallel.DistributedDataParallel", _FakeDDP
+    )
+    monkeypatch.setattr(
+        "ocean_emulators.train.torch.distributed.broadcast",
+        lambda tensor, src=0: None,
+    )
+
+    with MultitonScope():
+        trainer = Trainer(train_config)
+
+    assert captured_timeout["value"] == 17
+    assert trainer.num_workers == 2
+    assert isinstance(train_config.data.loading, CpuDataLoadingConfig)
+    assert train_config.data.loading.num_workers == 2
+    assert "Scaling data.loading.num_workers from 8 to 2 per rank" in caplog.text
+    assert "Initializing DDP with options" in caplog.text
+
+
+@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("mock-om4", "test/train_default_2step.yaml")],
+    indirect=True,
+)
+def test_trainer_disables_no_sync_with_static_graph(train_config, monkeypatch, caplog):
+    caplog.set_level(logging.WARNING)
+    train_config.gradient_accumulation_steps = 2
+    train_config.ddp_static_graph = True
+    train_config.ddp_use_no_sync_for_accumulation = True
+    train_config.inference_epochs = []
+
+    def fake_init_train_backend(backend, ddp_timeout_minutes=60):
+        set_device(torch.device("cpu"))
+        return torch.device("cpu"), DistributedConfig(world_size=2, rank=0, gpu=0)
+
+    monkeypatch.setattr(
+        "ocean_emulators.train.init_train_backend", fake_init_train_backend
+    )
+    monkeypatch.setattr("ocean_emulators.train.get_world_size", lambda: 2)
+    monkeypatch.setattr(
+        "ocean_emulators.train.nn.SyncBatchNorm.convert_sync_batchnorm",
+        lambda model: model,
+    )
+    monkeypatch.setattr(
+        "ocean_emulators.train.nn.parallel.DistributedDataParallel", _FakeDDP
+    )
+    monkeypatch.setattr(
+        "ocean_emulators.train.torch.distributed.broadcast",
+        lambda tensor, src=0: None,
+    )
+
+    with MultitonScope():
+        trainer = Trainer(train_config)
+
+    assert trainer.ddp_use_no_sync_for_accumulation is False
+    assert (
+        "Disabling DDP no_sync accumulation because ddp_static_graph=true"
+        in caplog.text
+    )
+
+
+@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("mock-om4", "test/train_default_2step.yaml")],
+    indirect=True,
+)
+def test_train_one_epoch_uses_no_sync_for_intermediate_microbatches(
+    trainer_pair: TrainPair, monkeypatch
+):
+    _, trainer = trainer_pair
+    trainer.num_batches_seen = 1
+    trainer.gradient_accumulation_steps = 2
+    trainer.ddp_static_graph = False
+    trainer.ddp_use_no_sync_for_accumulation = True
+    trainer.distributed = DistributedConfig(world_size=2, rank=0, gpu=0)
+
+    monkeypatch.setattr(
+        "ocean_emulators.train.torch.nn.parallel.DistributedDataParallel", _FakeDDP
+    )
+    trainer.model = cast(
+        torch.nn.parallel.DistributedDataParallel,
+        _FakeDDP(trainer.model),
+    )
+    monkeypatch.setattr(
+        "ocean_emulators.train.Stepper.train_batch",
+        lambda model, data, loss_fn: TrainBatchOutput(
+            loss=torch.tensor(1.0, requires_grad=True),
+            loss_per_channel=torch.ones(trainer.num_out),
+        ),
+    )
+    monkeypatch.setattr("ocean_emulators.train.all_reduce_mean", lambda x: x)
+    monkeypatch.setattr(trainer, "_maybe_update_loss", lambda *args, **kwargs: None)
+    monkeypatch.setattr(trainer.profiler, "after_batch", lambda *args, **kwargs: None)
+
+    total_batches = len(trainer.train_loader)
+    trainer.train_one_epoch(1)
+
+    expected_no_sync_calls = sum(
+        1
+        for batch_idx in range(total_batches)
+        if (batch_idx + 1) % trainer.gradient_accumulation_steps != 0
+        and batch_idx + 1 != total_batches
+    )
+    assert trainer.model.no_sync_calls == expected_no_sync_calls
+
+
+@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("mock-om4", "test/train_default_2step.yaml")],
+    indirect=True,
+)
+def test_train_one_epoch_warns_for_slow_batches(
+    trainer_pair: TrainPair, monkeypatch, caplog
+):
+    caplog.set_level(logging.WARNING)
+    _, trainer = trainer_pair
+    trainer.num_batches_seen = 1
+    trainer.slow_batch_log_threshold_seconds = -1.0
+
+    monkeypatch.setattr(
+        "ocean_emulators.train.Stepper.train_batch",
+        lambda model, data, loss_fn: TrainBatchOutput(
+            loss=torch.tensor(1.0, requires_grad=True),
+            loss_per_channel=torch.ones(trainer.num_out),
+        ),
+    )
+    monkeypatch.setattr("ocean_emulators.train.all_reduce_mean", lambda x: x)
+    monkeypatch.setattr(trainer, "_maybe_update_loss", lambda *args, **kwargs: None)
+    monkeypatch.setattr(trainer.profiler, "after_batch", lambda *args, **kwargs: None)
+
+    trainer.train_one_epoch(1)
+
+    assert "Slow batch load time" in caplog.text
+
+
+@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
 @pytest.mark.parametrize(
     "data_source,config_name",
     [("mock-om4", "test/train_default_2step.yaml")],


### PR DESCRIPTION
## Summary
This is PR 6 in the LLC stack, based on #672.

It pulls the generic trainer and distributed-runtime hardening to the end of the stack: DDP worker scaling, no-sync/static-graph handling, slow-batch warnings, emergency checkpoint handling, and related trainer robustness updates.

## Why
These changes are useful beyond LLC, but they are easier to review once the dataset and GPU-decode changes are already isolated. Moving this PR to the end keeps the earlier LLC/data review focused.

## Notes
This remains a draft stacked PR.
