### PR TITLE
Asymmetric eval/inference support: coarse forcings can perform a high resolution rollout.

### DIFF
--- a/configs/fomo_om4/eval_cross_resolution.yaml
+++ b/configs/fomo_om4/eval_cross_resolution.yaml
@@ -1,0 +1,56 @@
+# yaml-language-server: $schema=../schemas/EvalConfig.json
+#
+# Cross-resolution eval for the FOMO model (KR2, issue #615).
+#
+# The rollout starts at ¼° and consumes 1° boundary forcings at each step.
+# Prognostics stay at ¼° throughout the rollout — only the boundaries come
+# from a coarser source. Enabled by the dual-perceiver encoder (PR #702),
+# which produces the same latent grid for both streams when patch_extent is
+# in degrees.
+#
+# As in eval_multiscale.yaml, all three resolutions must appear in
+# `sources` so FOMOConfig.build computes `max_patch_size` correctly for the
+# Perceiver's Fourier frequency range. The first source is the one used for
+# inference (¼° here), and `boundary_source` specifies where to load
+# boundary forcings from (1° here).
+
+debug: false
+save_zarr: true
+disk_mode: true
+inference_time:
+  start: "2014-10-05"
+  end: "2015-10-05"
+num_model_steps_forward: 25
+
+experiment:
+  name: fomo_om4_eval_cross_resolution
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+  prognostic_vars_key: thermo_dynamic_all
+  boundary_vars_key: tau_hfds_hfds_anom
+
+data:
+  static_data_vars: []
+  concurrent_compute: true
+  sources:
+    # First source is used for inference prognostics.
+    - data_location: om4_quarterdeg_v2/OM4.zarr
+      data_means_location: om4_quarterdeg_v2/OM4_means.zarr
+      data_stds_location: om4_quarterdeg_v2/OM4_stds.zarr
+    - data_location: om4_halfdeg_v4/OM4.zarr
+      data_means_location: om4_halfdeg_v4/OM4_means.zarr
+      data_stds_location: om4_halfdeg_v4/OM4_stds.zarr
+    - data_location: om4_onedeg_v3/OM4.zarr
+      data_means_location: om4_onedeg_v3/OM4_means.zarr
+      data_stds_location: om4_onedeg_v3/OM4_stds.zarr
+  # Boundary forcings come from the 1° source, while prognostics come from
+  # `sources[0]` (¼°). This is the KR2 asymmetric-inference setup.
+  boundary_source:
+    data_location: om4_onedeg_v3/OM4.zarr
+    data_means_location: om4_onedeg_v3/OM4_means.zarr
+    data_stds_location: om4_onedeg_v3/OM4_stds.zarr
+
+model: !include model.yaml

--- a/configs/fomo_om4/train_cross_resolution.yaml
+++ b/configs/fomo_om4/train_cross_resolution.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=../schemas/TrainConfig.json
+#
+# Cross-resolution training for FOMO (KR2, issue #615).
+#
+# Prognostic inputs and labels come from the first source (0.25 degree here),
+# while boundary forcings come from the explicit 1 degree boundary_source.
+# The additional sources are listed so FOMOConfig.build can compute
+# max_patch_size across the supported scales.
+
+debug: false
+disk_mode: true
+pin_mem: true
+save_freq: 5
+epochs: 70
+batch_size: 2
+learning_rate: 0.0006
+scheduler: { type: cosine }
+loss:
+  type: dynamic
+  metric: mse
+finetune: false
+resume_ckpt_path: null
+inference_epochs: []
+data_percent: 1.0
+train_time:
+  start: "1975-01-03"
+  end: "2013-10-05"
+val_time:
+  start: "2013-10-05"
+  end: "2014-10-05"
+inference_times:
+  - start: "1975-01-03"
+    end: "1976-01-03"
+  - start: "1985-01-03"
+    end: "1986-01-03"
+  - start: "1995-01-03"
+    end: "1996-01-03"
+  - start: "2004-10-05"
+    end: "2005-10-05"
+data_stride: [1]
+steps: [4]
+step_transition: []
+preemptible: false
+
+backend: auto
+
+experiment:
+  name: fomo_om4_train_cross_resolution
+  rand_seed: 15
+  base_output_dir: .LOCAL
+  wandb:
+    mode: disabled
+    project: default
+  prognostic_vars_key: thermo_dynamic_all
+  boundary_vars_key: tau_hfds_hfds_anom
+
+data:
+  static_data_vars: []
+  concurrent_compute: true
+  sources:
+    - data_location: om4_quarterdeg_v2/OM4.zarr
+      data_means_location: om4_quarterdeg_v2/OM4_means.zarr
+      data_stds_location: om4_quarterdeg_v2/OM4_stds.zarr
+    - data_location: om4_halfdeg_v4/OM4.zarr
+      data_means_location: om4_halfdeg_v4/OM4_means.zarr
+      data_stds_location: om4_halfdeg_v4/OM4_stds.zarr
+    - data_location: om4_onedeg_v3/OM4.zarr
+      data_means_location: om4_onedeg_v3/OM4_means.zarr
+      data_stds_location: om4_onedeg_v3/OM4_stds.zarr
+  boundary_source:
+    data_location: om4_onedeg_v3/OM4.zarr
+    data_means_location: om4_onedeg_v3/OM4_means.zarr
+    data_stds_location: om4_onedeg_v3/OM4_stds.zarr
+
+model: !include model.yaml

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -194,6 +194,17 @@ class DataConfig(BaseConfig):
         ),
         min_length=1,
     )
