### PR TITLE
Capture validated Torch multires training defaults

### DIFF
--- a/configs/samudra_multi_om4/train.yaml
+++ b/configs/samudra_multi_om4/train.yaml
@@ -36,7 +36,7 @@ inference_times:
 data_stride: [1]
 steps: [4]
 step_transition: []
-preemptible: true
+preemptible: false
 
 backend: auto
 
@@ -57,10 +57,7 @@ data:
   concurrent_compute: true
   loading:
     type: cpu
-    # Two workers per rank were validated for the three-resolution, 4-GPU
-    # Torch run with the RTX6000 partition's 800G host-memory limit.
-    num_workers: 2
-    persistent_workers: true
+    num_workers: 4
   sources:
     - data_location: om4_quarterdeg_v2/OM4.zarr
       data_means_location: om4_quarterdeg_v2/OM4_means.zarr

--- a/configs/samudra_multi_om4/train.yaml
+++ b/configs/samudra_multi_om4/train.yaml
@@ -57,8 +57,8 @@ data:
   concurrent_compute: true
   loading:
     type: cpu
-    # Two workers per rank avoided OOMs in the three-resolution, 4-GPU Torch
-    # run with the RTX6000 partition's 800G host-memory limit.
+    # Two workers per rank were validated for the three-resolution, 4-GPU
+    # Torch run with the RTX6000 partition's 800G host-memory limit.
     num_workers: 2
     persistent_workers: true
   sources:

--- a/configs/samudra_multi_om4/train.yaml
+++ b/configs/samudra_multi_om4/train.yaml
@@ -36,7 +36,7 @@ inference_times:
 data_stride: [1]
 steps: [4]
 step_transition: []
-preemptible: false
+preemptible: true
 
 backend: auto
 
@@ -57,7 +57,10 @@ data:
   concurrent_compute: true
   loading:
     type: cpu
-    num_workers: 4
+    # Two workers per rank avoided OOMs in the three-resolution, 4-GPU Torch
+    # run with the RTX6000 partition's 800G host-memory limit.
+    num_workers: 2
+    persistent_workers: true
   sources:
     - data_location: om4_quarterdeg_v2/OM4.zarr
       data_means_location: om4_quarterdeg_v2/OM4_means.zarr

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -144,12 +144,17 @@ sbatch \
 ### Validated 4x RTX6000 Multi-Resolution Training
 
 One known-working configuration on torch is:
-* The 1, 1/2, and 1/4 degree configuration on `configs/samudra_multi_om4/train.yaml`
-* 4 x RTX6000, 24 CPUs, 800G memory and 2 data load workers (for CPU memory reasons)
-* Using `--preemptible=true` and a 48-hour wall time to make it scheduable.
+
+- The 1, 1/2, and 1/4 degree configuration in
+  `configs/samudra_multi_om4/train.yaml`.
+- 4 x RTX6000, 24 CPUs, 800G memory, and two data-loader workers per rank.
+- `--preemptible=true` with a seven-day walltime. Torch accepts this shape
+  under the `gpu168` QoS, which limits jobs over 48 hours to four GPUs total
+  per user.
 
 The 24-CPU request was sufficient to keep observed data wait near zero, and
