### PR TITLE
Avoid single-node torchrun rendezvous port collisions

### DIFF
--- a/docs/torch.md
+++ b/docs/torch.md
@@ -76,6 +76,8 @@ Key behavior:
 - Fails early if either `${DATA_ROOT}` or `${OUTPUT_BASE}` does not exist, with
   instructions to set the corresponding env var.
 - Uses the container venv explicitly (`/workspace/.venv/bin/python`) to avoid missing deps.
+- Lets `torchrun --standalone` choose a free rendezvous port for single-node jobs.
+  Multi-node jobs use a job-derived port unless `MASTER_PORT` is set explicitly.
 - To change training code or YAML configs, rebuild/publish a new container tag and
   point the harness at it (e.g. via `CONTAINER_HASH=<git_sha>`).
 - Caches the pulled SIF under `${REPO_DIR}/.apptainer-images/` by default.

--- a/scripts/empireai_nvl72_train.sbatch
+++ b/scripts/empireai_nvl72_train.sbatch
@@ -42,7 +42,7 @@ CONFIG="${CONFIG:-configs/samudra_om4_v2/train.yaml}"
 DATA_ROOT="${DATA_ROOT:-${HOME}/data/om4_halfdeg}"
 OUTPUT_BASE="${OUTPUT_BASE:-${HOME}/runs}"
 DATA_CACHE_DIR="${DATA_CACHE_DIR:-${HOME}/.cache/samudra/${SLURM_JOB_ID:-manual}}"
-MASTER_PORT="${MASTER_PORT:-29500}"
+MASTER_PORT="${MASTER_PORT:-}"
 EXTRA_ARGS="${EXTRA_ARGS:-}"
 WANDB_ENTITY="${WANDB_ENTITY:-ocean_emulators}"
 WANDB_PROJECT="${WANDB_PROJECT:-default}"
@@ -167,7 +167,13 @@ if [[ -n "${EXTRA_ARGS}" ]]; then
 fi
 
 MASTER_ADDR="$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)"
-export MASTER_ADDR MASTER_PORT
+TORCHRUN_STANDALONE=0
+if [[ -z "${MASTER_PORT}" && "${SLURM_NNODES}" == "1" ]]; then
+  TORCHRUN_STANDALONE=1
+elif [[ -z "${MASTER_PORT}" ]]; then
+  MASTER_PORT="$((15000 + SLURM_JOB_ID % 40000))"
+fi
+export MASTER_ADDR MASTER_PORT TORCHRUN_STANDALONE
 
 container_mounts="${DATA_ROOT}:${DATA_ROOT},${OUTPUT_BASE}:${OUTPUT_BASE},${DATA_CACHE_DIR}:/workspace/.data_cache"
 
@@ -176,7 +182,11 @@ echo "Job id:        ${SLURM_JOB_ID}"
 echo "Nodes:         ${SLURM_NNODES}"
 echo "GPUs/node:     ${GPUS_PER_NODE}"
 echo "Total GPUs:    ${TOTAL_GPUS}"
-echo "Master:        ${MASTER_ADDR}:${MASTER_PORT}"
+if [[ "${TORCHRUN_STANDALONE}" == "1" ]]; then
+  echo "Rendezvous:    automatic free port (--standalone)"
+else
+  echo "Rendezvous:    ${MASTER_ADDR}:${MASTER_PORT}"
+fi
 echo "Image:         ${IMAGE_REF}"
 echo "Config:        ${CONFIG_IN_CONTAINER}"
 echo "Data root:     ${DATA_ROOT}"
@@ -211,11 +221,20 @@ srun --ntasks="${SLURM_NNODES}" --ntasks-per-node=1 \
       echo "ERROR: config not found inside container: $1" >&2
       exit 2
     fi
+    torchrun_args=(
+      --nnodes="${SLURM_NNODES}"
+      --nproc_per_node="${GPUS_PER_NODE}"
+      --node_rank="${SLURM_PROCID}"
+    )
+    if [[ "${TORCHRUN_STANDALONE}" == "1" ]]; then
+      torchrun_args+=(--standalone)
+    else
+      torchrun_args+=(
+        --master_addr="${MASTER_ADDR}"
+        --master_port="${MASTER_PORT}"
+      )
+    fi
     exec /workspace/.venv/bin/python -m torch.distributed.run \
-      --nnodes="${SLURM_NNODES}" \
-      --nproc_per_node="${GPUS_PER_NODE}" \
-      --master_addr="${MASTER_ADDR}" \
-      --master_port="${MASTER_PORT}" \
-      --node_rank="${SLURM_PROCID}" \
+      "${torchrun_args[@]}" \
       -m samudra.train "$@"
   ' bash "${train_args[@]}"

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -196,10 +196,22 @@ else
   echo "Using existing SIF."
 fi
 
-# Distributed rendezvous info (shared by all nodes).
+# Distributed rendezvous info. Let torchrun atomically choose a free port for
+# single-node jobs. Multi-node jobs need a shared, predetermined endpoint.
 MASTER_ADDR="$(scontrol show hostnames "${SLURM_JOB_NODELIST}" | head -n 1)"
-MASTER_PORT="${MASTER_PORT:-8008}"
-export MASTER_ADDR MASTER_PORT
+MASTER_PORT="${MASTER_PORT:-}"
+TORCHRUN_STANDALONE=0
+if [[ -z "${MASTER_PORT}" && "${SLURM_NNODES}" == "1" ]]; then
+  TORCHRUN_STANDALONE=1
+elif [[ -z "${MASTER_PORT}" ]]; then
+  MASTER_PORT="$((15000 + SLURM_JOB_ID % 40000))"
+fi
+export MASTER_ADDR MASTER_PORT TORCHRUN_STANDALONE
+if [[ "${TORCHRUN_STANDALONE}" == "1" ]]; then
+  echo "Rendezvous: automatic free port (--standalone)"
+else
+  echo "Rendezvous: ${MASTER_ADDR}:${MASTER_PORT}"
+fi
 
 # This harness launches one torchrun per node via srun. Each torchrun spawns one
 # process per GPU on that node, and sets RANK/LOCAL_RANK/WORLD_SIZE via env://.
@@ -274,6 +286,19 @@ srun --ntasks="${SLURM_NNODES}" --ntasks-per-node=1 \
         echo \"Hint: rebuild/pull a container tag that includes /workspace/configs.\" >&2
         exit 2
       fi
+      torchrun_args=(
+        --nnodes=${SLURM_NNODES}
+        --nproc_per_node=${GPUS_PER_NODE}
+        --node_rank=\${SLURM_PROCID}
+      )
+      if [[ \"\${TORCHRUN_STANDALONE}\" == \"1\" ]]; then
+        torchrun_args+=(--standalone)
+      else
+        torchrun_args+=(
+          --master_addr=\${MASTER_ADDR}
+          --master_port=\${MASTER_PORT}
+        )
+      fi
       profiler_cmd=()
       if [[ -n \"\${OE_NSYS_ARGS:-}\" ]]; then
         if ! command -v nsys >/dev/null 2>&1; then
@@ -299,11 +324,7 @@ srun --ntasks="${SLURM_NNODES}" --ntasks-per-node=1 \
         echo \"Nsight Systems profiling enabled on proc \${SLURM_PROCID:-unset}.\"
       fi
       \"\${profiler_cmd[@]}\" /workspace/.venv/bin/python -m torch.distributed.run \
-        --nnodes=${SLURM_NNODES} \
-        --nproc_per_node=${GPUS_PER_NODE} \
-        --master_addr=${MASTER_ADDR} \
-        --master_port=${MASTER_PORT} \
-        --node_rank=\${SLURM_PROCID} \
+        \"\${torchrun_args[@]}\" \
         -m samudra.train \"${CONFIG_IN_CONTAINER}\" \
         --experiment.name=\"${NAME}\" \
         --experiment.data_root=\"${DATA_ROOT}\" \


### PR DESCRIPTION
The training harnesses defaulted every job to the same static rendezvous port (`8008` or `29500`). Concurrent jobs placed on the same host therefore raced to bind the same TCP port and one failed during distributed initialization.

For single-node launches, `torchrun --standalone` asks the launcher to choose a free port atomically, removing the shared static default. Multi-node launches still require a predetermined endpoint shared by every node.