### PR TITLE
Point Samudra2 page Hugging Face link to model repo

### DIFF
--- a/docs/static/samudra2/index.html
+++ b/docs/static/samudra2/index.html
@@ -72,7 +72,7 @@ SPDX-License-Identifier: CC-BY-4.0
           </a>
         </span>
         <span class="link-block">
-          <a href="#" class="external-link button is-normal is-rounded is-dark">
+          <a href="https://huggingface.co/M2LInES/Samudra2" class="external-link button is-normal is-rounded is-dark" target="_blank" rel="noreferrer">
             <span class="icon"><i class="fas fa-cube"></i></span>
             <span>Hugging Face</span>
           </a>


### PR DESCRIPTION
## What

The Hugging Face button on the Samudra v2 paper page (`docs/static/samudra2/index.html`) was a placeholder (`href="#"`). This points it at the model repo and adds `target="_blank" rel="noreferrer"` to match the sibling Paper and Code links.

- **Before:** `<a href="#" ...>`
- **After:** `<a href="https://huggingface.co/M2LInES/Samudra2" ... target="_blank" rel="noreferrer">`

## Deploy

Touches `docs/**`, so merging triggers `.github/workflows/pages.yml` and redeploys the GitHub Pages site automatically.

Related: #694.

🤖 Generated with [Claude Code](https://claude.com/claude-code)