### PR TITLE
Fix GitHub Pages deployment for docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "src/**"
       - ".github/workflows/pages.yml"
   workflow_dispatch:
 
@@ -20,6 +21,9 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
 
     steps:
       - name: Checkout
@@ -32,7 +36,7 @@ jobs:
         run: uv run --only-group docs zensical build
 
       - name: Copy static pages into build output
-        run: cp -r docs/static/* site/
+        run: cp -R docs/static/. site/
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/docs/static/samudra2/index.html
+++ b/docs/static/samudra2/index.html
@@ -54,7 +54,7 @@
 
       <div class="publication-links" style="margin-top: 1.5rem;">
         <span class="link-block">
-          <a href="#" class="external-link button is-normal is-rounded is-dark">
+          <a href="./assets/paper/samudra2-jmlr.pdf" class="external-link button is-normal is-rounded is-dark">
             <span class="icon"><i class="fas fa-file-pdf"></i></span>
             <span>Paper PDF</span>
           </a>


### PR DESCRIPTION
## Summary
- grant the docs build job Pages permission so configure-pages can read Pages settings
- copy static pages with dotfiles so .nojekyll is included in the Pages artifact
- wire the Samudra 2 Paper PDF button to the bundled PDF asset

## Verification
- uv run --only-group docs zensical build
- copied docs/static into site and verified site/samudra2/index.html, site/samudra2/assets/paper/samudra2-jmlr.pdf, and site/.nojekyll exist