### PR TITLE
Add DUACS daily->5-day-average preprocessing script

### DIFF
--- a/data/ocean_preprocessing/make_duacs_5day.py
+++ b/data/ocean_preprocessing/make_duacs_5day.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Ocean Emulator Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coarsen the daily (P1D) DUACS L4 altimetry product to a 5-day-average (P5D) Zarr.
+
+DUACS is a global, gridded (0.125 deg) observational sea-surface-height product
+distributed at daily resolution. This utility reduces it to non-overlapping
+consecutive 5-day means, mirroring the 5-day "simple average" convention used for
+the OM4 model data, so the observations can sit alongside the emulator inputs.
+
+The reduction is a streaming time-coarsen: the native on-disk time chunk is 50
+steps -- an exact multiple of the 5-step window -- so each output step is produced
+from a single input chunk with no cross-chunk shuffle. That keeps the whole job a
+cheap, embarrassingly-parallel pass that runs on a laptop LocalCluster or a Coiled
+cluster alike.
+
+Usage (dry run first, then the real thing on Coiled):
+
+    export FSSPEC_S3_ENDPOINT_URL=https://nyu1.osn.mghpcc.org/
+    export AWS_ACCESS_KEY_ID=...
+    export AWS_SECRET_ACCESS_KEY=...
+
+    # Validate the pipeline against a small slice without writing anything.
+    OCEAN_DUACS_CLUSTER=local python -m ocean_preprocessing.make_duacs_5day --dry_run
+
+    # Run the full reduction on a Coiled cluster (the default target).
+    python -m ocean_preprocessing.make_duacs_5day
+
+    # ... or locally, streaming the ~67 GB read on your own machine.
+    OCEAN_DUACS_CLUSTER=local python -m ocean_preprocessing.make_duacs_5day
+"""
+
+import os
+
+# Match the OM4 pipeline: pin blosc/numexpr to single-threaded so concurrent
+# workers reading blosc-compressed Zarr chunks don't trip thread-safety bugs.
+# Must be set before any blosc operation occurs.
+os.environ.setdefault("BLOSC_NTHREADS", "1")
+os.environ.setdefault("BLOSC_NOLOCK", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+import datetime
+import logging
+import sys
+
+import fire
+import numpy as np
+import xarray as xr
+
+from ocean_preprocessing.__main__ import init_cluster
+from ocean_preprocessing.utils import get_git_url_hash
+
+logger = logging.getLogger("ocean_preprocessing")
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s][%(levelname)-8s][%(name)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+# The daily DUACS L4 multi-satellite product on the OSN pod.
+DEFAULT_SRC = (
+    "s3://emulators/jr7309/data/duacs/"
+    "cmems_obs-sl_glo_phy-ssh_my_allsat-l4-duacs-0.125deg_P1D_multi-vars_"
+    "179.94W-179.94E_89.94S-89.94N_2022-01-01-2023-01-01.zarr"
+)
+# Sibling P5D store in the user's own bucket. Mirrors the source name but with the
+# P1D -> P5D temporal-resolution token swapped.
+DEFAULT_OUTPUT = (
+    "s3://emulators/am16581/data/2026-06/"
+    "cmems_obs-sl_glo_phy-ssh_my_allsat-l4-duacs-0.125deg_P5D_multi-vars_"
+    "179.94W-179.94E_89.94S-89.94N_2022-01-01-2023-01-01.zarr"
+)
+
+# Sea-surface-height + geostrophic velocity fields used for emulation. The formal
+# mapping-error fields (err_*) and tpa_correction are intentionally dropped.
+CORE_VARS = ("adt", "sla", "ugos", "ugosa", "vgos", "vgosa")
+# A 0/1 sea-ice status flag. Averaging it over a window yields the fraction of days
+# flagged as ice, which is the form we keep.
+ICE_VAR = "flag_ice"
+
+
+def coarsen_5day(
+    ds: xr.Dataset,
+    window: int = 5,
+    core_vars=CORE_VARS,
+    ice_var: str = ICE_VAR,
+) -> xr.Dataset:
+    """Reduce a daily dataset to non-overlapping ``window``-day means.
+
+    Selects the core ocean fields plus the ice flag, then applies
+    ``coarsen(time=window, boundary="trim").mean()``: consecutive, non-overlapping
+    blocks, with any trailing remainder of fewer than ``window`` days dropped. The
+    mean skips NaNs, so land/missing cells stay NaN and the ice flag becomes the
+    fractional ice presence over each window.
+
+    The ``time`` coordinate is coarsened by the same mean, labelling each window by
+    its midpoint.
+
+    Args:
+        ds: Daily dataset with a ``time`` dimension. Values are expected to already
+            be decoded to floats (e.g. via ``xr.open_zarr`` with mask-and-scale on).
+        window: Number of consecutive time steps per output step.
+        core_vars: Continuous variables to average.
+        ice_var: Name of the 0/1 ice flag to fold in as a fraction (skipped if absent).
+
+    Returns:
+        A dataset with the same spatial dims and a ``time`` dimension of length
+        ``len(ds.time) // window``.
+    """
+    keep = [v for v in (*core_vars, ice_var) if v in ds.data_vars]
+    missing = set(core_vars) - set(ds.data_vars)
+    if missing:
+        raise KeyError(
+            f"source dataset is missing expected variables: {sorted(missing)}"
+        )
+
+    coarsened = ds[keep].coarsen(time=window, boundary="trim").mean()
+
+    if ice_var in coarsened:
+        # No longer a status flag once averaged -- relabel so the metadata is honest.
+        ice = coarsened[ice_var]
+        ice.attrs = {
+            "long_name": f"fraction of days flagged as sea ice over each {window}-day window",
+            "comment": (
+                f"Mean of the original 0/1 '{ice_var}' status flag over each "
+                f"{window}-day window; ranges from 0 (ice-free every day) to 1 "
+                f"(ice-flagged every day)."
+            ),
+            "units": "1",
+            "valid_min": 0.0,
+            "valid_max": 1.0,
+        }
+
+    return coarsened
+
+
+def _finalize(ds: xr.Dataset, src: str, window: int) -> xr.Dataset:
+    """Cast to float32, fix chunks/encoding, and stamp provenance for writing."""
+    ds = ds.astype("float32")
+
+    # The decoded source carries int32 scale-factor encoding; clearing it makes
+    # to_zarr write honest, uncompressed float32 instead of re-quantizing.
+    for var in (*ds.data_vars, *ds.coords):
+        ds[var].encoding = {}
+
+    # One chunk per output step, full spatial domain per chunk (~16 MB at float32).
+    spatial = {d: -1 for d in ds.dims if d != "time"}
+    ds = ds.chunk({"time": 1, **spatial})
+
+    ds.attrs["m2lines/source_dataset"] = src
+    ds.attrs["m2lines/temporal_coarsening"] = (
+        f"{window}-day consecutive simple mean (coarsen boundary='trim')"
+    )
+    ds.attrs["m2lines/ocean_emulators_git_hash"] = get_git_url_hash()
+    ds.attrs["m2lines/date_created"] = datetime.datetime.now().isoformat()
+    ds.attrs["m2lines/cli_args"] = " ".join(sys.argv)
+    return ds
+
+
+def main(
+    src: str = DEFAULT_SRC,
+    output_path: str = DEFAULT_OUTPUT,
+    window: int = 5,
+    cluster: str = os.environ.get("OCEAN_DUACS_CLUSTER", "coiled"),
+    n_workers: int = int(os.environ.get("OCEAN_DUACS_WORKERS", "20")),
+    dry_run: bool = False,
+    small_run: bool = False,
+    write_retries: int = 5,
+) -> None:
+    """Coarsen the daily DUACS product to a ``window``-day-average Zarr store.
+
+    Args:
+        src: Path to the daily (P1D) DUACS Zarr store.
+        output_path: Destination for the coarsened (P5D) Zarr store.
+        window: Number of consecutive days to average per output step (default 5).
+        cluster: Dask cluster target ('coiled', 'local', 'off', ...). Defaults to
+            'coiled'; override with the OCEAN_DUACS_CLUSTER env var or this flag.
+        n_workers: Worker count for the cluster (Coiled/local). Override with
+            OCEAN_DUACS_WORKERS.
+        dry_run: If True, build the lazy result, print its structure, materialize a
+            small corner to confirm the reduction runs, and write nothing.
+        small_run: If True, restrict to the first ``window * 5`` days (5 output
+            steps) before coarsening -- a quick end-to-end smoke of the write path.
+        write_retries: Distributed-scheduler retry count for the final Zarr write,
+            guarding against transient blosc/S3 chunk-read failures. Ignored without
+            a cluster.
+    """
+    cluster_opts = {}
+    if cluster in ("coiled", "local"):
+        cluster_opts = {"n_workers": n_workers, "wait_for_workers": True}
+    client = init_cluster(cluster, **cluster_opts)
+
+    logger.info(f"opening daily DUACS source: {src}")
+    # chunks={} keeps the native on-disk chunking (time=50); mask-and-scale (on by
+    # default) decodes the int32 scale-factor encoding to float with NaN fill.
+    ds = xr.open_zarr(src, chunks={})
+
+    if small_run:
+        n = window * 5
+        logger.info(f"**small-run**: restricting to the first {n} days.")
+        ds = ds.isel(time=slice(0, n))
+
+    logger.info(f"coarsening to {window}-day means.")
+    coarsened = coarsen_5day(ds, window=window)
+    out = _finalize(coarsened, src=src, window=window)
+
+    if dry_run:
+        logger.info("**dry-run**: resulting dataset structure (nothing written):")
+        logger.info("\n%s", out)
+        # Print the full time axis (every window-center label), not the truncated
+        # repr -- this is what gets pasted into the PR for review.
+        logger.info("ds.time coordinate (%d steps):", out.sizes["time"])
+        logger.info("\n%r", out.time)
+        with np.printoptions(threshold=out.sizes["time"] + 1):
+            logger.info("ds.time values:\n%s", out.time.values)
+        # Sample a mid-grid (near-equatorial) window: the polar corners are
+        # legitimately all-NaN for the absolute fields (no MDT reference under the
+        # ice), which would make the smoke test look broken when it isn't.
+        sample = out.isel(
+            time=slice(0, 2),
+            **{
+                d: slice(out.sizes[d] // 2, out.sizes[d] // 2 + 64)
+                for d in out.dims
+                if d != "time"
+            },
+        )
+        logger.info("materializing a small corner to validate the reduction...")
+        sample = sample.compute()
+        for var in CORE_VARS:
+            if var in sample:
+                da = sample[var]
+                logger.info(
+                    f"  {var}: min={float(da.min()):.4g} max={float(da.max()):.4g} "
+                    f"mean={float(da.mean()):.4g}"
+                )
+        logger.info("dry run complete.")
+        return
+
+    logger.info(f"writing {window}-day-average dataset to {output_path}")
+    delayed = out.to_zarr(
+        output_path,
+        mode="w",
+        zarr_format=2,
+        consolidated=True,
+        encoding={var: {"compressor": None} for var in out.data_vars},
+        compute=False,
+    )
+    # Reading blosc-compressed source chunks over S3 occasionally returns a
+    # truncated buffer (numcodecs#810); retry the task rather than abort the job.
+    if client is not None:
+        client.compute(delayed, retries=write_retries, sync=True)
+    else:
+        delayed.compute()
+    logger.info("zarr write complete.")
+
+
+if __name__ == "__main__":
+    fire.Fire(main, name="make_duacs_5day")

--- a/data/tests/test_make_duacs_5day.py
+++ b/data/tests/test_make_duacs_5day.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Ocean Emulator Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+import xarray as xr
+from ocean_preprocessing.make_duacs_5day import CORE_VARS, ICE_VAR, coarsen_5day
+
+
+def _daily_dataset(n_time: int) -> xr.Dataset:
+    time = xr.date_range("2022-01-01", periods=n_time, freq="1D", use_cftime=False)
+    rng = np.random.default_rng(0)
+    data = {
+        v: xr.DataArray(
+            rng.standard_normal((n_time, 3, 4)),
+            dims=["time", "latitude", "longitude"],
+            coords={"time": time},
+        )
+        for v in CORE_VARS
+    }
+    # Ice flag: day i flagged (1) iff i is even, else 0.
+    flag = (np.arange(n_time) % 2 == 0).astype("float64")
+    data[ICE_VAR] = xr.DataArray(
+        np.broadcast_to(flag[:, None, None], (n_time, 3, 4)).copy(),
+        dims=["time", "latitude", "longitude"],
+        coords={"time": time},
+    )
+    return xr.Dataset(data)
+
+
+def test_coarsen_is_block_mean_with_trimmed_remainder():
+    # 12 daily steps, window 5 -> 2 full blocks; the trailing 2 days are dropped.
+    ds = _daily_dataset(12)
+    out = coarsen_5day(ds, window=5)
+
+    assert out.sizes["time"] == 2
+    # Spatial dims untouched.
+    assert out.sizes["latitude"] == 3 and out.sizes["longitude"] == 4
+    # Each output block equals the simple mean of its 5 source days.
+    for block in range(2):
+        src = ds["adt"].isel(time=slice(block * 5, block * 5 + 5)).mean("time")
+        np.testing.assert_allclose(out["adt"].isel(time=block).values, src.values)
+
+
+def test_ice_flag_becomes_window_fraction():
+    # Window of days [0..4] -> flags [1,0,1,0,1] -> fraction 3/5.
+    ds = _daily_dataset(5)
+    out = coarsen_5day(ds, window=5)
+    np.testing.assert_allclose(out[ICE_VAR].values, 0.6)
+    # Relabelled: no longer advertised as a status flag.
+    assert "flag_values" not in out[ICE_VAR].attrs
+    assert out[ICE_VAR].attrs["units"] == "1"
+
+
+def test_missing_core_variable_raises():
+    ds = _daily_dataset(5).drop_vars("sla")
+    with pytest.raises(KeyError, match="sla"):
+        coarsen_5day(ds, window=5)

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -259,6 +259,50 @@ sbatch \
   scripts/slurm_apptainer_eval.sbatch
 ```
 
+## Data Preprocessing On Torch (CPU, No Container)
+
+The `data/` subproject (`ocean_preprocessing`) can run its data-engineering jobs on
+Torch instead of a Coiled/AWS cluster. This is purely a cost/locality win: both the
+source and output Zarr stores live on OSN (`nyu1.osn.mghpcc.org`), which has no
+egress fees, so running the compute on HPC removes the Coiled/AWS bill while the
+OSN<->Torch transfer stays free.
+
+These jobs are **CPU-only** (streaming dask reductions, no GPU, no xESMF) and use
+the `ocean_preprocessing` conda/mamba env directly -- **not** the PhysicsNeMo
+Apptainer container, which does not carry `s3fs`/`fire`/`xarray`. Create the env
+once on the cluster:
+
+```bash
+mamba env create -f data/mamba_env.yaml   # creates the `ocean_preprocessing` env
+```
+
+### DUACS daily -> 5-day-average
+
+Main script:
+
+- `scripts/slurm_duacs_5day.sbatch`
+
+It reads the daily DUACS store from OSN, coarsens it to 5-day means, and writes the
+result back to OSN -- no `/scratch` staging. Credentials are kept out of the repo:
+put your OSN keys in `~/.osn_env` (a shell file that `export`s `AWS_ACCESS_KEY_ID`
+and `AWS_SECRET_ACCESS_KEY`), or export them into the submission environment. The
+harness sources that file, defaults `FSSPEC_S3_ENDPOINT_URL` to the OSN endpoint,
+and runs a `LocalCluster` sized to `--cpus-per-task`.
+
+```bash
+# Validate first (prints the dataset + full time axis, writes nothing):
+DRY_RUN=1 sbatch scripts/slurm_duacs_5day.sbatch
+
+# Then the real reduction:
+sbatch scripts/slurm_duacs_5day.sbatch
+```
+
+Recognized env vars: `OSN_ENV_FILE` (default `~/.osn_env`), `ENV_NAME` (default
+`ocean_preprocessing`), `PYTHON_BIN`, `SRC`, `OUTPUT_PATH`, `WINDOW`, `DRY_RUN`,
+`ARGS`. Defaults (1 node, 16 CPUs, 64 GB, 1 h) are sized for the streaming reduction;
+the native time chunk (50) is an exact multiple of the 5-day window, so the pass is
+embarrassingly parallel with no cross-chunk shuffle. Monitor via `slurm-<jobid>.out`.
+
 ## NCCL Gotcha On RTX6000 Nodes
 
 On Torch RTX6000 nodes we observed NCCL hangs for 8-GPU single-node training unless P2P is disabled.

--- a/scripts/slurm_duacs_5day.sbatch
+++ b/scripts/slurm_duacs_5day.sbatch
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Ocean Emulator Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Slurm harness to run the DUACS daily->5-day-average reduction on Torch (NYU HPC)
+# instead of a Coiled/AWS cluster. The job is CPU-only (a streaming dask reduction,
+# no GPU, no xESMF) and reads/writes OSN directly -- both the source and the output
+# live on OSN (nyu1.osn.mghpcc.org), which has no egress fees, so running the
+# compute on HPC removes the Coiled/AWS bill entirely.
+#
+# Unlike the train/eval harnesses, this does NOT use Apptainer: the data subproject
+# is developed against the `ocean_preprocessing` conda/mamba env (the PhysicsNeMo
+# container does not carry s3fs/fire/xarray). Create it once on the cluster:
+#   mamba env create -f data/mamba_env.yaml
+#
+# Submit with env vars (dry run first, then the real write):
+#   DRY_RUN=1 sbatch scripts/slurm_duacs_5day.sbatch     # validate, write nothing
+#   sbatch scripts/slurm_duacs_5day.sbatch               # full reduction
+#
+# Recognized env vars:
+#   OSN_ENV_FILE   file sourced for OSN credentials (default: ~/.osn_env). Must export
+#                  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (and optionally
+#                  FSSPEC_S3_ENDPOINT_URL). Skipped if AWS_ACCESS_KEY_ID is already set.
+#   ENV_NAME       conda/mamba env name (default: ocean_preprocessing)
+#   PYTHON_BIN     explicit python to use, bypassing `mamba/conda run` env resolution
+#   SRC            source Zarr path        (default: the script's built-in DEFAULT_SRC)
+#   OUTPUT_PATH    destination Zarr path   (default: the script's built-in DEFAULT_OUTPUT)
+#   WINDOW         coarsening window in days (default: 5)
+#   DRY_RUN        if non-empty, pass --dry_run (prints structure + sample, no write)
+#   ARGS           extra CLI overrides forwarded verbatim, e.g. ARGS="--small_run"
+
+#SBATCH --job-name=oe-duacs-5day
+#SBATCH --output=slurm-%j.out
+#SBATCH --account=torch_pr_347_courant
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=01:00:00
+# Note: no --gres (CPU-only) and no --partition (let Slurm place the job).
+
+set -euo pipefail
+
+# --- OSN credentials -------------------------------------------------------
+# Keep secrets out of the repo: source them from a file on the cluster. Skip if
+# the credentials are already exported into the submission environment.
+OSN_ENV_FILE="${OSN_ENV_FILE:-${HOME}/.osn_env}"
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" && -f "${OSN_ENV_FILE}" ]]; then
+  echo "Sourcing OSN credentials from ${OSN_ENV_FILE}"
+  # shellcheck disable=SC1090
+  source "${OSN_ENV_FILE}"
+fi
+# OSN endpoint is not a secret; default it if unset.
+export FSSPEC_S3_ENDPOINT_URL="${FSSPEC_S3_ENDPOINT_URL:-https://nyu1.osn.mghpcc.org/}"
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+  echo "ERROR: OSN credentials not found." >&2
+  echo "Export AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or place them in" >&2
+  echo "${OSN_ENV_FILE} (a shell file that 'export's them). Tip: you can copy them" >&2
+  echo "from your rclone config, e.g.:" >&2
+  echo "  rclone config show nyu-osn | sed -n 's/^access_key_id *= *//p'" >&2
+  exit 2
+fi
+
+# --- Python environment ----------------------------------------------------
+# Pin numeric/blosc thread pools to single-threaded: the LocalCluster runs one
+# process per worker, and blosc's multithreaded path is not safe under the
+# concurrent Zarr chunk reads (matches the in-script defaults).
+export BLOSC_NTHREADS=1 BLOSC_NOLOCK=1 NUMEXPR_NUM_THREADS=1
+export OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1
+export PYTHONUNBUFFERED=1
+
+# Run a LocalCluster sized to the node's CPU allocation.
+export OCEAN_DUACS_CLUSTER="${OCEAN_DUACS_CLUSTER:-local}"
+export OCEAN_DUACS_WORKERS="${OCEAN_DUACS_WORKERS:-${SLURM_CPUS_PER_TASK:-16}}"
+
+ENV_NAME="${ENV_NAME:-ocean_preprocessing}"
+REPO_DIR="${REPO_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
+cd "${REPO_DIR}/data"
+
+# Resolve a runner: explicit PYTHON_BIN wins; otherwise use `mamba/conda run -n`,
+# which works in non-interactive batch shells without an activate hook.
+if [[ -n "${PYTHON_BIN:-}" ]]; then
+  RUNNER=("${PYTHON_BIN}")
+elif command -v mamba >/dev/null 2>&1; then
+  RUNNER=(mamba run -n "${ENV_NAME}" python)
+elif command -v conda >/dev/null 2>&1; then
+  RUNNER=(conda run --no-capture-output -n "${ENV_NAME}" python)
+else
+  echo "ERROR: no mamba/conda on PATH and PYTHON_BIN unset." >&2
+  echo "Create the env with: mamba env create -f data/mamba_env.yaml" >&2
+  echo "or set PYTHON_BIN=/path/to/envs/${ENV_NAME}/bin/python" >&2
+  exit 3
+fi
+
+# --- Assemble CLI ----------------------------------------------------------
+cli_args=()
+[[ -n "${SRC:-}" ]] && cli_args+=("--src=${SRC}")
+[[ -n "${OUTPUT_PATH:-}" ]] && cli_args+=("--output_path=${OUTPUT_PATH}")
+[[ -n "${WINDOW:-}" ]] && cli_args+=("--window=${WINDOW}")
+[[ -n "${DRY_RUN:-}" ]] && cli_args+=("--dry_run")
+# shellcheck disable=SC2206
+[[ -n "${ARGS:-}" ]] && cli_args+=(${ARGS})
+
+echo "Repo dir:    ${REPO_DIR}/data"
+echo "Env:         ${ENV_NAME}  (runner: ${RUNNER[*]})"
+echo "Cluster:     ${OCEAN_DUACS_CLUSTER}  (workers: ${OCEAN_DUACS_WORKERS})"
+echo "Endpoint:    ${FSSPEC_S3_ENDPOINT_URL}"
+echo "Dry run:     ${DRY_RUN:+yes}${DRY_RUN:-no}"
+echo "CLI:         ${cli_args[*]:-(defaults)}"
+
+srun --ntasks=1 --ntasks-per-node=1 \
+  "${RUNNER[@]}" -m ocean_preprocessing.make_duacs_5day "${cli_args[@]}"


### PR DESCRIPTION
## What

New `ocean_preprocessing.make_duacs_5day` utility that coarsens the daily (P1D) global gridded **DUACS** L4 altimetry product to **non-overlapping consecutive 5-day means**, mirroring the OM4 5-daily convention so the observations can sit alongside the emulator inputs.

## How

- **Binning:** `coarsen(time=5, boundary="trim").mean()` — drops the trailing 1-day remainder → **366 → 73 steps**. Each window is labelled by its midpoint timestamp.
- **Variables:** core ocean fields `adt, sla, ugos, ugosa, vgos, vgosa` + `flag_ice` re-derived as a 0–1 ice-presence fraction (metadata relabelled). `err_*` and `tpa_correction` dropped.
- **Output:** uncompressed float32, one chunk per timestep, written to `s3://emulators/am16581/data/2026-06/...P5D...zarr` (P1D→P5D name swap).
- **Compute:** reuses the OM4 pipeline's `init_cluster`, blosc single-thread guards, and retry-on-write. Coiled by default; `OCEAN_DUACS_CLUSTER=local` to run locally. Native time chunk (50) is a clean multiple of the window → no cross-chunk shuffle.
- Native DUACS naming/grid preserved (`latitude`/`longitude`, −180…180, 0.125°) — **not** conformed to the emulator x/y/0–360 schema.

## Validation

`--dry_run` against the live store: structure correct, mid-grid sample yields physically sensible values (adt ≈ 0.43 m, sla ≈ 0.045 m, velocities m/s). Dry-run output (final dataset repr + full `ds.time`) to be pasted in a comment below for review.

## Tests

`tests/test_make_duacs_5day.py` — block-mean correctness, ice-flag→fraction, missing-var guard.

Run:
```bash
cd data/
export FSSPEC_S3_ENDPOINT_URL=https://nyu1.osn.mghpcc.org/
export AWS_ACCESS_KEY_ID=...  AWS_SECRET_ACCESS_KEY=...
OCEAN_DUACS_CLUSTER=local python -m ocean_preprocessing.make_duacs_5day --dry_run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)