### PR TITLE
Add merge queue triggers to required checks

### DIFF
--- a/.github/workflows/container-physicsnemo.yml
+++ b/.github/workflows/container-physicsnemo.yml
@@ -14,6 +14,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/data-tests-xesmf.yaml
+++ b/.github/workflows/data-tests-xesmf.yaml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/data-tests.yaml
+++ b/.github/workflows/data-tests.yaml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - "**"
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Add the `merge_group` event trigger to each workflow that currently runs as a pull-request check:

- CPU and GPU tests
- pre-commit checks
- standard and xESMF data-test matrices
- PhysicsNeMo container checks

This lets the required checks run for GitHub merge queue groups instead of remaining pending when a PR enters the queue, see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions