### PR TITLE
Make mask matching test deterministic

### DIFF
--- a/data/tests/test_utils.py
+++ b/data/tests/test_utils.py
@@ -22,10 +22,10 @@ def test_assert_mask_match(mask_dtype):
     y = np.arange(0, 3)
     z = np.arange(0, 4)
     data_2d = xr.DataArray(
-        np.random.random([2, 3]), dims=["x", "y"], coords={"x": x, "y": y}
+        np.arange(6).reshape(2, 3), dims=["x", "y"], coords={"x": x, "y": y}
     )
     data_3d = xr.DataArray(
-        np.random.random([2, 3, 4]),
+        np.arange(24).reshape(2, 3, 4),
         dims=["x", "y", "z"],
         coords={"x": x, "y": y, "z": z},
     )

--- a/data/tests/test_utils.py
+++ b/data/tests/test_utils.py
@@ -29,7 +29,7 @@ def test_assert_mask_match(mask_dtype):
         dims=["x", "y", "z"],
         coords={"x": x, "y": y, "z": z},
     )
-    mask_3d = data_3d > 0.25
+    mask_3d = data_3d % 3 == 0
     if mask_dtype is not None:
         mask_3d = mask_3d.astype(mask_dtype)
     ds = xr.Dataset({"3d": data_3d, "2d": data_2d})


### PR DESCRIPTION
The test built a 24-element mask from random values using `data_3d > 0.25`. There was a roughly 0.10% chance that every mask element was `True`; in that case the unmasked dataset correctly matched the mask and the expected `ValueError` was not raised. This caused [this CI failure](https://github.com/m2lines/Samudra/actions/runs/29930540130/job/88958781028?pr=670). We now use deterministic data.