### PR TITLE
Reduce multiscale dataset test I/O

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -54,10 +54,10 @@ jobs:
           python-version: "3.12"
 
       - name: Run CPU benchmarks
-        run: uv run --locked pytest -m "not cuda" --benchmark-only --benchmark-json output-cpu.json
+        run: uv run --locked pytest -m "not cuda" --benchmark-only --benchmark-json output-cpu.json --durations=20 --durations-min=1.0
 
       - name: Run GPU benchmarks
-        run: uv run --locked pytest -m "cuda" --benchmark-only --benchmark-json output-gpu.json
+        run: uv run --locked pytest -m "cuda" --benchmark-only --benchmark-json output-gpu.json --durations=20 --durations-min=1.0
 
       # Avoid issues checking out the gh-pages branch (eg uv.lock updated)
       - name: Stash

--- a/.github/workflows/container-physicsnemo.yml
+++ b/.github/workflows/container-physicsnemo.yml
@@ -199,7 +199,7 @@ jobs:
             "${TEST_IMAGE}" -lc '
               set -euo pipefail
               . .venv/bin/activate
-              python -m pytest -p no:zarr -n 2 -v -m "not manual and not cuda"
+              python -m pytest -p no:zarr -n 2 -v -m "not manual and not cuda" --durations=20 --durations-min=1.0
             '
 
       - name: Run GPU tests in container
@@ -213,7 +213,7 @@ jobs:
             "${TEST_IMAGE}" -lc '
               set -euo pipefail
               . .venv/bin/activate
-              python -m pytest -p no:zarr -v -m "not manual and cuda" -x
+              python -m pytest -p no:zarr -v -m "not manual and cuda" -x --durations=20 --durations-min=1.0
             '
 
   build-test-publish-arm64:
@@ -314,7 +314,7 @@ jobs:
               . .venv/bin/activate
               # The smaller arm64 runner is more prone to losing the GitHub runner
               # process under xdist CPU-test load after the local image build.
-              python -m pytest -p no:zarr -v -m "not manual and not cuda"
+              python -m pytest -p no:zarr -v -m "not manual and not cuda" --durations=20 --durations-min=1.0
             '
 
   report-container-test-status:

--- a/.github/workflows/data-tests-xesmf.yaml
+++ b/.github/workflows/data-tests-xesmf.yaml
@@ -46,5 +46,5 @@ jobs:
         shell: bash -l {0}
         run: |
           cd data
-          pytest tests -v
+          pytest tests -v --durations=20 --durations-min=1.0
           # for now I am running all tests again. We could only cover the preprocessing here to save time.

--- a/.github/workflows/data-tests.yaml
+++ b/.github/workflows/data-tests.yaml
@@ -47,4 +47,4 @@ jobs:
         shell: bash -l {0}
         run: |
           cd data/
-          pytest tests -v
+          pytest tests -v --durations=20 --durations-min=1.0

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Each test runs with a 5-minute timeout. The `-x` flag will stop on the first failure or hang.
       - name: Run pytest
-        run: uv run --with pytest-timeout --locked pytest -n 2 -v -m "not manual and cuda" --timeout=300 --timeout-method=signal -x
+        run: uv run --with pytest-timeout --locked pytest -n 2 -v -m "not manual and cuda" --timeout=300 --timeout-method=signal -x --durations=20 --durations-min=1.0
         timeout-minutes: 30
 
   # This exists beacuse the run-tests job will be skipped if the ec2 job fails,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,4 +46,4 @@ jobs:
         run: uv sync --locked --dev
 
       - name: Run pytest