-the 2 data load workers kept CPU memory under 800G. Ie something like:
+the two-worker run progressed without an OOM, although it touched the 800G
+cgroup limit under peak loading. For example:
 
 ```bash
 export CONFIG=configs/samudra_multi_om4/train.yaml
@@ -158,7 +163,7 @@ export DATA_ROOT=/scratch/$USER/data
 export OUTPUT_BASE=/scratch/$USER/runs
 export WANDB_MODE=online
 export REQUEUE_ON_USR1=1
-export ARGS="--data.loading.num_workers=4 --preemptible=true"
+export ARGS="--data.loading.num_workers=2 --preemptible=true"
 
 # Pin the exact image rather than depending on mutable wrapper defaults.
 export IMAGE_REF=ghcr.io/<owner>/ocean-emulator-physicsnemo:<pinned-tag>

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -66,13 +66,17 @@ It expects environment variables:
   `--experiment.base_output_dir` (default: `/scratch/<current_user>/runs`)
 - `ARGS` (optional): extra CLI overrides, e.g. `--batch_size=1`
 - `NSYS_ARGS` (optional): if set, wrap the training launch with `nsys profile`
+- `REQUEUE_ON_USR1` (optional): set to `1` when submitting with
+  `--requeue --signal=B:USR1@300`; the harness requeues the job when Slurm sends
+  the warning signal.
 - `WANDB_API_KEY` (optional): if set and `WANDB_MODE` unset, defaults to W&B online
 - `WANDB_MODE` (optional): `online` or `disabled` (if unset, defaults based on
   whether `WANDB_API_KEY` is present)
 
 Key behavior:
 
-- Refuses to run if `${OUTPUT_BASE}/$NAME` already exists (forces unique run names).
+- Refuses to run if `${OUTPUT_BASE}/$NAME` already exists, except when
+  `SLURM_RESTART_COUNT` indicates that Slurm restarted the same requeued job.
 - Fails early if either `${DATA_ROOT}` or `${OUTPUT_BASE}` does not exist, with
   instructions to set the corresponding env var.
 - Uses the container venv explicitly (`/workspace/.venv/bin/python`) to avoid missing deps.
@@ -81,9 +85,14 @@ Key behavior:
 - Caches the pulled SIF under `${REPO_DIR}/.apptainer-images/` by default.
 - If `NSYS_ARGS` is set and does not include `-o`/`--output`, reports are written under
   `${OUTPUT_BASE}/${NAME}/nsys/`.
-- Defaults to a 8-hour walltime in `scripts/slurm_apptainer_train.sbatch`.
-- Our 1-degree jobs take around 4-6 hours, so this is safe; you should probalby
+- Defaults to an 8-hour walltime in `scripts/slurm_apptainer_train.sbatch`.
+- Our 1-degree jobs take around 4-6 hours, so this is safe; you should probably
   increase it by data size for 1/2-degree (i.e. 4x more data = 4x more time) etc.
+
+When `preemptible: true`, training detects the latest checkpoint in an existing
+run directory and resumes from it after a Slurm requeue. The requeue hook does
+not create a checkpoint at signal time, so checkpoint frequently enough that
+restarting from the most recent completed epoch is acceptable.
 
 ### Example: 1 Node, 8x RTX6000 on the NYU Torch HPC
 
@@ -91,20 +100,23 @@ For Torch RTX6000 nodes, size CPU and memory proportionally to GPUs. If you
 request all GPUs on a node, also request the node's full CPU and memory.
 
 Current `gr102` capacity:
+
 - `8` GPUs (`rtx6000`)
 - `128` CPUs total
 - `1,400G` memory available via SLURM
 
 So, sizing rule for this node when using our sbatch script which spawns a process
 per GPU within a task:
+
 - `--cpus-per-task=16 * <num_gpus>`
 - `--mem=175G * <num_gpus>`
 
 ie for an 8-GPU run, use `--cpus-per-task=128 --mem=1400G`.
 
 Partition guidance:
-- Do not set `--partition` by default.
-- Let Slurm place the job unless you have a specific partition requirement.
+
+- Use `--account=torch_pr_347_lzanna --partition=rtx6000_lzanna` for RTX6000
+  training unless another allocation is explicitly required.
 
 ```bash
 export CONFIG=configs/samudra_om4/train.yaml
@@ -120,7 +132,8 @@ export CONTAINER_HASH=<git_sha>
 # export IMAGE_REF=ghcr.io/<owner>/ocean-emulator-physicsnemo:25.11-<git_sha>
 
 sbatch \
-  --account=torch_pr_347_courant \
+  --account=torch_pr_347_lzanna \
+  --partition=rtx6000_lzanna \
   --nodes=1 \
   --ntasks-per-node=1 \
   --cpus-per-task=128 \
@@ -129,6 +142,69 @@ sbatch \
   --time=24:00:00 \
   scripts/slurm_apptainer_train.sbatch
 ```
+
+### Validated 4x RTX6000 Multi-Resolution Training
+
+The 1, 1/2, and 1/4 degree configuration is
+`configs/samudra_multi_om4/train.yaml`. It uses a matching-resolution schedule,
+concurrent CPU loading, pinned memory, and two persistent loader workers per
+rank.
+
+On `rtx6000_lzanna`, the validated request is 4 GPUs, 24 CPUs, and 800G host
+memory. The current submit policy rejects a 900G request for 4 GPUs; a 700G run
+exhausted host memory. The 800G run can still touch its cgroup limit under peak
+loading, so monitor `memory.events` and Slurm `MaxRSS`. After both training and
+validation loaders have been used, persistent loading produces 16 worker
+processes: two workers x two loaders x four ranks.
+
+The 24-CPU request was sufficient to keep observed data wait near zero and can
+start when CPU-only work prevents a 64-CPU request from being placed. Submit
+with a 48-hour limit and requeue five minutes before the deadline:
+
+```bash
+export CONFIG=configs/samudra_multi_om4/train.yaml
+export NAME="$(date +%F)-samudra-multi-om4-multires-4gpu"
+export DATA_ROOT=/scratch/$USER/data
+export OUTPUT_BASE=/scratch/$USER/runs
+export WANDB_MODE=online
+export REQUEUE_ON_USR1=1
+
+# Pin the exact image rather than depending on mutable wrapper defaults.
+export IMAGE_REF=ghcr.io/<owner>/ocean-emulator-physicsnemo:<pinned-tag>
+
+# Keep logs, images, and data caches off the home filesystem.
+export REPO_DIR=/scratch/$USER
+export SIF_DIR=/scratch/$USER/.apptainer-images
+export APPTAINER_CACHEDIR=/scratch/$USER/apptainer-cache
+export SINGULARITY_CACHEDIR=/scratch/$USER/singularity-cache
+export DATA_CACHE_DIR=/scratch/$USER/.data_cache/$NAME
+
+export NCCL_P2P_DISABLE=1
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
+
+sbatch \
+  --account=torch_pr_347_lzanna \
+  --partition=rtx6000_lzanna \
+  --nodes=1 \
+  --ntasks-per-node=1 \
+  --cpus-per-task=24 \
+  --mem=800G \
+  --gres=gpu:rtx6000:4 \
+  --time=2-00:00:00 \
+  --requeue \
+  --signal=B:USR1@300 \
+  --open-mode=append \
+  --chdir=/scratch/$USER \
+  --output=/scratch/$USER/slurm-%j.out \
+  --error=/scratch/$USER/slurm-%j.err \
+  --export=ALL \
+  scripts/slurm_apptainer_train.sbatch
+```
+
+Use `--open-mode=append` because a requeued job keeps the same job ID and log
+paths. The batch-level (`B:`) USR1 signal reaches the harness, which calls
+`scontrol requeue`; on restart, the preemptible training configuration selects
+the run's latest checkpoint.
 
 To enable profiling for a run, you typically want something like this:
 
@@ -248,7 +324,7 @@ export CONTAINER_HASH=<git_sha>
 # export IMAGE_REF=ghcr.io/<owner>/ocean-emulator-physicsnemo:25.11-<git_sha>
 
 sbatch \
-  --account=torch_pr_347_courant \
+  --account=torch_pr_347_lzanna \
   --partition=rtx6000_lzanna \
   --nodes=1 \
   --ntasks-per-node=1 \

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -152,9 +152,12 @@ concurrent CPU loading, pinned memory, and two persistent loader workers per
 rank.
 
 On `rtx6000_lzanna`, the validated request is 4 GPUs, 24 CPUs, and 800G host
-memory. The current submit policy rejects a 900G request for 4 GPUs; a 700G run
-exhausted host memory. The 800G run can still touch its cgroup limit under peak
-loading, so monitor `memory.events` and Slurm `MaxRSS`. After both training and
+memory. A four-worker-per-rank run exhausted its 700G allocation, while the
+two-worker-per-rank retry used 800G and progressed successfully. Because both
+worker count and allocated memory changed, this does not show that four workers
+would fail at 800G. The validated 800G run can still touch its cgroup limit
+under peak loading, so monitor `memory.events` and Slurm `MaxRSS`. The current
+submit policy rejects a 900G request for 4 GPUs. After both training and
 validation loaders have been used, persistent loading produces 16 worker
 processes: two workers x two loaders x four ranks.
 

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -137,7 +137,7 @@ sbatch \
   --cpus-per-task=128 \
   --mem=1400G \
   --gres=gpu:rtx6000:8 \
-  --time=24:00:00 \
+  --time=8:00:00 \
   scripts/slurm_apptainer_train.sbatch
 ```
 
@@ -169,6 +169,10 @@ export ARGS="--data.loading.num_workers=2 --preemptible=true"
 export IMAGE_REF=ghcr.io/<owner>/ocean-emulator-physicsnemo:<pinned-tag>
 
 sbatch \
+  --cpus-per-task=24 \
+  --mem=800G \
+  --gres=gpu:rtx6000:4 \
+  --time=7-00:00:00 \
   --requeue \
   --signal=B:USR1@300 \
   scripts/slurm_apptainer_train.sbatch

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -82,8 +82,9 @@ Key behavior:
 - Uses the container venv explicitly (`/workspace/.venv/bin/python`) to avoid missing deps.
 - To change training code or YAML configs, rebuild/publish a new container tag and
   point the harness at it (e.g. via `CONTAINER_HASH=<git_sha>`).
-- Keeps the repository working directory, pulled SIF, Apptainer caches, data
-  cache, and Slurm logs under `/scratch/$USER` by default.
+- Uses the Slurm submission directory for the working directory, pulled SIF,
+  data cache, and logs by default. The Torch training examples below override
+  these locations to `/scratch/$USER` so large files do not consume home quota.
 - If `NSYS_ARGS` is set and does not include `-o`/`--output`, reports are written under
   `${OUTPUT_BASE}/${NAME}/nsys/`.
 
@@ -118,8 +119,15 @@ Partition guidance:
 
 ```bash
 export CONFIG=configs/samudra_om4/train.yaml
-export NAME_SUFFIX=om4_samudra_baseline
+export NAME="$(date +%F)-om4-samudra-baseline"
 export ARGS="--batch_size=1"
+export REPO_DIR=/scratch/$USER
+export SIF_DIR=/scratch/$USER/.apptainer-images
+export APPTAINER_CACHEDIR=/scratch/$USER/apptainer-cache
+export SINGULARITY_CACHEDIR=/scratch/$USER/singularity-cache
+export DATA_CACHE_DIR=/scratch/$USER/.data_cache/$NAME
+export NCCL_P2P_DISABLE=1
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
 # Optional overrides (defaults are /scratch/$USER/data/om4_onedeg_v3 and /scratch/$USER/runs)
 # export DATA_ROOT=/scratch/$USER/data/om4_onedeg_v3
 # export OUTPUT_BASE=/scratch/$USER/runs
@@ -132,6 +140,9 @@ export CONTAINER_HASH=<git_sha>
 sbatch \
   --account=torch_pr_347_lzanna \
   --partition=rtx6000_lzanna \
+  --chdir=/scratch/$USER \
+  --output=/scratch/$USER/slurm-%j.out \
+  --error=/scratch/$USER/slurm-%j.err \
   --nodes=1 \
   --ntasks-per-node=1 \
   --cpus-per-task=128 \
@@ -164,11 +175,25 @@ export OUTPUT_BASE=/scratch/$USER/runs
 export WANDB_MODE=online
 export REQUEUE_ON_USR1=1
 export ARGS="--data.loading.num_workers=2 --preemptible=true"
+export REPO_DIR=/scratch/$USER
+export SIF_DIR=/scratch/$USER/.apptainer-images
+export APPTAINER_CACHEDIR=/scratch/$USER/apptainer-cache
+export SINGULARITY_CACHEDIR=/scratch/$USER/singularity-cache
+export DATA_CACHE_DIR=/scratch/$USER/.data_cache/$NAME
+export NCCL_P2P_DISABLE=1
+export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
 
 # Pin the exact image rather than depending on mutable wrapper defaults.
 export IMAGE_REF=ghcr.io/<owner>/ocean-emulator-physicsnemo:<pinned-tag>
 
 sbatch \
+  --account=torch_pr_347_lzanna \
+  --partition=rtx6000_lzanna \
+  --chdir=/scratch/$USER \
+  --output=/scratch/$USER/slurm-%j.out \
+  --error=/scratch/$USER/slurm-%j.err \
+  --nodes=1 \
+  --ntasks-per-node=1 \
   --cpus-per-task=24 \
   --mem=800G \
   --gres=gpu:rtx6000:4 \
@@ -178,12 +203,12 @@ sbatch \
   scripts/slurm_apptainer_train.sbatch
 ```
 
