### PR TITLE
Coalesce TorchTrainDataset rollout loads

### DIFF
--- a/src/samudra/datasets.py
+++ b/src/samudra/datasets.py
@@ -472,6 +472,9 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         super().__init__()
         self.id = f"{self.__class__.__name__}_{str(id(self))}"
         # If the src and dst DataSource are the same, we can do a lot less work.
+        # Callers often pass separately sliced instances, so compare DataSource names
+        # rather than object identity.
+        self._shared_prognostic_source = dst is None or src.name == dst.name
         srcs = [src, dst] if dst else [src]
 
         self.hist: int = hist
@@ -536,58 +539,57 @@ class TorchTrainDataset(Dataset[RawTrainData]):
         start_time = time.perf_counter()
         TD = RawTrainData(self.id)
 
-        for step in range(self.steps):
-            x_index = self._get_x_index(idx, step)
-            current_x_index = x_index.isel(time=slice(0, self.hist + 1))
-            forecast_x_index = x_index.isel(time=slice(self.hist + 1, None))
+        self._validate_idx(idx)
+        step_time_count = self.hist + 1
+        shared_prognostic_source = self._shared_prognostic_source
 
-            # Only materialize the time ranges we actually use to reduce memory.
-            input_selected = self.prognostic_srcs[0].data.isel(time=current_x_index)
-            boundary_selected = self.boundary_src.data.isel(time=current_x_index)
-            label_selected = self.prognostic_srcs[-1].data.isel(
-                time=forecast_x_index
-            )  # forecasted data
-            prognostic_selected = [input_selected, label_selected]
-
-            if self._concurrent_compute:
-                datasets = prognostic_selected + [boundary_selected]
-                concurrent_compute(
-                    *datasets,
-                    executor=self._get_executor(),
-                )
-
-            if "lev" in prognostic_selected[0].dims:
-                prognostics = [
-                    torch.from_numpy(
-                        conditional_rearrange(
-                            selected,
-                            "time (variable lev)=var lat lon",
-                            concat_dim="var",
-                        )
-                        .rename({"var": "variable"})
-                        .to_numpy()
-                        .astype(np.float32, copy=False)
-                    )
-                    for selected in prognostic_selected
-                ]
-            else:
-                prognostics = [
-                    torch.from_numpy(
-                        selected.to_array()
-                        .transpose("time", "variable", "lat", "lon")
-                        .to_numpy()
-                        .astype(np.float32, copy=False)
-                    )
-                    for selected in prognostic_selected
-                ]
-            boundary = torch.from_numpy(
-                boundary_selected.to_array()
-                .transpose("time", "variable", "lat", "lon")
-                .to_numpy()
-                .astype(np.float32, copy=False)
+        # Select each contiguous rollout range once, then slice the materialized
+        # tensors into per-step examples. When input and label prognostic sources
+        # are shared, this avoids loading the step-N label again as the step-(N+1)
+        # input.
+        if shared_prognostic_source:
+            prognostic_selected = self.prognostic_srcs[0].data.isel(
+                time=self._get_time_slice(idx, step_count=self.steps + 1)
             )
-            input_, label = prognostics[0], prognostics[-1]
-            TD.insert(input_, boundary, label)
+            label_offset = step_time_count
+            datasets_to_compute = [prognostic_selected]
+        else:
+            input_selected = self.prognostic_srcs[0].data.isel(
+                time=self._get_time_slice(idx, step_count=self.steps)
+            )
+            label_selected = self.prognostic_srcs[-1].data.isel(
+                time=self._get_time_slice(idx, start_step=1, step_count=self.steps)
+            )
+            label_offset = 0
+            datasets_to_compute = [input_selected, label_selected]
+
+        boundary_selected = self.boundary_src.data.isel(
+            time=self._get_time_slice(idx, step_count=self.steps)
+        )
+
+        if self._concurrent_compute:
+            concurrent_compute(
+                *(datasets_to_compute + [boundary_selected]),
+                executor=self._get_executor(),
+            )
+
+        if shared_prognostic_source:
+            input_tensor = self._selected_to_tensor(prognostic_selected)
+            label_tensor = input_tensor
+        else:
+            input_tensor = self._selected_to_tensor(input_selected)
+            label_tensor = self._selected_to_tensor(label_selected)
+        boundary = self._selected_to_tensor(boundary_selected)
+
+        for step in range(self.steps):
+            start = step * step_time_count
+            stop = start + step_time_count
+            label_start = start + label_offset
+            label_stop = stop + label_offset
+            input_ = input_tensor[start:stop]
+            label = label_tensor[label_start:label_stop]
+            boundary_step = boundary[start:stop]
+            TD.insert(input_, boundary_step, label)
         TD.load_stats = LoadStats(time.perf_counter() - start_time)
 
         return TD
@@ -647,12 +649,47 @@ class TorchTrainDataset(Dataset[RawTrainData]):
             steps, "batch time variable lat lon -> batch (time variable) lat lon"
         )
 
-    def _get_x_index(self, idx: int, step: int) -> xr.DataArray:
-        assert isinstance(idx, int)
+    def _selected_to_tensor(
+        self, selected: xr.Dataset
+    ) -> Float[torch.Tensor, "time variable lat lon"]:
+        if "lev" in selected.dims:
+            selected_np = (
+                conditional_rearrange(
+                    selected,
+                    "time (variable lev)=var lat lon",
+                    concat_dim="var",
+                )
+                .rename({"var": "variable"})
+                .to_numpy()
+                .astype(np.float32, copy=False)
+            )
+        else:
+            selected_np = (
+                selected.to_array()
+                .transpose("time", "variable", "lat", "lon")
+                .to_numpy()
+                .astype(np.float32, copy=False)
+            )
+        return torch.from_numpy(selected_np)
+
+    def _validate_idx(self, idx: int) -> None:
         if idx < 0:
             raise IndexError("Sorry, negative indexing is not supported!")
         if idx >= len(self):
             raise IndexError("Index out of range")
+
+    def _get_time_slice(
+        self, idx: int, *, step_count: int, start_step: int = 0
+    ) -> slice:
+        self._validate_idx(idx)
+        step_time_count = self.hist + 1
+        start = idx + start_step * step_time_count * self.stride
+        stop = start + step_count * step_time_count * self.stride
+        return slice(start, stop, self.stride)
+
+    def _get_x_index(self, idx: int, step: int) -> xr.DataArray:
+        assert isinstance(idx, int)
+        self._validate_idx(idx)
 
         window_index = idx + step * (self.hist + 1) * self.stride
         return self.rolling_indices.isel(window=window_index, drop=True)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -696,6 +696,32 @@ def test_train_dataset_no_input_change(
     assert torch.equal(bnd1_new, bnd1_orig)
 
 
+@pytest.mark.parametrize("normalize_before_mask", [False])
+@pytest.mark.parametrize("masked_fill_value", [0.0])
+def test_train_dataset_coalesces_shared_prognostic_loads(
+    tiny_dataset_input, monkeypatch, normalize_before_mask, masked_fill_value
+):
+    train_loader, _ = tiny_dataset_input
+    dataset = train_loader.dataset
+    assert isinstance(dataset, TorchTrainDataset)
+    dataset._concurrent_compute = True
+
+    selected_time_lengths = []
+
+    def record_concurrent_compute(*datasets: xr.Dataset, executor):
+        selected_time_lengths.append([ds.sizes["time"] for ds in datasets])
+
+    monkeypatch.setattr(
+        "samudra.datasets.concurrent_compute", record_concurrent_compute
+    )
+
+    raw_data = dataset[0]
+
+    assert selected_time_lengths == [[6, 4]]
+    assert len(raw_data.raw_data) == 2
+    assert torch.equal(raw_data.raw_data[0][2], raw_data.raw_data[1][0])
+
+
 @pytest.mark.parametrize("normalize_before_mask", [True, False])
 @pytest.mark.parametrize("masked_fill_value", [0.0, -1.0])
 def test_train_dataset_normalize_pre_fill(


### PR DESCRIPTION
## Summary
- Confirmed `TorchTrainDataset` was materializing each autoregressive rollout step independently.
- For shared prognostic sources, the step-N label range is the same data as the step-(N+1) input range, so non-dask loading duplicated adjacent time reads.
- Coalesce each sample's rollout time range into one selected prognostic tensor when input and label sources are shared, then slice that tensor into per-step examples.
- Keep split-source paths for cross-resolution training, while still selecting each input, label, and boundary range once per sample.
- Add a regression test that verifies shared-source training selects one `steps + 1` prognostic range and preserves the overlapping label/input values.

## Validation
- `uv run pytest tests/test_datasets.py -k 'train_dataset_coalesces_shared_prognostic_loads or train_dataset_normalize_pre_fill or train_dataset_no_input_change'`
- `uv run pytest tests/test_datasets.py -k 'loader__data_shape__across_schedules or train_dataset_coalesces_shared_prognostic_loads'`
- `uvx ruff format --check src/samudra/datasets.py tests/test_datasets.py`
- `uvx ruff check src/samudra/datasets.py tests/test_datasets.py`
- `uvx pre-commit run --files src/samudra/datasets.py tests/test_datasets.py`

Note: `uv run pytest tests/test_datasets.py` reached the unrelated `samudra_multi` inference setup and errored because `flash_perceiver` is not installed for auto flash mode in this environment; the training dataset tests before that point passed (`117 passed`, `12 errors`).

Refs #798