-        run: uv run --locked pytest -n 2 -v -m "not manual and not cuda"
+        run: uv run --locked pytest -n 2 -v -m "not manual and not cuda" --durations=20 --durations-min=1.0

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -416,8 +416,9 @@ def test_loader__data_shape__across_schedules(
             case _:
                 assert_never(schedule)
 
+        min_checked_batches = 10
         observed_patterns = set()
-        for sample in loader:
+        for batch_idx, sample in enumerate(loader, start=1):
             X, y = extract_sample_arrays(sample)
             # Exclude the coordinate shape information for now; we'll test that separately.
             assert X.shape[:-2] == (
@@ -433,7 +434,10 @@ def test_loader__data_shape__across_schedules(
             observed_patterns.add(
                 ((X.shape[-2], X.shape[-1]), (y.shape[-2], y.shape[-1]))
             )
-            if observed_patterns == expected_patterns:
+            if (
+                observed_patterns == expected_patterns
+                and batch_idx >= min_checked_batches
+            ):
                 break
 
         assert observed_patterns == expected_patterns, (

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -53,6 +53,18 @@ def coarsen_data(ds: xr.Dataset) -> xr.Dataset:
     return ds.coarsen(lat=2, lon=2).mean()  # type: ignore
 
 
+def coarsen_source(
+    src: DataSource,
+    prognostic: list[str],
+    boundary: list[str],
+) -> DataSource:
+    # Coarsening the full mock OM4 dataset forces many unnecessary Zarr reads.
+    # Multiscale loader tests only need the variables in the active test config.
+    coarsen_input = src.filter(prognostic + boundary, prefix="coarsen-input")
+    coarsened_src = coarsen_input.map_data(coarsen_data, suffix="half-size")
+    return dataclasses.replace(coarsened_src, masks=coarsen_masks(src.masks))
+
+
 def coarsen_masks(masks: Masks) -> Masks:
     """Coarsen masks to half resolution using max pooling (any True -> True)."""
     # For masks, we use max pooling: if any cell in the 2x2 block is True (valid),
@@ -108,17 +120,11 @@ def make_loader(
             case "standard":
                 srcs: Iterable[tuple[DataSource, DataSource | None]] = [(src, None)]
             case "match":
-                coarsened_src = src.map_data(coarsen_data, suffix="half-size")
-                coarsened_src = dataclasses.replace(
-                    coarsened_src, masks=coarsen_masks(src.masks)
-                )
+                coarsened_src = coarsen_source(src, prognostic, boundary)
                 scales = [src, coarsened_src]
                 srcs = [(s, s) for s in scales]
             case "mix":
-                coarsened_src = src.map_data(coarsen_data, suffix="half-size")
-                coarsened_src = dataclasses.replace(
-                    coarsened_src, masks=coarsen_masks(src.masks)
-                )
+                coarsened_src = coarsen_source(src, prognostic, boundary)
                 scales = [src, coarsened_src]
                 srcs = list(itertools.product(scales, repeat=2))  # type: ignore
             case _:
@@ -332,16 +338,14 @@ def test_loader__data_shape(
         n_samples = calc_num_samples(
             train_config, train_config.train_time.time_slice, "standard"
         )
-        samples = list(loader)
-
-        assert len(samples) == n_samples, (
+        assert len(loader) == n_samples, (
             f"Current config {train_config} only supports {n_samples} examples; "
-            f"got {len(samples)}."
+            f"got {len(loader)}."
         )
 
         # Only check the first 2 samples; this should be proof enough that everything is
         # the right shape.
-        for sample in samples[:2]:
+        for sample in itertools.islice(loader, 2):
             X, y = extract_sample_arrays(sample)
             assert X.shape == (
                 train_config.steps[0],
@@ -368,7 +372,10 @@ def test_loader__data_shape__across_schedules(
     history = train_config.data.hist
 
     with make_loader(
-        train_config, version=LoaderVersion.OM4_TORCH, schedule=schedule
+        train_config,
+        version=LoaderVersion.OM4_TORCH,
+        schedule=schedule,
+        shuffle=False,
     ) as loader:
         dataset_spec = train_config.data.dataset.build()
         batch_size = train_config.batch_size
@@ -383,16 +390,34 @@ def test_loader__data_shape__across_schedules(
         n_samples = calc_num_samples(
             train_config, train_config.train_time.time_slice, schedule
         )
-        samples = list(loader)
-
-        assert len(samples) == n_samples, (
+        assert len(loader) == n_samples, (
             f"Current config {train_config} only supports {n_samples} examples; "
-            f"got {len(samples)}."
+            f"got {len(loader)}."
         )
 
-        example_resolutions = []
-        # Subsample the examples; this should be proof enough that everything is the right shape.
-        for sample in samples[::3]:
+        match schedule:
+            case "standard":
+                expected_patterns = {
+                    ((180, 360), (180, 360)),
+                }
+            case "match":
+                expected_patterns = {
+                    ((180, 360), (180, 360)),
+                    ((90, 180), (90, 180)),
+                }
+            case "mix":
+                # In mix mode with 2 scales, multiplex creates pattern: (0,0), (0,1), (1,0), (1,1)
+                expected_patterns = {
+                    ((180, 360), (180, 360)),  # (0,0): full-res input, full-res label
+                    ((180, 360), (90, 180)),  # (0,1): full-res input, half-res label
+                    ((90, 180), (180, 360)),  # (1,0): half-res input, full-res label
+                    ((90, 180), (90, 180)),  # (1,1): half-res input, half-res label
+                }
+            case _:
+                assert_never(schedule)
+
+        observed_patterns = set()
+        for sample in loader:
             X, y = extract_sample_arrays(sample)
             # Exclude the coordinate shape information for now; we'll test that separately.
             assert X.shape[:-2] == (
@@ -405,38 +430,18 @@ def test_loader__data_shape__across_schedules(
                 batch_size,
                 output_var_dim,
             )
-            example_resolutions.append((X.shape[-2:], y.shape[-2:]))
+            observed_patterns.add(
+                ((X.shape[-2], X.shape[-1]), (y.shape[-2], y.shape[-1]))
+            )
+            if observed_patterns == expected_patterns:
+                break
 
-        match schedule:
-            case "standard":
-                assert example_resolutions[0][0] == example_resolutions[0][1], (
-                    "The input and output should be equal"
-                )
-                assert all(
-                    example_resolutions[0] == eg for eg in example_resolutions[1:]
-                ), "All resolutions should be equal"
-            case "match":
-                for x_res, y_res in example_resolutions:
-                    assert x_res == y_res, (
-                        f"Resolutions must match across batches for 'match' schedule multiscale loader. {example_resolutions=}"
-                    )
-            case "mix":
-                # In mix mode with 2 scales, multiplex creates pattern: (0,0), (0,1), (1,0), (1,1)
-                # With grouped batch sampler, order may vary due to shuffling within groups.
-                # With drop_last=True and small sample counts, some groups might not produce any batches
-                valid_patterns = {
-                    ((180, 360), (180, 360)),  # (0,0): full-res input, full-res label
-                    ((180, 360), (90, 180)),  # (0,1): full-res input, half-res label
-                    ((90, 180), (180, 360)),  # (1,0): half-res input, full-res label
-                    ((90, 180), (90, 180)),  # (1,1): half-res input, half-res label
-                }
-                observed_patterns = set(example_resolutions)
-                # All observed patterns must be valid
-                assert observed_patterns == valid_patterns, (
-                    f"All resolutions must be valid members of the cartesian product for 'mix' schedule. "
-                    f"Valid patterns: {valid_patterns}, got {observed_patterns}, "
-                    f"invalid patterns: {observed_patterns - valid_patterns}"
-                )
+        assert observed_patterns == expected_patterns, (
+            f"Loader did not produce the expected resolution patterns for {schedule=}. "
+            f"Expected: {expected_patterns}, got: {observed_patterns}, "
+            f"missing: {expected_patterns - observed_patterns}, "
+            f"invalid: {observed_patterns - expected_patterns}"
+        )
 
 
 def test_inference__data_shape(inference_loader_pair):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -58,8 +58,8 @@ def coarsen_source(
     prognostic: list[str],
     boundary: list[str],
 ) -> DataSource:
-    # Coarsening the full mock OM4 dataset forces many unnecessary Zarr reads.
-    # Multiscale loader tests only need the variables in the active test config.
+    # DEFAULT_CONFIG selects thermo_dynamic_5 plus tau_hfds from the larger mock
+    # OM4 source; coarsen only those active variables to avoid extra Zarr reads.
     coarsen_input = src.filter(prognostic + boundary, prefix="coarsen-input")
     coarsened_src = coarsen_input.map_data(coarsen_data, suffix="half-size")
     return dataclasses.replace(coarsened_src, masks=coarsen_masks(src.masks))
@@ -375,6 +375,7 @@ def test_loader__data_shape__across_schedules(
         train_config,
         version=LoaderVersion.OM4_TORCH,
         schedule=schedule,
+        # Keep grouped-sampler ordering deterministic for resolution coverage.
         shuffle=False,
     ) as loader:
         dataset_spec = train_config.data.dataset.build()


### PR DESCRIPTION
Our GPU tests were [timing out](https://github.com/m2lines/Samudra/actions/runs/28035329848/job/82987734124) due to I/O time. This reduces that time by avoiding reading data we don't need, both during coarsening and during iteration through the dataset.