### PR TITLE
[test] ec2-gha #5: pull python:3.12 base from public.ecr.aws mirror

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -19,8 +19,9 @@ permissions:
 jobs:
   ec2:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
+    uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@33a2a68a9b8f62968297a8d98b1a15474c6ca532 # ecr-base-image (Open-Athena/ec2-gha#5)
     with:
+      action_ref: 33a2a68a9b8f62968297a8d98b1a15474c6ca532 # ecr-base-image: pull python:3.12 from public.ecr.aws mirror
       ec2_instance_type: g6.xlarge
       ec2_image_id: ami-0365bff494b18bf93 # Deep Learning OSS Nvidia Driver AMI GPU PyTorch 2.7 (Ubuntu 22.04) in oa-ci-dev
       ec2_root_device_size: "+10" # AMI's reported VolumeSize (40GB) +1GB; leaves headroom for test I/O; instance runs out of disk otherwise


### PR DESCRIPTION
Test-only PR to exercise [Open-Athena/ec2-gha#5](https://github.com/Open-Athena/ec2-gha/pull/5), which switches the launcher Docker action's base image from Docker Hub `python:3.12` to `public.ecr.aws/docker/library/python:3.12` to avoid [anonymous pull rate limits](https://github.com/m2lines/Samudra/actions/runs/27713076069/job/82732494816) when building the action on the GitHub-hosted launcher.

Pins `test-gpu.yml` to ec2-gha ref `33a2a68` (the `ecr-base-image` branch). **Do not merge** — revert to `@v2` once verified.