### PR TITLE
Harden GitHub Actions workflows and pin actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,12 +14,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write # Allow updating content on GitHub pages
-  deployments: write # Allow to deploy to GitHub pages
-  id-token: write # This is required for interacting with AWS via OIDC
+  contents: read
 
 jobs:
   ec2:
+    permissions:
+      contents: read
+      id-token: write # Required for interacting with AWS via OIDC
     uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
     with:
       ec2_instance_type: g6.xlarge
@@ -32,24 +33,27 @@ jobs:
   benchmark:
     needs: ec2
     runs-on: ${{ needs.ec2.outputs.id }}
+    permissions:
+      contents: write # Allow updating content on GitHub pages
+      deployments: write # Allow to deploy to GitHub pages
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
         # Invalidate the data cache every time the data source changes.
         # If an exact cache isn't found, fall back to previous cache.
       - name: Cache test data
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: .data_cache/
           key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/test/*.yaml') }}
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 
@@ -65,7 +69,7 @@ jobs:
 
       # gh-pages branch is automatically updated with extracted benchmark data.
       - name: Store benchmark result (CPU)
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba
         with:
           name: Python Benchmark with pytest-benchmark
           tool: "pytest"
@@ -80,7 +84,7 @@ jobs:
 
       # gh-pages branch is automatically updated with extracted benchmark data.
       - name: Store benchmark result (GPU)
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba
         with:
           name: Python Benchmark with pytest-benchmark (GPU)
           tool: "pytest"

--- a/.github/workflows/container-physicsnemo.yml
+++ b/.github/workflows/container-physicsnemo.yml
@@ -17,9 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
-  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -28,6 +26,9 @@ concurrency:
 jobs:
   ec2-build:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      id-token: write
     uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
     with:
       aws_region: us-east-1
@@ -48,11 +49,14 @@ jobs:
   build-and-smoke:
     needs: ec2-build
     runs-on: ${{ needs.ec2-build.outputs.id }}
+    permissions:
+      contents: read
+      packages: write
     env:
       LOCAL_IMAGE_TAG: ocean-emulator:physicsnemo-26.05-${{ github.sha }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
       - name: Confirm x86_64 runner
         run: |
@@ -82,7 +86,7 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -124,6 +128,9 @@ jobs:
   ec2:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: build-and-smoke
+    permissions:
+      contents: read
+      id-token: write
     uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
     with:
       ec2_instance_type: g6.xlarge
@@ -135,6 +142,9 @@ jobs:
 
   ec2-arm:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    permissions:
+      contents: read
+      id-token: write
     uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
     with:
       aws_region: us-east-1
@@ -156,20 +166,23 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [build-and-smoke, ec2]
     runs-on: ${{ needs.ec2.outputs.id }}
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           ref: ${{ github.sha }}
 
       - name: Cache test data
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: .data_cache/
           key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/test/*.yaml') }}
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -220,11 +233,14 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: ec2-arm
     runs-on: ${{ needs.ec2-arm.outputs.id }}
+    permissions:
+      contents: read
+      packages: write
     env:
       LOCAL_ARM64_IMAGE_TAG: ocean-emulator:physicsnemo-26.05-arm64-${{ github.sha }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
         with:
           ref: ${{ github.sha }}
 
@@ -247,7 +263,7 @@ jobs:
           docker buildx version
 
       - name: Cache test data
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: .data_cache/
           key: ${{ runner.os }}-${{ runner.arch }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/test/*.yaml') }}
@@ -266,7 +282,7 @@ jobs:
           bash scripts/container/build_physicsnemo_26_05.sh
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/data-tests-xesmf.yaml
+++ b/.github/workflows/data-tests-xesmf.yaml
@@ -25,11 +25,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 🫙 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0 # checkout tags (which is not done by default)
       - name: 🔁 Create mamba environment
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@4b9113af4fba0e9e1124b252dd6497a419e7396d
         with:
           environment-name: ci
           cache-downloads: true

--- a/.github/workflows/data-tests.yaml
+++ b/.github/workflows/data-tests.yaml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 🫙 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0 # checkout tags (which is not done by default)
       - name: 🔁 Setup Python
         id: setup-python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
 
       - name: Build API docs with Zensical
         run: uv run --only-group docs zensical build
@@ -53,7 +53,7 @@ jobs:
       # via benchmark-action/github-action-benchmark. We bring those files into
       # the artifact so they're served at /dev/bench/ alongside the docs site.
       - name: Check out benchmark data from gh-pages
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09
         with:
           ref: gh-pages
           path: gh-pages-data
@@ -66,10 +66,10 @@ jobs:
           fi
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: site
 
@@ -86,4 +86,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -13,12 +13,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write # Required for interacting with AWS via OIDC
   contents: read # Required for actions/checkout (normally set by default, but must explicitly specify when defining a custom `permissions` block.
 
 jobs:
   ec2:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      id-token: write # Required for interacting with AWS via OIDC
     uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
     with:
       ec2_instance_type: g6.xlarge
@@ -32,23 +34,23 @@ jobs:
     runs-on: ${{ needs.ec2.outputs.id }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
         # Invalidate the data cache every time the data source changes.
         # If an exact cache isn't found, fall back to previous cache.
       - name: Cache test data
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: .data_cache/
           key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/test/*.yaml') }}
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,23 +22,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
 
         # Invalidate the data cache every time the data source changes.
         # If an exact cache isn't found, fall back to previous cache.
       - name: Cache test data
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
         with:
           path: .data_cache/
           key: ${{ runner.os }}-test-data-${{ hashFiles('tests/conftest.py', 'configs/test/*.yaml') }}
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
- Narrow workflow and job-level permissions to the minimum required for each CI path
- Pin third-party GitHub Actions to commit SHAs across test, benchmark, pages, and container workflows
- Keep benchmark publishing and GHCR publishing permissions scoped to the jobs that need them

## Testing
- Not run (not requested)