-The harness uses append mode because a requeued job keeps the same job ID and
-log paths. The batch-level (`B:`) USR1 signal reaches the harness, which calls
-`scontrol requeue`; on restart, the preemptible training configuration selects
-the run's latest checkpoint. The harness also defaults `NCCL_P2P_DISABLE=1` and
-`TORCH_NCCL_ASYNC_ERROR_HANDLING=1` for RTX6000 jobs; export different values
-before submission when another platform requires them.
+Command-line `sbatch` options override the corresponding directives embedded in
+the harness. The harness uses append mode because a requeued job keeps the same
+job ID and log paths. The batch-level (`B:`) USR1 signal reaches the harness,
+which calls `scontrol requeue`; on restart, the preemptible training
+configuration selects the run's latest checkpoint. The Torch examples set the
+RTX6000 NCCL environment explicitly instead of making it a harness default.
 
 To enable profiling for a run, you typically want something like this:
 
@@ -195,7 +220,8 @@ export NSYS_ARGS="--trace=cuda,nvtx,osrt,nccl --sample=cpu --delay=300 --duratio
 
 After submission:
 
-- Slurm stdout: `slurm-<jobid>.out` in the submission directory (usually the repo root on torch).
+- Slurm stdout: the path passed with `--output` (the examples use
+  `/scratch/$USER/slurm-<jobid>.out`).
 - Training log: `${OUTPUT_BASE}/${NAME:-$(date +%Y-%m-%d)-${NAME_SUFFIX}}/experiment.log`
 
 Useful commands:

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -82,12 +82,13 @@ Key behavior:
 - Uses the container venv explicitly (`/workspace/.venv/bin/python`) to avoid missing deps.
 - To change training code or YAML configs, rebuild/publish a new container tag and
   point the harness at it (e.g. via `CONTAINER_HASH=<git_sha>`).
-- Caches the pulled SIF under `${REPO_DIR}/.apptainer-images/` by default.
+- Keeps the repository working directory, pulled SIF, Apptainer caches, data
+  cache, and Slurm logs under `/scratch/$USER` by default.
 - If `NSYS_ARGS` is set and does not include `-o`/`--output`, reports are written under
   `${OUTPUT_BASE}/${NAME}/nsys/`.
-- Defaults to an 8-hour walltime in `scripts/slurm_apptainer_train.sbatch`.
-- Our 1-degree jobs take around 4-6 hours, so this is safe; you should probably
-  increase it by data size for 1/2-degree (i.e. 4x more data = 4x more time) etc.
+- Defaults to the validated 4-GPU multi-resolution request on
+  `rtx6000_lzanna`: 24 CPUs, 800G memory, and a 48-hour walltime. Override the
+  `#SBATCH` defaults at submission time for other model or node sizes.
 
 When `preemptible: true`, training detects the latest checkpoint in an existing
 run directory and resumes from it after a Slurm requeue. The requeue hook does
@@ -158,8 +159,10 @@ validation loaders have been used, persistent loading produces 16 worker
 processes: two workers x two loaders x four ranks.
 
 The 24-CPU request was sufficient to keep observed data wait near zero and can
-start when CPU-only work prevents a 64-CPU request from being placed. Submit
-with a 48-hour limit and requeue five minutes before the deadline:
+start when CPU-only work prevents a 64-CPU request from being placed. These
+resources, scratch-backed execution paths, and append-mode logging are defaults
+in the training harness. The submit command only needs to opt into deadline
+requeueing:
 
 ```bash
 export CONFIG=configs/samudra_multi_om4/train.yaml
@@ -172,39 +175,18 @@ export REQUEUE_ON_USR1=1
 # Pin the exact image rather than depending on mutable wrapper defaults.
 export IMAGE_REF=ghcr.io/<owner>/ocean-emulator-physicsnemo:<pinned-tag>
 
-# Keep logs, images, and data caches off the home filesystem.
-export REPO_DIR=/scratch/$USER
-export SIF_DIR=/scratch/$USER/.apptainer-images
-export APPTAINER_CACHEDIR=/scratch/$USER/apptainer-cache
-export SINGULARITY_CACHEDIR=/scratch/$USER/singularity-cache
-export DATA_CACHE_DIR=/scratch/$USER/.data_cache/$NAME
-
-export NCCL_P2P_DISABLE=1
-export TORCH_NCCL_ASYNC_ERROR_HANDLING=1
-
 sbatch \
-  --account=torch_pr_347_lzanna \
-  --partition=rtx6000_lzanna \
-  --nodes=1 \
-  --ntasks-per-node=1 \
-  --cpus-per-task=24 \
-  --mem=800G \
-  --gres=gpu:rtx6000:4 \
-  --time=2-00:00:00 \
   --requeue \
   --signal=B:USR1@300 \
-  --open-mode=append \
-  --chdir=/scratch/$USER \
-  --output=/scratch/$USER/slurm-%j.out \
-  --error=/scratch/$USER/slurm-%j.err \
-  --export=ALL \
   scripts/slurm_apptainer_train.sbatch
 ```
 