+    boundary_source: DataSourceConfig | None = Field(
+        default=None,
+        description=(
+            "Optional separate boundary source for inference. When set, "
+            "InferenceDataset loads boundary forcings from this source "
+            "(typically at a coarser resolution than the prognostic source), "
+            "enabling cross-resolution rollouts such as ¼° prognostics + "
+            "1° boundaries. When unset, boundaries are loaded from the same "
+            "source as the prognostics (current default behavior)."
+        ),
+    )
     static_data_vars: list[str] | None = None
     loading: DataLoadingConfig = Field(default_factory=CpuDataLoadingConfig)
     hist: int = 1
@@ -271,12 +282,22 @@ class DataConfig(BaseConfig):
             else None
         )
 
+        inference_boundary_source: DataSource | None = None
+        if self.boundary_source is not None:
+            inference_boundary_source, _ = make_source(
+                self.boundary_source.data_location,
+                self.boundary_source.data_means_location,
+                self.boundary_source.data_stds_location,
+                turn_on_dask=True,
+            )
+
         return DataContainer(
             sources,
             inference_source,
             loader_version,
             supports_fork,
             static_data,
+            inference_boundary_source=inference_boundary_source,
         )
 
 

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -197,12 +197,12 @@ class DataConfig(BaseConfig):
     boundary_source: DataSourceConfig | None = Field(
         default=None,
         description=(
-            "Optional separate boundary source for inference. When set, "
-            "InferenceDataset loads boundary forcings from this source "
-            "(typically at a coarser resolution than the prognostic source), "
-            "enabling cross-resolution rollouts such as ¼° prognostics + "
-            "1° boundaries. When unset, boundaries are loaded from the same "
-            "source as the prognostics (current default behavior)."
+            "Optional separate boundary source. When set, training, validation, "
+            "and inference load boundary forcings from this source (typically at "
+            "a coarser resolution than the prognostic source), enabling "
+            "cross-resolution runs such as ¼° prognostics + 1° boundaries. When "
+            "unset, boundaries are loaded from the same source as the "
+            "prognostics (current default behavior)."
         ),
     )
     static_data_vars: list[str] | None = None
@@ -260,8 +260,6 @@ class DataConfig(BaseConfig):
             )
             sources.append(src)
             supports_forks.append(fork)
-        supports_fork = all(supports_forks)
-
         primary_source = sources[0]
         if use_dask:
             # If we're already using dask, we don't need a second source
@@ -282,14 +280,26 @@ class DataConfig(BaseConfig):
             else None
         )
 
+        boundary_source: DataSource | None = None
         inference_boundary_source: DataSource | None = None
         if self.boundary_source is not None:
-            inference_boundary_source, _ = make_source(
+            boundary_source, boundary_fork = make_source(
                 self.boundary_source.data_location,
                 self.boundary_source.data_means_location,
                 self.boundary_source.data_stds_location,
-                turn_on_dask=True,
             )
+            supports_forks.append(boundary_fork)
+            if use_dask:
+                inference_boundary_source = boundary_source
+            else:
+                inference_boundary_source, _ = make_source(
+                    self.boundary_source.data_location,
+                    self.boundary_source.data_means_location,
+                    self.boundary_source.data_stds_location,
+                    turn_on_dask=True,
+                )
+
+        supports_fork = all(supports_forks)
 
         return DataContainer(
             sources,
@@ -297,6 +307,7 @@ class DataConfig(BaseConfig):
             loader_version,
             supports_fork,
             static_data,
+            boundary_source=boundary_source,
             inference_boundary_source=inference_boundary_source,
         )
 

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -490,11 +490,13 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         masked_fill_value: float,
         stride: int = 1,
         concurrent_compute_: bool = False,
+        boundary_src: DataSource | None = None,
     ):
         super().__init__()
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         # If the src and dst DataSource are the same, we can do a lot less work.
         srcs = [src, dst] if dst else [src]
