### PR TITLE
Consistent 2d Fourier features for each (encoder) Perceiver impl.

### DIFF
--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -459,8 +459,6 @@ class PerceiverConfig(BaseConfig):
         # This is not really a "frequency" but a maximum of the width appears to be reasonable from looking at the code.
         max_freq = max(*max_patch_size)
 
-        # Match the naive perceiver's `num_freq_bands=4`; both paths therefore
-        # encode intra-patch position with the same Fourier-feature layout.
         num_freq_bands = 4
         if _use_flash(implementation):
             try:

--- a/src/ocean_emulators/config.py
+++ b/src/ocean_emulators/config.py
@@ -42,7 +42,11 @@ from ocean_emulators.models.modules import (
     TransposedConvUpsample,
     UNetBackbone,
 )
-from ocean_emulators.models.modules.augment_input import Concat3dCoordinates
+from ocean_emulators.models.modules.augment_input import (
+    Concat3dCoordinates,
+    FourierFeatures2D,
+    fourier_features_2d_dim,
+)
 from ocean_emulators.models.modules.blocks import ZonallyPeriodicBilinearUpsample
 from ocean_emulators.models.modules.encoder import patch_from
 from ocean_emulators.utils.data import DataContainer, DataSource, Normalize
@@ -455,6 +459,9 @@ class PerceiverConfig(BaseConfig):
         # This is not really a "frequency" but a maximum of the width appears to be reasonable from looking at the code.
         max_freq = max(*max_patch_size)
 
+        # Match the naive perceiver's `num_freq_bands=4`; both paths therefore
+        # encode intra-patch position with the same Fourier-feature layout.
+        num_freq_bands = 4
         if _use_flash(implementation):
             try:
                 from flash_perceiver import Perceiver as FlashPerceiver  # type: ignore
@@ -462,15 +469,20 @@ class PerceiverConfig(BaseConfig):
                 raise _flash_import_error() from e
             from einops.layers.torch import Rearrange
 
-            # Flash perceiver expects (batch, seq_len, dim); naive handles
-            # (batch, ph, pw, dim) natively via input_axis=2.  Bake the
-            # spatial-flatten into the module so callers don't need to care.
+            # Flash perceiver expects (batch, seq_len, dim) and only adds rotary
+            # positions on its latents — it has no built-in intra-patch
+            # positional signal on the input. Naive Perceiver handles
+            # (batch, ph, pw, dim) and adds 2D Fourier features via
+            # `input_axis=2, fourier_encode_data=True`. Prepend an explicit
+            # FourierFeatures2D so flash matches naive on intra-patch position.
+            fourier_dim = fourier_features_2d_dim(num_freq_bands)
             perceiver: nn.Module = nn.Sequential(
+                FourierFeatures2D(num_freq_bands=num_freq_bands, max_freq=max_freq),
                 Rearrange("b ph pw v -> b (ph pw) v"),
                 FlashPerceiver(
                     latent_rotary_emb_dim=max_freq,
                     depth=self.depth,
-                    input_dim=in_channels,
+                    input_dim=in_channels + fourier_dim,
                     output_dim=out_channels,
                     output_mode="average",
                     latent_dim=self.latent_dim,
@@ -482,7 +494,7 @@ class PerceiverConfig(BaseConfig):
             )
         elif _use_naive(implementation):
             perceiver = NaivePerceiver(
-                num_freq_bands=4,
+                num_freq_bands=num_freq_bands,
                 max_freq=max_freq,
                 depth=self.depth,
                 input_axis=2,

--- a/src/ocean_emulators/models/modules/augment_input.py
+++ b/src/ocean_emulators/models/modules/augment_input.py
@@ -2,8 +2,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+
 import torch
 from aurora.model.posencoding import lat_lon_meshgrid
+from einops import rearrange
 from jaxtyping import Float
 from torch import nn
 
@@ -62,3 +65,56 @@ class Concat3dCoordinates(nn.Module):
             .expand(fts.shape[0], -1, -1, -1)
         )
         return torch.cat((fts, grid), dim=1)
+
+
+def fourier_features_2d_dim(num_freq_bands: int) -> int:
+    """Channel-dim contribution of `FourierFeatures2D(num_freq_bands)`."""
+    return 2 * (2 * num_freq_bands + 1)
+
+
+class FourierFeatures2D(nn.Module):
+    """Concatenate 2D Fourier positional features along the channel dim.
+
+    Mirrors the `fourier_encode_data=True, input_axis=2` behavior of
+    perceiver-pytorch's Perceiver, so that the flash and naive perceiver
+    paths encode intra-patch position equivalently. Without this, the flash
+    perceiver only sees rotary positions on its latents and has no
+    intra-patch positional signal on the input tokens.
+
+    Frequency layout matches `perceiver_pytorch.fourier_encode`: scales are
+    `linspace(1., max_freq / 2, num_freq_bands)`, applied to positions
+    in [-1, 1].
+
+    Input:  (..., ph, pw, V)
+    Output: (..., ph, pw, V + fourier_features_2d_dim(num_freq_bands))
+    """
+
+    def __init__(self, num_freq_bands: int, max_freq: float) -> None:
+        super().__init__()
+        self.num_freq_bands = num_freq_bands
+        self.max_freq = max_freq
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        ph, pw = x.shape[-3], x.shape[-2]
+        ph_pos = torch.linspace(-1.0, 1.0, steps=ph, device=x.device, dtype=x.dtype)
+        pw_pos = torch.linspace(-1.0, 1.0, steps=pw, device=x.device, dtype=x.dtype)
+        # (ph, pw, 2)
+        pos = torch.stack(torch.meshgrid(ph_pos, pw_pos, indexing="ij"), dim=-1)
+
+        scales = torch.linspace(
+            1.0,
+            self.max_freq / 2,
+            self.num_freq_bands,
+            device=x.device,
+            dtype=x.dtype,
+        )
+        # (ph, pw, 2, 1) * (num_bands,) -> (ph, pw, 2, num_bands)
+        scaled = pos.unsqueeze(-1) * scales * math.pi
+        enc = torch.cat([scaled.sin(), scaled.cos(), pos.unsqueeze(-1)], dim=-1)
+        # Flatten (axis, freq) into a single feature dim.
+        enc = rearrange(enc, "ph pw ax feat -> ph pw (ax feat)")
+
+        # Broadcast across leading batch dims; concat along channel dim.
+        leading = x.shape[:-3]
+        enc = enc.expand(*leading, *enc.shape)
+        return torch.cat((x, enc), dim=-1)


### PR DESCRIPTION
During trial and error experiments with FOMO, Claude and I detected a possible source of error in the initial runs where the production Perceiver used in the encoder has sub-par positional encodings. Specifically, our Flash perceiver impl doesn't encode the 2d patch information in the same way as the naive Perceiver impl. This PR augments the input of that Perceiver, borrowing the Fourier encoding scheme from our "naive" impl library (a Lucid Rains dependency). 

CC: @jder - I wonder if this affects your recent Fomini experiments at all. I'm not sure if I should apply this to the PerceiverIO/decoder module, too. 