-Use `--open-mode=append` because a requeued job keeps the same job ID and log
-paths. The batch-level (`B:`) USR1 signal reaches the harness, which calls
+The harness uses append mode because a requeued job keeps the same job ID and
+log paths. The batch-level (`B:`) USR1 signal reaches the harness, which calls
 `scontrol requeue`; on restart, the preemptible training configuration selects
-the run's latest checkpoint.
+the run's latest checkpoint. The harness also defaults `NCCL_P2P_DISABLE=1` and
+`TORCH_NCCL_ASYNC_ERROR_HANDLING=1` for RTX6000 jobs; export different values
+before submission when another platform requires them.
 
 To enable profiling for a run, you typically want something like this:
 

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -86,9 +86,6 @@ Key behavior:
   cache, and Slurm logs under `/scratch/$USER` by default.
 - If `NSYS_ARGS` is set and does not include `-o`/`--output`, reports are written under
   `${OUTPUT_BASE}/${NAME}/nsys/`.
-- Defaults to the validated 4-GPU multi-resolution request on
-  `rtx6000_lzanna`: 24 CPUs, 800G memory, and a 48-hour walltime. Override the
-  `#SBATCH` defaults at submission time for other model or node sizes.
 
 When `preemptible: true`, training detects the latest checkpoint in an existing
 run directory and resumes from it after a Slurm requeue. The requeue hook does
@@ -146,26 +143,13 @@ sbatch \
 
 ### Validated 4x RTX6000 Multi-Resolution Training
 
-The 1, 1/2, and 1/4 degree configuration is
-`configs/samudra_multi_om4/train.yaml`. It uses a matching-resolution schedule,
-concurrent CPU loading, pinned memory, and two persistent loader workers per
-rank.
+One known-working configuration on torch is:
+* The 1, 1/2, and 1/4 degree configuration on `configs/samudra_multi_om4/train.yaml`
+* 4 x RTX6000, 24 CPUs, 800G memory and 2 data load workers (for CPU memory reasons)
+* Using `--preemptible=true` and a 48-hour wall time to make it scheduable.
 
