### PR TITLE
Parallel eval

### DIFF
--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -1355,8 +1355,8 @@ class PostTrainCheckpointSweepConfig(BaseConfig):
     eval_config_path: str | None = None
     viz_config_path: str | None = None
     last_n_checkpoints: int | None = Field(default=None, ge=1)
-    eval_dirname: str = "post_train_eval"
-    viz_dirname: str = "viz"
+    eval_dirname: str | None = None
+    viz_dirname: str | None = None
 
 
 class EvalConfig(TopLevelConfig):

--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -1383,7 +1383,7 @@ class PostTrainEvalConfig(BaseConfig):
             eval_config_path=self.eval_config_path,
             checkpoint_paths=CheckpointPaths(nets_dir),
             data_root=data_root,
-            sweep_root=output_dir / self.eval_dirname,
+            sweep_output_dir=output_dir / self.eval_dirname,
             viz_config_path=self.viz_config_path,
             last_n_checkpoints=self.last_n_checkpoints,
             checkpoints=self.epochs,

--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -1355,8 +1355,24 @@ class PostTrainCheckpointSweepConfig(BaseConfig):
     eval_config_path: str | None = None
     viz_config_path: str | None = None
     last_n_checkpoints: int | None = Field(default=None, ge=1)
+    checkpoints: list[int] | None = Field(
+        default=None,
+        description="Explicit list of checkpoint epochs (matching ckpt_<epoch>.pt) "
+        "to evaluate; the final EMA checkpoint is always added. Mutually "
+        "exclusive with last_n_checkpoints.",
+    )
     eval_dirname: str | None = None
     viz_dirname: str | None = None
+
+    @pydantic.model_validator(mode="after")
+    def _check_checkpoint_selection(self) -> "PostTrainCheckpointSweepConfig":
+        if self.last_n_checkpoints is not None and self.checkpoints is not None:
+            raise ValueError(
+                "set only one of last_n_checkpoints or checkpoints, not both"
+            )
+        if self.checkpoints is not None and len(self.checkpoints) == 0:
+            raise ValueError("checkpoints must be a non-empty list when provided")
+        return self
 
 
 class EvalConfig(TopLevelConfig):

--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -1253,9 +1253,7 @@ class TrainConfig(TopLevelConfig):
     steps: list[int] = [4]
     step_transition: list[int] = []
     inference_epochs: list[int] = [-1]
-    post_train_eval: "PostTrainCheckpointSweepConfig" = Field(
-        default_factory=lambda: PostTrainCheckpointSweepConfig()
-    )
+    post_train_eval: "PostTrainEvalConfig | None" = None
 
     # Config components
     experiment: ExperimentConfig
@@ -1352,58 +1350,43 @@ class ObsMetricsConfig(BaseConfig):
 EvalBackendConfig = Literal["cpu", "cuda", "auto"]
 
 
-class PostTrainCheckpointSweepConfig(BaseConfig):
-    enabled: bool = False
-    eval_config_path: str | None = None
-    viz_config_path: str | None = None
+class PostTrainEvalConfig(BaseConfig):
+    eval_config_path: Path
+    viz_config_path: Path | None = None
     last_n_checkpoints: int | None = Field(default=None, ge=1)
-    checkpoints: list[int] | None = Field(
+    epochs: list[int] | None = Field(
         default=None,
         description="Explicit list of checkpoint epochs (matching ckpt_<epoch>.pt) "
         "to evaluate; the final EMA checkpoint is always added. Mutually "
         "exclusive with last_n_checkpoints.",
     )
-    eval_dirname: str | None = None
+    eval_dirname: str = "evals"
     # Subdirectory for visualization outputs within each checkpoint evaluation directory.
     viz_dirname: str = "viz"
 
     @pydantic.model_validator(mode="after")
-    def _check_checkpoint_selection(self) -> "PostTrainCheckpointSweepConfig":
-        if self.enabled and self.eval_config_path is None:
-            raise ValueError("eval_config_path must be set when enabled is true")
-        if self.last_n_checkpoints is not None and self.checkpoints is not None:
-            raise ValueError(
-                "set only one of last_n_checkpoints or checkpoints, not both"
-            )
-        if self.checkpoints is not None and len(self.checkpoints) == 0:
-            raise ValueError("checkpoints must be a non-empty list when provided")
+    def _check_checkpoint_selection(self) -> "PostTrainEvalConfig":
+        if self.last_n_checkpoints is not None and self.epochs is not None:
+            raise ValueError("set only one of last_n_checkpoints or epochs, not both")
+        if self.epochs is not None and len(self.epochs) == 0:
+            raise ValueError("epochs must be a non-empty list when provided")
         return self
 
     def build(
         self,
         nets_dir: Path,
         output_dir: Path,
-        data_root: Location | None,
-    ) -> "CheckpointSweep | None":
-        """Build the runtime sweep, or return None when it is disabled."""
-        if not self.enabled:
-            return None
-
-        assert self.eval_config_path is not None  # enforced by the validator
+        data_root: ResolvedLocation,
+    ) -> "CheckpointSweep":
+        """Build the runtime sweep."""
         return CheckpointSweep(
-            eval_config_path=Path(self.eval_config_path),
+            eval_config_path=self.eval_config_path,
             checkpoint_paths=CheckpointPaths(nets_dir),
             data_root=data_root,
-            sweep_root=(
-                output_dir / self.eval_dirname
-                if self.eval_dirname is not None
-                else None
-            ),
-            viz_config_path=(
-                Path(self.viz_config_path) if self.viz_config_path is not None else None
-            ),
+            sweep_root=output_dir / self.eval_dirname,
+            viz_config_path=self.viz_config_path,
             last_n_checkpoints=self.last_n_checkpoints,
-            checkpoints=self.checkpoints,
+            checkpoints=self.epochs,
             viz_dirname=self.viz_dirname,
         )
 

--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -58,6 +58,7 @@ from samudra.models.modules.augment_input import (
 )
 from samudra.models.modules.blocks import ZonallyPeriodicBilinearUpsample
 from samudra.models.modules.encoder import patch_from
+from samudra.post_train_eval import CheckpointSweep
 from samudra.utils.data import (
     CanonicalSource,
     DataBundle,
@@ -84,6 +85,7 @@ from samudra.utils.loss import (
 )
 from samudra.utils.profiler import Profiler
 from samudra.utils.schedule import SchedulerConfig
+from samudra.utils.train import CheckpointPaths
 
 
 class WandBConfig(BaseConfig):
@@ -1362,10 +1364,13 @@ class PostTrainCheckpointSweepConfig(BaseConfig):
         "exclusive with last_n_checkpoints.",
     )
     eval_dirname: str | None = None
-    viz_dirname: str | None = None
+    # Subdirectory for visualization outputs within each checkpoint evaluation directory.
+    viz_dirname: str = "viz"
 
     @pydantic.model_validator(mode="after")
     def _check_checkpoint_selection(self) -> "PostTrainCheckpointSweepConfig":
