### PR TITLE
Restore benchmark dashboard publishing to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,8 @@ on:
     workflows: ["Benchmark"]
     types:
       - completed
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,10 @@ on:
       - "mkdocs.yml"
       - "src/**"
       - ".github/workflows/pages.yml"
+  workflow_run:
+    workflows: ["Benchmark"]
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -21,6 +25,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       pages: write
@@ -37,6 +42,22 @@ jobs:
 
       - name: Copy static pages into build output
         run: cp -R docs/static/. site/
+
+      # Benchmark results are pushed to the gh-pages branch by benchmarks.yml
+      # via benchmark-action/github-action-benchmark. We bring those files into
+      # the artifact so they're served at /dev/bench/ alongside the docs site.
+      - name: Check out benchmark data from gh-pages
+        uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+          path: gh-pages-data
+
+      - name: Copy benchmark dashboard into build output
+        run: |
+          if [ -d gh-pages-data/dev/bench ]; then
+            mkdir -p site/dev/bench
+            cp -R gh-pages-data/dev/bench/. site/dev/bench/
+          fi
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
## Summary
- The pytest-benchmark dashboard at `/dev/bench/` has been 404ing since the Pages site moved to the `actions/deploy-pages` flow (#705/#721). `benchmarks.yml` keeps pushing results to the `gh-pages` branch via `benchmark-action/github-action-benchmark`, but `pages.yml` now publishes a Zensical-built artifact and never reads from `gh-pages`.
- Bridge the gap in `pages.yml`: check out `gh-pages` into a sibling path and copy `dev/bench/` into the `site/` artifact before upload.
- Add a `workflow_run` trigger so docs redeploys after each successful `Benchmark` run, with a conclusion guard so failed runs don't kick off pointless rebuilds.
- `benchmarks.yml` is unchanged — `gh-pages` remains the historical data store, which `github-action-benchmark` requires for its append-history behavior.

Closes #723

## Test plan
`workflow_run` triggers only fire from the default branch, so full end-to-end verification has to happen post-merge. After merge:
- [ ] Manually `workflow_dispatch` the `docs` workflow on `main`. Confirm `https://openathena.ai/Ocean_Emulator/dev/bench/` resolves and renders the existing benchmark history (data already in `gh-pages` as of `69e1e688`).
- [ ] On the next `Benchmark` run completion, confirm `docs` auto-runs via `workflow_run` and the dashboard reflects the new commit's data.
- [ ] Verify a failed `Benchmark` run does NOT trigger a `docs` rebuild (the `if: conclusion == 'success'` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)