### PR TITLE
Track prognostic resolution across autoregressive rollout steps

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -387,12 +387,22 @@ class PerceiverConfig(BaseConfig):
     def build(
         self,
         in_channels: int,
-        out_channels: int,
         max_patch_size: tuple[int, int],
         implementation: PerceiverImpl,
     ) -> nn.Module:
-        """Build a regular Perceiver (used by the encoder)."""
-        # This is not really a "frequency" but a maximum of the width appears to be reasonable from looking at the code.
+        """Build a Perceiver that maps 2-D patches to a pooled latent vector.
+
+        The Perceiver receives raw 2-D patches
+        ``(batch, ph, pw, input_channels)`` with internal Fourier position
+        encoding.  It returns ``(batch, latent_dim)`` after mean-pooling
+        its latent vectors.
+
+        Args:
+            in_channels: Number of input channels per patch pixel.
+            max_patch_size: Largest ``(ph, pw)`` across data sources,
+                used to set the Fourier frequency range.
+            implementation: Which Perceiver backend to use.
+        """
         max_freq = max(*max_patch_size)
 
         if _use_flash(implementation):
@@ -411,7 +421,7 @@ class PerceiverConfig(BaseConfig):
                     latent_rotary_emb_dim=max_freq,
                     depth=self.depth,
                     input_dim=in_channels,
-                    output_dim=out_channels,
+                    output_dim=self.latent_dim,
                     output_mode="average",
                     latent_dim=self.latent_dim,
                     num_latents=self.num_latents,
@@ -427,7 +437,7 @@ class PerceiverConfig(BaseConfig):
                 depth=self.depth,
                 input_axis=2,
                 input_channels=in_channels,
-                num_classes=out_channels,
+                num_classes=self.latent_dim,
                 latent_dim=self.latent_dim,
                 num_latents=self.num_latents,
                 weight_tie_layers=True,
@@ -504,23 +514,32 @@ def _flash_import_error() -> ValueError:
 
 class EncoderConfig(BaseConfig):
     perceiver: PerceiverConfig = PerceiverConfig()
+    boundary_perceiver: PerceiverConfig = PerceiverConfig(
+        depth=2,
+        num_latents=64,
+    )
 
     def build(
         self,
-        in_channels: int,
+        prog_channels: int,
+        boundary_channels: int,
         out_channels: int,
         patch_extent: tuple[float, float],
-        max_lat_size: int,
-        max_lon_size: int,
+        max_patch_size: tuple[int, int],
         implementation: PerceiverImpl,
     ) -> PerceiverEncoder:
-        max_patch_size = patch_from(patch_extent, max_lat_size, max_lon_size)
         return PerceiverEncoder(
-            in_channels=in_channels,
+            prog_channels=prog_channels,
+            boundary_channels=boundary_channels,
             out_channels=out_channels,
+            prog_latent_dim=self.perceiver.latent_dim,
+            boundary_latent_dim=self.boundary_perceiver.latent_dim,
             patch_extent=patch_extent,
             perceiver=self.perceiver.build(
-                in_channels, out_channels, max_patch_size, implementation
+                prog_channels, max_patch_size, implementation
+            ),
+            boundary_perceiver=self.boundary_perceiver.build(
+                boundary_channels, max_patch_size, implementation
             ),
         )
 
@@ -764,12 +783,6 @@ class FOMOConfig(BaseModelConfig):
         assert len(self.patch_extent) == 2, "patch_extent must be a pair of floats."
         extent = self.patch_extent[0], self.patch_extent[1]
 
-        all_grid_sizes = [s.grid_size for s in srcs]
-        max_lat_size, max_lon_size = (
-            max(g[0] for g in all_grid_sizes),
-            max(g[1] for g in all_grid_sizes),
-        )
-
         impl = self.perceiver_implementation
         if _use_flash(impl) and not self.use_bfloat16:
             raise ValueError(
@@ -777,15 +790,25 @@ class FOMOConfig(BaseModelConfig):
                 "Please set `use_bfloat16=True` or `perceiver_implementation='naive'`."
             )
 
-        in_channels = prog_channels + boundary_channels
-        total_in_channels = in_channels + (3 if self.add_3d_coordinates else 0)
+        # 3D coordinates are appended to the prognostic stream only.
+        encoder_prog_channels = prog_channels + (3 if self.add_3d_coordinates else 0)
+
+        # Compute the largest patch size (in pixels) across all data source
+        # resolutions.  Used to set the Perceiver's Fourier frequency range.
+        all_grid_sizes = [s.grid_size for s in srcs]
+        max_ph, max_pw = 0, 0
+        for grid_h, grid_w in all_grid_sizes:
+            ph, pw = patch_from(extent, grid_h, grid_w)
+            max_ph = max(max_ph, ph)
+            max_pw = max(max_pw, pw)
+        max_patch_size = (max_ph, max_pw)
 
         encoder = self.encoder.build(
-            total_in_channels,
+            encoder_prog_channels,
+            boundary_channels,
             self.embedding_dim,
             extent,
-            max_lat_size,
-            max_lon_size,
+            max_patch_size,
             impl,
         )
         processor = self.processor.build(
@@ -801,8 +824,9 @@ class FOMOConfig(BaseModelConfig):
         )
 
         add_3d_coordinates = Concat3dCoordinates() if self.add_3d_coordinates else None
+        # TODO(alxmrs): `in_channels` isn't used anywhere :/ Consider removing from base model.
         return FOMO(
-            in_channels=total_in_channels,
+            in_channels=encoder_prog_channels + boundary_channels,
             out_channels=out_channels,
             pred_residuals=self.pred_residuals,
             last_kernel_size=self.last_kernel_size,

--- a/src/ocean_emulators/models/base.py
+++ b/src/ocean_emulators/models/base.py
@@ -1,5 +1,6 @@
 # TODO: Need to return step-wise losses for logging
 
+import dataclasses
 import logging
 
 import torch
@@ -47,6 +48,7 @@ class BaseModel(torch.nn.Module):
     ) -> torch.Tensor | list[torch.Tensor]:
         outputs: list[torch.Tensor] = []
         loss = torch.tensor(torch.nan)
+        ctx = train_data.ctx
         for step in range(len(train_data)):
             if step == 0:
                 prog_tensor, boundary_tensor = train_data.get_initial_input()
@@ -59,8 +61,15 @@ class BaseModel(torch.nn.Module):
                     prev_output = prev_output.detach()
                 _, boundary_tensor = train_data.get_input(step)
                 prog_tensor = prev_output
+                # From step 1 onward the prognostic is the previous decoder
+                # output, which sits on the output grid — update the context
+                # so the encoder uses the correct resolution. This is a no-op
+                # when input and output resolutions are equal (match schedule).
+                ctx = dataclasses.replace(
+                    ctx, input_resolution_cpu=ctx.output_resolution_cpu
+                )
 
-            decodings = self.forward_once(prog_tensor, boundary_tensor, train_data.ctx)
+            decodings = self.forward_once(prog_tensor, boundary_tensor, ctx)
             if self.pred_residuals:
                 pred = prog_tensor + decodings  # Residual prediction
             else:
@@ -100,6 +109,7 @@ class BaseModel(torch.nn.Module):
         initial_prognostic = initial_prognostic.to(get_device())
         target_time = dataset.get_target_time(steps_completed, num_steps)
 
+        ctx = dataset.ctx
         for step in range(num_steps):
             logger.info(
                 f"Inference [epoch {epoch}]: Rollout step {steps_completed + step} "
@@ -116,7 +126,14 @@ class BaseModel(torch.nn.Module):
                     steps_completed + step,
                 ).to(device=prog_tensor.device)
 
-            decodings = self.forward_once(prog_tensor, boundary_tensor, dataset.ctx)
+                # From step 1 onward the prognostic is the previous decoder
+                # output, which sits on the output grid — update the context
+                # so the encoder uses the correct resolution. This is a no-op
+                # when input and output resolutions are equal (match schedule).
+                ctx = dataclasses.replace(
+                    ctx, input_resolution_cpu=ctx.output_resolution_cpu
+                )
+            decodings = self.forward_once(prog_tensor, boundary_tensor, ctx)
             if self.pred_residuals:
                 pred = prog_tensor[0].to(device=get_device()) + decodings
             else:

--- a/src/ocean_emulators/models/fomo.py
+++ b/src/ocean_emulators/models/fomo.py
@@ -89,15 +89,14 @@ class FOMO(BaseModel):
     def forward_once(
         self, prognostic: Prognostic, boundary: Boundary, ctx: GridContext
     ) -> Prognostic:
-        # Prognostic and boundary are carried as separate tensors through the
-        # data pipeline, but this encoder still expects a single concatenated
-        # input.  The dual-perceiver encoder that fuses them at the token level
-        # (enabling cross-resolution) lands in a follow-up PR.
-        fts = torch.cat((prognostic, boundary), dim=1)
         with autocast(enabled=self.use_bfloat16, dtype=torch.bfloat16):
+            # 3D coordinates describe the grid the prognostic tensor sits on.
             if self.maybe_add_3d_coordinates is not None:
-                fts = self.maybe_add_3d_coordinates(fts, ctx.input_resolution_cpu)
-            fts = self.encoder(fts, ctx.input_resolution_cpu)
+                prognostic = self.maybe_add_3d_coordinates(
+                    prognostic, ctx.input_resolution_cpu
+                )
+
+            fts = self.encoder(prognostic, boundary, ctx.input_resolution_cpu)
             fts = self.processor(fts)
 
             # TODO(alxmrs): When the output resolution differs from the input (i.e. in a "mix" schedule), we cannot use

--- a/src/ocean_emulators/models/modules/encoder.py
+++ b/src/ocean_emulators/models/modules/encoder.py
@@ -3,6 +3,7 @@
 # - https://github.com/microsoft/aurora/blob/main/aurora/model/encoder.py
 # - https://github.com/lucidrains/vit-pytorch
 
+
 import torch
 from aurora.model.fourier import pos_expansion, scale_expansion
 from aurora.model.posencoding import pos_scale_enc
@@ -10,7 +11,7 @@ from einops import rearrange
 from jaxtyping import Float
 from torch import nn
 
-from ocean_emulators.constants import Input, Lat, Lon
+from ocean_emulators.constants import Boundary, Lat, Lon, Prognostic
 
 
 def patch_from(
@@ -28,26 +29,34 @@ def patch_from(
 
 
 class PerceiverEncoder(nn.Module):
-    """A perceiver-based encoder for Samudra's flattened data (a whole column of the ocean, with history).
+    """A dual-perceiver encoder that fuses prognostic and boundary streams.
 
-    We adopt some of Aurora's positional encodings[1], which uses log-spaced fourier features with geometry-informed
-    wavelengths. These encode 2d positions (the average latitude and longitude of each patch) as well as grid cell area
-    (measured in km^2) for each token before it enters the processor.
+    Each stream gets its own Perceiver.  The prognostic Perceiver is the
+    primary workhorse; the boundary Perceiver is typically configured to be
+    lightweight (fewer latents, shallower depth).  Both operate on 2-D
+    spatial patches with ``input_axis=2``, so they get native Fourier
+    position encoding within each patch for free.
 
-    > Note: We assume that data along the lat/lon coordinates are positioned at the center of each grid point! Please
-    > ensure this is the case at the data processing time.
+    Because ``patch_extent`` is specified in degrees, both streams produce
+    the **same latent grid** regardless of their spatial resolution.
 
-    This encoder is designed to make the same number of patches with the same spatial extents across different scales
-    of input data (input data may vary in resolution of lat/lng grid). To accomplish this with a single perceiver model,
-    our `forward` call requires supplementary information: the resolution (a pair of Lat/Lon tensors), which is used to
-    make consistent positional encodings for patches across different scales. While higher resolution scales will
-    contain more data per patch, the patch will refer to the same physical area on Earth as all other scales.
+    After mean-pooling each Perceiver's latents independently, the two
+    representations are concatenated and projected back to ``latent_dim``
+    via a learned linear layer.
+
+    Patch-level positional and scale encodings (Aurora-style Fourier
+    features [1]) are computed on the prognostic (output) grid and added
+    after fusion.
 
     Args:
-        in_channels (int): the number of input channels (roughly:  time x variable x (surface + depths)).
-        out_channels (int): size of the latent dimension (aka, the embedding dimension).
-        patch_extent (tuple[float, float]): spatial extent of each patch measured in degrees of lat/lon.
-        perceiver (nn.Module): the perceiver module implementation to use.
+        prog_channels: Number of prognostic input channels.
+        boundary_channels: Number of boundary input channels.
+        out_channels: Size of the output embedding dimension.
+        prog_latent_dim: Output dimension of the prognostic Perceiver.
+        boundary_latent_dim: Output dimension of the boundary Perceiver.
+        patch_extent: Spatial extent of each patch in degrees ``(lat, lon)``.
+        perceiver: Perceiver module for the prognostic stream.
+        boundary_perceiver: Perceiver module for the boundary stream.
 
     References:
         [1]: https://ar5iv.labs.arxiv.org/html/2405.13063#A2.SS4
@@ -56,56 +65,102 @@ class PerceiverEncoder(nn.Module):
     # TODO(alxmrs): Implement gradient checkpointing
     def __init__(
         self,
-        in_channels: int,
+        prog_channels: int,
+        boundary_channels: int,
         out_channels: int,
+        prog_latent_dim: int,
+        boundary_latent_dim: int,
         patch_extent: tuple[float, float],
         perceiver: nn.Module,
+        boundary_perceiver: nn.Module,
     ) -> None:
         super().__init__()
-        self.in_channels = in_channels
-        self.out_channels: int = out_channels  # aka, `embed_dim`.
+        self.prog_channels = prog_channels
+        self.boundary_channels = boundary_channels
+        self.out_channels: int = out_channels
         self.patch_extent = patch_extent
         self.perceiver = perceiver
+        self.boundary_perceiver = boundary_perceiver
+
+        # Fuse the two Perceiver outputs and project to embedding dim.
+        self.fusion_proj = nn.Linear(
+            prog_latent_dim + boundary_latent_dim, out_channels
+        )
+
         # TODO(#451): The input to these position and scale linear units could be a hparam.
         self.pos_embed = nn.Linear(self.out_channels, self.out_channels)
         self.scale_embed = nn.Linear(self.out_channels, self.out_channels)
 
-    def forward(
-        self, x: Input, resolution: tuple[Lat, Lon]
-    ) -> Float[torch.Tensor, "batch {self.embed_dim} h w"]:
-        _, V, H, W = x.shape
-        lat, lon = resolution
-        patch_h, patch_w = patch_from(self.patch_extent, H, W)
-        # V is a cross product of variable, level (encoded in vars), and time (has history).
-        assert V == self.in_channels
-        # Ensure patch_size is appropriate for the data.
-        assert H % patch_h == 0, f"{H} % {patch_h} != 0."
-        assert W % patch_w == 0, f"{W} % {patch_w} != 0."
+    def _patchify_params(
+        self, shape: torch.Size, expected_channels: int
+    ) -> tuple[int, int, int, int]:
+        """Validate channels and compute patch / latent-grid dims.
 
-        # Perceiver experiment ideas:
-        # 1. leave it as it is: treating each pixel as a token -- i.e. all channels (includes depths) per pixel
-        # 2. change to original plan, where each float is its own token
-        # 3. Add a third dim -- ph pw d v -- so each spatial position is a token
-        x = rearrange(
-            x,
+        Returns ``(ph, pw, lat_h, lat_w)``.
+        """
+        _, v, h, w = shape
+        assert v == expected_channels, (
+            f"Expected {expected_channels} channels, got {v}."
+        )
+        ph, pw = patch_from(self.patch_extent, h, w)
+        assert h % ph == 0, f"{h} % {ph} != 0."
+        assert w % pw == 0, f"{w} % {pw} != 0."
+        return ph, pw, h // ph, w // pw
+
+    def forward(
+        self,
+        prog: Prognostic,
+        boundary: Boundary,
+        prog_res: tuple[Lat, Lon],
+    ) -> Float[torch.Tensor, "batch {self.out_channels} h w"]:
+        patch_h, patch_w, lat_h, lat_w = self._patchify_params(
+            prog.shape, self.prog_channels
+        )
+        b_patch_h, b_patch_w, b_lat_h, b_lat_w = self._patchify_params(
+            boundary.shape, self.boundary_channels
+        )
+        assert lat_h == b_lat_h and lat_w == b_lat_w, (
+            f"Latent grid mismatch: prog ({lat_h}, {lat_w}) vs "
+            f"boundary ({b_lat_h}, {b_lat_w}). Check that patch_extent "
+            f"divides both grids evenly."
+        )
+
+        # --- Prognostic stream: 2-D patches → Perceiver ---
+        prog_patches = rearrange(
+            prog,
             "b v (h ph) (w pw) -> (b h w) ph pw v",
             ph=patch_h,
             pw=patch_w,
         )
-        # NB(alxmrs): This is includes a mean and LayerNorm before linear projection!
-        x = self.perceiver(x)  # (B_H_W, ..., V) -> (B_H_W, out_channels)
+        prog_pooled = self.perceiver(prog_patches)  # (B_HW, latent_dim)
 
-        # Make `x` amenable to adding position + scale encoding
-        x = rearrange(
-            x,
-            "(b h w) l -> b (h w) l ",
-            h=(H // patch_h),
-            w=(W // patch_w),
+        # --- Boundary stream: 2-D patches → boundary Perceiver ---
+        boundary_patches = rearrange(
+            boundary,
+            "b v (h ph) (w pw) -> (b h w) ph pw v",
+            ph=b_patch_h,
+            pw=b_patch_w,
         )
+        boundary_pooled = self.boundary_perceiver(
+            boundary_patches
+        )  # (B_HW, latent_dim)
 
-        # Calculate and add positional + scale encoding
+        # TODO(alxmrs): Linear fusion may not be a strong enough way to encode the
+        #  boundary signal. If this doesn't prove effective, consider using a
+        #  PerceiverIO model to cross-attend the prognostic and boundary latents.
+        #  For this, we could simply add a PerceiverIO after the two above perceivers,
+        #  or replace the boundary perceiver with a PerceiverIO that cross attends the
+        #  boundary input with the prognostic latents.
+        # --- Fusion: concat pooled representations, project ---
+        x = self.fusion_proj(
+            torch.cat([prog_pooled, boundary_pooled], dim=-1)
+        )  # (B_HW, out_channels)
+
+        # --- Patch-level positional + scale encoding ---
+        x = rearrange(x, "(b h w) l -> b (h w) l", h=lat_h, w=lat_w)
+        lat, lon = prog_res
         pos_encode, scale_encode = pos_scale_enc(
-            self.out_channels,  # aka "embed_dim"
+            self.out_channels,
             lat,
             lon,
             (patch_h, patch_w),
@@ -122,12 +177,7 @@ class PerceiverEncoder(nn.Module):
         ).unsqueeze(0)
         x = x + pos_encoding + scale_encoding
 
-        # Unpack spatial channels, move channel dimension to correct location.
-        x = rearrange(
-            x,
-            "b (h w) l -> b l h w",
-            h=(H // patch_h),
-            w=(W // patch_w),
-        )
+        # --- Unpack spatial dims, move channel dim to standard location ---
+        x = rearrange(x, "b (h w) l -> b l h w", h=lat_h, w=lat_w)
 
         return x

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -21,19 +21,22 @@ NH, NW = 2, 4
 H, W = 8, 16
 
 
-def make_perceiver_encoder(in_channels, out_channels, *, num_latents=2):
-    """Build a regular Perceiver for the encoder (uses mean-pooling)."""
+ENCODER_LATENT_DIM = 4
+
+
+def make_perceiver_encoder(prog_channels, *, num_latents=2, max_freq=10.0):
+    """Build a 2-D Perceiver for the encoder's prognostic stream."""
     from perceiver_pytorch import Perceiver
 
     return Perceiver(
         num_freq_bands=4,
-        max_freq=1.0,
+        max_freq=max_freq,
         depth=2,
         input_axis=2,
-        input_channels=in_channels,
-        latent_dim=3,
+        input_channels=prog_channels,
+        latent_dim=ENCODER_LATENT_DIM,
         num_latents=num_latents,
-        num_classes=out_channels,
+        num_classes=ENCODER_LATENT_DIM,
         weight_tie_layers=True,
         self_per_cross_attn=2,
     )
@@ -119,24 +122,30 @@ def make_decoder_with_shared_weights(
 
 def test_roundtrip():
     H_rt, W_rt = 4, 8
-    x = torch.randn(3, 10, H_rt, W_rt)
+    embed_dim = 4
+    prog = torch.randn(3, 7, H_rt, W_rt)
+    boundary = torch.randn(3, 3, H_rt, W_rt)
 
     patch_embed = PerceiverEncoder(
-        in_channels=10,
-        out_channels=4,
+        prog_channels=7,
+        boundary_channels=3,
+        out_channels=embed_dim,
+        prog_latent_dim=ENCODER_LATENT_DIM,
+        boundary_latent_dim=ENCODER_LATENT_DIM,
         patch_extent=(180, 180),
-        perceiver=make_perceiver_encoder(10, 4),
+        perceiver=make_perceiver_encoder(7),
+        boundary_perceiver=make_perceiver_encoder(3),
     )
 
-    patches = patch_embed(x, make_resolution(x))
-    res = make_resolution(x)
+    res = make_resolution(prog)
+    patches = patch_embed(prog, boundary, res)
 
     decode = PerceiverDecoder(
-        in_channels=4,
+        in_channels=embed_dim,
         out_channels=10,
         patch_extent=(180, 180),
         queries_dim=QUERIES_DIM,
-        perceiver_io=make_decoder_perceiver_io(4, 10),
+        perceiver_io=make_decoder_perceiver_io(embed_dim, 10),
         window_patches=None,
         context_patches=None,
     )

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -4,19 +4,35 @@ from perceiver_pytorch import Perceiver
 from ocean_emulators.constants import Lat, Lon
 from ocean_emulators.models.modules.encoder import PerceiverEncoder, patch_from
 
+LATENT_DIM = 4
 
-def make_perceiver(in_channels, out_channels, *, num_latents=2, input_axis=2):
+
+def make_perceiver(input_channels, *, num_latents=2, max_freq=10.0):
+    """Build a naive 2-D Perceiver."""
     return Perceiver(
         num_freq_bands=4,
-        max_freq=1.0,
+        max_freq=max_freq,
         depth=2,
-        input_axis=input_axis,
-        input_channels=in_channels,
-        latent_dim=3,
+        input_axis=2,
+        input_channels=input_channels,
+        latent_dim=LATENT_DIM,
         num_latents=num_latents,
-        num_classes=out_channels,
+        num_classes=LATENT_DIM,
         weight_tie_layers=True,
         self_per_cross_attn=2,
+    )
+
+
+def make_encoder(prog_channels, boundary_channels, out_channels, patch_extent):
+    return PerceiverEncoder(
+        prog_channels=prog_channels,
+        boundary_channels=boundary_channels,
+        out_channels=out_channels,
+        prog_latent_dim=LATENT_DIM,
+        boundary_latent_dim=LATENT_DIM,
+        patch_extent=patch_extent,
+        perceiver=make_perceiver(prog_channels),
+        boundary_perceiver=make_perceiver(boundary_channels),
     )
 
 
@@ -27,68 +43,47 @@ def make_resolution(x: torch.Tensor) -> tuple[Lat, Lon]:
 
 
 def test_makes_patches():
-    x = torch.randn(3, 10, 4, 8)
+    prog = torch.randn(3, 7, 4, 8)
+    boundary = torch.randn(3, 3, 4, 8)
+    embed_dim = 4
 
-    patch_embed = PerceiverEncoder(
-        in_channels=10,
-        out_channels=4,
-        patch_extent=(180, 180),
-        perceiver=make_perceiver(10, 4),
-    )
+    encoder = make_encoder(7, 3, embed_dim, (180, 180))
+    patches = encoder(prog, boundary, make_resolution(prog))
 
-    patches = patch_embed(x, make_resolution(x))
-
-    assert patches.shape == (3, 4, 1, 2)
+    assert patches.shape == (3, embed_dim, 1, 2)
 
 
 def test_makes_rectangular_patches():
-    x = torch.randn(1, 10, 4, 8)
+    prog = torch.randn(1, 7, 4, 8)
+    boundary = torch.randn(1, 3, 4, 8)
+    embed_dim = 4
 
-    patch_embed = PerceiverEncoder(
-        in_channels=10,
-        out_channels=4,
-        patch_extent=(180, 90),
-        perceiver=make_perceiver(10, 4),
-    )
+    encoder = make_encoder(7, 3, embed_dim, (180, 90))
+    patches = encoder(prog, boundary, make_resolution(prog))
 
-    patches = patch_embed(x, make_resolution(x))
-
-    assert patches.shape == (
-        1,
-        4,
-        1,
-        4,
-    )
+    assert patches.shape == (1, embed_dim, 1, 4)
 
 
 def test_makes_patches__high_res():
-    x = torch.randn(1, 10, 14, 21)
+    prog = torch.randn(1, 7, 14, 21)
+    boundary = torch.randn(1, 3, 14, 21)
+    embed_dim = 4
 
-    patch_embed = PerceiverEncoder(
-        in_channels=10,
-        out_channels=4,
-        patch_extent=(90.0, 120.0),
-        perceiver=make_perceiver(10, 4),
-    )
+    encoder = make_encoder(7, 3, embed_dim, (90.0, 120.0))
+    patches = encoder(prog, boundary, make_resolution(prog))
 
-    patches = patch_embed(x, make_resolution(x))
-
-    assert patches.shape == (1, 4, 2, 3)
+    assert patches.shape == (1, embed_dim, 2, 3)
 
 
 def test_makes_patches__more_variables():
-    x = torch.randn(1, 20, 4, 8)
+    prog = torch.randn(1, 17, 4, 8)
+    boundary = torch.randn(1, 3, 4, 8)
+    embed_dim = 4
 
-    patch_embed = PerceiverEncoder(
-        in_channels=20,
-        out_channels=4,
-        patch_extent=(180, 180),
-        perceiver=make_perceiver(20, 4),
-    )
+    encoder = make_encoder(17, 3, embed_dim, (180, 180))
+    patches = encoder(prog, boundary, make_resolution(prog))
 
-    patches = patch_embed(x, make_resolution(x))
-
-    assert patches.shape == (1, 4, 1, 2)
+    assert patches.shape == (1, embed_dim, 1, 2)
 
 
 def test_patch_from__full_globe():

--- a/tests/test_fomo_cross_resolution.py
+++ b/tests/test_fomo_cross_resolution.py
@@ -183,3 +183,54 @@ def test_fomo_forward_once_mix_schedule(add_3d_coordinates: bool):
 
     assert output.shape == (1, out_channels, output_h, output_w)
     assert torch.isfinite(output).all(), "Output contains NaN or Inf."
+
+
+@pytest.mark.parametrize("add_3d_coordinates", [False, True])
+def test_fomo_autoregressive_mix_schedule(add_3d_coordinates: bool):
+    """Two-step autoregressive rollout with mix schedule via BaseModel.forward.
+
+    Step 0: prog at input resolution (4x8) → output at output resolution (16x32).
+    Step 1: BaseModel.forward feeds back decoder output (16x32) as prog, updating
+    ctx.input_resolution_cpu to output_resolution_cpu so the encoder sees the
+    correct grid.
+    """
+    from ocean_emulators.datasets import TrainData
+
+    prog_channels, boundary_channels, out_channels = 7, 3, 7
+    input_h, input_w = 4, 8
+    output_h, output_w = 16, 32
+
+    model = _make_fomo(
+        prog_channels,
+        boundary_channels,
+        out_channels,
+        add_3d_coordinates=add_3d_coordinates,
+    )
+    input_res = _make_resolution(input_h, input_w)
+    output_res = _make_resolution(output_h, output_w)
+    ctx = GridContext(
+        label_mask=torch.ones(out_channels, output_h, output_w, dtype=torch.bool),
+        input_resolution_cpu=input_res,
+        output_resolution_cpu=output_res,
+    )
+
+    train_data = TrainData(prog_channels, boundary_channels, ctx)
+    # Step 0: prog and boundary at input resolution
+    train_data.append(
+        torch.randn(1, prog_channels, input_h, input_w),
+        torch.randn(1, boundary_channels, input_h, input_w),
+        torch.randn(1, out_channels, output_h, output_w),
+    )
+    # Step 1: boundary at input resolution, prog will come from step 0 output
+    train_data.append(
+        torch.randn(1, prog_channels, input_h, input_w),  # unused as prog
+        torch.randn(1, boundary_channels, input_h, input_w),
+        torch.randn(1, out_channels, output_h, output_w),
+    )
+
+    outputs = model.forward(train_data, loss_fn=None)
+
+    assert len(outputs) == 2
+    for out in outputs:
+        assert out.shape == (1, out_channels, output_h, output_w)
+        assert torch.isfinite(out).all(), "Output contains NaN or Inf."

--- a/tests/test_fomo_cross_resolution.py
+++ b/tests/test_fomo_cross_resolution.py
@@ -1,0 +1,185 @@
+"""End-to-end test: FOMO.forward_once with mismatched prog/boundary resolutions."""
+
+import pytest
+import torch
+from perceiver_pytorch import Perceiver
+from perceiver_pytorch.perceiver_io import PerceiverIO
+
+from ocean_emulators.models.fomo import FOMO
+from ocean_emulators.models.modules import (
+    PerceiverDecoder,
+    PerceiverEncoder,
+    UNetBackbone,
+)
+from ocean_emulators.models.modules.augment_input import Concat3dCoordinates
+from ocean_emulators.models.modules.blocks import (
+    BilinearUpsample,
+    ConvNeXtBlock,
+    CoreBlock,
+)
+from ocean_emulators.utils.ctx import GridContext
+
+LATENT_DIM = 4
+EMBED_DIM = 8
+QUERIES_DIM = 16
+PATCH_EXTENT = (90.0, 90.0)
+
+
+def _create_block(
+    in_channels: int,
+    out_channels: int,
+    dilation: int,
+    n_layers: int,
+    pad: str,
+    checkpoint_simple: bool,
+) -> CoreBlock:
+    return ConvNeXtBlock(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        dilation=dilation,
+        n_layers=n_layers,
+        pad=pad,
+        checkpoint_simple=checkpoint_simple,
+    )
+
+
+def _create_upsample(in_channels: int, out_channels: int) -> BilinearUpsample:
+    return BilinearUpsample()
+
+
+def _make_perceiver(input_channels: int, depth: int = 2) -> Perceiver:
+    return Perceiver(
+        num_freq_bands=4,
+        max_freq=10.0,
+        depth=depth,
+        input_axis=2,
+        input_channels=input_channels,
+        latent_dim=LATENT_DIM,
+        num_latents=2,
+        num_classes=LATENT_DIM,
+        weight_tie_layers=True,
+        self_per_cross_attn=2,
+    )
+
+
+def _make_fomo(
+    prog_channels: int,
+    boundary_channels: int,
+    out_channels: int,
+    add_3d_coordinates: bool = False,
+) -> FOMO:
+    encoder_prog_channels = prog_channels + (3 if add_3d_coordinates else 0)
+    encoder = PerceiverEncoder(
+        prog_channels=encoder_prog_channels,
+        boundary_channels=boundary_channels,
+        out_channels=EMBED_DIM,
+        prog_latent_dim=LATENT_DIM,
+        boundary_latent_dim=LATENT_DIM,
+        patch_extent=PATCH_EXTENT,
+        perceiver=_make_perceiver(encoder_prog_channels),
+        boundary_perceiver=_make_perceiver(boundary_channels, depth=1),
+    )
+    processor = UNetBackbone(
+        in_channels=EMBED_DIM,
+        ch_width=[EMBED_DIM],
+        dilation=[1],
+        n_layers=[1],
+        pad="circular",
+        create_block=_create_block,
+        downsampling_block=torch.nn.Identity(),
+        create_upsampling_block=_create_upsample,
+        checkpointing=None,
+    )
+    perceiver_io = PerceiverIO(
+        depth=2,
+        dim=EMBED_DIM,
+        queries_dim=QUERIES_DIM,
+        logits_dim=out_channels,
+        num_latents=4,
+        latent_dim=LATENT_DIM,
+        weight_tie_layers=True,
+        decoder_ff=True,
+    )
+    decoder = PerceiverDecoder(
+        in_channels=EMBED_DIM,
+        out_channels=out_channels,
+        patch_extent=PATCH_EXTENT,
+        queries_dim=QUERIES_DIM,
+        perceiver_io=perceiver_io,
+        window_patches=None,
+        context_patches=None,
+    )
+    return FOMO(
+        in_channels=prog_channels + boundary_channels,
+        out_channels=out_channels,
+        pred_residuals=False,
+        last_kernel_size=1,
+        pad="circular",
+        add_3d_coordinates=Concat3dCoordinates() if add_3d_coordinates else None,
+        encoder=encoder,
+        processor=processor,
+        decoder=decoder,
+        hist=0,
+        checkpointing=None,
+        gradient_detach_interval=0,
+        use_bfloat16=False,
+    )
+
+
+def _make_resolution(h: int, w: int) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.linspace(-90, 90, h), torch.linspace(0, 360, w)
+
+
+def test_fomo_forward_once_cross_resolution():
+    """FOMO produces output at prognostic resolution when boundary resolution differs."""
+    prog_channels, boundary_channels, out_channels = 7, 3, 7
+    # Prognostic: 1/4 degree (8x16), Boundary: 1 degree (2x4)
+    prog_h, prog_w = 8, 16
+    boundary_h, boundary_w = 2, 4
+
+    model = _make_fomo(prog_channels, boundary_channels, out_channels)
+    prog = torch.randn(2, prog_channels, prog_h, prog_w)
+    boundary = torch.randn(2, boundary_channels, boundary_h, boundary_w)
+
+    prog_res = _make_resolution(prog_h, prog_w)
+    ctx = GridContext(
+        label_mask=torch.ones(out_channels, prog_h, prog_w, dtype=torch.bool),
+        input_resolution_cpu=prog_res,
+        output_resolution_cpu=prog_res,
+    )
+
+    output = model.forward_once(prog, boundary, ctx)
+
+    assert output.shape == (2, out_channels, prog_h, prog_w)
+    assert torch.isfinite(output).all(), "Output contains NaN or Inf."
+
+
+@pytest.mark.parametrize("add_3d_coordinates", [False, True])
+def test_fomo_forward_once_mix_schedule(add_3d_coordinates: bool):
+    """Mix schedule: prog at 1° input grid, output at ¼° grid."""
+    prog_channels, boundary_channels, out_channels = 7, 3, 7
+    # Input (prognostic) at 1 degree (4x8), output at 1/4 degree (16x32)
+    input_h, input_w = 4, 8
+    output_h, output_w = 16, 32
+
+    model = _make_fomo(
+        prog_channels,
+        boundary_channels,
+        out_channels,
+        add_3d_coordinates=add_3d_coordinates,
+    )
+    prog = torch.randn(1, prog_channels, input_h, input_w)
+    boundary = torch.randn(1, boundary_channels, input_h, input_w)
+
+    input_res = _make_resolution(input_h, input_w)
+    output_res = _make_resolution(output_h, output_w)
+    ctx = GridContext(
+        label_mask=torch.ones(out_channels, output_h, output_w, dtype=torch.bool),
+        input_resolution_cpu=input_res,
+        output_resolution_cpu=output_res,
+    )
+
+    output = model.forward_once(prog, boundary, ctx)
+
+    assert output.shape == (1, out_channels, output_h, output_w)
+    assert torch.isfinite(output).all(), "Output contains NaN or Inf."


### PR DESCRIPTION
In BaseModel.forward and BaseModel.inference, update ctx.input_resolution_cpu to output_resolution_cpu from step 1 onward. The prognostic tensor fed back is the previous decoder output, which sits on the output grid — the encoder's positional encoding must match. This is a no-op when input and output resolutions are equal (match schedule).

Without this fix, multi-step mix-schedule training would use incorrect positional features from step 1 onward, and would crash with 3D coordinates enabled (shape mismatch).

This is https://github.com/Open-Athena/Ocean_Emulator/pull/681 broken up into a stack of three small PRs. 3/3