+        if self.enabled and self.eval_config_path is None:
+            raise ValueError("eval_config_path must be set when enabled is true")
         if self.last_n_checkpoints is not None and self.checkpoints is not None:
             raise ValueError(
                 "set only one of last_n_checkpoints or checkpoints, not both"
@@ -1373,6 +1378,34 @@ class PostTrainCheckpointSweepConfig(BaseConfig):
         if self.checkpoints is not None and len(self.checkpoints) == 0:
             raise ValueError("checkpoints must be a non-empty list when provided")
         return self
+
+    def build(
+        self,
+        nets_dir: Path,
+        output_dir: Path,
+        data_root: Location | None,
+    ) -> "CheckpointSweep | None":
+        """Build the runtime sweep, or return None when it is disabled."""
+        if not self.enabled:
+            return None
+
+        assert self.eval_config_path is not None  # enforced by the validator
+        return CheckpointSweep(
+            eval_config_path=Path(self.eval_config_path),
+            checkpoint_paths=CheckpointPaths(nets_dir),
+            data_root=data_root,
+            sweep_root=(
+                output_dir / self.eval_dirname
+                if self.eval_dirname is not None
+                else None
+            ),
+            viz_config_path=(
+                Path(self.viz_config_path) if self.viz_config_path is not None else None
+            ),
+            last_n_checkpoints=self.last_n_checkpoints,
+            checkpoints=self.checkpoints,
+            viz_dirname=self.viz_dirname,
+        )
 
 
 class EvalConfig(TopLevelConfig):

--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -1251,6 +1251,9 @@ class TrainConfig(TopLevelConfig):
     steps: list[int] = [4]
     step_transition: list[int] = []
     inference_epochs: list[int] = [-1]
+    post_train_eval: "PostTrainCheckpointSweepConfig" = Field(
+        default_factory=lambda: PostTrainCheckpointSweepConfig()
+    )
 
     # Config components
     experiment: ExperimentConfig
@@ -1345,6 +1348,15 @@ class ObsMetricsConfig(BaseConfig):
 
 # See backend.py for how these are turned into concrete devices
 EvalBackendConfig = Literal["cpu", "cuda", "auto"]
+
+
+class PostTrainCheckpointSweepConfig(BaseConfig):
+    enabled: bool = False
+    eval_config_path: str
+    viz_config_path: str
+    last_n_checkpoints: int | None = Field(default=None, ge=1)
+    eval_dirname: str = "post_train_eval"
+    viz_dirname: str = "viz"
 
 
 class EvalConfig(TopLevelConfig):

--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -1352,8 +1352,8 @@ EvalBackendConfig = Literal["cpu", "cuda", "auto"]
 
 class PostTrainCheckpointSweepConfig(BaseConfig):
     enabled: bool = False
-    eval_config_path: str
-    viz_config_path: str
+    eval_config_path: str | None = None
+    viz_config_path: str | None = None
     last_n_checkpoints: int | None = Field(default=None, ge=1)
     eval_dirname: str = "post_train_eval"
     viz_dirname: str = "viz"

--- a/src/samudra/config_base.py
+++ b/src/samudra/config_base.py
@@ -90,6 +90,20 @@ class TopLevelConfig(BaseSettings):
         return (init_settings,)
 
     @classmethod
+    def from_yaml(cls, config_path: Path | str) -> Self:
+        """Load and validate a YAML config without CLI overrides."""
+        return cls(**cls._load_yaml(config_path))
+
+    @classmethod
+    def _load_yaml(cls, config_path: Path | str) -> dict[str, Any]:
+        resolved_path = Path(config_path).expanduser().resolve()
+        if not resolved_path.exists():
+            raise FileNotFoundError(
+                f"Config file `{config_path}` (full path: {resolved_path}) not found"
+            )
+        return YamlConfigSettingsSource(cls, yaml_file=resolved_path)()
+
+    @classmethod
     def from_yaml_and_cli(
         cls,
         args_to_parse: list[str] | None = None,
@@ -126,20 +140,9 @@ class TopLevelConfig(BaseSettings):
         # so the help is complete on error.
         args = parser.parse_args(args_to_parse)
 
-        # Then we read the YAML file specified in the CLI. A bare path resolves
-        # against the filesystem; if it's missing we try a preset bundled in the
-        # installed package before giving up.
-        # Note that by default, YamlConfigSettingsSource will ignore missing files
-        config_path = resolve_config_path(args.config)
-        if not config_path.exists():
-            raise FileNotFoundError(
-                f"Config file `{args.config}` (full path: {config_path}) not found"
-            )
-        yaml_values = YamlConfigSettingsSource(cls, yaml_file=config_path)()
-
         return cls(
             _cli_settings_source=cli_source,
-            **yaml_values,
+            **cls._load_yaml(args.config),
         )
 
     def save_yaml(self, save_path: Path) -> None:

--- a/src/samudra/config_base.py
+++ b/src/samudra/config_base.py
@@ -96,7 +96,7 @@ class TopLevelConfig(BaseSettings):
 
     @classmethod
     def _load_yaml(cls, config_path: Path | str) -> dict[str, Any]:
-        resolved_path = Path(config_path).expanduser().resolve()
+        resolved_path = resolve_config_path(str(config_path))
         if not resolved_path.exists():
             raise FileNotFoundError(
                 f"Config file `{config_path}` (full path: {resolved_path}) not found"

--- a/src/samudra/config_schema.py
+++ b/src/samudra/config_schema.py
@@ -14,7 +14,7 @@ import yaml
 
 from samudra.config import EvalConfig, TrainConfig
 from samudra.search.config import SearchConfig
-from samudra.viz import VizConfig
+from samudra.viz import VizConfig, VizTemplateConfig
 
 
 def get_pydantic_models(
@@ -168,6 +168,7 @@ def main():
     models.update(get_pydantic_models(EvalConfig))
     models.update(get_pydantic_models(VizConfig))
     models.update(get_pydantic_models(SearchConfig))
+    models.update(get_pydantic_models(VizTemplateConfig))
 
     generate_schemas(args.output_dir, models)
 

--- a/src/samudra/post_train_eval.py
+++ b/src/samudra/post_train_eval.py
@@ -11,18 +11,17 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 import torch
 
-from samudra.config import EvalConfig, TrainConfig
-from samudra.eval import Eval
-from samudra.utils.location import LocalLocation, Location
+from samudra.utils.location import LocalLocation, Location, ResolvedLocation
 from samudra.utils.multiton import MultitonScope
 from samudra.utils.train import CheckpointPaths
-from samudra.viz import VizConfig
-from samudra.viz.config import VizRunConfig, run_with_prepared_groundtruth
-from samudra.viz.core import PreparedVizGroundtruth
+
+if TYPE_CHECKING:
+    from samudra.config import EvalConfig
+    from samudra.viz import VizTemplate
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +74,8 @@ def discover_checkpoints_from_directory(
 ) -> list[CheckpointEvalTarget]:
     if last_n_checkpoints is not None and checkpoints is not None:
         raise ValueError("pass only one of last_n_checkpoints or checkpoints, not both")
+    if last_n_checkpoints is not None and last_n_checkpoints < 1:
+        raise ValueError(f"last_n_checkpoints must be >= 1, got {last_n_checkpoints}")
 
     checkpoint_dir = checkpoint_paths.checkpoint_dir
     periodic: dict[int, Path] = {}
@@ -100,8 +101,11 @@ def discover_checkpoints_from_directory(
             _entry_from_file(path, "periodic", epoch=epoch)
             for epoch, path in sorted(periodic.items())
         ]
+        if last_n_checkpoints is not None:
+            targets = targets[-last_n_checkpoints:]
 
-    # The final EMA checkpoint is always included when present.
+    # The final EMA checkpoint is always included in addition to the selected
+    # periodic checkpoints.
     if checkpoint_paths.ema_checkpoint_path.exists():
         targets.append(
             _entry_from_file(
@@ -111,12 +115,6 @@ def discover_checkpoints_from_directory(
             )
         )
 
-    if last_n_checkpoints is not None:
-        if last_n_checkpoints < 1:
-            raise ValueError(
-                f"last_n_checkpoints must be >= 1, got {last_n_checkpoints}"
-            )
-        targets = targets[-last_n_checkpoints:]
     return targets
 
 
@@ -155,18 +153,37 @@ def _write_summary(results: list[dict[str, object]], sweep_root: Path) -> None:
     )
 
 
+def _load_eval_config(
+    eval_config_path: Path,
+    eval_override_args: tuple[str, ...],
+) -> "EvalConfig":
+    # Imported lazily so config.py can import the built CheckpointSweep type.
+    from samudra.config import EvalConfig
+
+    if eval_override_args:
+        return EvalConfig.from_yaml_and_cli(
+            [str(eval_config_path), *eval_override_args]
+        )
+    return EvalConfig.from_yaml(eval_config_path)
+
+
 def _run_single_checkpoint_eval(
     entry: CheckpointEvalTarget,
-    eval_config_args: tuple[str, ...],
+    eval_config_path: Path,
+    eval_override_args: tuple[str, ...],
     sweep_root: Path,
     data_root: Location | None,
     gpu_index: int | None,
 ) -> dict[str, object]:
+    # Eval imports EvalConfig, so keep it out of this module's import path while
+    # config.py is defining the CheckpointSweep builder.
+    from samudra.eval import Eval
+
     if gpu_index is not None:
         torch.cuda.set_device(gpu_index)
 
     with MultitonScope():
-        cfg = EvalConfig.from_yaml_and_cli(list(eval_config_args))
+        cfg = _load_eval_config(eval_config_path, eval_override_args)
         cfg.ckpt_path = entry.path
         cfg.experiment.base_output_dir = str(sweep_root)
         cfg.experiment.name = checkpoint_label(entry)
@@ -204,10 +221,14 @@ def _run_single_checkpoint_eval(
 
 def _run_single_checkpoint_viz(
     result: dict[str, object],
-    template_cfg: VizConfig,
-    prepared_groundtruth: PreparedVizGroundtruth,
-    viz_dirname: str | None = None,
+    template: "VizTemplate",
+    steps: list[str],
+    viz_dirname: str,
 ) -> dict[str, object]:
+    # Viz config imports TimeConfig, so these need to stay off config.py's
+    # module initialization path.
+    from samudra.viz.config import VizRunConfig, run_steps
+
     label = cast(str, result["label"])
     eval_output_dir = Path(cast(str, result["output_dir"]))
     prediction_path = eval_output_dir / "predictions.zarr"
@@ -216,31 +237,24 @@ def _run_single_checkpoint_viz(
             f"Expected saved predictions at {prediction_path} for post-train viz sweep"
         )
 
-    with MultitonScope():
-        # Build a viz config that points its first run at this checkpoint's predictions,
-        # inheriting variables (and any extra runs) from the template.
-        if viz_dirname is None:
-            viz_dirname = template_cfg.name
-        checkpoint_run = VizRunConfig(
-            name=label,
-            location=LocalLocation(path=prediction_path.resolve()),
-            variables=template_cfg.runs[0].variables,
-        )
-        updated = template_cfg.model_dump(mode="python")
-        updated["base_output_dir"] = eval_output_dir
-        updated["name"] = viz_dirname
-        updated["runs"] = [
-            checkpoint_run.model_dump(mode="python"),
-            *[run.model_dump(mode="python") for run in template_cfg.runs[1:]],
-        ]
-        cfg = VizConfig.model_validate(updated)
+    checkpoint_run = VizRunConfig(
+        name=label,
+        location=LocalLocation(path=prediction_path.resolve()),
+        variables=template.variables,
+    )
+    output_path = eval_output_dir / viz_dirname
+    output_path.mkdir(parents=True, exist_ok=True)
 
-        start = time.perf_counter()
-        run_with_prepared_groundtruth(cfg, prepared_groundtruth)
-        elapsed_seconds = time.perf_counter() - start
+    start = time.perf_counter()
+    viz = template.instantiate(
+        output_path,
+        [checkpoint_run.build(template.data_root)],
+    )
+    run_steps(viz, steps)
+    elapsed_seconds = time.perf_counter() - start
 
     return {
-        "output_dir": str(cfg.output_path),
+        "output_dir": str(output_path),
         "prediction_path": str(prediction_path),
         "elapsed_seconds": elapsed_seconds,
     }
@@ -248,7 +262,8 @@ def _run_single_checkpoint_viz(
 
 def _worker_main(
     entries: list[CheckpointEvalTarget],
-    eval_config_args: tuple[str, ...],
+    eval_config_path: Path,
+    eval_override_args: tuple[str, ...],
     sweep_root: str,
     data_root: Location | None,
     gpu_index: int | None,
@@ -259,7 +274,8 @@ def _worker_main(
             queue.put(
                 _run_single_checkpoint_eval(
                     entry=entry,
-                    eval_config_args=eval_config_args,
+                    eval_config_path=eval_config_path,
+                    eval_override_args=eval_override_args,
                     sweep_root=Path(sweep_root),
                     data_root=data_root,
                     gpu_index=gpu_index,
@@ -270,15 +286,44 @@ def _worker_main(
         raise
 
 
+@dataclass(frozen=True)
+class CheckpointSweep:
+    """Ready-to-run checkpoint sweep built from configuration."""
+
+    eval_config_path: Path
+    checkpoint_paths: CheckpointPaths
+    eval_override_args: tuple[str, ...] = ()
+    data_root: Location | None = None
+    sweep_root: Path | None = None
+    viz_config_path: Path | None = None
+    last_n_checkpoints: int | None = None
+    checkpoints: list[int] | None = None
+    viz_dirname: str = "viz"
+
+    def run(self) -> list[dict[str, object]]:
+        return run_checkpoint_sweep(
+            eval_config_path=self.eval_config_path,
+            checkpoint_paths=self.checkpoint_paths,
+            eval_override_args=self.eval_override_args,
+            data_root=self.data_root,
+            sweep_root=self.sweep_root,
+            viz_config_path=self.viz_config_path,
+            last_n_checkpoints=self.last_n_checkpoints,
+            checkpoints=self.checkpoints,
+            viz_dirname=self.viz_dirname,
+        )
+
+
 def run_checkpoint_sweep(
-    eval_config_args: tuple[str, ...],
+    eval_config_path: Path,
     checkpoint_paths: CheckpointPaths,
+    eval_override_args: tuple[str, ...] = (),
     data_root: Location | None = None,
     sweep_root: Path | None = None,
-    viz_config_args: tuple[str, ...] | None = None,
+    viz_config_path: Path | None = None,
     last_n_checkpoints: int | None = None,
     checkpoints: list[int] | None = None,
-    viz_dirname: str | None = None,
+    viz_dirname: str = "viz",
 ) -> list[dict[str, object]]:
     targets = discover_checkpoints_from_directory(
         checkpoint_paths,
@@ -289,12 +334,12 @@ def run_checkpoint_sweep(
         logger.warning("No checkpoints selected for post-train eval sweep")
         return []
 
-    eval_cfg = EvalConfig.from_yaml_and_cli(list(eval_config_args))
+    eval_cfg = _load_eval_config(eval_config_path, eval_override_args)
     if sweep_root is None:
         sweep_root = checkpoint_paths.checkpoint_dir.parent / eval_cfg.experiment.name
     sweep_root.mkdir(parents=True, exist_ok=True)
 
-    if viz_config_args is not None and not eval_cfg.save_zarr:
+    if viz_config_path is not None and not eval_cfg.save_zarr:
         raise ValueError(
             "post-train viz sweep requires eval.save_zarr = true so predictions.zarr is written"
         )
@@ -314,7 +359,8 @@ def run_checkpoint_sweep(
             results.append(
                 _run_single_checkpoint_eval(
                     entry=entry,
-                    eval_config_args=eval_config_args,
+                    eval_config_path=eval_config_path,
+                    eval_override_args=eval_override_args,
                     sweep_root=sweep_root,
                     data_root=data_root,
                     gpu_index=gpu_index,
@@ -330,7 +376,8 @@ def run_checkpoint_sweep(
                 target=_worker_main,
                 args=(
                     shard,
-                    eval_config_args,
+                    eval_config_path,
+                    eval_override_args,
                     str(sweep_root),
                     data_root,
                     gpu_index,
@@ -369,64 +416,25 @@ def run_checkpoint_sweep(
 
     _write_summary(results, sweep_root)
 
-    if viz_config_args is not None:
+    if viz_config_path is not None:
+        from samudra.viz import VizTemplateConfig
+
         logger.info("Running post-train viz sweep for %d checkpoints", len(results))
-        with MultitonScope():
-            template_cfg = VizConfig.from_yaml_and_cli(list(viz_config_args))
-            if not template_cfg.runs:
-                raise ValueError(
-                    "post-train viz config must define at least one run so variables can be inferred"
-                )
-            prepared_groundtruth = template_cfg.prepare_groundtruth(
-                LocalLocation(path=Path.cwd())
-            )
+        template_cfg = VizTemplateConfig.from_yaml(viz_config_path)
+        default_data_root: ResolvedLocation = LocalLocation(path=Path.cwd())
+        if data_root is not None:
+            default_data_root = default_data_root.resolve(data_root)
+        template = template_cfg.build_template(default_data_root)
         for result in results:
             result["viz"] = _run_single_checkpoint_viz(
                 result,
-                template_cfg,
-                prepared_groundtruth,
+                template,
+                template_cfg.selected_steps,
                 viz_dirname=viz_dirname,
             )
         _write_summary(results, sweep_root)
 
     return results
-
-
-def run_post_train_checkpoint_sweep(
-    train_cfg: TrainConfig, checkpoint_paths: CheckpointPaths
-) -> list[dict[str, object]]:
-    if not train_cfg.post_train_eval.enabled:
-        return []
-
-    if train_cfg.post_train_eval.eval_config_path is None:
-        raise ValueError(
-            "post_train_eval.eval_config_path must be set when post_train_eval.enabled is true"
-        )
-
-    eval_config_path = (
-        Path(train_cfg.post_train_eval.eval_config_path).expanduser().resolve()
-    )
-    viz_config_args = None
-    if train_cfg.post_train_eval.viz_config_path is not None:
-        viz_config_path = (
-            Path(train_cfg.post_train_eval.viz_config_path).expanduser().resolve()
-        )
-        viz_config_args = (str(viz_config_path),)
-    sweep_root = None
-    if train_cfg.post_train_eval.eval_dirname is not None:
-        sweep_root = (
-            train_cfg.experiment.output_dir / train_cfg.post_train_eval.eval_dirname
-        )
-    return run_checkpoint_sweep(
-        eval_config_args=(str(eval_config_path),),
-        checkpoint_paths=checkpoint_paths,
-        data_root=train_cfg.experiment.data_root,
-        sweep_root=sweep_root,
-        viz_config_args=viz_config_args,
-        last_n_checkpoints=train_cfg.post_train_eval.last_n_checkpoints,
-        checkpoints=train_cfg.post_train_eval.checkpoints,
-        viz_dirname=train_cfg.post_train_eval.viz_dirname,
-    )
 
 
 def run_standalone_checkpoint_sweep(
@@ -437,16 +445,14 @@ def run_standalone_checkpoint_sweep(
     last_n_checkpoints: int | None = None,
     checkpoints: list[int] | None = None,
 ) -> list[dict[str, object]]:
-    eval_config_args = (str(eval_config_path), *(eval_override_args or []))
-    viz_config_args = (str(viz_config_path),) if viz_config_path is not None else None
-
-    return run_checkpoint_sweep(
-        eval_config_args=eval_config_args,
+    return CheckpointSweep(
+        eval_config_path=eval_config_path,
         checkpoint_paths=CheckpointPaths(checkpoint_dir),
-        viz_config_args=viz_config_args,
+        eval_override_args=tuple(eval_override_args or []),
+        viz_config_path=viz_config_path,
         last_n_checkpoints=last_n_checkpoints,
         checkpoints=checkpoints,
-    )
+    ).run()
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/samudra/post_train_eval.py
+++ b/src/samudra/post_train_eval.py
@@ -2,10 +2,12 @@ import argparse
 import json
 import logging
 import multiprocessing
+import queue as queue_module
 import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import torch
 
@@ -15,16 +17,10 @@ from samudra.utils.location import LocalLocation
 from samudra.utils.multiton import MultitonScope
 from samudra.utils.train import CheckpointPaths
 from samudra.viz import VizConfig
-from samudra.viz.config import VizRunConfig, main as run_viz
+from samudra.viz.config import VizRunConfig, run_with_prepared_groundtruth
+from samudra.viz.core import PreparedVizGroundtruth
 
 logger = logging.getLogger(__name__)
-
-
-def _default_viz_dirname() -> str:
-    default = PostTrainCheckpointSweepConfig.model_fields["viz_dirname"].default
-    if not isinstance(default, str):
-        raise TypeError("PostTrainCheckpointSweepConfig.viz_dirname must default to str")
-    return default
 
 
 @dataclass(frozen=True)
@@ -51,13 +47,15 @@ def _entry_from_file(
     *,
     epoch: int | None = None,
     for_inference: bool = False,
- ) -> CheckpointEvalTarget:
+) -> CheckpointEvalTarget:
     if epoch is None:
         # Read epoch from the checkpoint file itself.
         checkpoint = torch.load(checkpoint_path, map_location="cpu")
         epoch = checkpoint.get("epoch")
         if not isinstance(epoch, int):
-            raise ValueError(f"Checkpoint at {checkpoint_path} is missing integer epoch")
+            raise ValueError(
+                f"Checkpoint at {checkpoint_path} is missing integer epoch"
+            )
     return CheckpointEvalTarget(
         epoch=epoch,
         kind=kind,
@@ -66,8 +64,60 @@ def _entry_from_file(
     )
 
 
-def _load_eval_config(eval_config_args: tuple[str, ...]) -> EvalConfig:
-    return EvalConfig.from_yaml_and_cli(list(eval_config_args))
+def discover_checkpoints_from_directory(
+    checkpoint_paths: CheckpointPaths,
+    last_n_checkpoints: int | None = None,
+) -> list[CheckpointEvalTarget]:
+    checkpoint_dir = checkpoint_paths.checkpoint_dir
+    periodic: list[tuple[int, Path]] = []
+    for path in checkpoint_dir.iterdir():
+        if not path.is_file():
+            continue
+        if match := re.match(r"^ckpt_(\d+)\.pt$", path.name):
+            periodic.append((int(match.group(1)), path))
+
+    targets: list[CheckpointEvalTarget] = [
+        _entry_from_file(path, "periodic", epoch=epoch)
+        for epoch, path in sorted(periodic)
+    ]
+    if checkpoint_paths.ema_checkpoint_path.exists():
+        targets.append(
+            _entry_from_file(
+                checkpoint_paths.ema_checkpoint_path,
+                "ema_latest",
+                for_inference=True,
+            )
+        )
+    if last_n_checkpoints is not None:
+        targets = targets[-last_n_checkpoints:]
+    return targets
+
+
+def partition_checkpoint_work(
+    entries: list[CheckpointEvalTarget],
+    worker_count: int,
+) -> list[list[CheckpointEvalTarget]]:
+    if worker_count < 1:
+        raise ValueError("worker_count must be at least 1")
+    return [entries[i::worker_count] for i in range(worker_count)]
+
+
+def _resolve_worker_count(
+    backend: str,
+    num_checkpoints: int,
+) -> tuple[int, list[int]]:
+    wants_gpu = backend in {"auto", "cuda"}
+    available_gpus = (
+        torch.cuda.device_count() if wants_gpu and torch.cuda.is_available() else 0
+    )
+    if backend == "cuda" and available_gpus == 0:
+        raise RuntimeError("post-train eval requested CUDA but no GPUs are available")
+    if available_gpus == 0:
+        logger.info("No GPUs available for post-train eval; falling back to serial CPU")
+        return 1, []
+
+    worker_count = max(1, min(num_checkpoints, available_gpus))
+    return worker_count, list(range(worker_count))
 
 
 def _write_summary(results: list[dict[str, object]], sweep_root: Path) -> None:
@@ -78,29 +128,23 @@ def _write_summary(results: list[dict[str, object]], sweep_root: Path) -> None:
     )
 
 
-def _require_result_str(result: dict[str, object], key: str) -> str:
-    value = result.get(key)
-    if not isinstance(value, str):
-        raise ValueError(f"checkpoint sweep result is missing string field '{key}'")
-    return value
-
-
 def _run_single_checkpoint_eval(
     entry: CheckpointEvalTarget,
     eval_config_args: tuple[str, ...],
     sweep_root: Path,
-    data_root: object,
+    data_root: object | None,
     gpu_index: int | None,
 ) -> dict[str, object]:
     if gpu_index is not None:
         torch.cuda.set_device(gpu_index)
 
     with MultitonScope():
-        cfg = _load_eval_config(eval_config_args)
+        cfg = EvalConfig.from_yaml_and_cli(list(eval_config_args))
         cfg.ckpt_path = entry.path
         cfg.experiment.base_output_dir = str(sweep_root)
         cfg.experiment.name = checkpoint_label(entry)
-        cfg.experiment.data_root = data_root
+        if data_root is not None:
+            cfg.experiment.data_root = data_root
         cfg.experiment.wandb.mode = "disabled"
 
         evaluator = Eval(cfg)
@@ -131,11 +175,55 @@ def _run_single_checkpoint_eval(
         }
 
 
+def _run_single_checkpoint_viz(
+    result: dict[str, object],
+    template_cfg: VizConfig,
+    prepared_groundtruth: PreparedVizGroundtruth,
+    viz_dirname: str | None = None,
+) -> dict[str, object]:
+    label = cast(str, result["label"])
+    eval_output_dir = Path(cast(str, result["output_dir"]))
+    prediction_path = eval_output_dir / "predictions.zarr"
+    if not prediction_path.exists():
+        raise FileNotFoundError(
+            f"Expected saved predictions at {prediction_path} for post-train viz sweep"
+        )
+
+    with MultitonScope():
+        # Build a viz config that points its first run at this checkpoint's predictions,
+        # inheriting variables (and any extra runs) from the template.
+        if viz_dirname is None:
+            viz_dirname = template_cfg.name
+        checkpoint_run = VizRunConfig(
+            name=label,
+            location=LocalLocation(path=prediction_path.resolve()),
+            variables=template_cfg.runs[0].variables,
+        )
+        updated = template_cfg.model_dump(mode="python")
+        updated["base_output_dir"] = eval_output_dir
+        updated["name"] = viz_dirname
+        updated["runs"] = [
+            checkpoint_run.model_dump(mode="python"),
+            *[run.model_dump(mode="python") for run in template_cfg.runs[1:]],
+        ]
+        cfg = VizConfig.model_validate(updated)
+
+        start = time.perf_counter()
+        run_with_prepared_groundtruth(cfg, prepared_groundtruth)
+        elapsed_seconds = time.perf_counter() - start
+
+    return {
+        "output_dir": str(cfg.output_path),
+        "prediction_path": str(prediction_path),
+        "elapsed_seconds": elapsed_seconds,
+    }
+
+
 def _worker_main(
     entries: list[CheckpointEvalTarget],
     eval_config_args: tuple[str, ...],
     sweep_root: str,
-    data_root: object,
+    data_root: object | None,
     gpu_index: int | None,
     queue: multiprocessing.Queue,
 ) -> None:
@@ -158,67 +246,31 @@ def _worker_main(
 def run_checkpoint_sweep(
     eval_config_args: tuple[str, ...],
     checkpoint_paths: CheckpointPaths,
-    data_root: object,
-    sweep_root: Path,
+    data_root: object | None = None,
+    sweep_root: Path | None = None,
     viz_config_args: tuple[str, ...] | None = None,
     last_n_checkpoints: int | None = None,
     viz_dirname: str | None = None,
 ) -> list[dict[str, object]]:
-    if viz_dirname is None:
-        viz_dirname = _default_viz_dirname()
-
-    # Discover checkpoints: periodic ckpt_<N>.pt files, plus the EMA checkpoint if present.
-    checkpoint_dir = checkpoint_paths.checkpoint_dir
-    periodic: list[tuple[int, Path]] = []
-    for path in checkpoint_dir.iterdir():
-        if not path.is_file():
-            continue
-        # Match periodic checkpoints named like ckpt_10.pt and capture the epoch.
-        if match := re.match(r"^ckpt_(\d+)\.pt$", path.name):
-            periodic.append((int(match.group(1)), path))
-
-    targets: list[CheckpointEvalTarget] = [
-        _entry_from_file(path, "periodic", epoch=epoch)
-        for epoch, path in sorted(periodic)
-    ]
-    if checkpoint_paths.ema_checkpoint_path.exists():
-        targets.append(
-            _entry_from_file(
-                checkpoint_paths.ema_checkpoint_path,
-                "ema_latest",
-                for_inference=True,
-            )
-        )
-    if last_n_checkpoints is not None:
-        targets = targets[-last_n_checkpoints:]
-
+    targets = discover_checkpoints_from_directory(
+        checkpoint_paths,
+        last_n_checkpoints=last_n_checkpoints,
+    )
     if not targets:
         logger.warning("No checkpoints selected for post-train eval sweep")
         return []
 
+    eval_cfg = EvalConfig.from_yaml_and_cli(list(eval_config_args))
+    if sweep_root is None:
+        sweep_root = checkpoint_paths.checkpoint_dir.parent / eval_cfg.experiment.name
     sweep_root.mkdir(parents=True, exist_ok=True)
 
-    eval_cfg = _load_eval_config(eval_config_args)
     if viz_config_args is not None and not eval_cfg.save_zarr:
         raise ValueError(
             "post-train viz sweep requires eval.save_zarr = true so predictions.zarr is written"
         )
 
-    # Resolve worker count: one process per available GPU, capped at the number of checkpoints.
-    backend = eval_cfg.backend
-    wants_gpu = backend in {"auto", "cuda"}
-    available_gpus = (
-        torch.cuda.device_count() if wants_gpu and torch.cuda.is_available() else 0
-    )
-    if backend == "cuda" and available_gpus == 0:
-        raise RuntimeError("post-train eval requested CUDA but no GPUs are available")
-    if available_gpus == 0:
-        logger.info("No GPUs available for post-train eval; falling back to serial CPU")
-        worker_count = 1
-        gpu_indices: list[int] = []
-    else:
-        worker_count = max(1, min(len(targets), available_gpus))
-        gpu_indices = list(range(worker_count))
+    worker_count, gpu_indices = _resolve_worker_count(eval_cfg.backend, len(targets))
 
     logger.info(
         "Running checkpoint sweep for %d checkpoints with %d worker(s)",
@@ -243,8 +295,7 @@ def run_checkpoint_sweep(
         ctx = multiprocessing.get_context("spawn")
         queue: multiprocessing.Queue = ctx.Queue()
         processes = []
-        # Round-robin shard checkpoints across workers.
-        shards = [targets[i::worker_count] for i in range(worker_count)]
+        shards = partition_checkpoint_work(targets, worker_count)
         for gpu_index, shard in zip(gpu_indices, shards, strict=True):
             process = ctx.Process(
                 target=_worker_main,
@@ -261,8 +312,20 @@ def run_checkpoint_sweep(
             processes.append(process)
 
         while len(results) < len(targets):
-            item = queue.get()
+            try:
+                item = queue.get(timeout=30)
+            except queue_module.Empty:
+                for process in processes:
+                    if process.exitcode not in {None, 0}:
+                        raise RuntimeError(
+                            f"checkpoint sweep worker exited with status {process.exitcode}"
+                        )
+                continue
             if "error" in item:
+                for process in processes:
+                    if process.is_alive():
+                        process.terminate()
+                    process.join()
                 raise RuntimeError(
                     f"checkpoint sweep worker failed on gpu {item['gpu_index']}: {item['error']}"
                 )
@@ -279,46 +342,22 @@ def run_checkpoint_sweep(
 
     if viz_config_args is not None:
         logger.info("Running post-train viz sweep for %d checkpoints", len(results))
+        with MultitonScope():
+            template_cfg = VizConfig.from_yaml_and_cli(list(viz_config_args))
+            if not template_cfg.runs:
+                raise ValueError(
+                    "post-train viz config must define at least one run so variables can be inferred"
+                )
+            prepared_groundtruth = template_cfg.prepare_groundtruth(
+                LocalLocation(path=Path.cwd())
+            )
         for result in results:
-            label = _require_result_str(result, "label")
-            eval_output_dir = Path(_require_result_str(result, "output_dir"))
-            prediction_path = eval_output_dir / "predictions.zarr"
-            if not prediction_path.exists():
-                raise FileNotFoundError(
-                    f"Expected saved predictions at {prediction_path} for post-train viz sweep"
-                )
-
-            with MultitonScope():
-                # Build a viz config that points its first run at this checkpoint's predictions,
-                # inheriting variables (and any extra runs) from the template.
-                template_cfg = VizConfig.from_yaml_and_cli(list(viz_config_args))
-                if not template_cfg.runs:
-                    raise ValueError(
-                        "post-train viz config must define at least one run so variables can be inferred"
-                    )
-                checkpoint_run = VizRunConfig(
-                    name=label,
-                    location=LocalLocation(path=prediction_path),
-                    variables=template_cfg.runs[0].variables,
-                )
-                updated = template_cfg.model_dump(mode="python")
-                updated["base_output_dir"] = eval_output_dir
-                updated["name"] = viz_dirname
-                updated["runs"] = [
-                    checkpoint_run.model_dump(mode="python"),
-                    *[run.model_dump(mode="python") for run in template_cfg.runs[1:]],
-                ]
-                cfg = VizConfig.model_validate(updated)
-
-                start = time.perf_counter()
-                run_viz(cfg)
-                elapsed_seconds = time.perf_counter() - start
-
-            result["viz"] = {
-                "output_dir": str(cfg.output_path),
-                "prediction_path": str(prediction_path),
-                "elapsed_seconds": elapsed_seconds,
-            }
+            result["viz"] = _run_single_checkpoint_viz(
+                result,
+                template_cfg,
+                prepared_groundtruth,
+                viz_dirname=viz_dirname,
+            )
         _write_summary(results, sweep_root)
 
     return results
@@ -335,19 +374,25 @@ def run_post_train_checkpoint_sweep(
             "post_train_eval.eval_config_path must be set when post_train_eval.enabled is true"
         )
 
-    eval_config_path = Path(train_cfg.post_train_eval.eval_config_path).expanduser().resolve()
+    eval_config_path = (
+        Path(train_cfg.post_train_eval.eval_config_path).expanduser().resolve()
+    )
     viz_config_args = None
     if train_cfg.post_train_eval.viz_config_path is not None:
         viz_config_path = (
             Path(train_cfg.post_train_eval.viz_config_path).expanduser().resolve()
         )
         viz_config_args = (str(viz_config_path),)
+    sweep_root = None
+    if train_cfg.post_train_eval.eval_dirname is not None:
+        sweep_root = (
+            train_cfg.experiment.output_dir / train_cfg.post_train_eval.eval_dirname
+        )
     return run_checkpoint_sweep(
         eval_config_args=(str(eval_config_path),),
         checkpoint_paths=checkpoint_paths,
         data_root=train_cfg.experiment.data_root,
-        sweep_root=train_cfg.experiment.output_dir
-        / train_cfg.post_train_eval.eval_dirname,
+        sweep_root=sweep_root,
         viz_config_args=viz_config_args,
         last_n_checkpoints=train_cfg.post_train_eval.last_n_checkpoints,
         viz_dirname=train_cfg.post_train_eval.viz_dirname,
@@ -362,21 +407,13 @@ def run_standalone_checkpoint_sweep(
     last_n_checkpoints: int | None = None,
 ) -> list[dict[str, object]]:
     eval_config_args = (str(eval_config_path), *(eval_override_args or []))
-    eval_cfg = _load_eval_config(eval_config_args)
     viz_config_args = (str(viz_config_path),) if viz_config_path is not None else None
-
-    eval_dirname_default = PostTrainCheckpointSweepConfig.model_fields["eval_dirname"].default
-    if not isinstance(eval_dirname_default, str):
-        raise TypeError("PostTrainCheckpointSweepConfig.eval_dirname must default to str")
 
     return run_checkpoint_sweep(
         eval_config_args=eval_config_args,
         checkpoint_paths=CheckpointPaths(checkpoint_dir),
-        data_root=eval_cfg.experiment.data_root,
-        sweep_root=checkpoint_dir.parent / eval_dirname_default,
         viz_config_args=viz_config_args,
         last_n_checkpoints=last_n_checkpoints,
-        viz_dirname=_default_viz_dirname(),
     )
 
 
@@ -384,13 +421,12 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         description="Run standalone inference sweeps for an existing saved_nets directory."
     )
-    parser.add_argument("--config",
-        required=True,
-        help="Path to eval config YAML"
+    parser.add_argument(
+        "config",
+        help="Path to eval config YAML",
     )
     parser.add_argument(
         "--viz_config",
-        required=True,
         help="Path to viz config YAML to run after the eval sweep",
     )
     parser.add_argument(
@@ -404,14 +440,15 @@ def main(argv: list[str] | None = None) -> None:
         help="Optional limit to only evaluate the last N discovered checkpoints",
     )
     args, eval_override_args = parser.parse_known_args(argv)
-    
+
     # Expand ~ in user-provided config paths before resolving them to absolute paths.
     sweep_kwargs: dict[str, object] = {
         "eval_config_path": Path(args.config).expanduser().resolve(),
         "checkpoint_dir": Path(args.checkpoint_dir).expanduser().resolve(),
         "eval_override_args": eval_override_args,
-        "viz_config_path": Path(args.viz_config).expanduser().resolve()
     }
+    if args.viz_config is not None:
+        sweep_kwargs["viz_config_path"] = Path(args.viz_config).expanduser().resolve()
     if args.last_n_checkpoints is not None:
         sweep_kwargs["last_n_checkpoints"] = args.last_n_checkpoints
 

--- a/src/samudra/post_train_eval.py
+++ b/src/samudra/post_train_eval.py
@@ -11,9 +11,9 @@ from typing import cast
 
 import torch
 
-from samudra.config import EvalConfig, PostTrainCheckpointSweepConfig, TrainConfig
+from samudra.config import EvalConfig, TrainConfig
 from samudra.eval import Eval
-from samudra.utils.location import LocalLocation
+from samudra.utils.location import LocalLocation, Location
 from samudra.utils.multiton import MultitonScope
 from samudra.utils.train import CheckpointPaths
 from samudra.viz import VizConfig
@@ -67,19 +67,37 @@ def _entry_from_file(
 def discover_checkpoints_from_directory(
     checkpoint_paths: CheckpointPaths,
     last_n_checkpoints: int | None = None,
+    checkpoints: list[int] | None = None,
 ) -> list[CheckpointEvalTarget]:
+    if last_n_checkpoints is not None and checkpoints is not None:
+        raise ValueError("pass only one of last_n_checkpoints or checkpoints, not both")
+
     checkpoint_dir = checkpoint_paths.checkpoint_dir
-    periodic: list[tuple[int, Path]] = []
+    periodic: dict[int, Path] = {}
     for path in checkpoint_dir.iterdir():
         if not path.is_file():
             continue
         if match := re.match(r"^ckpt_(\d+)\.pt$", path.name):
-            periodic.append((int(match.group(1)), path))
+            periodic[int(match.group(1))] = path
 
-    targets: list[CheckpointEvalTarget] = [
-        _entry_from_file(path, "periodic", epoch=epoch)
-        for epoch, path in sorted(periodic)
-    ]
+    if checkpoints is not None:
+        # Evaluate exactly the requested epochs; fail loudly if any are missing.
+        missing = sorted(set(checkpoints) - periodic.keys())
+        if missing:
+            raise ValueError(
+                f"requested checkpoint epochs not found in {checkpoint_dir}: {missing}"
+            )
+        targets = [
+            _entry_from_file(periodic[epoch], "periodic", epoch=epoch)
+            for epoch in sorted(set(checkpoints))
+        ]
+    else:
+        targets = [
+            _entry_from_file(path, "periodic", epoch=epoch)
+            for epoch, path in sorted(periodic.items())
+        ]
+
+    # The final EMA checkpoint is always included when present.
     if checkpoint_paths.ema_checkpoint_path.exists():
         targets.append(
             _entry_from_file(
@@ -88,7 +106,12 @@ def discover_checkpoints_from_directory(
                 for_inference=True,
             )
         )
+
     if last_n_checkpoints is not None:
+        if last_n_checkpoints < 1:
+            raise ValueError(
+                f"last_n_checkpoints must be >= 1, got {last_n_checkpoints}"
+            )
         targets = targets[-last_n_checkpoints:]
     return targets
 
@@ -132,7 +155,7 @@ def _run_single_checkpoint_eval(
     entry: CheckpointEvalTarget,
     eval_config_args: tuple[str, ...],
     sweep_root: Path,
-    data_root: object | None,
+    data_root: Location | None,
     gpu_index: int | None,
 ) -> dict[str, object]:
     if gpu_index is not None:
@@ -223,7 +246,7 @@ def _worker_main(
     entries: list[CheckpointEvalTarget],
     eval_config_args: tuple[str, ...],
     sweep_root: str,
-    data_root: object | None,
+    data_root: Location | None,
     gpu_index: int | None,
     queue: multiprocessing.Queue,
 ) -> None:
@@ -246,15 +269,17 @@ def _worker_main(
 def run_checkpoint_sweep(
     eval_config_args: tuple[str, ...],
     checkpoint_paths: CheckpointPaths,
-    data_root: object | None = None,
+    data_root: Location | None = None,
     sweep_root: Path | None = None,
     viz_config_args: tuple[str, ...] | None = None,
     last_n_checkpoints: int | None = None,
+    checkpoints: list[int] | None = None,
     viz_dirname: str | None = None,
 ) -> list[dict[str, object]]:
     targets = discover_checkpoints_from_directory(
         checkpoint_paths,
         last_n_checkpoints=last_n_checkpoints,
+        checkpoints=checkpoints,
     )
     if not targets:
         logger.warning("No checkpoints selected for post-train eval sweep")
@@ -395,6 +420,7 @@ def run_post_train_checkpoint_sweep(
         sweep_root=sweep_root,
         viz_config_args=viz_config_args,
         last_n_checkpoints=train_cfg.post_train_eval.last_n_checkpoints,
+        checkpoints=train_cfg.post_train_eval.checkpoints,
         viz_dirname=train_cfg.post_train_eval.viz_dirname,
     )
 
@@ -405,6 +431,7 @@ def run_standalone_checkpoint_sweep(
     eval_override_args: list[str] | None = None,
     viz_config_path: Path | None = None,
     last_n_checkpoints: int | None = None,
+    checkpoints: list[int] | None = None,
 ) -> list[dict[str, object]]:
     eval_config_args = (str(eval_config_path), *(eval_override_args or []))
     viz_config_args = (str(viz_config_path),) if viz_config_path is not None else None
@@ -414,6 +441,7 @@ def run_standalone_checkpoint_sweep(
         checkpoint_paths=CheckpointPaths(checkpoint_dir),
         viz_config_args=viz_config_args,
         last_n_checkpoints=last_n_checkpoints,
+        checkpoints=checkpoints,
     )
 
 
@@ -439,20 +467,29 @@ def main(argv: list[str] | None = None) -> None:
         type=int,
         help="Optional limit to only evaluate the last N discovered checkpoints",
     )
+    parser.add_argument(
+        "--checkpoints",
+        type=int,
+        nargs="+",
+        help="Explicit checkpoint epochs to evaluate; mutually exclusive with "
+        "--last_n_checkpoints",
+    )
     args, eval_override_args = parser.parse_known_args(argv)
 
     # Expand ~ in user-provided config paths before resolving them to absolute paths.
-    sweep_kwargs: dict[str, object] = {
-        "eval_config_path": Path(args.config).expanduser().resolve(),
-        "checkpoint_dir": Path(args.checkpoint_dir).expanduser().resolve(),
-        "eval_override_args": eval_override_args,
-    }
-    if args.viz_config is not None:
-        sweep_kwargs["viz_config_path"] = Path(args.viz_config).expanduser().resolve()
-    if args.last_n_checkpoints is not None:
-        sweep_kwargs["last_n_checkpoints"] = args.last_n_checkpoints
-
-    run_standalone_checkpoint_sweep(**sweep_kwargs)
+    viz_config_path = (
+        Path(args.viz_config).expanduser().resolve()
+        if args.viz_config is not None
+        else None
+    )
+    run_standalone_checkpoint_sweep(
+        eval_config_path=Path(args.config).expanduser().resolve(),
+        checkpoint_dir=Path(args.checkpoint_dir).expanduser().resolve(),
+        eval_override_args=eval_override_args,
+        viz_config_path=viz_config_path,
+        last_n_checkpoints=args.last_n_checkpoints,
+        checkpoints=args.checkpoints,
+    )
 
 
 if __name__ == "__main__":

--- a/src/samudra/post_train_eval.py
+++ b/src/samudra/post_train_eval.py
@@ -1,0 +1,422 @@
+import argparse
+import json
+import logging
+import multiprocessing
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+
+from samudra.config import EvalConfig, PostTrainCheckpointSweepConfig, TrainConfig
+from samudra.eval import Eval
+from samudra.utils.location import LocalLocation
+from samudra.utils.multiton import MultitonScope
+from samudra.utils.train import CheckpointPaths
+from samudra.viz import VizConfig
+from samudra.viz.config import VizRunConfig, main as run_viz
+
+logger = logging.getLogger(__name__)
+
+
+def _default_viz_dirname() -> str:
+    default = PostTrainCheckpointSweepConfig.model_fields["viz_dirname"].default
+    if not isinstance(default, str):
+        raise TypeError("PostTrainCheckpointSweepConfig.viz_dirname must default to str")
+    return default
+
+
+@dataclass(frozen=True)
+class CheckpointEvalTarget:
+    epoch: int
+    kind: str
+    path: str
+    for_inference: bool
+
+
+def checkpoint_label(entry: CheckpointEvalTarget) -> str:
+    match entry.kind:
+        case "periodic":
+            return f"epoch_{entry.epoch:04d}"
+        case "ema_latest":
+            return "final_ema"
+        case _:
+            return f"{entry.kind}_epoch_{entry.epoch:04d}"
+
+
+def _entry_from_file(
+    checkpoint_path: Path,
+    kind: str,
+    *,
+    epoch: int | None = None,
+    for_inference: bool = False,
+ ) -> CheckpointEvalTarget:
+    if epoch is None:
+        # Read epoch from the checkpoint file itself.
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+        epoch = checkpoint.get("epoch")
+        if not isinstance(epoch, int):
+            raise ValueError(f"Checkpoint at {checkpoint_path} is missing integer epoch")
+    return CheckpointEvalTarget(
+        epoch=epoch,
+        kind=kind,
+        path=str(checkpoint_path),
+        for_inference=for_inference,
+    )
+
+
+def _load_eval_config(eval_config_args: tuple[str, ...]) -> EvalConfig:
+    return EvalConfig.from_yaml_and_cli(list(eval_config_args))
+
+
+def _write_summary(results: list[dict[str, object]], sweep_root: Path) -> None:
+    summary_path = sweep_root / "summary.json"
+    summary_path.write_text(
+        json.dumps(results, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _require_result_str(result: dict[str, object], key: str) -> str:
+    value = result.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"checkpoint sweep result is missing string field '{key}'")
+    return value
+
+
+def _run_single_checkpoint_eval(
+    entry: CheckpointEvalTarget,
+    eval_config_args: tuple[str, ...],
+    sweep_root: Path,
+    data_root: object,
+    gpu_index: int | None,
+) -> dict[str, object]:
+    if gpu_index is not None:
+        torch.cuda.set_device(gpu_index)
+
+    with MultitonScope():
+        cfg = _load_eval_config(eval_config_args)
+        cfg.ckpt_path = entry.path
+        cfg.experiment.base_output_dir = str(sweep_root)
+        cfg.experiment.name = checkpoint_label(entry)
+        cfg.experiment.data_root = data_root
+        cfg.experiment.wandb.mode = "disabled"
+
+        evaluator = Eval(cfg)
+        start = time.perf_counter()
+        metrics = evaluator.standalone_inference()
+        elapsed_seconds = time.perf_counter() - start
+        evaluator.finish()
+
+        # Serialize metrics to JSON-safe primitives, dropping non-scalar tensors.
+        serialized: dict[str, float | int | str | bool] = {}
+        for key, value in metrics.items():
+            if isinstance(value, torch.Tensor):
+                if value.numel() != 1:
+                    continue
+                serialized[key] = float(value.item())
+            elif isinstance(value, (bool, int, float, str)):
+                serialized[key] = value
+
+        return {
+            "checkpoint_kind": entry.kind,
+            "checkpoint_epoch": entry.epoch,
+            "checkpoint_path": entry.path,
+            "for_inference": entry.for_inference,
+            "label": checkpoint_label(entry),
+            "output_dir": str(cfg.experiment.output_dir),
+            "elapsed_seconds": elapsed_seconds,
+            "metrics": serialized,
+        }
+
+
+def _worker_main(
+    entries: list[CheckpointEvalTarget],
+    eval_config_args: tuple[str, ...],
+    sweep_root: str,
+    data_root: object,
+    gpu_index: int | None,
+    queue: multiprocessing.Queue,
+) -> None:
+    try:
+        for entry in entries:
+            queue.put(
+                _run_single_checkpoint_eval(
+                    entry=entry,
+                    eval_config_args=eval_config_args,
+                    sweep_root=Path(sweep_root),
+                    data_root=data_root,
+                    gpu_index=gpu_index,
+                )
+            )
+    except Exception as exc:
+        queue.put({"error": str(exc), "gpu_index": gpu_index})
+        raise
+
+
+def run_checkpoint_sweep(
+    eval_config_args: tuple[str, ...],
+    checkpoint_paths: CheckpointPaths,
+    data_root: object,
+    sweep_root: Path,
+    viz_config_args: tuple[str, ...] | None = None,
+    last_n_checkpoints: int | None = None,
+    viz_dirname: str | None = None,
+) -> list[dict[str, object]]:
+    if viz_dirname is None:
+        viz_dirname = _default_viz_dirname()
+
+    # Discover checkpoints: periodic ckpt_<N>.pt files, plus the EMA checkpoint if present.
+    checkpoint_dir = checkpoint_paths.checkpoint_dir
+    periodic: list[tuple[int, Path]] = []
+    for path in checkpoint_dir.iterdir():
+        if not path.is_file():
+            continue
+        # Match periodic checkpoints named like ckpt_10.pt and capture the epoch.
+        if match := re.match(r"^ckpt_(\d+)\.pt$", path.name):
+            periodic.append((int(match.group(1)), path))
+
+    targets: list[CheckpointEvalTarget] = [
+        _entry_from_file(path, "periodic", epoch=epoch)
+        for epoch, path in sorted(periodic)
+    ]
+    if checkpoint_paths.ema_checkpoint_path.exists():
+        targets.append(
+            _entry_from_file(
+                checkpoint_paths.ema_checkpoint_path,
+                "ema_latest",
+                for_inference=True,
+            )
+        )
+    if last_n_checkpoints is not None:
+        targets = targets[-last_n_checkpoints:]
+
+    if not targets:
+        logger.warning("No checkpoints selected for post-train eval sweep")
+        return []
+
+    sweep_root.mkdir(parents=True, exist_ok=True)
+
+    eval_cfg = _load_eval_config(eval_config_args)
+    if viz_config_args is not None and not eval_cfg.save_zarr:
+        raise ValueError(
+            "post-train viz sweep requires eval.save_zarr = true so predictions.zarr is written"
+        )
+
+    # Resolve worker count: one process per available GPU, capped at the number of checkpoints.
+    backend = eval_cfg.backend
+    wants_gpu = backend in {"auto", "cuda"}
+    available_gpus = (
+        torch.cuda.device_count() if wants_gpu and torch.cuda.is_available() else 0
+    )
+    if backend == "cuda" and available_gpus == 0:
+        raise RuntimeError("post-train eval requested CUDA but no GPUs are available")
+    if available_gpus == 0:
+        logger.info("No GPUs available for post-train eval; falling back to serial CPU")
+        worker_count = 1
+        gpu_indices: list[int] = []
+    else:
+        worker_count = max(1, min(len(targets), available_gpus))
+        gpu_indices = list(range(worker_count))
+
+    logger.info(
+        "Running checkpoint sweep for %d checkpoints with %d worker(s)",
+        len(targets),
+        worker_count,
+    )
+
+    results: list[dict[str, object]] = []
+    if worker_count == 1:
+        gpu_index = gpu_indices[0] if gpu_indices else None
+        for entry in targets:
+            results.append(
+                _run_single_checkpoint_eval(
+                    entry=entry,
+                    eval_config_args=eval_config_args,
+                    sweep_root=sweep_root,
+                    data_root=data_root,
+                    gpu_index=gpu_index,
+                )
+            )
+    else:
+        ctx = multiprocessing.get_context("spawn")
+        queue: multiprocessing.Queue = ctx.Queue()
+        processes = []
+        # Round-robin shard checkpoints across workers.
+        shards = [targets[i::worker_count] for i in range(worker_count)]
+        for gpu_index, shard in zip(gpu_indices, shards, strict=True):
+            process = ctx.Process(
+                target=_worker_main,
+                args=(
+                    shard,
+                    eval_config_args,
+                    str(sweep_root),
+                    data_root,
+                    gpu_index,
+                    queue,
+                ),
+            )
+            process.start()
+            processes.append(process)
+
+        while len(results) < len(targets):
+            item = queue.get()
+            if "error" in item:
+                raise RuntimeError(
+                    f"checkpoint sweep worker failed on gpu {item['gpu_index']}: {item['error']}"
+                )
+            results.append(item)
+
+        for process in processes:
+            process.join()
+            if process.exitcode != 0:
+                raise RuntimeError(
+                    f"checkpoint sweep worker exited with status {process.exitcode}"
+                )
+
+    _write_summary(results, sweep_root)
+
+    if viz_config_args is not None:
+        logger.info("Running post-train viz sweep for %d checkpoints", len(results))
+        for result in results:
+            label = _require_result_str(result, "label")
+            eval_output_dir = Path(_require_result_str(result, "output_dir"))
+            prediction_path = eval_output_dir / "predictions.zarr"
+            if not prediction_path.exists():
+                raise FileNotFoundError(
+                    f"Expected saved predictions at {prediction_path} for post-train viz sweep"
+                )
+
+            with MultitonScope():
+                # Build a viz config that points its first run at this checkpoint's predictions,
+                # inheriting variables (and any extra runs) from the template.
+                template_cfg = VizConfig.from_yaml_and_cli(list(viz_config_args))
+                if not template_cfg.runs:
+                    raise ValueError(
+                        "post-train viz config must define at least one run so variables can be inferred"
+                    )
+                checkpoint_run = VizRunConfig(
+                    name=label,
+                    location=LocalLocation(path=prediction_path),
+                    variables=template_cfg.runs[0].variables,
+                )
+                updated = template_cfg.model_dump(mode="python")
+                updated["base_output_dir"] = eval_output_dir
+                updated["name"] = viz_dirname
+                updated["runs"] = [
+                    checkpoint_run.model_dump(mode="python"),
+                    *[run.model_dump(mode="python") for run in template_cfg.runs[1:]],
+                ]
+                cfg = VizConfig.model_validate(updated)
+
+                start = time.perf_counter()
+                run_viz(cfg)
+                elapsed_seconds = time.perf_counter() - start
+
+            result["viz"] = {
+                "output_dir": str(cfg.output_path),
+                "prediction_path": str(prediction_path),
+                "elapsed_seconds": elapsed_seconds,
+            }
+        _write_summary(results, sweep_root)
+
+    return results
+
+
+def run_post_train_checkpoint_sweep(
+    train_cfg: TrainConfig, checkpoint_paths: CheckpointPaths
+) -> list[dict[str, object]]:
+    if not train_cfg.post_train_eval.enabled:
+        return []
+
+    if train_cfg.post_train_eval.eval_config_path is None:
+        raise ValueError(
+            "post_train_eval.eval_config_path must be set when post_train_eval.enabled is true"
+        )
+
+    eval_config_path = Path(train_cfg.post_train_eval.eval_config_path).expanduser().resolve()
+    viz_config_args = None
+    if train_cfg.post_train_eval.viz_config_path is not None:
+        viz_config_path = (
+            Path(train_cfg.post_train_eval.viz_config_path).expanduser().resolve()
+        )
+        viz_config_args = (str(viz_config_path),)
+    return run_checkpoint_sweep(
+        eval_config_args=(str(eval_config_path),),
+        checkpoint_paths=checkpoint_paths,
+        data_root=train_cfg.experiment.data_root,
+        sweep_root=train_cfg.experiment.output_dir
+        / train_cfg.post_train_eval.eval_dirname,
+        viz_config_args=viz_config_args,
+        last_n_checkpoints=train_cfg.post_train_eval.last_n_checkpoints,
+        viz_dirname=train_cfg.post_train_eval.viz_dirname,
+    )
+
+
+def run_standalone_checkpoint_sweep(
+    eval_config_path: Path,
+    checkpoint_dir: Path,
+    eval_override_args: list[str] | None = None,
+    viz_config_path: Path | None = None,
+    last_n_checkpoints: int | None = None,
+) -> list[dict[str, object]]:
+    eval_config_args = (str(eval_config_path), *(eval_override_args or []))
+    eval_cfg = _load_eval_config(eval_config_args)
+    viz_config_args = (str(viz_config_path),) if viz_config_path is not None else None
+
+    eval_dirname_default = PostTrainCheckpointSweepConfig.model_fields["eval_dirname"].default
+    if not isinstance(eval_dirname_default, str):
+        raise TypeError("PostTrainCheckpointSweepConfig.eval_dirname must default to str")
+
+    return run_checkpoint_sweep(
+        eval_config_args=eval_config_args,
+        checkpoint_paths=CheckpointPaths(checkpoint_dir),
+        data_root=eval_cfg.experiment.data_root,
+        sweep_root=checkpoint_dir.parent / eval_dirname_default,
+        viz_config_args=viz_config_args,
+        last_n_checkpoints=last_n_checkpoints,
+        viz_dirname=_default_viz_dirname(),
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Run standalone inference sweeps for an existing saved_nets directory."
+    )
+    parser.add_argument("--config",
+        required=True,
+        help="Path to eval config YAML"
+    )
+    parser.add_argument(
+        "--viz_config",
+        required=True,
+        help="Path to viz config YAML to run after the eval sweep",
+    )
+    parser.add_argument(
+        "--checkpoint_dir",
+        required=True,
+        help="Path to a saved_nets directory from an old run",
+    )
+    parser.add_argument(
+        "--last_n_checkpoints",
+        type=int,
+        help="Optional limit to only evaluate the last N discovered checkpoints",
+    )
+    args, eval_override_args = parser.parse_known_args(argv)
+    
+    # Expand ~ in user-provided config paths before resolving them to absolute paths.
+    sweep_kwargs: dict[str, object] = {
+        "eval_config_path": Path(args.config).expanduser().resolve(),
+        "checkpoint_dir": Path(args.checkpoint_dir).expanduser().resolve(),
+        "eval_override_args": eval_override_args,
+        "viz_config_path": Path(args.viz_config).expanduser().resolve()
+    }
+    if args.last_n_checkpoints is not None:
+        sweep_kwargs["last_n_checkpoints"] = args.last_n_checkpoints
+
+    run_standalone_checkpoint_sweep(**sweep_kwargs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/samudra/post_train_eval.py
+++ b/src/samudra/post_train_eval.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import json
 import logging

--- a/src/samudra/post_train_eval.py
+++ b/src/samudra/post_train_eval.py
@@ -7,9 +7,10 @@ import json
 import logging
 import multiprocessing
 import queue as queue_module
-import re
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
+from multiprocessing.process import BaseProcess
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -24,66 +25,31 @@ if TYPE_CHECKING:
     from samudra.viz import VizTemplate
 
 logger = logging.getLogger(__name__)
+WORKER_TIMEOUT_SECONDS = 6 * 60 * 60
 
 
-@dataclass(frozen=True)
-class CheckpointEvalTarget:
-    epoch: int
-    kind: str
-    path: str
-    for_inference: bool
-
-
-def checkpoint_label(entry: CheckpointEvalTarget) -> str:
-    match entry.kind:
-        case "periodic":
-            return f"epoch_{entry.epoch:04d}"
-        case "ema_latest":
-            return "final_ema"
-        case _:
-            return f"{entry.kind}_epoch_{entry.epoch:04d}"
-
-
-def _entry_from_file(
-    checkpoint_path: Path,
-    kind: str,
-    *,
-    epoch: int | None = None,
-    for_inference: bool = False,
-) -> CheckpointEvalTarget:
-    if epoch is None:
-        # Read epoch from the checkpoint file itself.
-        checkpoint = torch.load(checkpoint_path, map_location="cpu")
-        epoch = checkpoint.get("epoch")
-        if not isinstance(epoch, int):
-            raise ValueError(
-                f"Checkpoint at {checkpoint_path} is missing integer epoch"
-            )
-    return CheckpointEvalTarget(
-        epoch=epoch,
-        kind=kind,
-        path=str(checkpoint_path),
-        for_inference=for_inference,
-    )
+def checkpoint_label(checkpoint_path: Path) -> str:
+    """Return the output label for a supported checkpoint filename."""
+    if checkpoint_path.name == CheckpointPaths.EMA_CHECKPOINT_NAME:
+        return "ema_latest"
+    epoch = CheckpointPaths.periodic_checkpoint_epoch(checkpoint_path)
+    if epoch is not None:
+        return f"epoch_{epoch:04d}"
+    raise ValueError(f"Unsupported checkpoint filename: {checkpoint_path.name}")
 
 
 def discover_checkpoints_from_directory(
     checkpoint_paths: CheckpointPaths,
     last_n_checkpoints: int | None = None,
     checkpoints: list[int] | None = None,
-) -> list[CheckpointEvalTarget]:
+) -> list[Path]:
     if last_n_checkpoints is not None and checkpoints is not None:
         raise ValueError("pass only one of last_n_checkpoints or checkpoints, not both")
     if last_n_checkpoints is not None and last_n_checkpoints < 1:
         raise ValueError(f"last_n_checkpoints must be >= 1, got {last_n_checkpoints}")
 
     checkpoint_dir = checkpoint_paths.checkpoint_dir
-    periodic: dict[int, Path] = {}
-    for path in checkpoint_dir.iterdir():
-        if not path.is_file():
-            continue
-        if match := re.match(r"^ckpt_(\d+)\.pt$", path.name):
-            periodic[int(match.group(1))] = path
+    periodic = checkpoint_paths.periodic_checkpoint_paths()
 
     if checkpoints is not None:
         # Evaluate exactly the requested epochs; fail loudly if any are missing.
@@ -92,45 +58,33 @@ def discover_checkpoints_from_directory(
             raise ValueError(
                 f"requested checkpoint epochs not found in {checkpoint_dir}: {missing}"
             )
-        targets = [
-            _entry_from_file(periodic[epoch], "periodic", epoch=epoch)
-            for epoch in sorted(set(checkpoints))
-        ]
+        targets = [periodic[epoch] for epoch in sorted(set(checkpoints))]
     else:
-        targets = [
-            _entry_from_file(path, "periodic", epoch=epoch)
-            for epoch, path in sorted(periodic.items())
-        ]
+        targets = [path for _, path in sorted(periodic.items())]
         if last_n_checkpoints is not None:
             targets = targets[-last_n_checkpoints:]
 
     # The final EMA checkpoint is always included in addition to the selected
     # periodic checkpoints.
     if checkpoint_paths.ema_checkpoint_path.exists():
-        targets.append(
-            _entry_from_file(
-                checkpoint_paths.ema_checkpoint_path,
-                "ema_latest",
-                for_inference=True,
-            )
-        )
+        targets.append(checkpoint_paths.ema_checkpoint_path)
 
     return targets
 
 
 def partition_checkpoint_work(
-    entries: list[CheckpointEvalTarget],
+    entries: list[Path],
     worker_count: int,
-) -> list[list[CheckpointEvalTarget]]:
+) -> list[list[Path]]:
     if worker_count < 1:
         raise ValueError("worker_count must be at least 1")
     return [entries[i::worker_count] for i in range(worker_count)]
 
 
-def _resolve_worker_count(
+def _resolve_workers(
     backend: str,
     num_checkpoints: int,
-) -> tuple[int, list[int]]:
+) -> list[torch.device]:
     wants_gpu = backend in {"auto", "cuda"}
     available_gpus = (
         torch.cuda.device_count() if wants_gpu and torch.cuda.is_available() else 0
@@ -139,14 +93,14 @@ def _resolve_worker_count(
         raise RuntimeError("post-train eval requested CUDA but no GPUs are available")
     if available_gpus == 0:
         logger.info("No GPUs available for post-train eval; falling back to serial CPU")
-        return 1, []
+        return [torch.device("cpu")]
 
     worker_count = max(1, min(num_checkpoints, available_gpus))
-    return worker_count, list(range(worker_count))
+    return [torch.device("cuda", index) for index in range(worker_count)]
 
 
-def _write_summary(results: list[dict[str, object]], sweep_root: Path) -> None:
-    summary_path = sweep_root / "summary.json"
+def _write_summary(results: list[dict[str, object]], sweep_output_dir: Path) -> None:
+    summary_path = sweep_output_dir / "summary.json"
     summary_path.write_text(
         json.dumps(results, indent=2, sort_keys=True),
         encoding="utf-8",
@@ -168,28 +122,26 @@ def _load_eval_config(
 
 
 def _run_single_checkpoint_eval(
-    entry: CheckpointEvalTarget,
+    checkpoint_path: Path,
     eval_config_path: Path,
     eval_override_args: tuple[str, ...],
-    sweep_root: Path,
-    data_root: Location | None,
-    gpu_index: int | None,
+    sweep_output_dir: Path,
+    data_root: ResolvedLocation,
+    device: torch.device,
 ) -> dict[str, object]:
     # Eval imports EvalConfig, so keep it out of this module's import path while
     # config.py is defining the CheckpointSweep builder.
     from samudra.eval import Eval
 
-    if gpu_index is not None:
-        torch.cuda.set_device(gpu_index)
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
 
     with MultitonScope():
         cfg = _load_eval_config(eval_config_path, eval_override_args)
-        cfg.ckpt_path = entry.path
-        cfg.experiment.base_output_dir = str(sweep_root)
-        cfg.experiment.name = checkpoint_label(entry)
-        if data_root is not None:
-            cfg.experiment.data_root = data_root
-        cfg.experiment.wandb.mode = "disabled"
+        cfg.ckpt_path = str(checkpoint_path)
+        cfg.experiment.base_output_dir = str(sweep_output_dir)
+        cfg.experiment.name = checkpoint_label(checkpoint_path)
+        cfg.experiment.data_root = cast(Location, data_root)
 
         evaluator = Eval(cfg)
         start = time.perf_counter()
@@ -208,11 +160,8 @@ def _run_single_checkpoint_eval(
                 serialized[key] = value
 
         return {
-            "checkpoint_kind": entry.kind,
-            "checkpoint_epoch": entry.epoch,
-            "checkpoint_path": entry.path,
-            "for_inference": entry.for_inference,
-            "label": checkpoint_label(entry),
+            "checkpoint_path": str(checkpoint_path),
+            "label": checkpoint_label(checkpoint_path),
             "output_dir": str(cfg.experiment.output_dir),
             "elapsed_seconds": elapsed_seconds,
             "metrics": serialized,
@@ -220,35 +169,30 @@ def _run_single_checkpoint_eval(
 
 
 def _run_single_checkpoint_viz(
-    result: dict[str, object],
+    label: str,
+    eval_output_dir: Path,
     template: "VizTemplate",
     steps: list[str],
     viz_dirname: str,
 ) -> dict[str, object]:
     # Viz config imports TimeConfig, so these need to stay off config.py's
     # module initialization path.
-    from samudra.viz.config import VizRunConfig, run_steps
+    from samudra.viz.config import run_steps
 
-    label = cast(str, result["label"])
-    eval_output_dir = Path(cast(str, result["output_dir"]))
     prediction_path = eval_output_dir / "predictions.zarr"
     if not prediction_path.exists():
         raise FileNotFoundError(
             f"Expected saved predictions at {prediction_path} for post-train viz sweep"
         )
 
-    checkpoint_run = VizRunConfig(
-        name=label,
-        location=LocalLocation(path=prediction_path.resolve()),
-        variables=template.variables,
-    )
     output_path = eval_output_dir / viz_dirname
     output_path.mkdir(parents=True, exist_ok=True)
 
     start = time.perf_counter()
-    viz = template.instantiate(
+    viz = template.instantiate_run(
         output_path,
-        [checkpoint_run.build(template.data_root)],
+        label,
+        LocalLocation(path=prediction_path.resolve()),
     )
     run_steps(viz, steps)
     elapsed_seconds = time.perf_counter() - start
@@ -261,44 +205,67 @@ def _run_single_checkpoint_viz(
 
 
 def _worker_main(
-    entries: list[CheckpointEvalTarget],
+    entries: list[Path],
     eval_config_path: Path,
     eval_override_args: tuple[str, ...],
-    sweep_root: str,
-    data_root: Location | None,
-    gpu_index: int | None,
+    sweep_output_dir: Path,
+    data_root: ResolvedLocation,
+    device: torch.device,
     queue: multiprocessing.Queue,
 ) -> None:
     try:
-        for entry in entries:
+        for checkpoint_path in entries:
             queue.put(
                 _run_single_checkpoint_eval(
-                    entry=entry,
+                    checkpoint_path=checkpoint_path,
                     eval_config_path=eval_config_path,
                     eval_override_args=eval_override_args,
-                    sweep_root=Path(sweep_root),
+                    sweep_output_dir=sweep_output_dir,
                     data_root=data_root,
-                    gpu_index=gpu_index,
+                    device=device,
                 )
             )
     except Exception as exc:
-        queue.put({"error": str(exc), "gpu_index": gpu_index})
+        exc.add_note(
+            f"checkpoint sweep worker on {device} failed for {checkpoint_path}"
+        )
+        queue.put(exc)
         raise
+
+
+def _terminate_workers(processes: Sequence[BaseProcess]) -> None:
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+    for process in processes:
+        process.join()
 
 
 @dataclass(frozen=True)
 class CheckpointSweep:
-    """Ready-to-run checkpoint sweep built from configuration."""
+    """Configuration for running a checkpoint evaluation sweep."""
 
     eval_config_path: Path
     checkpoint_paths: CheckpointPaths
+    data_root: ResolvedLocation
+    sweep_output_dir: Path
     eval_override_args: tuple[str, ...] = ()
-    data_root: Location | None = None
-    sweep_root: Path | None = None
     viz_config_path: Path | None = None
     last_n_checkpoints: int | None = None
     checkpoints: list[int] | None = None
     viz_dirname: str = "viz"
+
+    def __post_init__(self) -> None:
+        eval_cfg = _load_eval_config(self.eval_config_path, self.eval_override_args)
+        if self.viz_config_path is not None:
+            if not eval_cfg.save_zarr:
+                raise ValueError(
+                    "post-train viz sweep requires eval.save_zarr = true so "
+                    "predictions.zarr is written"
+                )
+            from samudra.viz import VizTemplateConfig
+
+            VizTemplateConfig.from_yaml(self.viz_config_path)
 
     def run(self) -> list[dict[str, object]]:
         return run_checkpoint_sweep(
@@ -306,7 +273,7 @@ class CheckpointSweep:
             checkpoint_paths=self.checkpoint_paths,
             eval_override_args=self.eval_override_args,
             data_root=self.data_root,
-            sweep_root=self.sweep_root,
+            sweep_output_dir=self.sweep_output_dir,
             viz_config_path=self.viz_config_path,
             last_n_checkpoints=self.last_n_checkpoints,
             checkpoints=self.checkpoints,
@@ -317,9 +284,9 @@ class CheckpointSweep:
 def run_checkpoint_sweep(
     eval_config_path: Path,
     checkpoint_paths: CheckpointPaths,
+    data_root: ResolvedLocation,
+    sweep_output_dir: Path,
     eval_override_args: tuple[str, ...] = (),
-    data_root: Location | None = None,
-    sweep_root: Path | None = None,
     viz_config_path: Path | None = None,
     last_n_checkpoints: int | None = None,
     checkpoints: list[int] | None = None,
@@ -335,104 +302,84 @@ def run_checkpoint_sweep(
         return []
 
     eval_cfg = _load_eval_config(eval_config_path, eval_override_args)
-    if sweep_root is None:
-        sweep_root = checkpoint_paths.checkpoint_dir.parent / eval_cfg.experiment.name
-    sweep_root.mkdir(parents=True, exist_ok=True)
+    sweep_output_dir.mkdir(parents=True, exist_ok=True)
 
-    if viz_config_path is not None and not eval_cfg.save_zarr:
-        raise ValueError(
-            "post-train viz sweep requires eval.save_zarr = true so predictions.zarr is written"
-        )
-
-    worker_count, gpu_indices = _resolve_worker_count(eval_cfg.backend, len(targets))
+    worker_devices = _resolve_workers(eval_cfg.backend, len(targets))
 
     logger.info(
         "Running checkpoint sweep for %d checkpoints with %d worker(s)",
         len(targets),
-        worker_count,
+        len(worker_devices),
     )
 
+    ctx = multiprocessing.get_context("spawn")
+    queue: multiprocessing.Queue = ctx.Queue()
+    processes = []
+    shards = partition_checkpoint_work(targets, len(worker_devices))
+    for device, shard in zip(worker_devices, shards, strict=True):
+        process = ctx.Process(
+            target=_worker_main,
+            args=(
+                shard,
+                eval_config_path,
+                eval_override_args,
+                sweep_output_dir,
+                data_root,
+                device,
+                queue,
+            ),
+        )
+        process.start()
+        processes.append(process)
+
     results: list[dict[str, object]] = []
-    if worker_count == 1:
-        gpu_index = gpu_indices[0] if gpu_indices else None
-        for entry in targets:
-            results.append(
-                _run_single_checkpoint_eval(
-                    entry=entry,
-                    eval_config_path=eval_config_path,
-                    eval_override_args=eval_override_args,
-                    sweep_root=sweep_root,
-                    data_root=data_root,
-                    gpu_index=gpu_index,
-                )
+    deadline = time.monotonic() + WORKER_TIMEOUT_SECONDS
+    while len(results) < len(targets):
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            _terminate_workers(processes)
+            raise TimeoutError(
+                f"checkpoint sweep exceeded {WORKER_TIMEOUT_SECONDS} seconds"
             )
-    else:
-        ctx = multiprocessing.get_context("spawn")
-        queue: multiprocessing.Queue = ctx.Queue()
-        processes = []
-        shards = partition_checkpoint_work(targets, worker_count)
-        for gpu_index, shard in zip(gpu_indices, shards, strict=True):
-            process = ctx.Process(
-                target=_worker_main,
-                args=(
-                    shard,
-                    eval_config_path,
-                    eval_override_args,
-                    str(sweep_root),
-                    data_root,
-                    gpu_index,
-                    queue,
-                ),
+        try:
+            item = queue.get(timeout=min(30, remaining_seconds))
+        except queue_module.Empty:
+            for process in processes:
+                if process.exitcode not in {None, 0}:
+                    _terminate_workers(processes)
+                    raise RuntimeError(
+                        f"checkpoint sweep worker exited with status {process.exitcode}"
+                    )
+            continue
+        if isinstance(item, Exception):
+            _terminate_workers(processes)
+            raise item
+        results.append(item)
+
+    for process in processes:
+        process.join()
+        if process.exitcode != 0:
+            raise RuntimeError(
+                f"checkpoint sweep worker exited with status {process.exitcode}"
             )
-            process.start()
-            processes.append(process)
 
-        while len(results) < len(targets):
-            try:
-                item = queue.get(timeout=30)
-            except queue_module.Empty:
-                for process in processes:
-                    if process.exitcode not in {None, 0}:
-                        raise RuntimeError(
-                            f"checkpoint sweep worker exited with status {process.exitcode}"
-                        )
-                continue
-            if "error" in item:
-                for process in processes:
-                    if process.is_alive():
-                        process.terminate()
-                    process.join()
-                raise RuntimeError(
-                    f"checkpoint sweep worker failed on gpu {item['gpu_index']}: {item['error']}"
-                )
-            results.append(item)
-
-        for process in processes:
-            process.join()
-            if process.exitcode != 0:
-                raise RuntimeError(
-                    f"checkpoint sweep worker exited with status {process.exitcode}"
-                )
-
-    _write_summary(results, sweep_root)
+    _write_summary(results, sweep_output_dir)
 
     if viz_config_path is not None:
         from samudra.viz import VizTemplateConfig
 
         logger.info("Running post-train viz sweep for %d checkpoints", len(results))
         template_cfg = VizTemplateConfig.from_yaml(viz_config_path)
-        default_data_root: ResolvedLocation = LocalLocation(path=Path.cwd())
-        if data_root is not None:
-            default_data_root = default_data_root.resolve(data_root)
-        template = template_cfg.build_template(default_data_root)
+        template = template_cfg.build_template(data_root)
         for result in results:
             result["viz"] = _run_single_checkpoint_viz(
-                result,
+                cast(str, result["label"]),
+                Path(cast(str, result["output_dir"])),
                 template,
                 template_cfg.selected_steps,
                 viz_dirname=viz_dirname,
             )
-        _write_summary(results, sweep_root)
+        _write_summary(results, sweep_output_dir)
 
     return results
 
@@ -440,14 +387,18 @@ def run_checkpoint_sweep(
 def run_standalone_checkpoint_sweep(
     eval_config_path: Path,
     checkpoint_dir: Path,
+    output_dir: Path,
     eval_override_args: list[str] | None = None,
     viz_config_path: Path | None = None,
     last_n_checkpoints: int | None = None,
     checkpoints: list[int] | None = None,
 ) -> list[dict[str, object]]:
+    eval_cfg = _load_eval_config(eval_config_path, tuple(eval_override_args or []))
     return CheckpointSweep(
         eval_config_path=eval_config_path,
         checkpoint_paths=CheckpointPaths(checkpoint_dir),
+        data_root=eval_cfg.experiment.resolved_data_root,
+        sweep_output_dir=output_dir,
         eval_override_args=tuple(eval_override_args or []),
         viz_config_path=viz_config_path,
         last_n_checkpoints=last_n_checkpoints,
@@ -473,6 +424,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Path to a saved_nets directory from an old run",
     )
     parser.add_argument(
+        "--output_dir",
+        required=True,
+        help="Directory for checkpoint evaluation outputs and summary.json",
+    )
+    parser.add_argument(
         "--last_n_checkpoints",
         type=int,
         help="Optional limit to only evaluate the last N discovered checkpoints",
@@ -486,15 +442,11 @@ def main(argv: list[str] | None = None) -> None:
     )
     args, eval_override_args = parser.parse_known_args(argv)
 
-    # Expand ~ in user-provided config paths before resolving them to absolute paths.
-    viz_config_path = (
-        Path(args.viz_config).expanduser().resolve()
-        if args.viz_config is not None
-        else None
-    )
+    viz_config_path = Path(args.viz_config) if args.viz_config is not None else None
     run_standalone_checkpoint_sweep(
-        eval_config_path=Path(args.config).expanduser().resolve(),
+        eval_config_path=Path(args.config),
         checkpoint_dir=Path(args.checkpoint_dir).expanduser().resolve(),
+        output_dir=Path(args.output_dir).expanduser().resolve(),
         eval_override_args=eval_override_args,
         viz_config_path=viz_config_path,
         last_n_checkpoints=args.last_n_checkpoints,

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -1414,6 +1414,9 @@ class Trainer:
         finally:
             self._ema.restore(parameters=self.model.parameters())
 
+    def finish(self):
+        self.wandb_logger.finish()
+
 
 def run_training(cfg: TrainConfig) -> None:
     trainer = Trainer(cfg)

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -530,7 +530,7 @@ class Trainer:
         total_time = time.perf_counter() - start_time
         total_time_str = str(datetime.timedelta(seconds=int(total_time)))
         logger.info(f"Training time {total_time_str}")
-        self.finish()
+        self.wandb_logger.finish()
 
     def probe_optimizer_step(self) -> None:
         """Exercise the real loader and training path through one optimizer update."""
@@ -1414,54 +1414,29 @@ class Trainer:
         finally:
             self._ema.restore(parameters=self.model.parameters())
 
-    def finish(self):
-        self.wandb_logger.finish()
-        # Capture rank-0 status before tearing down the process group: once the
-        # group is destroyed, is_main_process() returns True on *every* rank
-        # (get_rank() falls back to 0 when distributed is not initialized), which
-        # would make all ranks launch the sweep concurrently and collide.
-        main_process = is_main_process()
-        if self.post_train_sweep is not None:
-            self._release_train_state()
-        if self.distributed is not None:
-            # Make sure every rank has finished training before rank 0 starts the
-            # post-train sweep, which claims every GPU via its own subprocesses.
-            # Tearing down the process group lets the non-main ranks exit and free
-            # their GPUs (and avoids the "destroy_process_group() was not called"
-            # warning at interpreter shutdown).
-            torch.distributed.barrier()
-            torch.distributed.destroy_process_group()
-        if main_process and self.post_train_sweep is not None:
-            self.post_train_sweep.run()
 
-    def _release_train_state(self) -> None:
-        # seems to be working for clearing gpu memory in tests
-        for attr in (
-            "model",
-            "optimizer",
-            "scheduler",
-            "_ema",
-            "loss_fn",
-            "train_loader",
-            "val_loader",
-            "inference_loader",
-            "train_sampler",
-            "val_sampler",
-            "inference_sampler",
-            "data_container",
-            "primary_src",
-            "inference_src",
-            "tensor_map",
-            "normalize",
-            "profiler",
-        ):
-            if hasattr(self, attr):
-                delattr(self, attr)
-        # collect the cpu pointers from python
-        gc.collect()
-        # clear the gpu memory
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
+def run_training(cfg: TrainConfig) -> None:
+    trainer = Trainer(cfg)
+    trainer.run()
+
+    # Keep only the lightweight orchestration state, then drop the whole trainer
+    # so future GPU-owning fields do not need to be added to a cleanup list.
+    main_process = is_main_process()
+    distributed = trainer.distributed is not None
+    post_train_sweep = trainer.post_train_sweep if main_process else None
+    del trainer
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    if distributed:
+        # Every rank releases its training state before rank 0 claims the GPUs for
+        # the post-training sweep.
+        torch.distributed.barrier()
+        torch.distributed.destroy_process_group()
+
+    if post_train_sweep is not None:
+        post_train_sweep.run()
 
 
 def main():
@@ -1472,10 +1447,8 @@ def main():
     handle_logging(cfg.debug, cfg.experiment.output_dir)
     handle_warnings()
 
-    trainer = Trainer(cfg)
-
     try:
-        trainer.run()
+        run_training(cfg)
     except Exception as e:
         logger.exception("Training failed with an exception")
         raise e

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -114,6 +114,7 @@ class Trainer:
     def __init__(self, cfg: TrainConfig) -> None:
         cfg.prepare_output_dirs()
         cfg.save_yaml(cfg.experiment.output_dir / "config.yaml")
+        self.cfg = cfg
         # Backend
         self.device, self.distributed = init_train_backend(cfg.backend)
 
@@ -1410,7 +1411,7 @@ class Trainer:
     def finish(self):
         self.wandb_logger.finish()
         if is_main_process():
-            run_post_train_checkpoint_sweep(self.post_train_eval, self.ckpt_paths)
+            run_post_train_checkpoint_sweep(self.cfg, self.ckpt_paths)
 
 
 def main():

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -1410,6 +1410,11 @@ class Trainer:
 
     def finish(self):
         self.wandb_logger.finish()
+        # Capture rank-0 status before tearing down the process group: once the
+        # group is destroyed, is_main_process() returns True on *every* rank
+        # (get_rank() falls back to 0 when distributed is not initialized), which
+        # would make all ranks launch the sweep concurrently and collide.
+        main_process = is_main_process()
         if self.distributed is not None:
             # Make sure every rank has finished training before rank 0 starts the
             # post-train sweep, which claims every GPU via its own subprocesses.
@@ -1418,7 +1423,7 @@ class Trainer:
             # warning at interpreter shutdown).
             torch.distributed.barrier()
             torch.distributed.destroy_process_group()
-        if is_main_process():
+        if main_process:
             run_post_train_checkpoint_sweep(self.cfg, self.ckpt_paths)
 
 

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -115,10 +115,14 @@ class Trainer:
     def __init__(self, cfg: TrainConfig) -> None:
         cfg.prepare_output_dirs()
         cfg.save_yaml(cfg.experiment.output_dir / "config.yaml")
-        self.post_train_sweep: CheckpointSweep | None = cfg.post_train_eval.build(
-            nets_dir=cfg.experiment.nets_dir,
-            output_dir=cfg.experiment.output_dir,
-            data_root=cfg.experiment.data_root,
+        self.post_train_sweep: CheckpointSweep | None = (
+            cfg.post_train_eval.build(
+                nets_dir=cfg.experiment.nets_dir,
+                output_dir=cfg.experiment.output_dir,
+                data_root=cfg.experiment.resolved_data_root,
+            )
+            if cfg.post_train_eval is not None
+            else None
         )
         # Backend
         self.device, self.distributed = init_train_backend(cfg.backend)

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import datetime
+import gc
 import logging
 import math
 import multiprocessing
@@ -51,7 +52,7 @@ from samudra.datasets import (
     TorchTrainDataset,
 )
 from samudra.models.base import BaseModel
-from samudra.post_train_eval import run_post_train_checkpoint_sweep
+from samudra.post_train_eval import CheckpointSweep
 from samudra.stepper import (
     TrainBatchOutput,
     ValBatchOutput,
@@ -114,7 +115,11 @@ class Trainer:
     def __init__(self, cfg: TrainConfig) -> None:
         cfg.prepare_output_dirs()
         cfg.save_yaml(cfg.experiment.output_dir / "config.yaml")
-        self.cfg = cfg
+        self.post_train_sweep: CheckpointSweep | None = cfg.post_train_eval.build(
+            nets_dir=cfg.experiment.nets_dir,
+            output_dir=cfg.experiment.output_dir,
+            data_root=cfg.experiment.data_root,
+        )
         # Backend
         self.device, self.distributed = init_train_backend(cfg.backend)
 
@@ -363,9 +368,6 @@ class Trainer:
         self.train_loader: BatchLoader
         self.val_loader: BatchLoader
         self.inference_loader: DataLoader[ModelBatch]
-
-        # post training evaluation
-        self.post_train_eval = cfg.post_train_eval
 
     def init_inference_stores(self):
         assert self.inference_source is not None
@@ -1415,6 +1417,8 @@ class Trainer:
         # (get_rank() falls back to 0 when distributed is not initialized), which
         # would make all ranks launch the sweep concurrently and collide.
         main_process = is_main_process()
+        if self.post_train_sweep is not None:
+            self._release_train_state()
         if self.distributed is not None:
             # Make sure every rank has finished training before rank 0 starts the
             # post-train sweep, which claims every GPU via its own subprocesses.
@@ -1423,8 +1427,37 @@ class Trainer:
             # warning at interpreter shutdown).
             torch.distributed.barrier()
             torch.distributed.destroy_process_group()
-        if main_process:
-            run_post_train_checkpoint_sweep(self.cfg, self.ckpt_paths)
+        if main_process and self.post_train_sweep is not None:
+            self.post_train_sweep.run()
+
+    def _release_train_state(self) -> None:
+        # seems to be working for clearing gpu memory in tests
+        for attr in (
+            "model",
+            "optimizer",
+            "scheduler",
+            "_ema",
+            "loss_fn",
+            "train_loader",
+            "val_loader",
+            "inference_loader",
+            "train_sampler",
+            "val_sampler",
+            "inference_sampler",
+            "data_container",
+            "primary_src",
+            "inference_src",
+            "tensor_map",
+            "normalize",
+            "profiler",
+        ):
+            if hasattr(self, attr):
+                delattr(self, attr)
+        # collect the cpu pointers from python
+        gc.collect()
+        # clear the gpu memory
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
 
 def main():

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -364,7 +364,7 @@ class Trainer:
         self.val_loader: BatchLoader
         self.inference_loader: DataLoader[ModelBatch]
 
-        #post training evaluation
+        # post training evaluation
         self.post_train_eval = cfg.post_train_eval
 
     def init_inference_stores(self):
@@ -1410,6 +1410,14 @@ class Trainer:
 
     def finish(self):
         self.wandb_logger.finish()
+        if self.distributed is not None:
+            # Make sure every rank has finished training before rank 0 starts the
+            # post-train sweep, which claims every GPU via its own subprocesses.
+            # Tearing down the process group lets the non-main ranks exit and free
+            # their GPUs (and avoids the "destroy_process_group() was not called"
+            # warning at interpreter shutdown).
+            torch.distributed.barrier()
+            torch.distributed.destroy_process_group()
         if is_main_process():
             run_post_train_checkpoint_sweep(self.cfg, self.ckpt_paths)
 

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -51,6 +51,7 @@ from samudra.datasets import (
     TorchTrainDataset,
 )
 from samudra.models.base import BaseModel
+from samudra.post_train_eval import run_post_train_checkpoint_sweep
 from samudra.stepper import (
     TrainBatchOutput,
     ValBatchOutput,
@@ -113,7 +114,6 @@ class Trainer:
     def __init__(self, cfg: TrainConfig) -> None:
         cfg.prepare_output_dirs()
         cfg.save_yaml(cfg.experiment.output_dir / "config.yaml")
-
         # Backend
         self.device, self.distributed = init_train_backend(cfg.backend)
 
@@ -362,6 +362,9 @@ class Trainer:
         self.train_loader: BatchLoader
         self.val_loader: BatchLoader
         self.inference_loader: DataLoader[ModelBatch]
+
+        #post training evaluation
+        self.post_train_eval = cfg.post_train_eval
 
     def init_inference_stores(self):
         assert self.inference_source is not None
@@ -1406,6 +1409,8 @@ class Trainer:
 
     def finish(self):
         self.wandb_logger.finish()
+        if is_main_process():
+            run_post_train_checkpoint_sweep(self.post_train_eval, self.ckpt_paths)
 
 
 def main():

--- a/src/samudra/utils/train.py
+++ b/src/samudra/utils/train.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import re
 from collections.abc import Sequence
 from itertools import tee
 from pathlib import Path
@@ -51,7 +50,7 @@ def collate_inference_data(
 
 
 class CheckpointPaths:
-    _PERIODIC_CHECKPOINT_PATTERN = re.compile(r"^ckpt_(\d+)\.pt$")
+    _PERIODIC_CHECKPOINT_PREFIX = "ckpt_"
     EMA_CHECKPOINT_NAME = "ema_ckpt.pt"
 
     def __init__(self, checkpoint_dir: Path):
@@ -75,8 +74,12 @@ class CheckpointPaths:
 
     @classmethod
     def periodic_checkpoint_epoch(cls, checkpoint_path: Path) -> int | None:
-        match = cls._PERIODIC_CHECKPOINT_PATTERN.fullmatch(checkpoint_path.name)
-        return int(match.group(1)) if match is not None else None
+        if checkpoint_path.suffix != ".pt" or not checkpoint_path.stem.startswith(
+            cls._PERIODIC_CHECKPOINT_PREFIX
+        ):
+            return None
+        epoch = checkpoint_path.stem.removeprefix(cls._PERIODIC_CHECKPOINT_PREFIX)
+        return int(epoch) if epoch.isdecimal() else None
 
     @property
     def best_inference_checkpoint_path(self) -> Path:

--- a/src/samudra/utils/train.py
+++ b/src/samudra/utils/train.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from collections.abc import Sequence
 from itertools import tee
 from pathlib import Path
@@ -50,6 +51,9 @@ def collate_inference_data(
 
 
 class CheckpointPaths:
+    _PERIODIC_CHECKPOINT_PATTERN = re.compile(r"^ckpt_(\d+)\.pt$")
+    EMA_CHECKPOINT_NAME = "ema_ckpt.pt"
+
     def __init__(self, checkpoint_dir: Path):
         self.checkpoint_dir = checkpoint_dir
 
@@ -60,13 +64,27 @@ class CheckpointPaths:
     def latest_checkpoint_path_with_epoch(self, epoch: int) -> Path:
         return self.checkpoint_dir / f"ckpt_{epoch}.pt"
 
+    def periodic_checkpoint_paths(self) -> dict[int, Path]:
+        """Return periodic checkpoints indexed by epoch."""
+        return {
+            epoch: path
+            for path in self.checkpoint_dir.iterdir()
+            if path.is_file()
+            and (epoch := self.periodic_checkpoint_epoch(path)) is not None
+        }
+
+    @classmethod
+    def periodic_checkpoint_epoch(cls, checkpoint_path: Path) -> int | None:
+        match = cls._PERIODIC_CHECKPOINT_PATTERN.fullmatch(checkpoint_path.name)
+        return int(match.group(1)) if match is not None else None
+
     @property
     def best_inference_checkpoint_path(self) -> Path:
         return self.checkpoint_dir / "best_inference_ckpt.pt"
 
     @property
     def ema_checkpoint_path(self) -> Path:
-        return self.checkpoint_dir / "ema_ckpt.pt"
+        return self.checkpoint_dir / self.EMA_CHECKPOINT_NAME
 
     @property
     def best_validation_checkpoint_path(self) -> Path:

--- a/src/samudra/viz/__init__.py
+++ b/src/samudra/viz/__init__.py
@@ -3,6 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from samudra.viz.config import VizConfig
-from samudra.viz.core import Viz, VizRun
+from samudra.viz.core import (
+    PreparedVizGroundtruth,
+    Viz,
+    VizRun,
+    prepare_viz_groundtruth,
+)
 
-__all__ = ["Viz", "VizConfig", "VizRun"]
+__all__ = [
+    "PreparedVizGroundtruth",
+    "Viz",
+    "VizConfig",
+    "VizRun",
+    "prepare_viz_groundtruth",
+]

--- a/src/samudra/viz/__init__.py
+++ b/src/samudra/viz/__init__.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from samudra.viz.config import VizConfig
+from samudra.viz.config import VizConfig, VizTemplateConfig
 from samudra.viz.core import (
     PreparedVizGroundtruth,
     Viz,
     VizRun,
+    VizTemplate,
     prepare_viz_groundtruth,
 )
 
@@ -15,5 +16,7 @@ __all__ = [
     "Viz",
     "VizConfig",
     "VizRun",
+    "VizTemplate",
+    "VizTemplateConfig",
     "prepare_viz_groundtruth",
 ]

--- a/src/samudra/viz/config.py
+++ b/src/samudra/viz/config.py
@@ -51,14 +51,13 @@ VizStep = Annotated[
 ]
 
 
-def default_viz_variables() -> list[str]:
-    return ["thetao", "so", "uo", "vo", "tos", "zos"]
+DEFAULT_VIZ_VARIABLES = ("thetao", "so", "uo", "vo", "tos", "zos")
 
 
 class VizRunConfig(BaseModel):
     name: str
     location: Location
-    variables: list[str] = Field(default_factory=default_viz_variables)
+    variables: list[str] = Field(default_factory=lambda: list(DEFAULT_VIZ_VARIABLES))
 
     def build(self, data_root: ResolvedLocation) -> VizRun:
         return VizRun(
@@ -72,7 +71,7 @@ class VizTemplateConfig(TopLevelConfig):
     base_output_dir: Path
     dataset_name: str
     # Return a fresh default variable list for each config instance.
-    variables: list[str] = Field(default_factory=default_viz_variables)
+    variables: list[str] = Field(default_factory=lambda: list(DEFAULT_VIZ_VARIABLES))
     data_root: Location | None = None
     data: DataConfig | None = Field(
         default=None,

--- a/src/samudra/viz/config.py
+++ b/src/samudra/viz/config.py
@@ -161,7 +161,7 @@ class VizConfig(TopLevelConfig):
 logger = logging.getLogger(__name__)
 
 
-def _run_with_prepared_groundtruth(
+def run_with_prepared_groundtruth(
     cfg: VizConfig,
     prepared_groundtruth: PreparedVizGroundtruth,
 ):
@@ -190,14 +190,7 @@ def _run_with_prepared_groundtruth(
 def main(cfg: VizConfig):
     default_root = LocalLocation(path=Path.cwd())
     prepared_groundtruth = cfg.prepare_groundtruth(default_root)
-    _run_with_prepared_groundtruth(cfg, prepared_groundtruth)
-
-
-def run_with_prepared_groundtruth(
-    cfg: VizConfig,
-    prepared_groundtruth: PreparedVizGroundtruth,
-):
-    _run_with_prepared_groundtruth(cfg, prepared_groundtruth)
+    run_with_prepared_groundtruth(cfg, prepared_groundtruth)
 
 
 def _run_step(viz: Viz, step: VizStep):

--- a/src/samudra/viz/config.py
+++ b/src/samudra/viz/config.py
@@ -19,6 +19,7 @@ from samudra.viz.core import (
     PreparedVizGroundtruth,
     Viz,
     VizRun,
+    VizTemplate,
     prepare_viz_groundtruth,
 )
 
@@ -50,12 +51,14 @@ VizStep = Annotated[
 ]
 
 
+def default_viz_variables() -> list[str]:
+    return ["thetao", "so", "uo", "vo", "tos", "zos"]
+
+
 class VizRunConfig(BaseModel):
     name: str
     location: Location
-    variables: list[str] = Field(
-        default_factory=lambda: ["thetao", "so", "uo", "vo", "tos", "zos"]
-    )
+    variables: list[str] = Field(default_factory=default_viz_variables)
 
     def build(self, data_root: ResolvedLocation) -> VizRun:
         return VizRun(
@@ -65,11 +68,11 @@ class VizRunConfig(BaseModel):
         )
 
 
-class VizConfig(TopLevelConfig):
+class VizTemplateConfig(TopLevelConfig):
     base_output_dir: Path
-    name: str
     dataset_name: str
-    runs: list[VizRunConfig]
+    # Return a fresh default variable list for each config instance.
+    variables: list[str] = Field(default_factory=default_viz_variables)
     data_root: Location | None = None
     data: DataConfig | None = Field(
         default=None,
@@ -106,10 +109,6 @@ class VizConfig(TopLevelConfig):
     )
     debug: bool = Field(default=False, description="")
 
-    @cached_property
-    def output_path(self) -> Path:
-        return Path(self.base_output_dir) / self.name
-
     def _groundtruth_location(self) -> Location:
         """Ground-truth location: explicit if given, else the primary data source."""
         if self.groundtruth_location is not None:
@@ -141,43 +140,41 @@ class VizConfig(TopLevelConfig):
             self.groundtruth_time_range.time_slice,
         )
 
-    def build(
-        self,
-        default_root: ResolvedLocation,
-        prepared_groundtruth: PreparedVizGroundtruth,
-    ) -> Viz:
+    @property
+    def selected_steps(self) -> list[VizStep]:
+        return [s for s in self.steps or _ordered_steps() if s not in self.not_steps]
+
+    def build_template(self, default_root: ResolvedLocation) -> VizTemplate:
         data_root = self._data_root(default_root)
-        return Viz(
-            # TODO(jder): change to Path
-            str(self.output_path),
-            self.dataset_name,
-            [run.build(data_root) for run in self.runs],
-            prepared_groundtruth=prepared_groundtruth,
-            observations=self.observations,
+        return VizTemplate(
+            dataset_name=self.dataset_name,
             data_root=data_root,
+            variables=self.variables,
+            prepared_groundtruth=self.prepare_groundtruth(default_root),
+            observations=self.observations,
+        )
+
+
+class VizConfig(VizTemplateConfig):
+    name: str
+    runs: list[VizRunConfig]
+
+    @cached_property
+    def output_path(self) -> Path:
+        return Path(self.base_output_dir) / self.name
+
+    def build(self, default_root: ResolvedLocation) -> Viz:
+        template = self.build_template(default_root)
+        return template.instantiate(
+            self.output_path,
+            [run.build(template.data_root) for run in self.runs],
         )
 
 
 logger = logging.getLogger(__name__)
 
 
-def run_with_prepared_groundtruth(
-    cfg: VizConfig,
-    prepared_groundtruth: PreparedVizGroundtruth,
-):
-    cfg.output_path.mkdir(parents=True, exist_ok=True)
-    handle_logging(cfg.debug, cfg.output_path)
-    cfg.save_yaml(cfg.output_path / "config.yaml")
-
-    logger.info(f"Writing results to {cfg.output_path}")
-
-    default_root = LocalLocation(path=Path.cwd())
-    viz = cfg.build(
-        default_root,
-        prepared_groundtruth=prepared_groundtruth,
-    )
-
-    steps = [s for s in cfg.steps or _ordered_steps() if s not in cfg.not_steps]
+def run_steps(viz: Viz, steps: list[VizStep]) -> None:
     logger.info(f"Running steps: {', '.join(steps)}")
 
     # TODO(jder): could use a ProcessPoolExecutor here, but steps currently
@@ -188,9 +185,14 @@ def run_with_prepared_groundtruth(
 
 
 def main(cfg: VizConfig):
-    default_root = LocalLocation(path=Path.cwd())
-    prepared_groundtruth = cfg.prepare_groundtruth(default_root)
-    run_with_prepared_groundtruth(cfg, prepared_groundtruth)
+    cfg.output_path.mkdir(parents=True, exist_ok=True)
+    handle_logging(cfg.debug, cfg.output_path)
+    cfg.save_yaml(cfg.output_path / "config.yaml")
+
+    logger.info(f"Writing results to {cfg.output_path}")
+
+    viz = cfg.build(LocalLocation(path=Path.cwd()))
+    run_steps(viz, cfg.selected_steps)
 
 
 def _run_step(viz: Viz, step: VizStep):

--- a/src/samudra/viz/config.py
+++ b/src/samudra/viz/config.py
@@ -15,7 +15,12 @@ from samudra.config import DataConfig, ObsMetricsConfig, Om4TimeConfig
 from samudra.config_base import TopLevelConfig
 from samudra.utils.location import LocalLocation, Location, ResolvedLocation
 from samudra.utils.logging import handle_logging
-from samudra.viz.core import Viz, VizRun
+from samudra.viz.core import (
+    PreparedVizGroundtruth,
+    Viz,
+    VizRun,
+    prepare_viz_groundtruth,
+)
 
 
 @functools.cache
@@ -116,24 +121,38 @@ class VizConfig(TopLevelConfig):
             "data source (e.g. --data @data/om4_demo.yaml)."
         )
 
-    def build(self, default_root: ResolvedLocation) -> Viz:
+    def _data_root(self, default_root: ResolvedLocation) -> ResolvedLocation:
         if self.data_root is None:
-            data_root = default_root
-        else:
-            data_root = default_root.resolve(self.data_root)
+            return default_root
+        return default_root.resolve(self.data_root)
 
+    def prepare_groundtruth(
+        self,
+        default_root: ResolvedLocation,
+    ) -> PreparedVizGroundtruth:
+        data_root = self._data_root(default_root)
         groundtruth_rollout = data_root.resolve(self._groundtruth_location()).open(
             chunks={}
         )
+        return prepare_viz_groundtruth(
+            self.dataset_name,
+            data_root.resolve(self.basins_location).open(),
+            groundtruth_rollout,
+            self.groundtruth_time_range.time_slice,
+        )
 
+    def build(
+        self,
+        default_root: ResolvedLocation,
+        prepared_groundtruth: PreparedVizGroundtruth,
+    ) -> Viz:
+        data_root = self._data_root(default_root)
         return Viz(
             # TODO(jder): change to Path
             str(self.output_path),
             self.dataset_name,
             [run.build(data_root) for run in self.runs],
-            data_root.resolve(self.basins_location).open(),
-            groundtruth_rollout,
-            self.groundtruth_time_range.time_slice,
+            prepared_groundtruth=prepared_groundtruth,
             observations=self.observations,
             data_root=data_root,
         )
@@ -142,14 +161,21 @@ class VizConfig(TopLevelConfig):
 logger = logging.getLogger(__name__)
 
 
-def main(cfg: VizConfig):
+def _run_with_prepared_groundtruth(
+    cfg: VizConfig,
+    prepared_groundtruth: PreparedVizGroundtruth,
+):
     cfg.output_path.mkdir(parents=True, exist_ok=True)
     handle_logging(cfg.debug, cfg.output_path)
     cfg.save_yaml(cfg.output_path / "config.yaml")
 
     logger.info(f"Writing results to {cfg.output_path}")
 
-    viz = cfg.build(LocalLocation(path=Path.cwd()))
+    default_root = LocalLocation(path=Path.cwd())
+    viz = cfg.build(
+        default_root,
+        prepared_groundtruth=prepared_groundtruth,
+    )
 
     steps = [s for s in cfg.steps or _ordered_steps() if s not in cfg.not_steps]
     logger.info(f"Running steps: {', '.join(steps)}")
@@ -159,6 +185,19 @@ def main(cfg: VizConfig):
     # there's some appending to a metrics file.)
     for step in steps:
         _run_step(viz, step)
+
+
+def main(cfg: VizConfig):
+    default_root = LocalLocation(path=Path.cwd())
+    prepared_groundtruth = cfg.prepare_groundtruth(default_root)
+    _run_with_prepared_groundtruth(cfg, prepared_groundtruth)
+
+
+def run_with_prepared_groundtruth(
+    cfg: VizConfig,
+    prepared_groundtruth: PreparedVizGroundtruth,
+):
+    _run_with_prepared_groundtruth(cfg, prepared_groundtruth)
 
 
 def _run_step(viz: Viz, step: VizStep):

--- a/src/samudra/viz/core.py
+++ b/src/samudra/viz/core.py
@@ -55,6 +55,20 @@ class VizRun:
     variables: list[str]
 
 
+@dataclasses.dataclass
+class PreparedVizGroundtruth:
+    data_layout: DataLayout
+    data: xr.Dataset
+    profile_groundtruth: xr.Dataset
+    basin_masks: xr.Dataset
+    time_indices: list[int]
+    prediction_coords: dict[str, xr.DataArray]
+    times: xr.DataArray
+    wetmask: xr.DataArray
+    areacello_values: np.ndarray
+    areacello_spherical_values: np.ndarray
+
+
 class Viz:
     """Generates maps, time series, and probability density plots from evaluation outputs."""
 
@@ -63,12 +77,13 @@ class Viz:
         output_path: str,
         dataset_name: str,
         runs: list["VizRun"],
-        basins: xr.Dataset,
-        groundtruth_rollout: xr.Dataset,
-        time_range: slice,
+        prepared_groundtruth: PreparedVizGroundtruth,
         observations: "ObsMetricsConfig | None" = None,
         data_root: ResolvedLocation | None = None,
     ):
+        if not runs:
+            raise ValueError("Viz requires at least one run")
+
         pred_dict: dict[str, dict[str, Any]] = {}
         for run in runs:
             pred_dict[run.name] = {
@@ -78,36 +93,8 @@ class Viz:
             }
 
         key1 = runs[0].name
-        # TODO: Support non-OM4 data layouts in visualization.
-        self.data_layout = build_om4_layout()
+        self.data_layout = prepared_groundtruth.data_layout
         levels = len(self.data_layout.depth_levels)
-
-        groundtruth_rollout = groundtruth_rollout.sel(time=time_range)
-
-        if "y" in groundtruth_rollout.coords:
-            groundtruth_rollout = groundtruth_rollout.drop_vars(
-                ["lat", "lon"], errors="ignore"
-            )
-            groundtruth_rollout = groundtruth_rollout.rename({"y": "lat", "x": "lon"})
-
-        groundtruth_rollout = groundtruth_rollout.assign(
-            areacello=(["lat", "lon"], spherical_area_weights(groundtruth_rollout))
-        )
-
-        # Compute real grid cell areas for physical calculations
-        groundtruth_rollout["areacello_spherical"] = (
-            ["lat", "lon"],
-            spherical_area(groundtruth_rollout),
-        )
-
-        # This function processes the ds_groundtruth and predictions for plotting
-        # The predictions are loaded into pred_dict
-        data, pred_dict = process_data(
-            groundtruth_rollout, pred_dict, data_layout=self.data_layout
-        )
-
-        last_index = len(data.time) - 1
-        self.time_indices = [0, last_index // 2, last_index]
 
         var_list = {
             "vo": r"$v$ $( m/s )$",
@@ -119,6 +106,8 @@ class Viz:
             "KE": r"$KE$ $( J/m^2 )$",
             "OHC": r"$OHC$ $Anomaly$ $( ZJ )$",
         }
+
+        pred_dict = process_prediction_runs(prepared_groundtruth, pred_dict)
 
         # Create folder paths
         self.timeseries_path = os.path.join(output_path, f"Timeseries")
@@ -155,45 +144,17 @@ class Viz:
 
         clist = ["#ff807a", "#1e8685", "#ffb579", "#63c8ab"]
 
-        atlantic_mask0 = basins["basin_atlantic"]
-        atlantic_mask = atlantic_mask0.where(atlantic_mask0["lat"] >= -32)
-        atlantic_mask = process_mask(data, atlantic_mask)
-        pacific_mask0 = basins["basin_pacific"]
-        pacific_mask = pacific_mask0.where(
-            pacific_mask0["lat"] >= -32
-        )  # TODO: include this -32 masking in the basin data
-        pacific_mask = process_mask(data, pacific_mask)
-        indian_ocean_mask0 = basins["basin_indian"]
-        indian_ocean_mask = indian_ocean_mask0.where(indian_ocean_mask0["lat"] >= -32)
-        indian_ocean_mask = process_mask(data, indian_ocean_mask)
-        southern_ocean_mask0 = basins["basin_southern"]
-        southern_ocean_mask = process_mask(data, southern_ocean_mask0)
-        arctic_mask0 = basins["basin_arctic"]
-        arctic_ocean_mask = process_mask(data, arctic_mask0)
-
-        self.basin_masks = xr.Dataset(
-            {
-                "Atlantic": atlantic_mask,
-                "Pacific": pacific_mask,
-                "Southern": southern_ocean_mask,
-                "Indian": indian_ocean_mask,
-                "Arctic": arctic_ocean_mask,
-            }
-        )
-
-        # Compute profile means
         with ProgressBar():
-            logger.info("Computing profile for ground truth " + dataset_name)
-            profile_groundtruth = profile_mean(data).load()
-
             for k in pred_dict.keys():
                 logger.info("Computing profile for prediction " + k)
                 pred_dict[k]["profile_prediction"] = profile_mean(
                     pred_dict[k]["ds_prediction"]
                 ).load()
 
-        self.data: xr.Dataset = data
-        self.profile_groundtruth: xr.Dataset = profile_groundtruth
+        self.time_indices = prepared_groundtruth.time_indices
+        self.basin_masks = prepared_groundtruth.basin_masks
+        self.data: xr.Dataset = prepared_groundtruth.data
+        self.profile_groundtruth: xr.Dataset = prepared_groundtruth.profile_groundtruth
         self.pred_dict: dict[str, dict[str, Any]] = pred_dict
         self.dataset_name: str = dataset_name
         self.clist: list[str] = clist
@@ -3986,6 +3947,159 @@ def postprocess_for_plot(
     ds_groundtruth = ds_groundtruth.rename({"lat": "y", "lon": "x"})
 
     return ds_groundtruth, pred_dict
+
+
+def _prepare_groundtruth_rollout(
+    groundtruth_rollout: xr.Dataset,
+    time_range: slice,
+) -> xr.Dataset:
+    groundtruth_rollout = groundtruth_rollout.sel(time=time_range)
+
+    if "y" in groundtruth_rollout.coords:
+        groundtruth_rollout = groundtruth_rollout.drop_vars(
+            ["lat", "lon"], errors="ignore"
+        )
+        groundtruth_rollout = groundtruth_rollout.rename({"y": "lat", "x": "lon"})
+
+    groundtruth_rollout = groundtruth_rollout.assign(
+        areacello=(["lat", "lon"], spherical_area_weights(groundtruth_rollout))
+    )
+
+    groundtruth_rollout["areacello_spherical"] = (
+        ["lat", "lon"],
+        spherical_area(groundtruth_rollout),
+    )
+    return groundtruth_rollout
+
+
+def _wetmask_for_groundtruth(ds_groundtruth: xr.Dataset) -> xr.DataArray:
+    if "mask" in ds_groundtruth.data_vars:
+        return ds_groundtruth["mask"].isel(time=0, missing_dims="ignore")
+    return ds_groundtruth.wetmask
+
+
+def _build_basin_masks(data: xr.Dataset, basins: xr.Dataset) -> xr.Dataset:
+    atlantic_mask0 = basins["basin_atlantic"]
+    atlantic_mask = atlantic_mask0.where(atlantic_mask0["lat"] >= -32)
+    atlantic_mask = process_mask(data, atlantic_mask)
+    pacific_mask0 = basins["basin_pacific"]
+    pacific_mask = pacific_mask0.where(
+        pacific_mask0["lat"] >= -32
+    )  # TODO: include this -32 masking in the basin data
+    pacific_mask = process_mask(data, pacific_mask)
+    indian_ocean_mask0 = basins["basin_indian"]
+    indian_ocean_mask = indian_ocean_mask0.where(indian_ocean_mask0["lat"] >= -32)
+    indian_ocean_mask = process_mask(data, indian_ocean_mask)
+    southern_ocean_mask0 = basins["basin_southern"]
+    southern_ocean_mask = process_mask(data, southern_ocean_mask0)
+    arctic_mask0 = basins["basin_arctic"]
+    arctic_ocean_mask = process_mask(data, arctic_mask0)
+
+    return xr.Dataset(
+        {
+            "Atlantic": atlantic_mask,
+            "Pacific": pacific_mask,
+            "Southern": southern_ocean_mask,
+            "Indian": indian_ocean_mask,
+            "Arctic": arctic_ocean_mask,
+        }
+    )
+
+
+def prepare_viz_groundtruth(
+    dataset_name: str,
+    basins: xr.Dataset,
+    groundtruth_rollout: xr.Dataset,
+    time_range: slice,
+) -> PreparedVizGroundtruth:
+    # TODO: Support non-OM4 data layouts in visualization.
+    data_layout = build_om4_layout()
+    groundtruth_rollout = _prepare_groundtruth_rollout(
+        groundtruth_rollout,
+        time_range,
+    )
+    ds_groundtruth = with_level_index_vars(
+        groundtruth_rollout, depth_levels=data_layout.depth_levels
+    )
+    ds_groundtruth = _combine_variables_by_level(
+        ds_groundtruth,
+        ["thetao", "so", "uo", "vo", "mask"],
+        data_layout,
+    )
+
+    areacello_values = ds_groundtruth.areacello.values
+    areacello_spherical_values = ds_groundtruth["areacello_spherical"].values
+    times = ds_groundtruth.time
+    wetmask = _wetmask_for_groundtruth(ds_groundtruth)
+
+    data = _postprocess_for_plot(
+        ds_groundtruth,
+        areacello_values,
+        areacello_spherical_values,
+        np.array(data_layout.depth_thickness),
+        times,
+        wetmask,
+    )
+    prediction_coords = {name: coord for name, coord in data.coords.items()}
+    data = data.rename({"lat": "y", "lon": "x"})
+
+    last_index = len(data.time) - 1
+    time_indices = [0, last_index // 2, last_index]
+    basin_masks = _build_basin_masks(data, basins)
+
+    with ProgressBar():
+        logger.info("Computing profile for ground truth " + dataset_name)
+        profile_groundtruth = profile_mean(data).load()
+
+    return PreparedVizGroundtruth(
+        data_layout=data_layout,
+        data=data,
+        profile_groundtruth=profile_groundtruth,
+        basin_masks=basin_masks,
+        time_indices=time_indices,
+        prediction_coords=prediction_coords,
+        times=times,
+        wetmask=wetmask,
+        areacello_values=areacello_values,
+        areacello_spherical_values=areacello_spherical_values,
+    )
+
+
+def process_prediction_runs(
+    prepared_groundtruth: PreparedVizGroundtruth,
+    pred_dict: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    for key in pred_dict.keys():
+        ds_prediction = pred_dict[key]["data"]
+
+        assert ds_prediction.time.size == prepared_groundtruth.data.time.size, (
+            f"Sizes different for {key}: {ds_prediction.time.size}!="
+            f"{prepared_groundtruth.data.time.size}; prediction range is "
+            f"{ds_prediction.time.values[0]} to "
+            f"{ds_prediction.time.values[-1]}\n"
+            f"groundtruth range is {prepared_groundtruth.data.time.values[0]} to "
+            f"{prepared_groundtruth.data.time.values[-1]}"
+        )
+        if "model_path" in ds_prediction.attrs:
+            pred_dict[key]["model_path"] = ds_prediction.attrs["model_path"]
+
+        ds_prediction = _combine_variables_by_level(
+            ds_prediction,
+            pred_dict[key]["ls"],
+            prepared_groundtruth.data_layout,
+        )
+        ds_prediction = _postprocess_for_plot(
+            ds_prediction,
+            prepared_groundtruth.areacello_values,
+            prepared_groundtruth.areacello_spherical_values,
+            np.array(prepared_groundtruth.data_layout.depth_thickness),
+            prepared_groundtruth.times,
+            prepared_groundtruth.wetmask,
+            coords=prepared_groundtruth.prediction_coords,
+        )
+        pred_dict[key]["ds_prediction"] = ds_prediction.rename({"lat": "y", "lon": "x"})
+
+    return pred_dict
 
 
 def process_data(

--- a/src/samudra/viz/core.py
+++ b/src/samudra/viz/core.py
@@ -37,7 +37,7 @@ from samudra.utils.data import (
     spherical_area_weights,
     with_level_index_vars,
 )
-from samudra.utils.location import ResolvedLocation
+from samudra.utils.location import Location, ResolvedLocation
 from samudra.viz import observations as obs_figures
 from samudra.viz.norms import percentile_norm, symmetric_percentile_norm
 
@@ -83,6 +83,19 @@ class VizTemplate:
             observations=self.observations,
             data_root=self.data_root,
         )
+
+    def instantiate_run(
+        self,
+        output_path: Path,
+        name: str,
+        location: Location,
+    ) -> "Viz":
+        run = VizRun(
+            name=name,
+            data=self.data_root.resolve(location).open(chunks={}),
+            variables=self.variables,
+        )
+        return self.instantiate(output_path, [run])
 
 
 class Viz:

--- a/src/samudra/viz/core.py
+++ b/src/samudra/viz/core.py
@@ -65,6 +65,26 @@ class PreparedVizGroundtruth:
     wetmask: xr.DataArray
 
 
+@dataclasses.dataclass
+class VizTemplate:
+    # save prepared ground truth
+    dataset_name: str
+    data_root: ResolvedLocation
+    variables: list[str]
+    prepared_groundtruth: PreparedVizGroundtruth
+    observations: "ObsMetricsConfig | None" = None
+
+    def instantiate(self, output_path: Path, runs: list[VizRun]) -> "Viz":
+        return Viz(
+            str(output_path),
+            self.dataset_name,
+            runs,
+            prepared_groundtruth=self.prepared_groundtruth,
+            observations=self.observations,
+            data_root=self.data_root,
+        )
+
+
 class Viz:
     """Generates maps, time series, and probability density plots from evaluation outputs."""
 

--- a/src/samudra/viz/core.py
+++ b/src/samudra/viz/core.py
@@ -11,7 +11,6 @@ import re
 import sys
 import warnings
 from collections.abc import Iterable
-from copy import deepcopy
 from pathlib import Path
 from subprocess import PIPE, STDOUT, Popen
 from typing import TYPE_CHECKING, Any
@@ -63,10 +62,7 @@ class PreparedVizGroundtruth:
     basin_masks: xr.Dataset
     time_indices: list[int]
     prediction_coords: dict[str, xr.DataArray]
-    times: xr.DataArray
     wetmask: xr.DataArray
-    areacello_values: np.ndarray
-    areacello_spherical_values: np.ndarray
 
 
 class Viz:
@@ -3825,31 +3821,6 @@ def _combine_variables_by_level(
     return ds
 
 
-def combine_variables_by_level(
-    ds_groundtruth: xr.Dataset,
-    pred_dict: dict[str, dict[str, Any]],
-    data_layout: DataLayout,
-) -> tuple[xr.Dataset, dict[str, dict[str, Any]]]:
-    """
-    Combine variables by level for ground truth and predictions.
-
-    Parameters:
-    ds_groundtruth (xarray.Dataset): The ground truth dataset.
-    pred_dict (dict): Dictionary containing prediction datasets.
-
-    Returns:
-    xarray.Dataset, dict: Updated ground truth and prediction datasets.
-    """
-    ds_groundtruth = _combine_variables_by_level(
-        ds_groundtruth, ["thetao", "so", "uo", "vo", "mask"], data_layout
-    )
-    for key in pred_dict.keys():
-        pred_dict[key]["ds_prediction"] = _combine_variables_by_level(
-            pred_dict[key]["ds_prediction"], pred_dict[key]["ls"], data_layout
-        )
-    return ds_groundtruth, pred_dict
-
-
 def _postprocess_for_plot(
     ds,
     areacello: np.ndarray,
@@ -3893,60 +3864,6 @@ def _postprocess_for_plot(
     ds["areacello_spherical"] = (["lat", "lon"], areacello_spherical)
     ds["dz"] = ("lev", dz)
     return ds
-
-
-def postprocess_for_plot(
-    ds_groundtruth, areacello: xr.DataArray, dz: np.ndarray, pred_dict
-):
-    """
-    Postprocess for plotting.
-
-    Parameters:
-    ds_groundtruth (xarray.Dataset): The ground truth dataset.
-    areacello (xarray.DataArray): areacello dataarray.
-    pred_dict (dict): Dictionary containing prediction datasets.
-
-    Returns:
-    xarray.Dataset, dict: Postprocessed ground truth and prediction datasets.
-    """
-    areacello_values = areacello.values
-    times = ds_groundtruth.time
-    areacello_spherical_values = ds_groundtruth["areacello_spherical"].values
-
-    # Masking land with NaNs
-    if "mask" in ds_groundtruth.data_vars:
-        wetmask = ds_groundtruth["mask"].isel(
-            time=0, missing_dims="ignore"
-        )  # our data does not always have time for a mask
-    else:
-        wetmask = ds_groundtruth.wetmask
-
-    ds_groundtruth = _postprocess_for_plot(
-        ds_groundtruth, areacello_values, areacello_spherical_values, dz, times, wetmask
-    )
-
-    coords = ds_groundtruth.coords
-
-    for key in pred_dict.keys():
-        pred_dict[key]["ds_prediction"] = _postprocess_for_plot(
-            pred_dict[key]["ds_prediction"],
-            areacello_values,
-            areacello_spherical_values,
-            dz,
-            times,
-            wetmask,
-            coords=coords,
-        )
-
-        # Rename lat and lon to y and x
-        pred_dict[key]["ds_prediction"] = pred_dict[key]["ds_prediction"].rename(
-            {"lat": "y", "lon": "x"}
-        )
-
-    # Rename lat and lon to y and x (This needs to be done in the end!)
-    ds_groundtruth = ds_groundtruth.rename({"lat": "y", "lon": "x"})
-
-    return ds_groundtruth, pred_dict
 
 
 def _prepare_groundtruth_rollout(
@@ -4058,10 +3975,7 @@ def prepare_viz_groundtruth(
         basin_masks=basin_masks,
         time_indices=time_indices,
         prediction_coords=prediction_coords,
-        times=times,
         wetmask=wetmask,
-        areacello_values=areacello_values,
-        areacello_spherical_values=areacello_spherical_values,
     )
 
 
@@ -4069,6 +3983,10 @@ def process_prediction_runs(
     prepared_groundtruth: PreparedVizGroundtruth,
     pred_dict: dict[str, dict[str, Any]],
 ) -> dict[str, dict[str, Any]]:
+    depth_thickness = np.array(prepared_groundtruth.data_layout.depth_thickness)
+    times = prepared_groundtruth.data.time
+    areacello_values = prepared_groundtruth.data.areacello.values
+    areacello_spherical_values = prepared_groundtruth.data.areacello_spherical.values
     for key in pred_dict.keys():
         ds_prediction = pred_dict[key]["data"]
 
@@ -4090,61 +4008,16 @@ def process_prediction_runs(
         )
         ds_prediction = _postprocess_for_plot(
             ds_prediction,
-            prepared_groundtruth.areacello_values,
-            prepared_groundtruth.areacello_spherical_values,
-            np.array(prepared_groundtruth.data_layout.depth_thickness),
-            prepared_groundtruth.times,
+            areacello_values,
+            areacello_spherical_values,
+            depth_thickness,
+            times,
             prepared_groundtruth.wetmask,
             coords=prepared_groundtruth.prediction_coords,
         )
         pred_dict[key]["ds_prediction"] = ds_prediction.rename({"lat": "y", "lon": "x"})
 
     return pred_dict
-
-
-def process_data(
-    data: xr.Dataset,
-    pred_dict: dict[str, dict[str, Any]],
-    data_layout: DataLayout,
-) -> tuple[xr.Dataset, dict[str, dict[str, Any]]]:
-    """
-    Get plot ready OM4 data.
-    """
-    ds_groundtruth = with_level_index_vars(data, depth_levels=data_layout.depth_levels)
-
-    # Store ds_prediction
-    copy_dict = deepcopy(pred_dict)
-
-    for key in pred_dict.keys():
-        ds_prediction = pred_dict[key]["data"]
-
-        assert ds_prediction.time.size == ds_groundtruth.time.size, (
-            f"Sizes different for {key}: {ds_prediction.time.size}!="
-            f"{ds_groundtruth.time.size}; prediction range is "
-            f"{ds_prediction.time.values[0]} to "
-            f"{ds_prediction.time.values[-1]}\n"
-            f"groundtruth range is {ds_groundtruth.time.values[0]} to "
-            f"{ds_groundtruth.time.values[-1]}"
-        )
-        if "model_path" in ds_prediction.attrs:
-            copy_dict[key]["model_path"] = ds_prediction.attrs["model_path"]
-
-        pred_dict[key]["ds_prediction"] = ds_prediction
-
-    ### Combine Variables by level
-    ds_groundtruth, pred_dict = combine_variables_by_level(
-        ds_groundtruth, pred_dict, data_layout
-    )
-
-    ### Postprocess predictions for plotting
-    ds_groundtruth, pred_dict = postprocess_for_plot(
-        ds_groundtruth,
-        ds_groundtruth.areacello,
-        np.array(data_layout.depth_thickness),
-        pred_dict,
-    )
-
-    return ds_groundtruth, pred_dict
 
 
 def remove_climatology(ds):

--- a/tests/test_post_train_eval.py
+++ b/tests/test_post_train_eval.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from samudra.config import PostTrainEvalConfig
+from samudra.post_train_eval import (
+    _resolve_workers,
+    checkpoint_label,
+    discover_checkpoints_from_directory,
+    partition_checkpoint_work,
+    run_checkpoint_sweep,
+)
+from samudra.utils.location import LocalLocation
+from samudra.utils.train import CheckpointPaths
+from samudra.viz import VizTemplate
+
+
+def test_resolve_workers_uses_cpu_when_cuda_is_unavailable(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert _resolve_workers("auto", num_checkpoints=3) == [torch.device("cpu")]
+
+
+def test_resolve_workers_assigns_one_checkpoint_per_gpu(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 3)
+    assert _resolve_workers("cuda", num_checkpoints=2) == [
+        torch.device("cuda", 0),
+        torch.device("cuda", 1),
+    ]
+
+
+@pytest.fixture
+def checkpoint_dir(tmp_path: Path) -> Path:
+    for epoch in range(1, 8):
+        torch.save({"epoch": epoch}, tmp_path / f"ckpt_{epoch}.pt")
+    torch.save({"epoch": 7}, tmp_path / "ema_ckpt.pt")
+    # Files the sweep should ignore.
+    torch.save({"epoch": 7}, tmp_path / "ckpt.pt")
+    torch.save({"epoch": 3}, tmp_path / "best_inference_ckpt.pt")
+    return tmp_path
+
+
+def test_discovers_all_periodic_plus_ema(checkpoint_dir: Path):
+    targets = discover_checkpoints_from_directory(CheckpointPaths(checkpoint_dir))
+    assert [target.name for target in targets] == [
+        *[f"ckpt_{epoch}.pt" for epoch in range(1, 8)],
+        "ema_ckpt.pt",
+    ]
+    assert checkpoint_label(targets[0]) == "epoch_0001"
+    assert checkpoint_label(targets[-1]) == "ema_latest"
+
+
+def test_last_n_counts_only_periodic_checkpoints(checkpoint_dir: Path):
+    targets = discover_checkpoints_from_directory(
+        CheckpointPaths(checkpoint_dir), last_n_checkpoints=3
+    )
+    # The EMA checkpoint is added on top of the last N periodic checkpoints,
+    # not counted against them.
+    assert [target.name for target in targets] == [
+        "ckpt_5.pt",
+        "ckpt_6.pt",
+        "ckpt_7.pt",
+        "ema_ckpt.pt",
+    ]
+
+
+def test_explicit_checkpoints_plus_ema(checkpoint_dir: Path):
+    targets = discover_checkpoints_from_directory(
+        CheckpointPaths(checkpoint_dir), checkpoints=[2, 5]
+    )
+    assert [target.name for target in targets] == [
+        "ckpt_2.pt",
+        "ckpt_5.pt",
+        "ema_ckpt.pt",
+    ]
+
+
+def test_missing_explicit_checkpoint_raises(checkpoint_dir: Path):
+    with pytest.raises(ValueError, match="not found"):
+        discover_checkpoints_from_directory(
+            CheckpointPaths(checkpoint_dir), checkpoints=[2, 99]
+        )
+
+
+def test_mutually_exclusive_selection(checkpoint_dir: Path):
+    with pytest.raises(ValueError, match="only one"):
+        discover_checkpoints_from_directory(
+            CheckpointPaths(checkpoint_dir), last_n_checkpoints=2, checkpoints=[1]
+        )
+
+
+def test_last_n_must_be_positive(checkpoint_dir: Path):
+    with pytest.raises(ValueError, match=">= 1"):
+        discover_checkpoints_from_directory(
+            CheckpointPaths(checkpoint_dir), last_n_checkpoints=0
+        )
+
+
+def test_no_ema_checkpoint(tmp_path: Path):
+    torch.save({"epoch": 1}, tmp_path / "ckpt_1.pt")
+    targets = discover_checkpoints_from_directory(CheckpointPaths(tmp_path))
+    assert targets == [tmp_path / "ckpt_1.pt"]
+
+
+def test_partition_checkpoint_work_covers_all_entries():
+    entries = [Path(f"p{i}") for i in range(5)]
+    shards = partition_checkpoint_work(entries, 2)
+    assert len(shards) == 2
+    assert sorted(path.name for shard in shards for path in shard) == [
+        f"p{i}" for i in range(5)
+    ]
+
+
+def test_single_worker_uses_process_path(tmp_path: Path, monkeypatch):
+    checkpoint_path = tmp_path / "ckpt_1.pt"
+    checkpoint_path.touch()
+    result = {"checkpoint_path": str(checkpoint_path)}
+    work_queue = Mock()
+    work_queue.get.return_value = result
+    process = Mock(exitcode=0)
+    context = Mock()
+    context.Queue.return_value = work_queue
+    context.Process.return_value = process
+    monkeypatch.setattr(
+        "samudra.post_train_eval._load_eval_config",
+        lambda *_: SimpleNamespace(backend="cpu"),
+    )
+    monkeypatch.setattr(
+        "samudra.post_train_eval.multiprocessing.get_context", lambda _: context
+    )
+
+    results = run_checkpoint_sweep(
+        eval_config_path=Path("eval.yaml"),
+        checkpoint_paths=CheckpointPaths(tmp_path),
+        data_root=LocalLocation(path=tmp_path.resolve()),
+        sweep_output_dir=tmp_path / "evals",
+    )
+
+    assert results == [result]
+    context.Process.assert_called_once()
+    process.start.assert_called_once()
+
+
+def test_sweep_config_builds_runtime_object(tmp_path: Path, monkeypatch):
+    viz_loader = Mock()
+    monkeypatch.setattr(
+        "samudra.post_train_eval._load_eval_config",
+        lambda *_: SimpleNamespace(save_zarr=True),
+    )
+    monkeypatch.setattr("samudra.viz.VizTemplateConfig.from_yaml", viz_loader)
+    cfg = PostTrainEvalConfig(
+        eval_config_path=Path("eval.yaml"),
+        viz_config_path=Path("viz.yaml"),
+        eval_dirname="checkpoint_evals",
+        epochs=[2, 5],
+    )
+    data_root = LocalLocation(path=tmp_path.resolve())
+
+    sweep = cfg.build(
+        nets_dir=tmp_path / "saved_nets",
+        output_dir=tmp_path,
+        data_root=data_root,
+    )
+
+    assert sweep.eval_config_path == Path("eval.yaml")
+    assert sweep.checkpoint_paths.checkpoint_dir == tmp_path / "saved_nets"
+    assert sweep.sweep_output_dir == tmp_path / "checkpoint_evals"
+    assert sweep.viz_config_path == Path("viz.yaml")
+    assert sweep.checkpoints == [2, 5]
+    assert sweep.data_root == data_root
+    viz_loader.assert_called_once_with(Path("viz.yaml"))
+
+
+def test_sweep_config_validates_viz_output_early(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "samudra.post_train_eval._load_eval_config",
+        lambda *_: SimpleNamespace(save_zarr=False),
+    )
+    cfg = PostTrainEvalConfig(
+        eval_config_path=Path("eval.yaml"),
+        viz_config_path=Path("viz.yaml"),
+    )
+
+    with pytest.raises(ValueError, match="save_zarr = true"):
+        cfg.build(
+            nets_dir=tmp_path / "saved_nets",
+            output_dir=tmp_path,
+            data_root=LocalLocation(path=tmp_path.resolve()),
+        )
+
+
+def test_sweep_config_validates_eval_config_early(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "samudra.post_train_eval._load_eval_config",
+        Mock(side_effect=ValueError("invalid eval config")),
+    )
+    cfg = PostTrainEvalConfig(eval_config_path=Path("eval.yaml"))
+
+    with pytest.raises(ValueError, match="invalid eval config"):
+        cfg.build(
+            nets_dir=tmp_path / "saved_nets",
+            output_dir=tmp_path,
+            data_root=LocalLocation(path=tmp_path.resolve()),
+        )
+
+
+def test_sweep_config_validates_viz_config_early(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "samudra.post_train_eval._load_eval_config",
+        lambda *_: SimpleNamespace(save_zarr=True),
+    )
+    monkeypatch.setattr(
+        "samudra.viz.VizTemplateConfig.from_yaml",
+        Mock(side_effect=ValueError("invalid viz config")),
+    )
+    cfg = PostTrainEvalConfig(
+        eval_config_path=Path("eval.yaml"), viz_config_path=Path("viz.yaml")
+    )
+
+    with pytest.raises(ValueError, match="invalid viz config"):
+        cfg.build(
+            nets_dir=tmp_path / "saved_nets",
+            output_dir=tmp_path,
+            data_root=LocalLocation(path=tmp_path.resolve()),
+        )
+
+
+def test_viz_template_instantiate_run_owns_run_defaults(tmp_path: Path, monkeypatch):
+    data = Mock()
+    resolved_location = Mock()
+    resolved_location.open.return_value = data
+    data_root = Mock()
+    data_root.resolve.return_value = resolved_location
+    template = VizTemplate("dataset", data_root, ["thetao"], Mock())
+    instantiate = Mock(return_value=Mock())
+    monkeypatch.setattr(template, "instantiate", instantiate)
+    location = LocalLocation(path=tmp_path.resolve())
+
+    result = template.instantiate_run(tmp_path / "viz", "epoch_0001", location)
+
+    run = instantiate.call_args.args[1][0]
+    assert result is instantiate.return_value
+    assert run.name == "epoch_0001"
+    assert run.data is data
+    assert run.variables == ["thetao"]
+    data_root.resolve.assert_called_once_with(location)

--- a/tests/test_post_train_eval.py
+++ b/tests/test_post_train_eval.py
@@ -57,6 +57,19 @@ def test_discovers_all_periodic_plus_ema(checkpoint_dir: Path):
     assert checkpoint_label(targets[-1]) == "ema_latest"
 
 
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        ("ckpt_12.pt", 12),
+        ("ckpt_latest.pt", None),
+        ("ckpt_12.pth", None),
+        ("checkpoint_12.pt", None),
+    ],
+)
+def test_periodic_checkpoint_epoch(filename: str, expected: int | None):
+    assert CheckpointPaths.periodic_checkpoint_epoch(Path(filename)) == expected
+
+
 def test_last_n_counts_only_periodic_checkpoints(checkpoint_dir: Path):
     targets = discover_checkpoints_from_directory(
         CheckpointPaths(checkpoint_dir), last_n_checkpoints=3

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -5,6 +5,7 @@
 import json
 import logging
 import tempfile
+import weakref
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -22,6 +23,7 @@ from samudra.config import (
 from samudra.models.base import BaseModel
 from samudra.train import (
     Trainer,
+    run_training,
     should_log_validation_images,
     should_run_on_epoch_freq,
 )
@@ -78,6 +80,43 @@ def test_handle_logging_replaces_handlers_between_local_jobs(tmp_path):
     assert "first candidate" in (first / "experiment.log").read_text()
     assert "second candidate" not in (first / "experiment.log").read_text()
     assert (second / "experiment.log").read_text().count("second candidate") == 1
+
+
+def test_run_training_drops_trainer_before_post_train_sweep(monkeypatch):
+    events = []
+    trainer_ref = None
+
+    class Sweep:
+        def run(self):
+            assert trainer_ref is not None and trainer_ref() is None
+            events.append("sweep")
+
+    class FakeTrainer:
+        distributed = object()
+        post_train_sweep = Sweep()
+
+        def run(self):
+            events.append("train")
+
+    def build_trainer(_cfg):
+        nonlocal trainer_ref
+        trainer = FakeTrainer()
+        trainer_ref = weakref.ref(trainer)
+        return trainer
+
+    monkeypatch.setattr("samudra.train.Trainer", build_trainer)
+    monkeypatch.setattr("samudra.train.is_main_process", lambda: True)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.distributed, "barrier", lambda: events.append("barrier"))
+    monkeypatch.setattr(
+        torch.distributed,
+        "destroy_process_group",
+        lambda: events.append("destroy"),
+    )
+
+    run_training(TrainConfig.model_construct())
+
+    assert events == ["train", "barrier", "destroy", "sweep"]
 
 
 @pytest.mark.manual


### PR DESCRIPTION
Post-train checkpoint eval/viz sweep

Adds an optional post-training sweep that evaluates selected checkpoints after training completes, always including the final EMA checkpoint, with optional visualization generation.

* Add `post_train_eval.py` to discover checkpoints in `saved_nets/`, shard eval jobs across available GPUs, run standalone inference per checkpoint, and write `summary.json`.
* Support either `last_n_checkpoints: N` or an explicit `checkpoints: [...]` epoch list, with validation for mutually exclusive settings and missing checkpoints.
* Edit `Trainer.finish()` to launch the sweep on the main process via a new `post_train_eval` config block.
* Add a DDP barrier and `destroy_process_group()` before the sweep so all training ranks finish cleanly and release GPUs. (still seems a little flacky)
* Refactor viz to prepare groundtruth once and reuse it across checkpoint visualizations.
* Support standalone usage via `python -m samudra.post_train_eval` for models already trained.

Notes:

* Viz sweep requires `eval.save_zarr=true`.
* In the current config, `checkpoints: [50, 55, 60, 65, 70]` evaluates those epochs plus the final EMA checkpoint.

#Config

Add a post_train_eval block to the train config to enable the post-training checkpoint sweep:

post_train_eval:
  enabled: true
  eval_config_path: configs/<model>/eval.yaml   # required when enabled
  viz_config_path: configs/<model>/viz.yaml     # optional; omit to skip viz

  Pick exactly one checkpoint selection mode:
  checkpoints: [50, 55, 60, 65, 70]             # explicit checkpoint epochs
  last_n_checkpoints: 10                       # or evaluate the last N checkpoints

The final EMA checkpoint is always included automatically.
wandb is disabled for this, will a follow up PR I will add all the evals in one run (ideally with timeline scrub) which is not tested yet! 