+        boundary_data_src = boundary_src if boundary_src is not None else src
 
         self.hist: int = hist
         self.steps: int = steps
@@ -508,11 +510,18 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         assert np.array_equal(srcs[0].data.time, srcs[-1].data.time), (
             "src and dst DataSource have different time slices!"
         )
+        if not boundary_data_src.data.time.equals(src.data.time):
+            raise ValueError(
+                "Boundary source time axis does not match the prognostic source. "
+                "Cross-resolution training requires both sources to share a time axis."
+            )
         time_ = src.data.time
         self.prognostic_srcs = [
             src.filter(prognostic_var_names, prefix="prog") for src in srcs
         ]
-        self.boundary_src = src.filter(boundary_var_names, prefix="boundary")
+        self.boundary_src = boundary_data_src.filter(
+            boundary_var_names, prefix="boundary"
+        )
 
         # This class will be used only for training and validation
         total_steps: int = 2 * self.hist + 2
@@ -536,7 +545,7 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         self.wet_prognostic: list[PrognosticMask] = [
             src.masks.prognostic for src in srcs
         ]
-        self.wet_surface: GridMask = src.masks.boundary
+        self.wet_surface: GridMask = boundary_data_src.masks.boundary
 
         self.ctx = GridContext(
             label_mask=self.prognostic_srcs[-1].masks.prognostic_with_hist(self.hist),

--- a/src/ocean_emulators/datasets.py
+++ b/src/ocean_emulators/datasets.py
@@ -60,6 +60,7 @@ class InferenceDataset(Dataset):
         normalize_before_mask,
         masked_fill_value,
         long_rollout,
+        boundary_src: DataSource | None = None,
     ):
         super().__init__()
         # NOTE: Keep tensors on CPU during initialization. This allows the dataset
@@ -72,7 +73,22 @@ class InferenceDataset(Dataset):
         data = src.data
         self.input_res = src.resolution
         self._prognostic_src = src.filter(prognostic_var_names, prefix="prognostic")
-        self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
+        # When boundary_src is provided, boundaries come from a different source
+        # (typically a coarser resolution) — enabling cross-resolution rollouts.
+        # The rolling indices are built off the prognostic source's time axis and
+        # reused for both streams, so the two sources must share a time axis.
+        if boundary_src is not None:
+            if not boundary_src.data.time.equals(data.time):
+                raise ValueError(
+                    "Boundary source time axis does not match the prognostic "
+                    "source. Cross-resolution inference requires both sources "
+                    "to share a time axis."
+                )
+            self._boundary_src = boundary_src.filter(
+                boundary_var_names, prefix="boundary"
+            )
+        else:
+            self._boundary_src = src.filter(boundary_var_names, prefix="boundary")
         self._times = data.time
         self.normalize_before_mask = normalize_before_mask
         self.masked_fill_value = masked_fill_value
@@ -102,7 +118,12 @@ class InferenceDataset(Dataset):
             )
 
         self.wet: PrognosticMask = src.masks.prognostic
-        self.wet_surface: GridMask = src.masks.boundary
+        # `wet_surface` is applied to the boundary tensor and must match its grid.
+        self.wet_surface: GridMask = (
+            boundary_src.masks.boundary
+            if boundary_src is not None
+            else src.masks.boundary
+        )
         self.wet_label = src.masks.prognostic_with_hist(self.hist)
         self.size = len(self.rolling_indices)
 

--- a/src/ocean_emulators/eval.py
+++ b/src/ocean_emulators/eval.py
@@ -97,6 +97,7 @@ class Eval:
         )
 
         self.src = self.data_container.inference_source
+        self.boundary_src = self.data_container.inference_boundary_source
         self.data = self.src.data
         self.static_data = self.data_container.static_data
         self.metadata = construct_metadata(self.data)
@@ -165,6 +166,11 @@ class Eval:
 
     def init_inference_store(self):
         sliced_src = self.src.slice(self.inference_time)
+        sliced_boundary_src = (
+            self.boundary_src.slice(self.inference_time)
+            if self.boundary_src is not None
+            else None
+        )
         self.num_time_steps = get_inference_steps(
             sliced_src,
             hist=self.hist,
@@ -177,6 +183,7 @@ class Eval:
             normalize_before_mask=self.normalize_before_mask,
             masked_fill_value=self.masked_fill_value,
             long_rollout=True,
+            boundary_src=sliced_boundary_src,
         )
 
     def run(self) -> None:

--- a/src/ocean_emulators/train.py
+++ b/src/ocean_emulators/train.py
@@ -205,6 +205,7 @@ class Trainer:
         # TODO(jder): Could rewrite inference dataset like we did for TorchTrainDataset
         # see https://github.com/suryadheeshjith/Ocean_Emulator/issues/208
         self.inference_src = self.data_container.inference_source
+        self.boundary_src = self.data_container.boundary_source
 
         self.loader_version = self.data_container.loader_version
 
@@ -793,10 +794,22 @@ class Trainer:
             case _:
                 assert_never(self.train_schedule)
 
+        train_boundary_src = (
+            self.boundary_src.slice(self.train_time)
+            if self.boundary_src is not None
+            else None
+        )
+        val_boundary_src = (
+            self.boundary_src.slice(self.val_time)
+            if self.boundary_src is not None
+            else None
+        )
+
         train_datasets = [
             TorchTrainDataset(
                 src=src.slice(self.train_time),
                 dst=dst.slice(self.train_time) if dst else None,
+                boundary_src=train_boundary_src,
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 hist=self.hist,
@@ -814,6 +827,7 @@ class Trainer:
             TorchTrainDataset(
                 src=src.slice(self.val_time),
                 dst=dst.slice(self.val_time) if dst else None,
+                boundary_src=val_boundary_src,
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 hist=self.hist,
@@ -855,9 +869,12 @@ class Trainer:
                 )
 
         # Create batch samplers - branch on distributed vs non-distributed
-        # Group by input AND label resolution to handle all training schedules
+        # Group by input, boundary, and label resolution so stacked batches have
+        # matching tensor shapes across all training schedules.
         def group_key(ds):
-            return tuple(prog.grid_size for prog in ds.prognostic_srcs)
+            return tuple(prog.grid_size for prog in ds.prognostic_srcs) + (
+                ds.boundary_src.grid_size,
+            )
 
         if self.distributed is not None:
             # Distributed training

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -421,6 +421,11 @@ class DataContainer:
     # TODO(559): static_data should belong to the DataSource, since we now
     #  deal with multiple resolutions.
     static_data: xr.Dataset | None = None
+    # Optional separate source for boundary forcings at inference time.
+    # When set, InferenceDataset loads boundaries from this source (typically
+    # at a coarser resolution than `inference_source`), enabling cross-resolution
+    # rollouts such as ¼° prognostics + 1° boundaries.
+    inference_boundary_source: DataSource | None = None
 
     @property
     def primary_source(self) -> DataSource:

--- a/src/ocean_emulators/utils/data.py
+++ b/src/ocean_emulators/utils/data.py
@@ -421,10 +421,10 @@ class DataContainer:
     # TODO(559): static_data should belong to the DataSource, since we now
     #  deal with multiple resolutions.
     static_data: xr.Dataset | None = None
-    # Optional separate source for boundary forcings at inference time.
-    # When set, InferenceDataset loads boundaries from this source (typically
-    # at a coarser resolution than `inference_source`), enabling cross-resolution
-    # rollouts such as ¼° prognostics + 1° boundaries.
+    # Optional separate source for boundary forcings during training/validation.
+    # When unset, training boundaries come from each prognostic input source.
+    boundary_source: DataSource | None = None
+    # Optional dask-backed boundary source for inference/eval rollouts.
     inference_boundary_source: DataSource | None = None
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -567,6 +567,47 @@ def trainer_pair(
         yield train_config, trainer
 
 
+def build_synthetic_source(
+    name: str,
+    h: int,
+    w: int,
+    n_times: int,
+    prognostic_var_names: list[str],
+    boundary_var_names: list[str],
+    seed: int | None = None,
+) -> DataSource:
+    """Build a synthetic DataSource at an arbitrary resolution, full-globe grid.
+
+    Lat/lon coordinates span the full globe so `patch_extent`-based slicing is
+    consistent across resolutions — required when combining two sources (e.g.
+    cross-resolution inference). Variable data is standard-normal; means/stds
+    are zero/one so `normalize_before_mask=True` is a no-op.
+    """
+    all_vars = list(prognostic_var_names) + list(boundary_var_names)
+    coords = {
+        "time": np.arange(n_times),
+        "lat": np.linspace(-90 + 180 / (2 * h), 90 - 180 / (2 * h), h),
+        "lon": np.linspace(360 / (2 * w), 360 - 360 / (2 * w), w),
+    }
+    generator = torch.Generator()
+    if seed is not None:
+        generator.manual_seed(seed)
+    arr = torch.randn(len(all_vars), n_times, h, w, generator=generator).numpy()
+    data = xr.Dataset(
+        {
+            v: xr.DataArray(arr[i], dims=["time", "lat", "lon"], coords=coords)
+            for i, v in enumerate(all_vars)
+        }
+    )
+    stats_coords = {"lat": [0], "lon": [0]}
+    mean_ds = xr.Dataset({v: 0.0 for v in all_vars}, coords=stats_coords)
+    std_ds = xr.Dataset({v: 1.0 for v in all_vars}, coords=stats_coords)
+    wet_surface = torch.ones(h, w)
+    wet = wet_surface.expand(len(prognostic_var_names), h, w)
+    masks = Masks(prognostic=wet, boundary=wet_surface)
+    return DataSource(name, data, mean_ds, std_ds, masks=masks)
+
+
 @pytest.fixture
 def dummy_src():
     h, w = 4, 8

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -719,6 +719,91 @@ def test_train_dataset_normalize_pre_fill(
         assert inf_prog[0, 0, 0, 0] == data
 
 
+def _make_synthetic_source(
+    name: str, lat_size: int, lon_size: int, times: int = 10
+) -> DataSource:
+    """Build a tiny synthetic DataSource at an arbitrary (lat, lon) resolution."""
+    coords = {"time": range(times), "lat": range(lat_size), "lon": range(lon_size)}
+    data_array = torch.arange(
+        4 * times * lat_size * lon_size, dtype=torch.float32
+    ).reshape(4, times, lat_size, lon_size)
+    data = xr.Dataset(
+        {
+            var: xr.DataArray(data_array[i], dims=["time", "lat", "lon"], coords=coords)
+            for i, var in enumerate(
+                ["prognostic1", "prognostic2", "boundary1", "boundary2"]
+            )
+        }
+    )
+    stats_coords = {"lat": [0], "lon": [0]}
+    mean_values = {v: 0.0 for v in data.data_vars}
+    std_values = {v: 1.0 for v in data.data_vars}
+    data_mean = xr.Dataset(mean_values, coords=stats_coords)
+    data_std = xr.Dataset(std_values, coords=stats_coords)
+    wet_surface = torch.ones(lat_size, lon_size)
+    wet = wet_surface.expand(2, lat_size, lon_size)
+    masks = Masks(prognostic=wet, boundary=wet_surface)
+    return DataSource(name, data, data_mean, data_std, masks=masks)
+
+
+def test_inference_dataset__cross_resolution():
+    """InferenceDataset yields mismatched prog/boundary shapes when given distinct sources."""
+    prog_src = _make_synthetic_source("high_res", lat_size=8, lon_size=16)
+    boundary_src = _make_synthetic_source("low_res", lat_size=2, lon_size=4)
+    prognostic_var_names = ["prognostic1", "prognostic2"]
+    boundary_var_names = ["boundary1", "boundary2"]
+
+    with MultitonScope():
+        Normalize.init_instance(
+            prog_src,
+            prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_var_names,
+        )
+        dataset = InferenceDataset(
+            src=prog_src,
+            prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_var_names,
+            hist=0,
+            normalize_before_mask=True,
+            masked_fill_value=0.0,
+            long_rollout=True,
+            boundary_src=boundary_src,
+        )
+
+        prog, boundary = dataset.get_initial_input()
+
+        # Prognostic sits on the high-res grid; boundary on the low-res grid.
+        assert prog.shape[-2:] == (8, 16)
+        assert boundary.shape[-2:] == (2, 4)
+        # Context tracks the prognostic resolution on both in and out.
+        assert dataset.ctx.input_resolution_cpu[0].shape == (8,)
+        assert dataset.ctx.output_resolution_cpu[0].shape == (8,)
+
+
+def test_inference_dataset__cross_resolution_time_mismatch_raises():
+    """Sources with different time axes must fail loudly."""
+    prog_src = _make_synthetic_source("prog", lat_size=8, lon_size=16, times=10)
+    boundary_src = _make_synthetic_source("boundary", lat_size=2, lon_size=4, times=5)
+
+    with MultitonScope():
+        Normalize.init_instance(
+            prog_src,
+            prognostic_var_names=["prognostic1", "prognostic2"],
+            boundary_var_names=["boundary1", "boundary2"],
+        )
+        with pytest.raises(ValueError, match="time axis"):
+            InferenceDataset(
+                src=prog_src,
+                prognostic_var_names=["prognostic1", "prognostic2"],
+                boundary_var_names=["boundary1", "boundary2"],
+                hist=0,
+                normalize_before_mask=True,
+                masked_fill_value=0.0,
+                long_rollout=True,
+                boundary_src=boundary_src,
+            )
+
+
 @pytest.mark.manual
 @pytest.mark.parametrize(
     "data_source,config_name", [("mock", DEFAULT_CONFIG)], indirect=True

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -137,6 +137,11 @@ def make_loader(
                     TorchTrainDataset(
                         src=src.slice(time_config),
                         dst=dst.slice(time_config) if dst else None,
+                        boundary_src=(
+                            container.boundary_source.slice(time_config)
+                            if container.boundary_source is not None
+                            else None
+                        ),
                         prognostic_var_names=prognostic,
                         boundary_var_names=boundary,
                         hist=cfg.data.hist,
@@ -156,8 +161,9 @@ def make_loader(
                 # This ensures datasets with same (src, dst) resolution pair but different strides can batch
                 batch_sampler = EquivalenceGroupBatchSampler.from_datasets(
                     datasets=dataset_list,
-                    group_key=lambda ds: tuple(
-                        prog.grid_size for prog in ds.prognostic_srcs
+                    group_key=lambda ds: (
+                        tuple(prog.grid_size for prog in ds.prognostic_srcs)
+                        + (ds.boundary_src.grid_size,)
                     ),
                     batch_size=cfg.batch_size,
                     drop_last=drop_last,
@@ -811,6 +817,88 @@ def test_inference_dataset__cross_resolution_time_mismatch_raises():
                 long_rollout=True,
                 boundary_src=boundary_src,
             )
+
+
+def test_torch_train_dataset__cross_resolution():
+    """TorchTrainDataset can train with a boundary source on another grid."""
+    prognostic_var_names = ["prognostic1", "prognostic2"]
+    boundary_var_names = ["boundary1", "boundary2"]
+    prog_src = build_synthetic_source(
+        "high_res",
+        h=8,
+        w=16,
+        n_times=10,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+    boundary_src = build_synthetic_source(
+        "low_res",
+        h=2,
+        w=4,
+        n_times=10,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+
+    dataset = TorchTrainDataset(
+        src=prog_src,
+        dst=None,
+        boundary_src=boundary_src,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+        hist=0,
+        steps=1,
+        normalize_before_mask=True,
+        masked_fill_value=0.0,
+        stride=1,
+    )
+    raw = collate_raw_train_data([dataset[0]])
+    train_data = dataset.to_train_data(raw, torch.device("cpu"))
+
+    prog, boundary = train_data.get_initial_input()
+    label = train_data.get_label(0)
+
+    assert prog.shape[-2:] == (8, 16)
+    assert boundary.shape[-2:] == (2, 4)
+    assert label.shape[-2:] == (8, 16)
+    assert train_data.ctx.input_resolution_cpu[0].shape == (8,)
+    assert train_data.ctx.output_resolution_cpu[0].shape == (8,)
+
+
+def test_torch_train_dataset__cross_resolution_time_mismatch_raises():
+    """Training sources with different time axes must fail loudly."""
+    prognostic_var_names = ["prognostic1", "prognostic2"]
+    boundary_var_names = ["boundary1", "boundary2"]
+    prog_src = build_synthetic_source(
+        "prog",
+        h=8,
+        w=16,
+        n_times=10,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+    boundary_src = build_synthetic_source(
+        "boundary",
+        h=2,
+        w=4,
+        n_times=5,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+
+    with pytest.raises(ValueError, match="time axis"):
+        TorchTrainDataset(
+            src=prog_src,
+            dst=None,
+            boundary_src=boundary_src,
+            prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_var_names,
+            hist=0,
+            steps=1,
+            normalize_before_mask=True,
+            masked_fill_value=0.0,
+            stride=1,
+        )
 
 
 @pytest.mark.manual

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -35,7 +35,13 @@ from ocean_emulators.utils.data import DataSource, Masks, Normalize
 from ocean_emulators.utils.multiton import MultitonScope
 from ocean_emulators.utils.samplers import EquivalenceGroupBatchSampler
 from ocean_emulators.utils.train import collate_raw_train_data
-from tests.conftest import DEFAULT_CONFIG, DataSourceDims, TrainPair, cache_dir
+from tests.conftest import (
+    DEFAULT_CONFIG,
+    DataSourceDims,
+    TrainPair,
+    build_synthetic_source,
+    cache_dir,
+)
 
 
 @pytest.fixture
@@ -719,39 +725,26 @@ def test_train_dataset_normalize_pre_fill(
         assert inf_prog[0, 0, 0, 0] == data
 
 
-def _make_synthetic_source(
-    name: str, lat_size: int, lon_size: int, times: int = 10
-) -> DataSource:
-    """Build a tiny synthetic DataSource at an arbitrary (lat, lon) resolution."""
-    coords = {"time": range(times), "lat": range(lat_size), "lon": range(lon_size)}
-    data_array = torch.arange(
-        4 * times * lat_size * lon_size, dtype=torch.float32
-    ).reshape(4, times, lat_size, lon_size)
-    data = xr.Dataset(
-        {
-            var: xr.DataArray(data_array[i], dims=["time", "lat", "lon"], coords=coords)
-            for i, var in enumerate(
-                ["prognostic1", "prognostic2", "boundary1", "boundary2"]
-            )
-        }
-    )
-    stats_coords = {"lat": [0], "lon": [0]}
-    mean_values = {v: 0.0 for v in data.data_vars}
-    std_values = {v: 1.0 for v in data.data_vars}
-    data_mean = xr.Dataset(mean_values, coords=stats_coords)
-    data_std = xr.Dataset(std_values, coords=stats_coords)
-    wet_surface = torch.ones(lat_size, lon_size)
-    wet = wet_surface.expand(2, lat_size, lon_size)
-    masks = Masks(prognostic=wet, boundary=wet_surface)
-    return DataSource(name, data, data_mean, data_std, masks=masks)
-
-
 def test_inference_dataset__cross_resolution():
     """InferenceDataset yields mismatched prog/boundary shapes when given distinct sources."""
-    prog_src = _make_synthetic_source("high_res", lat_size=8, lon_size=16)
-    boundary_src = _make_synthetic_source("low_res", lat_size=2, lon_size=4)
     prognostic_var_names = ["prognostic1", "prognostic2"]
     boundary_var_names = ["boundary1", "boundary2"]
+    prog_src = build_synthetic_source(
+        "high_res",
+        h=8,
+        w=16,
+        n_times=10,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+    boundary_src = build_synthetic_source(
+        "low_res",
+        h=2,
+        w=4,
+        n_times=10,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
 
     with MultitonScope():
         Normalize.init_instance(
@@ -782,20 +775,36 @@ def test_inference_dataset__cross_resolution():
 
 def test_inference_dataset__cross_resolution_time_mismatch_raises():
     """Sources with different time axes must fail loudly."""
-    prog_src = _make_synthetic_source("prog", lat_size=8, lon_size=16, times=10)
-    boundary_src = _make_synthetic_source("boundary", lat_size=2, lon_size=4, times=5)
+    prognostic_var_names = ["prognostic1", "prognostic2"]
+    boundary_var_names = ["boundary1", "boundary2"]
+    prog_src = build_synthetic_source(
+        "prog",
+        h=8,
+        w=16,
+        n_times=10,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+    boundary_src = build_synthetic_source(
+        "boundary",
+        h=2,
+        w=4,
+        n_times=5,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
 
     with MultitonScope():
         Normalize.init_instance(
             prog_src,
-            prognostic_var_names=["prognostic1", "prognostic2"],
-            boundary_var_names=["boundary1", "boundary2"],
+            prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_var_names,
         )
         with pytest.raises(ValueError, match="time axis"):
             InferenceDataset(
                 src=prog_src,
-                prognostic_var_names=["prognostic1", "prognostic2"],
-                boundary_var_names=["boundary1", "boundary2"],
+                prognostic_var_names=prognostic_var_names,
+                boundary_var_names=boundary_var_names,
                 hist=0,
                 normalize_before_mask=True,
                 masked_fill_value=0.0,

--- a/tests/test_fomo_cross_resolution.py
+++ b/tests/test_fomo_cross_resolution.py
@@ -5,7 +5,7 @@ import torch
 from perceiver_pytorch import Perceiver
 from perceiver_pytorch.perceiver_io import PerceiverIO
 
-from ocean_emulators.datasets import InferenceDataset
+from ocean_emulators.datasets import InferenceDataset, TorchTrainDataset
 from ocean_emulators.models.fomo import FOMO
 from ocean_emulators.models.modules import (
     PerceiverDecoder,
@@ -21,6 +21,7 @@ from ocean_emulators.models.modules.blocks import (
 from ocean_emulators.utils.ctx import GridContext
 from ocean_emulators.utils.data import Normalize
 from ocean_emulators.utils.multiton import MultitonScope
+from ocean_emulators.utils.train import collate_raw_train_data
 from tests.conftest import build_synthetic_source
 
 LATENT_DIM = 4
@@ -313,3 +314,63 @@ def test_fomo_inference_cross_resolution_ar_rollout():
     assert torch.isfinite(output.prediction).all(), (
         "AR rollout prediction contains NaN or Inf."
     )
+
+
+def test_fomo_training_cross_resolution_ar_rollout():
+    """FOMO training forward works with boundary forcings from a coarser source."""
+    prognostic_var_names = ["prognostic1", "prognostic2"]
+    boundary_var_names = ["boundary1", "boundary2"]
+    high_h, high_w = 8, 16
+    low_h, low_w = 2, 4
+    n_times = 10
+    num_prog, num_boundary = (
+        len(prognostic_var_names),
+        len(boundary_var_names),
+    )
+
+    prog_src = build_synthetic_source(
+        "high_res",
+        h=high_h,
+        w=high_w,
+        n_times=n_times,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+    boundary_src = build_synthetic_source(
+        "low_res",
+        h=low_h,
+        w=low_w,
+        n_times=n_times,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+
+    model = _make_fomo(
+        prog_channels=num_prog,
+        boundary_channels=num_boundary,
+        out_channels=num_prog,
+    )
+
+    dataset = TorchTrainDataset(
+        src=prog_src,
+        dst=None,
+        boundary_src=boundary_src,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+        hist=0,
+        steps=2,
+        normalize_before_mask=True,
+        masked_fill_value=0.0,
+        stride=1,
+    )
+    raw = collate_raw_train_data([dataset[0]])
+    train_data = dataset.to_train_data(raw, torch.device("cpu"))
+
+    outputs = model.forward(train_data, loss_fn=None)
+
+    assert len(outputs) == 2
+    for output in outputs:
+        assert output.shape == (1, num_prog, high_h, high_w)
+        assert torch.isfinite(output).all(), (
+            "Training rollout output contains NaN or Inf."
+        )

--- a/tests/test_fomo_cross_resolution.py
+++ b/tests/test_fomo_cross_resolution.py
@@ -5,6 +5,7 @@ import torch
 from perceiver_pytorch import Perceiver
 from perceiver_pytorch.perceiver_io import PerceiverIO
 
+from ocean_emulators.datasets import InferenceDataset
 from ocean_emulators.models.fomo import FOMO
 from ocean_emulators.models.modules import (
     PerceiverDecoder,
@@ -18,6 +19,9 @@ from ocean_emulators.models.modules.blocks import (
     CoreBlock,
 )
 from ocean_emulators.utils.ctx import GridContext
+from ocean_emulators.utils.data import Normalize
+from ocean_emulators.utils.multiton import MultitonScope
+from tests.conftest import build_synthetic_source
 
 LATENT_DIM = 4
 EMBED_DIM = 8
@@ -234,3 +238,78 @@ def test_fomo_autoregressive_mix_schedule(add_3d_coordinates: bool):
     for out in outputs:
         assert out.shape == (1, out_channels, output_h, output_w)
         assert torch.isfinite(out).all(), "Output contains NaN or Inf."
+
+
+def test_fomo_inference_cross_resolution_ar_rollout():
+    """BaseModel.inference runs a multi-step AR rollout with asymmetric sources.
+
+    Prognostics come from a high-res source (¼°-like grid, 8×16) and boundaries
+    from a low-res source (1°-like grid, 2×4), sharing a time axis. This is
+    the KR2 asymmetric-inference path: prognostics stay at the fine grid
+    throughout the rollout while boundary forcings come from a coarser source
+    at every step.
+    """
+    prognostic_var_names = ["prognostic1", "prognostic2"]
+    boundary_var_names = ["boundary1", "boundary2"]
+    high_h, high_w = 8, 16
+    low_h, low_w = 2, 4
+    n_times = 10
+    num_prog, num_boundary = (
+        len(prognostic_var_names),
+        len(boundary_var_names),
+    )
+
+    prog_src = build_synthetic_source(
+        "high_res",
+        h=high_h,
+        w=high_w,
+        n_times=n_times,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+    boundary_src = build_synthetic_source(
+        "low_res",
+        h=low_h,
+        w=low_w,
+        n_times=n_times,
+        prognostic_var_names=prognostic_var_names,
+        boundary_var_names=boundary_var_names,
+    )
+
+    model = _make_fomo(
+        prog_channels=num_prog,
+        boundary_channels=num_boundary,
+        out_channels=num_prog,
+    )
+    model.eval()
+
+    with MultitonScope():
+        Normalize.init_instance(
+            prog_src,
+            prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_var_names,
+        )
+        dataset = InferenceDataset(
+            src=prog_src,
+            prognostic_var_names=prognostic_var_names,
+            boundary_var_names=boundary_var_names,
+            hist=0,
+            normalize_before_mask=True,
+            masked_fill_value=0.0,
+            long_rollout=True,
+            boundary_src=boundary_src,
+        )
+        initial_prog = dataset.initial_prognostic
+
+        with torch.no_grad():
+            output = model.inference(
+                dataset=dataset,
+                initial_prognostic=initial_prog,
+                steps_completed=0,
+                num_steps=7,
+            )
+
+    assert output.prediction.shape == (7, num_prog, high_h, high_w)
+    assert torch.isfinite(output.prediction).all(), (
+        "AR rollout prediction contains NaN or Inf."
+    )


### PR DESCRIPTION
Fixes #615, 4/4 in the stack.