### PR TITLE
Restore primary-source validation metrics

### DIFF
--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -28,7 +28,7 @@ from torch.utils.data import (
 )
 
 from samudra import config
-from samudra.aggregator import Aggregator, ValidateAggregator
+from samudra.aggregator import Aggregator
 from samudra.aggregator.loss import (
     get_channel_loss_dict,
     get_channel_loss_scale_dict,
@@ -678,26 +678,15 @@ class Trainer:
             and self.validation_images_enabled
         )
 
-        if self.train_schedule == "standard":
-            # The standard val aggregator only supports a single scale.
-            val_aggregator = Aggregator.get_validation_aggregator(
-                self.primary_src.metadata,
-                self.hist,
-                self.primary_src.spherical_area_weights.to(self.device),
-                self.num_out,
-                self.tensor_map,
-                self.normalize,
-                include_image_aggregators=log_validation_images,
-            )
-        else:
-            # Create a validation aggregator that handles multiple scales.
-            val_aggregator = ValidateAggregator(
-                {},  # Currently, don't do anything else besides record the training loss.
-                self.hist,
-                self.num_out,
-                tensor_map=self.tensor_map,
-                normalize=self.normalize,
-            )
+        val_aggregator = Aggregator.get_validation_aggregator(
+            self.primary_src.metadata,
+            self.hist,
+            self.primary_src.spherical_area_weights.to(self.device),
+            self.num_out,
+            self.tensor_map,
+            self.normalize,
+            include_image_aggregators=log_validation_images,
+        )
         metric_logger = MetricLogger(delimiter="  ")
         header = f"One-Step Validation Epoch: [{epoch}]"
 
@@ -824,10 +813,13 @@ class Trainer:
             for src, dst in srcs
         ]
 
+        # Validation is always evaluated on the primary source. This keeps the
+        # validation loss and physical-space metrics comparable across epochs,
+        # regardless of the set of resolutions used for training.
         val_datasets = [
             TorchTrainDataset(
-                src=src.slice(self.val_time),
-                dst=dst.slice(self.val_time) if dst else None,
+                src=self.primary_src.slice(self.val_time),
+                dst=None,
                 prognostic_var_names=self.prognostic_var_names,
                 boundary_var_names=self.boundary_var_names,
                 hist=self.hist,
@@ -838,7 +830,6 @@ class Trainer:
                 concurrent_compute_=self.concurrent_compute,
             )
             for stride in self.data_stride
-            for src, dst in srcs
         ]
 
         # Create datasets

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -15,7 +15,7 @@ from samudra.train import Trainer, should_log_validation_images
 from samudra.utils.ctx import GridContext
 from samudra.utils.loss import DynamicLoss
 from samudra.utils.multiton import MultitonScope
-from tests.conftest import DEFAULT_CONFIG, TrainPair
+from tests.conftest import DEFAULT_CONFIG, SAMUDRA_MULTI_CONFIG, TrainPair
 
 
 @pytest.mark.manual
@@ -186,6 +186,45 @@ def test_should_log_validation_images_rejects_invalid_inputs():
 
     with pytest.raises(ValueError, match="Validation image log frequency must be >= 1"):
         should_log_validation_images(1, 0)
+
+
+@pytest.mark.parametrize("backend", ["cpu"], indirect=True)
+@pytest.mark.parametrize(
+    "data_source,config_name",
+    [("mock-om4", SAMUDRA_MULTI_CONFIG)],
+    indirect=True,
+)
+def test_multiscale_training_validates_primary_source_and_logs_reduced_metrics(
+    train_config,
+):
+    train_config.data.sources.append(train_config.data.sources[0].model_copy(deep=True))
+    train_config.experiment.train_schedule = "match"
+    train_config.data.loading.num_workers = 0
+    train_config.model.perceiver_implementation = "naive"
+    train_config.debug = True
+
+    with MultitonScope():
+        trainer = Trainer(train_config)
+        trainer.init_data_loaders(cur_step=train_config.steps[0])
+
+        assert len(trainer.train_loader._datasets) == 2
+        assert len(trainer.val_loader._datasets) == 1
+        val_dataset = next(iter(trainer.val_loader._datasets.values()))
+        assert len(val_dataset.prognostic_srcs) == 1
+        assert val_dataset.prognostic_srcs[0].grid_size == trainer.primary_src.grid_size
+
+        class PerfectModel(BaseModel):
+            def __init__(self):
+                super().__init__(0, 0, 0, False, 1, "constant", 0)
+
+            def forward(self, batch, loss_fn=None):
+                return [batch.get_label(0)]
+
+        trainer.model = PerfectModel()
+        trainer.test_using_ema = False
+        val_logs = trainer.validate_one_epoch(epoch=1)
+
+    assert any(key.startswith("val/reduced/weighted_rmse/") for key in val_logs)
 
 
 @pytest.mark.parametrize("backend", ["cpu"], indirect=True)


### PR DESCRIPTION
Validating against the primary source only is not ideal, but it seems better than no validation at all (and is sufficient for several of our upcoming goals), so seems like a reasonable step in the right direction. 