### PR TITLE
Separate prognostic and boundary tensors end-to-end

### DIFF
--- a/notebooks/Multi_seed_Generation_and_Plotting_3D_Disk.py
+++ b/notebooks/Multi_seed_Generation_and_Plotting_3D_Disk.py
@@ -762,7 +762,7 @@ def generate_model_rollout(
     model_pred = np.zeros((N_eval, *test_data[0][0].shape[2:], N_out))
 
     with torch.no_grad():
-        outs = model.inference(test_data, initial_input, num_steps=N_eval // (hist + 1))
+        outs = model.run_rollout(test_data, initial_input, num_steps=N_eval // (hist + 1))
     for i in range(N_eval // (hist + 1)):
         pred_temp = outs[i]
         pred_temp = torch.nan_to_num(pred_temp)

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -665,7 +665,8 @@ class BaseModelConfig(BaseConfig, abc.ABC):
     @abc.abstractmethod
     def build(
         self,
-        in_channels: int,
+        prog_channels: int,
+        boundary_channels: int,
         out_channels: int,
         hist: int,
         static_data_for_corrector: xr.Dataset | None,
@@ -688,7 +689,8 @@ class SamudraConfig(BaseModelConfig):
 
     def build(
         self,
-        in_channels: int,
+        prog_channels: int,
+        boundary_channels: int,
         out_channels: int,
         hist: int,
         static_data_for_corrector: xr.Dataset | None,
@@ -704,6 +706,7 @@ class SamudraConfig(BaseModelConfig):
             corrector = self.corrector.build(
                 hist, src.spherical_area_weights, static_data_for_corrector
             )
+        in_channels = prog_channels + boundary_channels
         total_in_channels = (
             in_channels + self.pos_channels + (3 if self.add_3d_coordinates else 0)
         )
@@ -751,7 +754,8 @@ class FOMOConfig(BaseModelConfig):
 
     def build(
         self,
-        in_channels: int,
+        prog_channels: int,
+        boundary_channels: int,
         out_channels: int,
         hist: int,
         static_data_for_corrector: xr.Dataset | None,
@@ -773,8 +777,16 @@ class FOMOConfig(BaseModelConfig):
                 "Please set `use_bfloat16=True` or `perceiver_implementation='naive'`."
             )
 
+        in_channels = prog_channels + boundary_channels
+        total_in_channels = in_channels + (3 if self.add_3d_coordinates else 0)
+
         encoder = self.encoder.build(
-            in_channels, self.embedding_dim, extent, max_lat_size, max_lon_size, impl
+            total_in_channels,
+            self.embedding_dim,
+            extent,
+            max_lat_size,
+            max_lon_size,
+            impl,
         )
         processor = self.processor.build(
             self.embedding_dim,
@@ -788,7 +800,6 @@ class FOMOConfig(BaseModelConfig):
             impl,
         )
 
-        total_in_channels = in_channels + (3 if self.add_3d_coordinates else 0)
         add_3d_coordinates = Concat3dCoordinates() if self.add_3d_coordinates else None
         return FOMO(
             in_channels=total_in_channels,
@@ -838,7 +849,8 @@ class FOMiniConfig(BaseModelConfig):
 
     def build(
         self,
-        in_channels: int,
+        prog_channels: int,
+        boundary_channels: int,
         out_channels: int,
         hist: int,
         static_data_for_corrector: xr.Dataset | None,
@@ -857,6 +869,7 @@ class FOMiniConfig(BaseModelConfig):
                 "Please set `use_bfloat16=True` or `perceiver_implementation='naive'`."
             )
 
+        in_channels = prog_channels + boundary_channels
         perceiver_io = self.perceiver.build_io(
             self.embedding_dim,
             self.queries_dim,

--- a/src/ocean_emulators/constants.py
+++ b/src/ocean_emulators/constants.py
@@ -29,7 +29,9 @@ Boundary = Float[Grid, "*batch boundary_vars"]
 # So, we'll leave this default and use symbolic axes locally.
 type Input = Float[Grid, "*batch total_vars"]
 
-Example = tuple[Input, Prognostic]
+Example = tuple[
+    Prognostic, Boundary, Prognostic
+]  # (prognostic_input, boundary_input, label)
 
 GridMask = Bool[Tensor, "lat lon"]
 PrognosticMask = Bool[GridMask, "prognostic_vars"]

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -13,6 +13,7 @@ from torch.utils.data import Dataset
 from xarray_einstats.einops import rearrange as xr_rearrange  # noqa: F401
 
 from ocean_emulators.constants import (
+    Boundary,
     BoundaryVarNames,
     Example,
     GridMask,
@@ -138,9 +139,9 @@ class InferenceDataset(Dataset):
         label = self._get_label(x_index)
         return label
 
-    def get_initial_input(self):
-        data = self.__getitem__(0)[0]
-        return data
+    def get_initial_input(self) -> tuple[Prognostic, Boundary]:
+        prog, boundary, _ = self.__getitem__(0)
+        return prog, boundary
 
     def get_target_time(self, start_step: int, num_steps: int):
         x_index = self._get_x_index(start_step)
@@ -154,20 +155,28 @@ class InferenceDataset(Dataset):
             )
         )
 
-    def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
+    def get_boundary_for_prognostic(
+        self, prognostic: Prognostic, step: int
+    ) -> tuple[Prognostic, Boundary]:
+        """Return ``(prognostic, boundary)`` at the requested step.
+
+        Prognostic is passed through verbatim; boundary is fetched from the
+        boundary source and returned on the same device as ``prognostic``. The
+        two tensors may live on different spatial grids once the cross-
+        resolution boundary source lands — the encoder is responsible for
+        fusing them.
+        """
         x_index = self._get_x_index(step)
         boundary = self._get_boundary(x_index).to(prognostic.device)
-        data = torch.cat((prognostic, boundary), dim=1)
-        return data
+        return prognostic, boundary
 
     @elapsed(level=logging.DEBUG)
     def __getitem__(self, idx):
         x_index = self._get_x_index(idx)
-        data_in = self._get_prognostic(x_index)
+        data_in_prog = self._get_prognostic(x_index)
         data_in_boundary = self._get_boundary(x_index)
-        data_in = torch.cat((data_in, data_in_boundary), dim=1)
         label = self._get_label(x_index)
-        return (data_in, label)
+        return (data_in_prog, data_in_boundary, label)
 
     def _get_x_index(self, idx):
         if isinstance(idx, slice):
@@ -357,44 +366,40 @@ class RawTrainData:
 class TrainData:
     """A single batch of training data.
 
-    A single batch contains multiple steps worth of `Example`s (i.e., input/output pairs). These steps are used during
-    autoregressive rollout in the training and inference process.
-
-    Constraint: The `Input` tensor is a combination of (flattened) prognostic variables (at all depth levels) and
-    boundary forcings. The top `num_prognostic_channels` number of channels must be prognostic variables whereas the
-    remaining bottom channels are boundary forcings.
+    A single batch contains multiple steps worth of ``Example`` entries, each
+    of which is a ``(prognostic_input, boundary_input, label)`` triple. The
+    prognostic and boundary tensors are carried *separately* (they are no
+    longer concatenated along the channel dim) so that the encoder can fuse
+    them at the token level, potentially at different spatial resolutions.
     """
 
-    def __init__(self, num_prognostic_channels: int, ctx: GridContext):
+    def __init__(
+        self, num_prognostic_channels: int, num_boundary_channels: int, ctx: GridContext
+    ):
         self.num_prognostic_channels = num_prognostic_channels
+        self.num_boundary_channels = num_boundary_channels
         self.ctx = ctx
         self.example_by_step: list[Example] = []
         self.load_stats: LoadStats | None = None
 
-    def append(self, input_: Input, label: Prognostic):
+    def append(
+        self, prognostic_input: Prognostic, boundary_input: Boundary, label: Prognostic
+    ) -> None:
         """Add another Example as a new step."""
-        self.example_by_step.append((input_, label))
+        self.example_by_step.append((prognostic_input, boundary_input, label))
 
-    def get_initial_input(self) -> Input:
+    def get_initial_input(self) -> tuple[Prognostic, Boundary]:
         return self.get_input(0)
 
-    def get_input(self, step: int) -> Input:
-        return self[step][0]
+    def get_input(self, step: int) -> tuple[Prognostic, Boundary]:
+        prog, boundary, _ = self.example_by_step[step]
+        return prog, boundary
 
     def get_label(self, step: int) -> Prognostic:
-        return self[step][1]
-
-    def merge_prognostic_and_boundary(self, prognostic: torch.Tensor, step: int):
-        input_ = self.get_input(step)
-        merged = input_.clone()
-        merged[:, : self.num_prognostic_channels] = prognostic
-        return merged
-
-    def values(self):
-        return self.example_by_step
+        return self.example_by_step[step][2]
 
     def __getitem__(self, step: int) -> Example:
-        """Converts index (step) into (data, label) tuple."""
+        """Converts index (step) into (prognostic, boundary, label) triple."""
         return self.example_by_step[step]
 
     def __len__(self) -> int:
@@ -405,16 +410,20 @@ class TrainData:
 
     def to(self, device: torch.device) -> None:
         for step in self:
+            prog, boundary, label = self.example_by_step[step]
             self.example_by_step[step] = (
-                self[step][0].to(device, non_blocking=True),
-                self[step][1].to(device, non_blocking=True),
+                prog.to(device, non_blocking=True),
+                boundary.to(device, non_blocking=True),
+                label.to(device, non_blocking=True),
             )
 
     def pin_memory(self):
         for step in self:
+            prog, boundary, label = self.example_by_step[step]
             self.example_by_step[step] = (
-                self[step][0].pin_memory(),
-                self[step][1].pin_memory(),
+                prog.pin_memory(),
+                boundary.pin_memory(),
+                label.pin_memory(),
             )
         return self
 
@@ -484,6 +493,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self._concurrent_compute = concurrent_compute_
 
         self.num_prognostic_channels: int = (hist + 1) * len(prognostic_var_names)
+        self.num_boundary_channels: int = (hist + 1) * len(boundary_var_names)
         assert np.array_equal(srcs[0].data.time, srcs[-1].data.time), (
             "src and dst DataSource have different time slices!"
         )
@@ -605,9 +615,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         Returns:
             TrainData with tensors on the target device
         """
-        train_data = TrainData(self.num_prognostic_channels, self.ctx.to(device))
+        train_data = TrainData(
+            self.num_prognostic_channels,
+            self.num_boundary_channels,
+            self.ctx.to(device),
+        )
         for input_, boundary, label in raw_train_data.raw_data:
-            input_, label = self._to_example(
+            prog_input, boundary_input, label_tensor = self._to_example(
                 OceanData.from_data_source(
                     input_,
                     self.wet_prognostic[0],
@@ -622,43 +636,27 @@ class TorchTrainDataset(Dataset[RawTrainData]):
                     label, self.wet_prognostic[-1], self.prognostic_srcs[-1]
                 ).to(device=device, non_blocking=True),
             )
-            train_data.append(input_, label)
+            train_data.append(prog_input, boundary_input, label_tensor)
         train_data.load_stats = raw_train_data.load_stats
         return train_data
 
     def _to_example(
         self, input_: OceanData, boundary: OceanData, label: OceanData
-    ) -> tuple[Input, Prognostic]:
+    ) -> Example:
         # Input/boundary only include current steps; label only includes forecasted steps.
-        total_input = self._prep_tensor_steps(input_, boundary)
+        prog_input = self._prep_tensor_steps(input_)
+        boundary_input = self._prep_tensor_steps(boundary)
         label_tensor = self._prep_tensor_steps(label)
-        return total_input, label_tensor
+        return prog_input, boundary_input, label_tensor
 
-    def _prep_tensor_steps(
-        self,
-        prognostic: OceanData,
-        boundary: OceanData | None = None,
-    ) -> Input:
-        """Prepare tensor steps by normalizing, masking and flattening dimensions."""
-        prognostic_steps = prognostic.normalize_and_mask(
+    def _prep_tensor_steps(self, ocean_data: OceanData) -> Input:
+        """Normalize, mask, and flatten (time, variable) dims into a channel dim."""
+        steps = ocean_data.normalize_and_mask(
             self.normalize_before_mask, self.masked_fill_value
         )
-
-        # Flatten time and variable dimensions
-        def flatten_dims(tensor: torch.Tensor) -> torch.Tensor:
-            return rearrange(
-                tensor, "batch time variable lat lon -> batch (time variable) lat lon"
-            )
-
-        prognostic_steps = flatten_dims(prognostic_steps)
-        if boundary is not None:
-            boundary_steps = boundary.normalize_and_mask(
-                self.normalize_before_mask, self.masked_fill_value
-            )
-            boundary_steps = flatten_dims(boundary_steps)
-            return torch.cat((prognostic_steps, boundary_steps), dim=1)
-
-        return prognostic_steps
+        return rearrange(
+            steps, "batch time variable lat lon -> batch (time variable) lat lon"
+        )
 
     def _get_x_index(self, idx: int, step: int) -> xr.DataArray:
         assert isinstance(idx, int)

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -155,20 +155,11 @@ class InferenceDataset(Dataset):
             )
         )
 
-    def get_boundary_for_prognostic(
-        self, prognostic: Prognostic, step: int
-    ) -> tuple[Prognostic, Boundary]:
-        """Return ``(prognostic, boundary)`` at the requested step.
-
-        Prognostic is passed through verbatim; boundary is fetched from the
-        boundary source and returned on the same device as ``prognostic``. The
-        two tensors may live on different spatial grids once the cross-
-        resolution boundary source lands — the encoder is responsible for
-        fusing them.
-        """
+    def get_boundary(self, step: int) -> Boundary:
+        """Return boundary at the requested step."""
         x_index = self._get_x_index(step)
-        boundary = self._get_boundary(x_index).to(prognostic.device)
-        return prognostic, boundary
+        boundary = self._get_boundary(x_index)
+        return boundary
 
     @elapsed(level=logging.DEBUG)
     def __getitem__(self, idx):

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -359,9 +359,8 @@ class TrainData:
 
     A single batch contains multiple steps worth of ``Example`` entries, each
     of which is a ``(prognostic_input, boundary_input, label)`` triple. The
-    prognostic and boundary tensors are carried *separately* (they are no
-    longer concatenated along the channel dim) so that the encoder can fuse
-    them at the token level, potentially at different spatial resolutions.
+    prognostic and boundary tensors are carried separately because the FOMO model
+    encodes them separately (Samudra just concatenates them later).
     """
 
     def __init__(

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -18,7 +18,7 @@ from ocean_emulators.constants import (
     construct_metadata,
 )
 from ocean_emulators.datasets import InferenceDataset
-from ocean_emulators.stepper import Stepper
+from ocean_emulators.stepper import inference
 from ocean_emulators.utils.data import (
     Normalize,
     get_inference_steps,
@@ -76,8 +76,10 @@ class Eval:
         self.N_bound = len(self.boundary_var_names)
         self.N_prog = len(self.prognostic_var_names)
 
-        self.num_in = int((cfg.data.hist + 1) * (self.N_prog + self.N_bound))
-        self.num_out = int((cfg.data.hist + 1) * self.N_prog)
+        self.num_prog_in = int((cfg.data.hist + 1) * self.N_prog)
+        self.num_boundary_in = int((cfg.data.hist + 1) * self.N_bound)
+        self.num_in = self.num_prog_in + self.num_boundary_in
+        self.num_out = self.num_prog_in
 
         self.tensor_map = TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
@@ -110,7 +112,8 @@ class Eval:
 
         # Model
         self.model = cfg.model.build(
-            in_channels=self.num_in,
+            prog_channels=self.num_prog_in,
+            boundary_channels=self.num_boundary_in,
             out_channels=self.num_out,
             hist=cfg.data.hist,
             static_data_for_corrector=self.static_data,
@@ -207,7 +210,7 @@ class Eval:
             self.prognostic_var_names,
         )
 
-        Stepper.inference(
+        inference(
             model=self.model,
             dataset=self.inference_dataset,
             inf_aggregator=inf_aggregator,

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -18,7 +18,7 @@ from ocean_emulators.constants import (
     construct_metadata,
 )
 from ocean_emulators.datasets import InferenceDataset
-from ocean_emulators.stepper import inference
+from ocean_emulators.stepper import run_rollout
 from ocean_emulators.utils.data import (
     Normalize,
     get_inference_steps,
@@ -210,7 +210,7 @@ class Eval:
             self.prognostic_var_names,
         )
 
-        inference(
+        run_rollout(
             model=self.model,
             dataset=self.inference_dataset,
             inf_aggregator=inf_aggregator,

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -4,6 +4,7 @@ import logging
 
 import torch
 
+from ocean_emulators.constants import Boundary, Prognostic
 from ocean_emulators.utils.ctx import GridContext
 
 logger = logging.getLogger(__name__)
@@ -34,7 +35,9 @@ class BaseModel(torch.nn.Module):
         self.hist = hist
         self.gradient_detach_interval = gradient_detach_interval
 
-    def forward_once(self, fts, ctx: GridContext):
+    def forward_once(
+        self, prognostic: Prognostic, boundary: Boundary, ctx: GridContext
+    ) -> Prognostic:
         raise NotImplementedError()
 
     def forward(
@@ -46,31 +49,20 @@ class BaseModel(torch.nn.Module):
         loss = torch.tensor(torch.nan)
         for step in range(len(train_data)):
             if step == 0:
-                input_tensor = train_data.get_initial_input()
+                prog_tensor, boundary_tensor = train_data.get_initial_input()
             else:
-                # TODO(alxmrs): With cross-resolution training (e.g. "mix" schedule where
-                #  input and output grids differ), the previous prediction lives on the
-                #  output grid but merge_prognostic_and_boundary expects the input grid.
-                #  Multi-step rollouts (steps > 1) will need regridding here.
                 prev_output = outputs[-1]
                 if (
                     self.gradient_detach_interval > 0
                     and step % self.gradient_detach_interval == 0
                 ):
                     prev_output = prev_output.detach()
-                input_tensor = train_data.merge_prognostic_and_boundary(
-                    prognostic=prev_output, step=step
-                )
+                _, boundary_tensor = train_data.get_input(step)
+                prog_tensor = prev_output
 
-            decodings = self.forward_once(input_tensor, train_data.ctx)
+            decodings = self.forward_once(prog_tensor, boundary_tensor, train_data.ctx)
             if self.pred_residuals:
-                pred = (
-                    input_tensor[
-                        :,
-                        : self.out_channels,
-                    ]  # Residuals on last state in input
-                    + decodings
-                )  # Residual prediction
+                pred = prog_tensor + decodings  # Residual prediction
             else:
                 pred = decodings  # Absolute prediction
 
@@ -101,7 +93,8 @@ class BaseModel(torch.nn.Module):
         num_steps=None,
         epoch=None,
     ) -> ModelInferenceOutput:
-        out_shape = (num_steps, *dataset[0][1].shape[1:])
+        # `dataset[idx]` returns `(prog, boundary, label)`.
+        out_shape = (num_steps, *dataset[0][-1].shape[1:])
 
         pred_tensor = torch.zeros(out_shape, device=get_device())
         initial_prognostic = initial_prognostic.to(get_device())
@@ -113,26 +106,18 @@ class BaseModel(torch.nn.Module):
                 f"of {steps_completed + num_steps - 1}."
             )
             if step == 0:
-                input_tensor = dataset.merge_prognostic_and_boundary(
+                prog_tensor, boundary_tensor = dataset.get_boundary_for_prognostic(
                     prognostic=initial_prognostic,
                     step=steps_completed,
                 )
             else:
-                input_tensor = dataset.merge_prognostic_and_boundary(
+                prog_tensor, boundary_tensor = dataset.get_boundary_for_prognostic(
                     prognostic=pred_tensor[step - 1].unsqueeze(0),
                     step=steps_completed + step,
                 )
-            decodings = self.forward_once(input_tensor, dataset.ctx)
+            decodings = self.forward_once(prog_tensor, boundary_tensor, dataset.ctx)
             if self.pred_residuals:
-                pred = (
-                    input_tensor[
-                        0,
-                        : self.out_channels,
-                    ].to(  # Residuals on last state in input
-                        device=get_device()
-                    )
-                    + decodings
-                )
+                pred = prog_tensor.to(device=get_device()) + decodings
             else:
                 pred = decodings
 

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -106,15 +106,16 @@ class BaseModel(torch.nn.Module):
                 f"of {steps_completed + num_steps - 1}."
             )
             if step == 0:
-                prog_tensor, boundary_tensor = dataset.get_boundary_for_prognostic(
-                    prognostic=initial_prognostic,
-                    step=steps_completed,
+                prog_tensor = initial_prognostic
+                boundary_tensor = dataset.get_boundary(steps_completed).to(
+                    device=prog_tensor.device
                 )
             else:
-                prog_tensor, boundary_tensor = dataset.get_boundary_for_prognostic(
-                    prognostic=pred_tensor[step - 1].unsqueeze(0),
-                    step=steps_completed + step,
-                )
+                prog_tensor = pred_tensor[step - 1].unsqueeze(0)
+                boundary_tensor = dataset.get_boundary(
+                    steps_completed + step,
+                ).to(device=prog_tensor.device)
+
             decodings = self.forward_once(prog_tensor, boundary_tensor, dataset.ctx)
             if self.pred_residuals:
                 pred = prog_tensor.to(device=get_device()) + decodings

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -118,7 +118,7 @@ class BaseModel(torch.nn.Module):
 
             decodings = self.forward_once(prog_tensor, boundary_tensor, dataset.ctx)
             if self.pred_residuals:
-                pred = prog_tensor.to(device=get_device()) + decodings
+                pred = prog_tensor[0].to(device=get_device()) + decodings
             else:
                 pred = decodings
 

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -111,7 +111,7 @@ class BaseModel(torch.nn.Module):
                     device=prog_tensor.device
                 )
             else:
-                prog_tensor = pred_tensor[step - 1].unsqueeze(0)
+                prog_tensor = pred_tensor[step - 1]
                 boundary_tensor = dataset.get_boundary(
                     steps_completed + step,
                 ).to(device=prog_tensor.device)

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -111,7 +111,7 @@ class BaseModel(torch.nn.Module):
                     device=prog_tensor.device
                 )
             else:
-                prog_tensor = pred_tensor[step - 1]
+                prog_tensor = pred_tensor[step - 1].unsqueeze(0)
                 boundary_tensor = dataset.get_boundary(
                     steps_completed + step,
                 ).to(device=prog_tensor.device)

--- a/src/ocean_emulators/models/fomini.py
+++ b/src/ocean_emulators/models/fomini.py
@@ -9,6 +9,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     apply_activation_checkpointing,
 )
 
+from ocean_emulators.constants import Boundary, Prognostic
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules.augment_input import make_3d_coordinate_grid
 from ocean_emulators.utils.ctx import GridContext
@@ -125,7 +126,12 @@ class FOMini(BaseModel):
             )
         return torch.cat(out_chunks, dim=1)
 
-    def forward_once(self, fts: torch.Tensor, ctx: GridContext) -> torch.Tensor:
+    def forward_once(
+        self, prognostic: Prognostic, boundary: Boundary, ctx: GridContext
+    ) -> Prognostic:
+        # FOMini is a single-scale pixel-token model; fuse prognostic +
+        # boundary into the single channel-stacked input it expects.
+        fts = torch.cat((prognostic, boundary), dim=1)
         B, _, H, W = fts.shape
         lat, lon = ctx.input_resolution_cpu
         if H != len(lat) or W != len(lon):

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -8,6 +8,7 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
     apply_activation_checkpointing,
 )
 
+from ocean_emulators.constants import Boundary, Prognostic
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules import PerceiverDecoder, PerceiverEncoder
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
@@ -85,7 +86,14 @@ class FOMO(BaseModel):
                 check_fn=lambda m: isinstance(m, _checkpoint_types),
             )
 
-    def forward_once(self, fts: torch.Tensor, ctx: GridContext) -> torch.Tensor:
+    def forward_once(
+        self, prognostic: Prognostic, boundary: Boundary, ctx: GridContext
+    ) -> Prognostic:
+        # Prognostic and boundary are carried as separate tensors through the
+        # data pipeline, but this encoder still expects a single concatenated
+        # input.  The dual-perceiver encoder that fuses them at the token level
+        # (enabling cross-resolution) lands in a follow-up PR.
+        fts = torch.cat((prognostic, boundary), dim=1)
         with autocast(enabled=self.use_bfloat16, dtype=torch.bfloat16):
             if self.maybe_add_3d_coordinates is not None:
                 fts = self.maybe_add_3d_coordinates(fts, ctx.input_resolution_cpu)

--- a/src/ocean_emulators/models/samudra.py
+++ b/src/ocean_emulators/models/samudra.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.utils.checkpoint
 
-from ocean_emulators.constants import GridSize
+from ocean_emulators.constants import Boundary, GridSize, Prognostic
 from ocean_emulators.models.base import BaseModel
 from ocean_emulators.models.modules.unet_backbone import UNetBackbone
 from ocean_emulators.utils.ctx import GridContext
@@ -49,7 +49,12 @@ class Samudra(BaseModel):
         self.corrector = corrector
         self.use_bfloat16 = use_bfloat16
 
-    def forward_once(self, fts: torch.Tensor, ctx: GridContext) -> torch.Tensor:
+    def forward_once(
+        self, prognostic: Prognostic, boundary: Boundary, ctx: GridContext
+    ) -> Prognostic:
+        # Samudra is a single-scale model; fuse prognostic + boundary into
+        # the single channel-stacked input its backbone expects.
+        fts = torch.cat((prognostic, boundary), dim=1)
         if self.corrector is not None:
             fts_input = fts.clone().detach()
 

--- a/src/ocean_emulators/stepper.py
+++ b/src/ocean_emulators/stepper.py
@@ -43,7 +43,7 @@ def validate_batch(
     loss = torch.mean(loss_per_channel)
     # `input_data` in ValBatchOutput is used for val visualization; pass the
     # channel-concatenated tensor for continuity with existing consumers.
-    # We only ever mix scales across boundary and prognostic during inference.
+    # We don't mix scales across boundary and prognostic during training.
     input_data = torch.cat((prognostic, boundary), dim=1)
     return ValBatchOutput(loss, loss_per_channel, input_data, label, outs, batch.ctx)
 

--- a/src/ocean_emulators/stepper.py
+++ b/src/ocean_emulators/stepper.py
@@ -20,112 +20,112 @@ from ocean_emulators.utils.wandb import get_record_to_wandb
 from ocean_emulators.utils.writer import ZarrWriter
 
 
-class Stepper:
-    def __init__(self):
-        pass
+def train_batch(
+    model: torch.nn.Module, batch: TrainData, loss_fn: Callable
+) -> TrainBatchOutput:
+    loss_per_channel = model(batch, loss_fn=partial(loss_fn, ctx=batch.ctx))
+    loss = torch.mean(loss_per_channel)
+    return TrainBatchOutput(loss, loss_per_channel)
 
-    @staticmethod
-    def train_batch(
-        model: torch.nn.Module, batch: TrainData, loss_fn: Callable
-    ) -> TrainBatchOutput:
-        loss_per_channel = model(batch, loss_fn=partial(loss_fn, ctx=batch.ctx))
-        loss = torch.mean(loss_per_channel)
-        return TrainBatchOutput(loss, loss_per_channel)
 
-    @staticmethod
-    @torch.no_grad()
-    def validate_batch(
-        model: BaseModel | torch.nn.parallel.DistributedDataParallel,
-        batch: TrainData,
-        loss_fn: Callable,
-    ) -> ValBatchOutput:
-        assert len(batch) == 1  # Assert we are using one step of input and output
-        input = batch.get_input(0)
-        label = batch.get_label(0)
-        outs = model(batch)[0]
-        loss_per_channel = loss_fn(outs, label, batch.ctx)
-        loss = torch.mean(loss_per_channel)
-        return ValBatchOutput(loss, loss_per_channel, input, label, outs, batch.ctx)
+@torch.no_grad()
+def validate_batch(
+    model: BaseModel | torch.nn.parallel.DistributedDataParallel,
+    batch: TrainData,
+    loss_fn: Callable,
+) -> ValBatchOutput:
+    assert len(batch) == 1  # Assert we are using one step of input and output
+    prognostic, boundary = batch.get_input(0)
+    label = batch.get_label(0)
 
-    @staticmethod
-    @torch.no_grad()
-    def inference(
-        model: BaseModel,
-        dataset: InferenceDataset,
-        inf_aggregator: InferenceEvaluatorAggregator,
-        epoch: int,
-        output_dir: str | PathLike | None = None,
-        model_path: str | PathLike | None = None,
-        num_model_steps_forward: int = 200,
-        save_zarr: bool = False,
-    ) -> None:
-        if save_zarr:
-            if output_dir is None or model_path is None:
-                raise ValueError(
-                    "output_dir and model_path must be provided if save_zarr is True"
-                )
-            coords = dataset.get_coords_dict()
-            if num_model_steps_forward > 0:
-                chunk_size = num_model_steps_forward
-            else:
-                chunk_size = 20
-            writer = ZarrWriter(
-                output_dir,
-                coords=coords,
-                hist=inf_aggregator.hist,
-                model_path=model_path,
-                time_chunk_size=chunk_size,
+    outs = model(batch)[0]
+    loss_per_channel = loss_fn(outs, label, batch.ctx)
+    loss = torch.mean(loss_per_channel)
+    # `input_data` in ValBatchOutput is used for val visualization; pass the
+    # channel-concatenated tensor for continuity with existing consumers.
+    # We only ever mix scales across boundary and prognostic during inference.
+    input_data = torch.cat((prognostic, boundary), dim=1)
+    return ValBatchOutput(loss, loss_per_channel, input_data, label, outs, batch.ctx)
+
+
+@torch.no_grad()
+def inference(
+    model: BaseModel,
+    dataset: InferenceDataset,
+    inf_aggregator: InferenceEvaluatorAggregator,
+    epoch: int,
+    output_dir: str | PathLike | None = None,
+    model_path: str | PathLike | None = None,
+    num_model_steps_forward: int = 200,
+    save_zarr: bool = False,
+) -> None:
+    if save_zarr:
+        if output_dir is None or model_path is None:
+            raise ValueError(
+                "output_dir and model_path must be provided if save_zarr is True"
             )
+        coords = dataset.get_coords_dict()
+        if num_model_steps_forward > 0:
+            chunk_size = num_model_steps_forward
         else:
-            writer = None
-        record_logs = get_record_to_wandb(label="inference")
-        logger.info(f"Inference [epoch {epoch}]: processing initial prognostic.")
-        logs = inf_aggregator.record_initial_prognostic(
-            initial_prognostic=dataset.initial_prognostic.to(get_device()),
+            chunk_size = 20
+        writer = ZarrWriter(
+            output_dir,
+            coords=coords,
+            hist=inf_aggregator.hist,
+            model_path=model_path,
+            time_chunk_size=chunk_size,
         )
-        record_logs(logs)
-        num_model_steps = len(dataset)
-        num_steps_list = []
+    else:
+        writer = None
+    record_logs = get_record_to_wandb(label="inference")
+    logger.info(f"Inference [epoch {epoch}]: processing initial prognostic.")
+    logs = inf_aggregator.record_initial_prognostic(
+        initial_prognostic=dataset.initial_prognostic.to(get_device()),
+    )
+    record_logs(logs)
+    num_model_steps = len(dataset)
+    num_steps_list = []
 
-        # If num_model_steps_forward is -1, then we are doing a full forward pass
-        if num_model_steps_forward == -1:
-            num_steps_list = [num_model_steps]
+    # If num_model_steps_forward is -1, then we are doing a full forward pass
+    if num_model_steps_forward == -1:
+        num_steps_list = [num_model_steps]
+    else:
+        # Windows of partial forward passes
+        num_loops = num_model_steps // num_model_steps_forward
+        if num_loops > 0:
+            num_steps_list = [num_model_steps_forward] * num_loops
+            last_model_steps_forward = num_model_steps % num_model_steps_forward
+            if last_model_steps_forward > 0:
+                num_steps_list = num_steps_list + [last_model_steps_forward]
         else:
-            # Windows of partial forward passes
-            num_loops = num_model_steps // num_model_steps_forward
-            if num_loops > 0:
-                num_steps_list = [num_model_steps_forward] * num_loops
-                last_model_steps_forward = num_model_steps % num_model_steps_forward
-                if last_model_steps_forward > 0:
-                    num_steps_list = num_steps_list + [last_model_steps_forward]
-            else:
-                num_steps_list = [num_model_steps]
+            num_steps_list = [num_model_steps]
 
-        num_loops = len(num_steps_list)
-        initial_prognostic = dataset.initial_prognostic
-        step = 0
-        for loop, num_steps in enumerate(num_steps_list):
-            logger.info(
-                f"Inference [epoch {epoch}]: loop {loop} of {num_loops - 1}. "
-                f"Stepping {num_steps} steps forward."
-            )
-            dataset.to(get_device())
-            IO: ModelInferenceOutput = model.inference(
-                dataset,
-                initial_prognostic=initial_prognostic,
-                steps_completed=step,
-                num_steps=num_steps,
-                epoch=epoch,
-            )
-            # Setting initial prognostic for next loop
-            initial_prognostic = IO.prediction[-1].unsqueeze(0).clone()
-            if writer:
-                logger.info(f"Writing to zarr...")
-                writer.record_batch(IO)
-                writer.write()
+    num_loops = len(num_steps_list)
+    initial_prognostic = dataset.initial_prognostic
+    step = 0
+    for loop, num_steps in enumerate(num_steps_list):
+        logger.info(
+            f"Inference [epoch {epoch}]: loop {loop} of {num_loops - 1}. "
+            f"Stepping {num_steps} steps forward."
+        )
+        dataset.to(get_device())
+        IO: ModelInferenceOutput = model.inference(
+            dataset,
+            initial_prognostic=initial_prognostic,
+            steps_completed=step,
+            num_steps=num_steps,
+            epoch=epoch,
+        )
+        # Setting initial prognostic for next loop
+        initial_prognostic = IO.prediction[-1].unsqueeze(0).clone()
+        if writer:
+            logger.info(f"Writing to zarr...")
+            writer.record_batch(IO)
+            writer.write()
 
-            logger.info(f"Recording logs...")
-            logs = inf_aggregator.record_batch(IO)
-            logger.info(f"Logging to wandb...")
-            record_logs(logs)
-            step += num_steps
+        logger.info(f"Recording logs...")
+        logs = inf_aggregator.record_batch(IO)
+        logger.info(f"Logging to wandb...")
+        record_logs(logs)
+        step += num_steps

--- a/src/ocean_emulators/stepper.py
+++ b/src/ocean_emulators/stepper.py
@@ -49,7 +49,7 @@ def validate_batch(
 
 
 @torch.no_grad()
-def inference(
+def run_rollout(
     model: BaseModel,
     dataset: InferenceDataset,
     inf_aggregator: InferenceEvaluatorAggregator,
@@ -59,6 +59,7 @@ def inference(
     num_model_steps_forward: int = 200,
     save_zarr: bool = False,
 ) -> None:
+    """Performs inference, which is an auto-regressive rollout."""
     if save_zarr:
         if output_dir is None or model_path is None:
             raise ValueError(

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -53,7 +53,7 @@ from ocean_emulators.models.base import BaseModel
 from ocean_emulators.stepper import (
     TrainBatchOutput,
     ValBatchOutput,
-    inference,
+    run_rollout,
     train_batch,
     validate_batch,
 )
@@ -725,7 +725,7 @@ class Trainer:
 
                 # TODO(jder): we need the underlying model so we can use forward_once;
                 # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/51
-                inference(
+                run_rollout(
                     model=self.model.module
                     if isinstance(self.model, torch.nn.parallel.DistributedDataParallel)
                     else self.model,

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -50,7 +50,13 @@ from ocean_emulators.datasets import (
     TrainDataLoader,
 )
 from ocean_emulators.models.base import BaseModel
-from ocean_emulators.stepper import Stepper, TrainBatchOutput, ValBatchOutput
+from ocean_emulators.stepper import (
+    TrainBatchOutput,
+    ValBatchOutput,
+    inference,
+    train_batch,
+    validate_batch,
+)
 from ocean_emulators.utils.data import DataSource, Normalize, get_inference_steps
 from ocean_emulators.utils.device import using_gpu
 from ocean_emulators.utils.distributed import (
@@ -164,8 +170,10 @@ class Trainer:
             else:
                 self.mp_context = multiprocessing.get_context("spawn")
 
-        self.num_in = int((cfg.data.hist + 1) * (self.N_prog + self.N_bound))
-        self.num_out = int((cfg.data.hist + 1) * self.N_prog)
+        self.num_prog_in = int((cfg.data.hist + 1) * self.N_prog)
+        self.num_boundary_in = int((cfg.data.hist + 1) * self.N_bound)
+        self.num_in = self.num_prog_in + self.num_boundary_in
+        self.num_out = self.num_prog_in
 
         self.tensor_map = TensorMap.init_instance(
             cfg.experiment.prognostic_vars_key, cfg.experiment.boundary_vars_key
@@ -208,7 +216,8 @@ class Trainer:
         )
 
         self.model = cfg.model.build(
-            in_channels=self.num_in,
+            prog_channels=self.num_prog_in,
+            boundary_channels=self.num_boundary_in,
             out_channels=self.num_out,
             hist=cfg.data.hist,
             # TODO(559): This won't work at multiple scales. Refactor as part of src.
@@ -520,7 +529,7 @@ class Trainer:
             if self.num_batches_seen == 0:
                 get_model_summary(self.model, data, self.debug)
 
-            TO: TrainBatchOutput = Stepper.train_batch(self.model, data, self.loss_fn)
+            TO: TrainBatchOutput = train_batch(self.model, data, self.loss_fn)
 
             # Scale loss by the actual number of microbatches that will be accumulated
             scaled_loss = TO.loss / r
@@ -643,9 +652,11 @@ class Trainer:
             # Run a fresh single-step forward pass so DynamicLoss sees an
             # up-to-date, unscaled loss signal
             with torch.no_grad():
-                single_step_data = TrainData(data.num_prognostic_channels, data.ctx)
-                input_, label = data[0]
-                single_step_data.append(input_, label)
+                single_step_data = TrainData(
+                    data.num_prognostic_channels, data.num_boundary_channels, data.ctx
+                )
+                prog_input, boundary_input, label = data[0]
+                single_step_data.append(prog_input, boundary_input, label)
                 pred = self.model(single_step_data)
                 # Compute the raw (unscaled) per-channel loss via the inner
                 # loss function, bypassing DynamicLoss scaling.
@@ -687,9 +698,7 @@ class Trainer:
                 if self.debug and (data_iter_step + 1) % 5 == 0:
                     break
 
-                VO: ValBatchOutput = Stepper.validate_batch(
-                    self.model, data, self.loss_fn
-                )
+                VO: ValBatchOutput = validate_batch(self.model, data, self.loss_fn)
                 val_aggregator.record_validation_batch(VO)
                 metric_logger.update(loss=VO.loss)
 
@@ -716,7 +725,7 @@ class Trainer:
 
                 # TODO(jder): we need the underlying model so we can use forward_once;
                 # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/51
-                Stepper.inference(
+                inference(
                     model=self.model.module
                     if isinstance(self.model, torch.nn.parallel.DistributedDataParallel)
                     else self.model,

--- a/src/ocean_emulators/utils/logging.py
+++ b/src/ocean_emulators/utils/logging.py
@@ -15,6 +15,8 @@ import torch
 from torch.nn.parallel import DistributedDataParallel
 from torchinfo import summary
 
+from ocean_emulators.constants import Boundary, Prognostic
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -230,9 +232,9 @@ class _ForwardOnceWrapper(torch.nn.Module):
         self._underlying: BaseModel = getattr(model, "module", model)  # type: ignore
         self._ctx = ctx
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, prognostic: Prognostic, boundary: Boundary) -> torch.Tensor:
         # Get the underlying model (handles DDP wrapping)
-        return self._underlying.forward_once(x, self._ctx)
+        return self._underlying.forward_once(prognostic, boundary, self._ctx)
 
 
 def get_model_summary(
@@ -245,14 +247,14 @@ def get_model_summary(
     # we pass verbose = 0 because we log the summary ourselves
     if data is not None:
         # TrainData is a complex wrapper that torchinfo cannot traverse.
-        # Extract the initial tensor and wrap the model to use forward_once.
-        input_tensor = data.get_initial_input()
-        # Wrap model to use forward_once for the summary
+        # Extract the initial prognostic + boundary and wrap the model to
+        # use forward_once.
+        prog_tensor, boundary_tensor = data.get_initial_input()
         wrapper = _ForwardOnceWrapper(model, data.ctx)
         logger.info(
             summary(
                 wrapper,
-                input_data=[input_tensor],
+                input_data=[prog_tensor, boundary_tensor],
                 depth=depth,
                 verbose=0,
             )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -171,9 +171,16 @@ def make_loader(
 
 
 def extract_sample_arrays(td: TrainData) -> tuple[np.ndarray, np.ndarray]:
-    """Extract underlying X, y pairs from TrainData object."""
+    """Extract underlying X, y pairs from TrainData object.
+
+    X is the channel-concatenated (prognostic + boundary) tensor for parity
+    with the pre-split-API shape checks these tests do.
+    """
     steps = len(td)
-    x_arrays = [td.get_input(s).numpy(force=True) for s in range(steps)]
+    x_arrays = []
+    for s in range(steps):
+        prog, boundary = td.get_input(s)
+        x_arrays.append(torch.cat((prog, boundary), dim=1).numpy(force=True))
     y_arrays = [td.get_label(s).numpy(force=True) for s in range(steps)]
 
     return np.stack(x_arrays, axis=0), np.stack(y_arrays, axis=0)
@@ -458,7 +465,8 @@ def test_inference__data_shape(inference_loader_pair):
 
     for sample in samples:
         inference_dataset, n = sample
-        for X, y in inference_dataset:
+        for prog, boundary, y in inference_dataset:
+            X = torch.cat((prog, boundary), dim=1)
             assert X.shape == (batch_size, input_var_dim, 180, 360)
             assert y.shape == (batch_size, output_var_dim, 180, 360)
 
@@ -479,7 +487,8 @@ def test_inference__data_is_not_zero(inference_loader_pair):
 
     for sample in loader:
         dataset, n = sample
-        for X, y in dataset:
+        for prog, boundary, y in dataset:
+            X = torch.cat((prog, boundary), dim=1)
             assert np.count_nonzero(np.zeros(X.shape)) == 0, (
                 "Sanity check: Zero is zero."
             )
@@ -666,14 +675,15 @@ def test_train_dataset_no_input_change(
 ):
     train_loader, _ = tiny_dataset_input
     td = train_loader[0]
-    pred = torch.randn_like(td.get_label(0)) * 0.1
 
-    inp1 = td.get_input(1).clone()
-    td.merge_prognostic_and_boundary(pred, 1)
+    prog1, bnd1 = td.get_input(1)
+    prog1_orig, bnd1_orig = prog1.clone(), bnd1.clone()
 
     # Get a fresh copy from the loader
     td_new = train_loader[0]
-    assert torch.equal(td_new.get_input(1), inp1)
+    prog1_new, bnd1_new = td_new.get_input(1)
+    assert torch.equal(prog1_new, prog1_orig)
+    assert torch.equal(bnd1_new, bnd1_orig)
 
 
 @pytest.mark.parametrize("normalize_before_mask", [True, False])
@@ -685,25 +695,28 @@ def test_train_dataset_normalize_pre_fill(
     td0 = train_loader[0]
     data = masked_fill_value
 
-    td0_step0_input = td0.get_input(0)
+    td0_prog, td0_boundary = td0.get_input(0)
     td0_step0_label = td0.get_label(0)
-    inf_step0_input, inf_step0_label = inference_dataset[0]
+    inf_prog, inf_boundary, inf_step0_label = inference_dataset[0]
 
-    assert td0_step0_input.shape == (1, 8, 2, 2)
+    # Prog and boundary each carry (hist+1)*2 channels over a 2x2 grid.
+    assert td0_prog.shape == (1, 4, 2, 2)
+    assert td0_boundary.shape == (1, 4, 2, 2)
     assert td0_step0_label.shape == (1, 4, 2, 2)
-    assert inf_step0_input.shape == (1, 8, 2, 2)
+    assert inf_prog.shape == (1, 4, 2, 2)
+    assert inf_boundary.shape == (1, 4, 2, 2)
     assert inf_step0_label.shape == (1, 4, 2, 2)
 
-    # We expect [0,0,0] to be masked
+    # We expect [0,0,0] to be masked in the prognostic stream.
     if normalize_before_mask:
-        assert td0.get_input(0)[0, 0, 0, 0] == data
-        assert inference_dataset[0][0][0][0, 0, 0] == data
+        assert td0_prog[0, 0, 0, 0] == data
+        assert inf_prog[0, 0, 0, 0] == data
     else:
         mean = 0.5
         std = 1.0
         data = (data - mean) / std
-        assert td0.get_input(0)[0, 0, 0, 0] == data
-        assert inference_dataset[0][0][0][0, 0, 0] == data
+        assert td0_prog[0, 0, 0, 0] == data
+        assert inf_prog[0, 0, 0, 0] == data
 
 
 @pytest.mark.manual

--- a/tests/test_fomini.py
+++ b/tests/test_fomini.py
@@ -48,15 +48,22 @@ def make_model(query_chunk_size: int | None) -> FOMini:
     )
 
 
+def _split_prog_boundary(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    # FOMini expects in_channels=10; split arbitrarily into 6 prog + 4 boundary.
+    return x[:, :6], x[:, 6:]
+
+
 def test_forward_shape():
     model = make_model(query_chunk_size=None)
     x = torch.randn(2, 10, 4, 8)
-    out = model.forward_once(x, make_ctx(out_channels=6, H=4, W=8))
+    prog, boundary = _split_prog_boundary(x)
+    out = model.forward_once(prog, boundary, make_ctx(out_channels=6, H=4, W=8))
     assert out.shape == (2, 6, 4, 8)
 
 
 def test_chunked_queries_match_full_decode():
     x = torch.randn(2, 10, 4, 8)
+    prog, boundary = _split_prog_boundary(x)
     ctx = make_ctx(out_channels=6, H=4, W=8)
 
     full = make_model(query_chunk_size=None)
@@ -67,8 +74,8 @@ def test_chunked_queries_match_full_decode():
     chunked.eval()
 
     with torch.no_grad():
-        y_full = full.forward_once(x, ctx)
-        y_chunked = chunked.forward_once(x, ctx)
+        y_full = full.forward_once(prog, boundary, ctx)
+        y_chunked = chunked.forward_once(prog, boundary, ctx)
     assert torch.allclose(y_full, y_chunked, atol=1e-5)
 
 

--- a/tests/test_gradient_detaching.py
+++ b/tests/test_gradient_detaching.py
@@ -67,22 +67,26 @@ def create_samudra_model():
                 pos_channels=0,
                 gradient_detach_interval=gradient_detach_interval,
             ).build(
-                in_channels=2,
+                prog_channels=1,
+                boundary_channels=1,
                 out_channels=1,
                 hist=1,
                 static_data_for_corrector=None,
                 srcs=[src],
             )
 
-            # Create TrainData compatible with model dimensions
+            # Create TrainData compatible with model dimensions.
+            # in_channels=2 splits into 1 prognostic + 1 boundary channel.
             train_data = TrainData(
                 num_prognostic_channels=1,
+                num_boundary_channels=1,
                 ctx=GridContext(masks.prognostic, src.resolution, src.resolution),
             )
             for step in range(4):
-                input_tensor = torch.randn(1, 2, h, w, requires_grad=True)
+                prog_tensor = torch.randn(1, 1, h, w, requires_grad=True)
+                boundary_tensor = torch.randn(1, 1, h, w, requires_grad=True)
                 label_tensor = torch.randn(1, 1, h, w)
-                train_data.append(input_tensor, label_tensor)
+                train_data.append(prog_tensor, boundary_tensor, label_tensor)
 
             return model, train_data
 

--- a/tests/test_positional_channels.py
+++ b/tests/test_positional_channels.py
@@ -21,7 +21,8 @@ def test_positional_parameters_update(dummy_src: DataSource):
         pos_channels=1,
     )
     model = config.build(
-        in_channels=2,
+        prog_channels=1,
+        boundary_channels=1,
         out_channels=1,
         hist=0,
         static_data_for_corrector=None,
@@ -38,10 +39,13 @@ def test_positional_parameters_update(dummy_src: DataSource):
 
     # Run a step and confirm they have changed
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
-    x = torch.randn(1, 2, h, w)
+    prog = torch.randn(1, 1, h, w)
+    boundary = torch.randn(1, 1, h, w)
     optimizer.zero_grad()
     out = model.forward_once(
-        x, GridContext(masks.prognostic, src.resolution, src.resolution)
+        prog,
+        boundary,
+        GridContext(masks.prognostic, src.resolution, src.resolution),
     )
     loss = out.sum()
     loss.backward()

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -6,7 +6,7 @@ import xarray as xr
 from ocean_emulators.constants import DEPTH_LEVELS, TensorMap
 from ocean_emulators.datasets import InferenceDataset, TrainData
 from ocean_emulators.models.base import BaseModel
-from ocean_emulators.stepper import Stepper
+from ocean_emulators.stepper import validate_batch
 from ocean_emulators.utils.ctx import GridContext
 from ocean_emulators.utils.data import DataSource, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
@@ -91,26 +91,34 @@ class MockModel(BaseModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def forward_once(self, x, ctx: GridContext):
-        return x[:, : self.out_channels] * 10.0 + x[:, -1]
+    def forward_once(
+        self,
+        prognostic: torch.Tensor,
+        boundary: torch.Tensor,
+        ctx: GridContext,
+    ):
+        # Exercises the two streams independently: scale prog, add the last
+        # boundary channel.
+        return prognostic * 10.0 + boundary[:, -1]
 
 
 class ConstantResidualModel(BaseModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def forward_once(self, x, ctx: GridContext):
-        return torch.ones_like(x[:, : self.out_channels])
+    def forward_once(self, prognostic, boundary, ctx: GridContext):
+        return torch.ones_like(prognostic)
 
 
 def test_validate_batch_uses_absolute_predictions_for_residual_models():
     wet = torch.ones((1, 1, 1, 1), dtype=torch.bool)
     grid = torch.zeros(1)
     ctx = GridContext(wet, (grid, grid), (grid, grid))
-    batch = TrainData(num_prognostic_channels=1, ctx=ctx)
-    input_ = torch.tensor([[[[10.0]], [[5.0]]]])
+    batch = TrainData(num_prognostic_channels=1, num_boundary_channels=1, ctx=ctx)
+    prog_input = torch.tensor([[[[10.0]]]])
+    boundary_input = torch.tensor([[[[5.0]]]])
     label = torch.tensor([[[[11.0]]]])
-    batch.append(input_, label)
+    batch.append(prog_input, boundary_input, label)
 
     model = ConstantResidualModel(
         in_channels=2,
@@ -122,13 +130,15 @@ def test_validate_batch_uses_absolute_predictions_for_residual_models():
         gradient_detach_interval=0,
     )
 
-    output = Stepper.validate_batch(
+    output = validate_batch(
         model,
         batch,
         lambda pred, target, ctx: ((pred - target) ** 2).mean(dim=(0, 2, 3)),
     )
 
-    assert torch.equal(output.input_data, input_)
+    assert torch.equal(
+        output.input_data, torch.cat((prog_input, boundary_input), dim=1)
+    )
     assert torch.equal(output.target_data, label)
     assert torch.equal(output.gen_data, label)
     assert torch.equal(output.loss_per_channel, torch.zeros(1))
@@ -142,7 +152,8 @@ def test_inference_dataset(inf_data_init, hist):
     num_input_channels = (hist + 1) * 2  # (hist + 1) * (thetao + hfds)
     num_prognostic_channels = hist + 1  # (hist + 1) * thetao
 
-    input_0, target_0 = inference_dataset[0]
+    prog_0, boundary_0, target_0 = inference_dataset[0]
+    input_0 = torch.cat((prog_0, boundary_0), dim=1)
 
     # Index 0 test
     # For hist = 0, input is [0, 1]
@@ -165,7 +176,8 @@ def test_inference_dataset(inf_data_init, hist):
     # Loop test
     for cur_step in range(1, len(inference_dataset)):
         base_step = cur_step * (hist + 1)
-        input_cur, target_cur = inference_dataset[cur_step]
+        prog_cur, boundary_cur, target_cur = inference_dataset[cur_step]
+        input_cur = torch.cat((prog_cur, boundary_cur), dim=1)
         assert input_cur.shape == (1, num_input_channels, 1, 1)
         expected_input = torch.tensor(
             [2 * i for i in range(base_step, base_step + hist + 1)]
@@ -252,7 +264,8 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     model.eval()
     num_input_channels = (hist + 1) * 2  # (hist + 1) * (thetao + hfds)
     num_prognostic_channels = hist + 1  # (hist + 1) * thetao
-    input_tensor = inference_dataset.get_initial_input()
+    prog_tensor, boundary_tensor = inference_dataset.get_initial_input()
+    input_tensor = torch.cat((prog_tensor, boundary_tensor), dim=1)
 
     assert input_tensor.shape == (1, num_input_channels, 1, 1)
     expected_input = torch.tensor(
@@ -262,7 +275,8 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     assert torch.equal(input_tensor.flatten(), expected_input)
 
     pred = model.forward_once(
-        input_tensor,
+        prog_tensor,
+        boundary_tensor,
         GridContext(wet, inference_dataset.input_res, inference_dataset.input_res),
     )
     assert pred.shape == (1, num_prognostic_channels, 1, 1)
@@ -271,10 +285,11 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     )
     assert torch.equal(pred.flatten(), expected_pred)
 
-    merged_input_tensor = inference_dataset.merge_prognostic_and_boundary(
+    merged_prog, merged_boundary = inference_dataset.get_boundary_for_prognostic(
         prognostic=pred,
         step=merge_step,
     )
+    merged_input_tensor = torch.cat((merged_prog, merged_boundary), dim=1)
     assert merged_input_tensor.shape == (1, num_input_channels, 1, 1)
 
     # For hist = 0, merge_step = 1, need to merge [3]

--- a/tests/test_stepper.py
+++ b/tests/test_stepper.py
@@ -285,10 +285,8 @@ def test_inference_rollout_methods(inf_data_init, hist, merge_step):
     )
     assert torch.equal(pred.flatten(), expected_pred)
 
-    merged_prog, merged_boundary = inference_dataset.get_boundary_for_prognostic(
-        prognostic=pred,
-        step=merge_step,
-    )
+    merged_prog = pred
+    merged_boundary = inference_dataset.get_boundary(merge_step)
     merged_input_tensor = torch.cat((merged_prog, merged_boundary), dim=1)
     assert merged_input_tensor.shape == (1, num_input_channels, 1, 1)
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -118,19 +118,22 @@ def test_checkpoint_inference(trainer_pair: TrainPair, caplog):
     wet = trainer.inference_src.masks.prognostic_with_hist(hist)
     ctx = GridContext(wet, resolution, resolution).to(trainer.device)
     data = trainer.inference_loader.dataset[0]
-    X, y = data
+    inference_dataset, _num_steps = data
+    prog, boundary, _label = inference_dataset[0]
+    prog = prog.to(trainer.device)
+    boundary = boundary.to(trainer.device)
     trainer.best_val_loss = 10
     trainer.best_inf_loss = 10
 
     model = trainer.model
     assert isinstance(model, BaseModel)
-    out = model.forward_once(X[0][0].to(trainer.device), ctx)
+    out = model.forward_once(prog, boundary, ctx)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         trainer.save_checkpoint(1, Path(tmpdir) / "test.pt")
         trainer.load_checkpoint(Path(tmpdir) / "test.pt")
 
-    out2 = model.forward_once(X[0][0].to(trainer.device), ctx)
+    out2 = model.forward_once(prog, boundary, ctx)
 
     assert torch.allclose(out, out2)
 


### PR DESCRIPTION
Thread prognostic and boundary inputs as separate tensors through the data pipeline, stepper, base model, and all model implementations. Previously they were concatenated along the channel dim before reaching the model; now each model's forward_once receives (prog, boundary, ctx).

FOMO concatenates before its single-stream encoder (the dual-perceiver encoder that enables cross-resolution fusion lands in a follow-up). Samudra and FOMini concatenate inside their forward_once as before.

This is #681 broken up into a stack of three small PRs. 1/3