-On `rtx6000_lzanna`, the validated request is 4 GPUs, 24 CPUs, and 800G host
-memory. A four-worker-per-rank run exhausted its 700G allocation, while the
-two-worker-per-rank retry used 800G and progressed successfully. Because both
-worker count and allocated memory changed, this does not show that four workers
-would fail at 800G. The validated 800G run can still touch its cgroup limit
-under peak loading, so monitor `memory.events` and Slurm `MaxRSS`. The current
-submit policy rejects a 900G request for 4 GPUs. After both training and
-validation loaders have been used, persistent loading produces 16 worker
-processes: two workers x two loaders x four ranks.
-
-The 24-CPU request was sufficient to keep observed data wait near zero and can
-start when CPU-only work prevents a 64-CPU request from being placed. These
-resources, scratch-backed execution paths, and append-mode logging are defaults
-in the training harness. The submit command only needs to opt into deadline
-requeueing:
+The 24-CPU request was sufficient to keep observed data wait near zero, and
+the 2 data load workers kept CPU memory under 800G. Ie something like:
 
 ```bash
 export CONFIG=configs/samudra_multi_om4/train.yaml
@@ -174,6 +158,7 @@ export DATA_ROOT=/scratch/$USER/data
 export OUTPUT_BASE=/scratch/$USER/runs
 export WANDB_MODE=online
 export REQUEUE_ON_USR1=1
+export ARGS="--data.loading.num_workers=4 --preemptible=true"
 
 # Pin the exact image rather than depending on mutable wrapper defaults.
 export IMAGE_REF=ghcr.io/<owner>/ocean-emulator-physicsnemo:<pinned-tag>

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -39,11 +39,11 @@
 #SBATCH --partition=rtx6000_lzanna
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
-# Validated defaults for three-resolution Samudra Multi training.
-#SBATCH --cpus-per-task=24
-#SBATCH --mem=800G
-#SBATCH --gres=gpu:rtx6000:4
-#SBATCH --time=7-00:00:00
+# For 8-GPU runs on gr102, request full-node CPUs and QOS-capped memory.
+#SBATCH --cpus-per-task=128
+#SBATCH --mem=1400G
+#SBATCH --gres=gpu:rtx6000:8
+#SBATCH --time=8:00:00
 
 set -euo pipefail
 

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -43,7 +43,7 @@
 #SBATCH --cpus-per-task=24
 #SBATCH --mem=800G
 #SBATCH --gres=gpu:rtx6000:4
-#SBATCH --time=2-00:00:00
+#SBATCH --time=7-00:00:00
 
 set -euo pipefail
 

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -11,11 +11,10 @@
 #   export NAME_SUFFIX=om4_samudra_baseline   # NAME becomes YYYY-MM-DD-<suffix>
 #   export ARGS="--epochs=2 --batch_size=1"
 #   export WANDB_API_KEY=...   # optional; if unset, wandb is disabled
-#   sbatch scripts/slurm_apptainer_train.sbatch
+#   sbatch --nodes=1 --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
 #
 # Multi-node example (requires enough nodes available):
-#   sbatch --nodes=2 --cpus-per-task=128 --mem=1400G \
-#     --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
+#   sbatch --nodes=2 --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
 #
 # Container selection (pick one):
 #   export IMAGE_REF=ghcr.io/m2lines/ocean-emulator-physicsnemo:26.05-<hash>
@@ -32,11 +31,9 @@
 #   #   ${OUTPUT_BASE}/${NAME}/nsys/
 
 #SBATCH --job-name=oe-train
-#SBATCH --output=/scratch/%u/slurm-%j.out
-#SBATCH --error=/scratch/%u/slurm-%j.err
+#SBATCH --output=slurm-%j.out
 #SBATCH --open-mode=append
-#SBATCH --account=torch_pr_347_lzanna
-#SBATCH --partition=rtx6000_lzanna
+#SBATCH --account=torch_pr_347_courant
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 # For 8-GPU runs on gr102, request full-node CPUs and QOS-capped memory.
@@ -160,13 +157,11 @@ if [[ -z "${IMAGE_REF}" ]]; then
   IMAGE_REF="${CONTAINER_REGISTRY}/${CONTAINER_ORG}/${CONTAINER_REPO}:${CONTAINER_TAG}"
 fi
 
-REPO_DIR="${REPO_DIR:-/scratch/${CURRENT_USER}}"
+REPO_DIR="${REPO_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
 cd "${REPO_DIR}"
 
 SIF_DIR="${SIF_DIR:-${REPO_DIR}/.apptainer-images}"
-export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-/scratch/${CURRENT_USER}/apptainer-cache}"
-export SINGULARITY_CACHEDIR="${SINGULARITY_CACHEDIR:-/scratch/${CURRENT_USER}/singularity-cache}"
-mkdir -p "${SIF_DIR}" "${APPTAINER_CACHEDIR}" "${SINGULARITY_CACHEDIR}"
+mkdir -p "${SIF_DIR}"
 # Default cache name keys off IMAGE_REF so distinct refs never collide.
 IMAGE_REF_SAFE="$(echo "${IMAGE_REF}" | tr '/:@' '---')"
 SIF_PATH="${SIF_PATH:-${SIF_DIR}/${IMAGE_REF_SAFE}.sif}"
@@ -238,8 +233,6 @@ export MKL_NUM_THREADS="${MKL_NUM_THREADS:-${OMP_NUM_THREADS}}"
 export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-${OMP_NUM_THREADS}}"
 export NUMEXPR_NUM_THREADS="${NUMEXPR_NUM_THREADS:-${OMP_NUM_THREADS}}"
 export PYTHONUNBUFFERED=1
-export NCCL_P2P_DISABLE="${NCCL_P2P_DISABLE:-1}"
-export TORCH_NCCL_ASYNC_ERROR_HANDLING="${TORCH_NCCL_ASYNC_ERROR_HANDLING:-1}"
 export PYTHONNOUSERSITE="${PYTHONNOUSERSITE:-1}"
 export APPTAINERENV_PYTHONNOUSERSITE="${APPTAINERENV_PYTHONNOUSERSITE:-${PYTHONNOUSERSITE}}"
 export SINGULARITYENV_PYTHONNOUSERSITE="${SINGULARITYENV_PYTHONNOUSERSITE:-${PYTHONNOUSERSITE}}"

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -11,10 +11,11 @@
 #   export NAME_SUFFIX=om4_samudra_baseline   # NAME becomes YYYY-MM-DD-<suffix>
 #   export ARGS="--epochs=2 --batch_size=1"
 #   export WANDB_API_KEY=...   # optional; if unset, wandb is disabled
-#   sbatch --nodes=1 --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
+#   sbatch scripts/slurm_apptainer_train.sbatch
 #
 # Multi-node example (requires enough nodes available):
-#   sbatch --nodes=2 --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
+#   sbatch --nodes=2 --cpus-per-task=128 --mem=1400G \
+#     --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
 #
 # Container selection (pick one):
 #   export IMAGE_REF=ghcr.io/m2lines/ocean-emulator-physicsnemo:26.05-<hash>
@@ -31,15 +32,18 @@
 #   #   ${OUTPUT_BASE}/${NAME}/nsys/
 
 #SBATCH --job-name=oe-train
-#SBATCH --output=slurm-%j.out
-#SBATCH --account=torch_pr_347_courant
+#SBATCH --output=/scratch/%u/slurm-%j.out
+#SBATCH --error=/scratch/%u/slurm-%j.err
+#SBATCH --open-mode=append
+#SBATCH --account=torch_pr_347_lzanna
+#SBATCH --partition=rtx6000_lzanna
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
-# For 8-GPU runs on gr102, request full-node CPUs and QOS-capped memory.
-#SBATCH --cpus-per-task=128
-#SBATCH --mem=1400G
-#SBATCH --gres=gpu:rtx6000:8
-#SBATCH --time=8:00:00
+# Validated defaults for three-resolution Samudra Multi training.
+#SBATCH --cpus-per-task=24
+#SBATCH --mem=800G
+#SBATCH --gres=gpu:rtx6000:4
+#SBATCH --time=2-00:00:00
 
 set -euo pipefail
 
@@ -156,11 +160,13 @@ if [[ -z "${IMAGE_REF}" ]]; then
   IMAGE_REF="${CONTAINER_REGISTRY}/${CONTAINER_ORG}/${CONTAINER_REPO}:${CONTAINER_TAG}"
 fi
 
-REPO_DIR="${REPO_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
+REPO_DIR="${REPO_DIR:-/scratch/${CURRENT_USER}}"
 cd "${REPO_DIR}"
 
 SIF_DIR="${SIF_DIR:-${REPO_DIR}/.apptainer-images}"
-mkdir -p "${SIF_DIR}"
+export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-/scratch/${CURRENT_USER}/apptainer-cache}"
+export SINGULARITY_CACHEDIR="${SINGULARITY_CACHEDIR:-/scratch/${CURRENT_USER}/singularity-cache}"
+mkdir -p "${SIF_DIR}" "${APPTAINER_CACHEDIR}" "${SINGULARITY_CACHEDIR}"
 # Default cache name keys off IMAGE_REF so distinct refs never collide.
 IMAGE_REF_SAFE="$(echo "${IMAGE_REF}" | tr '/:@' '---')"
 SIF_PATH="${SIF_PATH:-${SIF_DIR}/${IMAGE_REF_SAFE}.sif}"
@@ -232,6 +238,8 @@ export MKL_NUM_THREADS="${MKL_NUM_THREADS:-${OMP_NUM_THREADS}}"
 export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-${OMP_NUM_THREADS}}"
 export NUMEXPR_NUM_THREADS="${NUMEXPR_NUM_THREADS:-${OMP_NUM_THREADS}}"
 export PYTHONUNBUFFERED=1
+export NCCL_P2P_DISABLE="${NCCL_P2P_DISABLE:-1}"
+export TORCH_NCCL_ASYNC_ERROR_HANDLING="${TORCH_NCCL_ASYNC_ERROR_HANDLING:-1}"
 export PYTHONNOUSERSITE="${PYTHONNOUSERSITE:-1}"
 export APPTAINERENV_PYTHONNOUSERSITE="${APPTAINERENV_PYTHONNOUSERSITE:-${PYTHONNOUSERSITE}}"
 export SINGULARITYENV_PYTHONNOUSERSITE="${SINGULARITYENV_PYTHONNOUSERSITE:-${PYTHONNOUSERSITE}}"


### PR DESCRIPTION
Adds in some docs for one example multi-res training run configuration which seems to work on torch, as well as a few missing documentation bits.

Validated run: [Weights & Biases](https://wandb.ai/ocean_emulators/default/runs/x285qor8).