### PR TITLE
Make config to document how we trained 1/4-degree models

### DIFF
--- a/configs/samudra_om4_v2_highres/README.md
+++ b/configs/samudra_om4_v2_highres/README.md
@@ -1,0 +1,5 @@
+# Samudra OM4 V2 High-Res Configration
+
+A variant of the V2 configuration which uses a reduced
+batch size, instance norm, and bfloat16, for handling
+higher spatial resolutions.

--- a/configs/samudra_om4_v2_highres/eval.yaml
+++ b/configs/samudra_om4_v2_highres/eval.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=../schemas/EvalConfig.json
+
+debug: false
+save_zarr: true
+disk_mode: true
+inference_time:
+  start: "2014-10-10"
+  end: "2022-12-24"
+num_model_steps_forward: 25
+
+experiment:
+  name: samudra_om4_v2_highres_eval
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+  prognostic_vars_key: thermo_dynamic_all
+  boundary_vars_key: tau_hfds_hfds_anom
+
+data: !include ../data/om4.yaml
+model: !include model.yaml

--- a/configs/samudra_om4_v2_highres/model.yaml
+++ b/configs/samudra_om4_v2_highres/model.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=../schemas/SamudraConfig.json
+
+checkpointing: all
+pred_residuals: false
+last_kernel_size: 3
+pad: "circular"
+use_bfloat16: true
+
+unet:
+  ch_width: [280, 380, 480, 520]
+  dilation: [1, 2, 4, 8]
+  n_layers: [1, 1, 1, 1]
+
+  core_block:
+    block_type: "conv_next_block"
+    kernel_size: 3
+    activation: "capped_gelu"
+    upscale_factor: 2
+    norm: "instance"
+
+  down_sampling_block: "avg_pool"
+  up_sampling_block: "zonally_periodic_upsample"
+
+corrector:
+  non_negative_corrector_names: null
+  ocean_heat_corrector: false

--- a/configs/samudra_om4_v2_highres/train.yaml
+++ b/configs/samudra_om4_v2_highres/train.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=../schemas/TrainConfig.json
+
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 70
+batch_size: 1
+learning_rate: 0.0006
+gradient_accumulation_steps: 4
+scheduler: { type: cosine }
+loss:
+  type: dynamic
+  metric: mse
+  limit: 20
+finetune: false
+resume_ckpt_path: null
+inference_epochs: []
+data_percent: 1.0
+train_time:
+  start: "1975-01-03"
+  end: "2013-10-05"
+val_time:
+  start: "2013-10-05"
+  end: "2014-10-05"
+inference_times:
+  - start: "1975-01-03"
+    end: "1976-01-03" # "1985-01-03"
+  - start: "1985-01-03"
+    end: "1986-01-03" # "1995-01-03"
+  - start: "1995-01-03"
+    end: "1996-01-03" # "2005-01-03"
+  - start: "2004-10-05"
+    end: "2005-10-05" # "2014-10-05"
+data_stride: [1]
+steps: [4]
+step_transition: []
+preemptible: false
+
+backend: auto
+
+experiment:
+  name: samudra_om4_v2_highres
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+  prognostic_vars_key: thermo_dynamic_all
+  boundary_vars_key: tau_hfds_hfds_anom
+
+data: !include ../data/om4.yaml
+model: !include model.yaml

--- a/configs/samudra_om4_v2_highres/viz.yaml
+++ b/configs/samudra_om4_v2_highres/viz.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=../schemas/VizConfig.json
+
+base_output_dir: ".LOCAL"
+name: "samudra_om4_v2_highres_viz"
+dataset_name: "OM4"
+groundtruth_location: "OM4.zarr"
+basins_location:
+  type: s3
+  bucket: "emulators"
+  path: "jr7309/basins/basin_masks_original.zarr"
+  endpoint_url: "https://nyu1.osn.mghpcc.org"
+groundtruth_time_range:
+  start: "2014-10-20"
+  end: "2022-12-24"
+runs:
+  - name: "samudra_om4_v2_highres_eval"
+    location: ".LOCAL/samudra_om4_v2_highres_eval/predictions.zarr"


### PR DESCRIPTION
Basically taking the cli args from https://wandb.ai/ocean_emulators/default/runs/9t6la3qq/overview?nw=nwuseroa_jder and turning them into a saved config we can reuse.