### PR TITLE
Small improvements from profiling on NYU torch

### DIFF
--- a/src/ocean_emulators/aggregator/validate/map.py
+++ b/src/ocean_emulators/aggregator/validate/map.py
@@ -2,7 +2,7 @@ import torch
 
 from ocean_emulators.aggregator.plotting import plot_paneled_data
 from ocean_emulators.aggregator.validate.sub_aggregator import ValidateSubAggregator
-from ocean_emulators.utils.distributed import all_reduce_mean
+from ocean_emulators.utils.distributed import all_reduce_mean, is_main_process
 
 
 class MapAggregator(ValidateSubAggregator):
@@ -73,6 +73,7 @@ class MapAggregator(ValidateSubAggregator):
         time_dim = 0
         target_time = self.hist  # Use latest time step
         image_logs = {}
+        render_images = is_main_process()
         sorted_names = sorted(list(self._gen_data.keys()))
         for name in sorted_names:
             # use first sample in batch
@@ -88,6 +89,8 @@ class MapAggregator(ValidateSubAggregator):
                 )
                 / self._n_batches
             )
+            if not render_images:
+                continue
             image_logs[f"image-error/{name}"] = plot_paneled_data(
                 [[(gen - target).cpu().numpy()]],
                 diverging=True,

--- a/src/ocean_emulators/aggregator/validate/snapshot.py
+++ b/src/ocean_emulators/aggregator/validate/snapshot.py
@@ -2,6 +2,7 @@ import torch
 
 from ocean_emulators.aggregator.plotting import plot_paneled_data
 from ocean_emulators.aggregator.validate.sub_aggregator import ValidateSubAggregator
+from ocean_emulators.utils.distributed import is_main_process
 from ocean_emulators.utils.wandb import Metrics
 
 
@@ -67,6 +68,9 @@ class SnapshotAggregator(ValidateSubAggregator):
         Args:
             label: Label to prepend to all log keys.
         """
+        if not is_main_process():
+            return {}
+
         time_dim = 1
         target_time = 0  # first output time step
         input_time = self.hist  # last input time step

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -156,6 +156,7 @@ class DataConfig(BaseConfig):
     )
     static_data_vars: list[str] | None = None
     num_workers: int = 4
+    persistent_workers: bool = True
     hist: int = 1
     loader_version: str = str(LoaderVersion.OM4_TORCH.value)
     normalize_before_mask: bool = True

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -316,6 +316,7 @@ class Trainer:
         self.batch_size: int = cfg.batch_size
         self.gradient_accumulation_steps: int = cfg.gradient_accumulation_steps
         self.num_workers: int = cfg.data.num_workers
+        self.persistent_workers: bool = cfg.data.persistent_workers
         self.pin_mem: bool = cfg.pin_mem
         self.train_time: config.TimeConfig = cfg.train_time
         self.val_time = cfg.val_time
@@ -329,6 +330,9 @@ class Trainer:
         self.delayed_loss_estimate: bool = cfg.delayed_loss_estimate
 
         self.profiler = cfg.profiler.build(self.output_dir, self.device)
+        self.validation_images_enabled = self._sync_flag_from_main(
+            self.wandb_logger.enabled
+        )
 
         assert self.tensor_map is not None
 
@@ -649,8 +653,9 @@ class Trainer:
 
     def validate_one_epoch(self, epoch):
         self.model.eval()
-        log_validation_images = should_log_validation_images(
-            epoch, self.validation_image_log_freq
+        log_validation_images = (
+            should_log_validation_images(epoch, self.validation_image_log_freq)
+            and self.validation_images_enabled
         )
 
         if self.train_schedule == "standard":
@@ -893,6 +898,7 @@ class Trainer:
             train_data,
             batch_sampler=train_batch_sampler,
             num_workers=self.num_workers,
+            persistent_workers=self.persistent_workers and self.num_workers > 0,
             pin_memory=self.pin_mem,
             collate_fn=collate_fn,
             multiprocessing_context=self.mp_context,
@@ -902,6 +908,7 @@ class Trainer:
             val_data,
             batch_sampler=val_batch_sampler,
             num_workers=self.num_workers,
+            persistent_workers=self.persistent_workers and self.num_workers > 0,
             pin_memory=self.pin_mem,
             collate_fn=collate_fn,
             multiprocessing_context=self.mp_context,
@@ -1055,6 +1062,15 @@ class Trainer:
 
     def is_wandb_enabled(self):
         return self.wandb_logger.enabled and is_main_process()
+
+    def _sync_flag_from_main(self, flag: bool) -> bool:
+        """Broadcast a boolean decision from rank 0 to every process."""
+        if self.distributed is None:
+            return flag
+
+        synced = torch.tensor([int(flag)], device=self.device)
+        torch.distributed.broadcast(synced, src=0)
+        return bool(synced.item())
 
     @contextlib.contextmanager
     def _test_context(self):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -179,3 +179,38 @@ def test_should_log_validation_images_rejects_invalid_inputs():
 
     with pytest.raises(ValueError, match="Validation image log frequency must be >= 1"):
         should_log_validation_images(1, 0)
+
+
+@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("mock-om4", "test/train_default.yaml")],
+    indirect=True,
+)
+def test_data_loaders_enable_persistent_workers_on_positive_num_workers(
+    trainer_pair: TrainPair,
+):
+    _, trainer = trainer_pair
+
+    assert trainer.train_loader._dataloader.persistent_workers is True
+    assert trainer.val_loader._dataloader.persistent_workers is True
+
+
+@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("mock-om4", "test/train_default.yaml")],
+    indirect=True,
+)
+def test_data_loaders_disable_persistent_workers_when_num_workers_is_zero(
+    train_config,
+):
+    train_config.data.num_workers = 0
+    train_config.data.persistent_workers = True
+
+    with MultitonScope():
+        trainer = Trainer(train_config)
+        trainer.init_data_loaders(cur_step=train_config.steps[0])
+
+    assert trainer.train_loader._dataloader.persistent_workers is False
+    assert trainer.val_loader._dataloader.persistent_workers is False

--- a/tests/test_validate_aggregator.py
+++ b/tests/test_validate_aggregator.py
@@ -1,7 +1,10 @@
+import pytest
 import torch
 
 from ocean_emulators.aggregator import Aggregator, ValidateAggregator
 from ocean_emulators.aggregator.train import TrainAggregator
+from ocean_emulators.aggregator.validate.map import MapAggregator
+from ocean_emulators.aggregator.validate.snapshot import SnapshotAggregator
 from ocean_emulators.aggregator.validate.sub_aggregator import ValidateSubAggregator
 from ocean_emulators.constants import TensorMap
 from ocean_emulators.utils.ctx import GridContext
@@ -148,3 +151,62 @@ def test_validation_aggregator__reduced_only__omits_image_logs(
     assert any(key.startswith("val/reduced/") for key in val_logs)
     assert not any("/snapshot/" in key for key in val_logs)
     assert not any("/mean_map/" in key for key in val_logs)
+
+
+def test_snapshot_aggregator__non_main_rank__skips_plot_rendering(
+    dummy_src: DataSource, monkeypatch: pytest.MonkeyPatch
+):
+    val_batch = val_batch_of(*dummy_src.grid_size)
+    aggregator = SnapshotAggregator(dummy_src.metadata, hist=0)
+
+    monkeypatch.setattr(
+        "ocean_emulators.aggregator.validate.snapshot.is_main_process",
+        lambda: False,
+    )
+
+    aggregator.record_batch(
+        loss=val_batch.loss,
+        target_data={"foo": val_batch.target_data.unsqueeze(1)[:, :, 0]},
+        gen_data={"foo": val_batch.gen_data.unsqueeze(1)[:, :, 0]},
+        input_data={"foo": val_batch.input_data.unsqueeze(1)[:, :, 0]},
+        target_data_norm={},
+        gen_data_norm={},
+        input_data_norm={},
+    )
+
+    assert aggregator.get_logs("snapshot") == {}
+
+
+def test_map_aggregator__non_main_rank__still_reduces_but_skips_plot_rendering(
+    dummy_src: DataSource, monkeypatch: pytest.MonkeyPatch
+):
+    aggregator = MapAggregator(dummy_src.metadata, hist=0)
+    reduce_calls: list[torch.Tensor] = []
+
+    monkeypatch.setattr(
+        "ocean_emulators.aggregator.validate.map.is_main_process",
+        lambda: False,
+    )
+
+    def fake_all_reduce_mean(tensor: torch.Tensor) -> torch.Tensor:
+        reduce_calls.append(tensor.clone())
+        return tensor
+
+    monkeypatch.setattr(
+        "ocean_emulators.aggregator.validate.map.all_reduce_mean",
+        fake_all_reduce_mean,
+    )
+
+    data = torch.ones(2, 1, *dummy_src.grid_size)
+    aggregator.record_batch(
+        loss=torch.tensor(1.0),
+        target_data={"foo": data},
+        gen_data={"foo": data},
+        input_data={},
+        target_data_norm={},
+        gen_data_norm={},
+        input_data_norm={},
+    )
+
+    assert aggregator.get_logs("mean_map") == {}
+    assert len(reduce_calls) == 2


### PR DESCRIPTION
3 small changes to help with GPU utilization:

* Don't compute validation images if w&b is off.
* Only compute images on rank 0 (this doesn't really change latency but it does mean other CPUs/GPUs are not competing for resources while we do this)
* Turn on persistent workers to reduce start-of-epoch delays. 