### PR TITLE
Add PyPI release workflow with weekly and stable channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Builds the pure-Python samudra wheel + sdist and publishes to PyPI via OIDC
+# trusted publishing -- no API token is stored anywhere. Triggers:
+#   schedule          -> nightly dev release (<base>.dev<stamp>)
+#   push tag v*       -> stable release, version from the v<version> tag
+#   workflow_dispatch -> manual cut (nightly / stable / manual)
+#   pull_request      -> build-only smoke when the build script or this
+#                        workflow file changes
+# One-time trusted-publisher setup is documented in docs/releasing.md.
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Build mode"
+        type: choice
+        options: [nightly, stable, manual]
+        default: manual
+      version:
+        description: "Version (required for stable mode, e.g. 1.0.0)"
+        type: string
+  schedule:
+    - cron: "0 6 * * *"   # 06:00 UTC daily
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "scripts/package.py"
+      - ".github/workflows/release.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false  # don't kill an in-flight publish
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.pick.outputs.mode }}
+      version: ${{ steps.resolved.outputs.version }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          fetch-depth: 0  # setuptools-scm + `git describe` need full tag history
+
+      # Hoist user-supplied dispatch inputs into env so they reach the shell as
+      # variables, not as `${{ ... }}` template substitutions -- free-form
+      # inputs interpolated into a shell script are an injection vector.
+      - id: pick
+        env:
+          INPUT_MODE: ${{ github.event.inputs.mode }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "mode=stable" >> "$GITHUB_OUTPUT"
+            echo "input_version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+            echo "mode=nightly" >> "$GITHUB_OUTPUT"
+            echo "input_version=" >> "$GITHUB_OUTPUT"
+          elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "mode=${INPUT_MODE}" >> "$GITHUB_OUTPUT"
+            echo "input_version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+          else
+            # pull_request: build-only smoke
+            echo "mode=manual" >> "$GITHUB_OUTPUT"
+            echo "input_version=" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Resolve the version exactly once for the whole run so the build job
+      # stamps the identical value -- a run straddling midnight UTC would
+      # otherwise compute a different nightly date in build vs resolve.
+      - id: resolved
+        env:
+          MODE: ${{ steps.pick.outputs.mode }}
+          INPUT_VERSION: ${{ steps.pick.outputs.input_version }}
+        run: |
+          python3 scripts/package.py --mode "$MODE" --version "$INPUT_VERSION" --resolve-only
+
+  build:
+    needs: resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          fetch-depth: 0  # setuptools-scm + `git describe` need full tag history
+      - uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff
+
+      - name: Build wheel + sdist
+        env:
+          MODE: ${{ needs.resolve.outputs.mode }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          python3 scripts/package.py --mode "$MODE" --version "$VERSION"
+
+      # Fail fast on broken metadata before we ever reach the publish step.
+      - name: Check distribution metadata
+        run: uvx twine check dist/*
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: samudra-dist
+          path: dist/*
+          retention-days: 14
+
+  publish:
+    # Manual mode produces local-version identifiers (`X.Y.Z+manual.<sha>`)
+    # which PyPI rejects, so manual cuts -- and every pull_request smoke --
+    # are build-only regardless of how they were triggered.
+    if: |
+      github.event_name != 'pull_request'
+      && needs.resolve.outputs.mode != 'manual'
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    environment: pypi-publish
+    permissions:
+      id-token: write   # mint the OIDC token for trusted publishing
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: samudra-dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247
+        with:
+          packages-dir: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ on:
         options: [nightly, stable, manual]
         default: manual
       version:
-        description: "Version (required for stable mode, e.g. 1.0.0)"
+        description: "Stable-cut version, e.g. 0.0.1 (required for stable; ignored for nightly/manual)"
         type: string
   schedule:
     - cron: "0 6 * * *"   # 06:00 UTC daily
@@ -68,7 +68,15 @@ jobs:
             echo "input_version=" >> "$GITHUB_OUTPUT"
           elif [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             echo "mode=${INPUT_MODE}" >> "$GITHUB_OUTPUT"
-            echo "input_version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+            # The version field is only meaningful for a stable cut. For nightly
+            # and manual dispatches, discard it so the version is always computed
+            # -- otherwise a value left in the field would be stamped verbatim
+            # and published as a bogus "nightly", burning a real PyPI version.
+            if [[ "${INPUT_MODE}" == "stable" ]]; then
+              echo "input_version=${INPUT_VERSION}" >> "$GITHUB_OUTPUT"
+            else
+              echo "input_version=" >> "$GITHUB_OUTPUT"
+            fi
           else
             # pull_request: build-only smoke
             echo "mode=manual" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Builds the pure-Python samudra wheel + sdist and publishes to PyPI via OIDC
-# trusted publishing -- no API token is stored anywhere. Triggers:
-#   schedule          -> nightly dev release (<base>.dev<stamp>)
+# trusted publishing -- no API token is stored anywhere. Publishing runs only
+# after the CPU test suite passes (see the `test` job). Triggers:
+#   schedule          -> weekly nightly dev release (<base>.dev<stamp>)
 #   push tag v*       -> stable release, version from the v<version> tag
-#   workflow_dispatch -> manual cut (nightly / stable / manual)
+#   workflow_dispatch -> hand-triggered cut (mode: nightly / stable / smoke)
 #   pull_request      -> build-only smoke when the build script or this
 #                        workflow file changes
-# One-time trusted-publisher setup is documented in docs/releasing.md.
+# The `smoke` mode is build-only (never publishes); note that every mode can be
+# hand-triggered via workflow_dispatch -- "smoke" names what it does, not how it
+# starts. One-time trusted-publisher setup is documented in docs/releasing.md.
 name: Release
 
 on:
@@ -18,13 +21,13 @@ on:
       mode:
         description: "Build mode"
         type: choice
-        options: [nightly, stable, manual]
-        default: manual
+        options: [nightly, stable, smoke]
+        default: smoke
       version:
-        description: "Stable-cut version, e.g. 0.0.1 (required for stable; ignored for nightly/manual)"
+        description: "Stable-cut version, e.g. 0.0.1 (required for stable; ignored for nightly/smoke)"
         type: string
   schedule:
-    - cron: "0 6 * * *"   # 06:00 UTC daily
+    - cron: "0 6 * * 1"   # 06:00 UTC every Monday
   push:
     tags:
       - "v*"
@@ -79,7 +82,7 @@ jobs:
             fi
           else
             # pull_request: build-only smoke
-            echo "mode=manual" >> "$GITHUB_OUTPUT"
+            echo "mode=smoke" >> "$GITHUB_OUTPUT"
             echo "input_version=" >> "$GITHUB_OUTPUT"
           fi
 
@@ -119,14 +122,24 @@ jobs:
           path: dist/*
           retention-days: 14
 
-  publish:
-    # Manual mode produces local-version identifiers (`X.Y.Z+manual.<sha>`)
-    # which PyPI rejects, so manual cuts -- and every pull_request smoke --
-    # are build-only regardless of how they were triggered.
+  # Gate every publish on the CPU test suite. A tag push doesn't otherwise run
+  # test.yml (it's push-to-main / PR only), so call it here as a required check.
+  test:
+    needs: resolve
     if: |
       github.event_name != 'pull_request'
-      && needs.resolve.outputs.mode != 'manual'
-    needs: [resolve, build]
+      && needs.resolve.outputs.mode != 'smoke'
+    uses: ./.github/workflows/test.yml
+
+  publish:
+    # Smoke mode produces local-version identifiers (`X.Y.Z+smoke.<sha>`) which
+    # PyPI rejects, so smoke cuts -- and every pull_request build -- are
+    # build-only regardless of how they were triggered. Publishing also waits on
+    # the test job, so a red test suite blocks the upload.
+    if: |
+      github.event_name != 'pull_request'
+      && needs.resolve.outputs.mode != 'smoke'
+    needs: [resolve, build, test]
     runs-on: ubuntu-latest
     environment: pypi-publish
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
     branches:
       - "**"
   merge_group:
+  workflow_call:  # let the Release workflow gate publishes on this suite
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ build/
 .claude/
 site/
 profiles/
+
+# Build artifacts
+dist/

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -11,9 +11,28 @@ SPDX-License-Identifier: CC-BY-4.0
 - Python 3.12
 - [uv](https://docs.astral.sh/uv/) package manager
 
-## Setup
+## Install from PyPI
 
-Clone the repository and install dependencies:
+Samudra is pure Python, so one wheel covers every platform. The GPU custom
+kernels are opt-in:
+
+```bash
+# Install with `uv` (recommended)
+uv add samudra                    # CPU (default)
+uv add "samudra[cuda]"            # adds flash-attn, flash-perceiver, torchvision
+uv add samudra --prerelease=allow # latest nightly dev build
+# Install with `pip`
+pip install samudra               # CPU (default)
+pip install "samudra[cuda]"       # adds flash-attn, flash-perceiver, torchvision
+pip install --pre samudra         # latest nightly dev build
+```
+
+The `cuda` extra compiles native kernels against your local CUDA + `torch`; see
+[Releasing to PyPI](../releasing.md#installing-the-package) for the details.
+
+## Development setup
+
+To work on Samudra itself, clone the repository and install dependencies:
 
 ```bash
 git clone https://github.com/m2lines/Samudra.git

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,100 @@
+<!--
+SPDX-FileCopyrightText: 2026 Samudra Authors
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Releasing to PyPI
+
+Samudra is published to [PyPI](https://pypi.org/project/samudra/) as a single
+pure-Python wheel by the [`Release`](https://github.com/Open-Athena/Samudra/actions/workflows/release.yml)
+workflow. It authenticates with [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/),
+so no API token is stored anywhere.
+
+## Installing the package
+
+Samudra itself is pure Python, so one universal wheel serves every platform.
+The GPU custom kernels are opt-in.
+
+```bash
+# CPU (default) — everything except the compiled GPU kernels
+uv add samudra
+pip install samudra
+
+# GPU — adds flash-attn, flash-perceiver, and torchvision, which compile
+# against your local CUDA + torch at install time
+uv add "samudra[cuda]"
+pip install "samudra[cuda]"
+
+# Latest nightly dev build
+uv add samudra --prerelease=allow
+pip install --pre samudra
+```
+
+The `cuda` extra builds native kernels, so it needs a CUDA toolchain and a
+matching `torch` already present. With `uv` the `[tool.uv]` build settings in
+`pyproject.toml` handle this automatically; with plain `pip` you typically want
+`pip install --no-build-isolation "samudra[cuda]"` in an environment that
+already has `torch`.
+
+## How versions are cut
+
+The version is owned by [setuptools-scm](https://setuptools-scm.readthedocs.io/):
+there is **no** `version = "..."` field to maintain — a git tag *is* the version.
+`[tool.setuptools_scm]` in `pyproject.toml` configures it, and `samudra.__version__`
+is available at runtime. The release paths differ only in what version reaches
+the build:
+
+| Trigger | Mode | Version | Published? |
+| --- | --- | --- | --- |
+| Push a `v*` tag | `stable` | the tag, e.g. `v1.0.0` → `1.0.0` (setuptools-scm) | ✅ PyPI |
+| Daily `schedule` (06:00 UTC) | `nightly` | `<next-patch>.dev<YYYYMMDDhhmm>` | ✅ PyPI |
+| `workflow_dispatch` → `nightly`/`stable` | as chosen | as above | ✅ PyPI |
+| `workflow_dispatch` → `manual` | `manual` | `<next-patch>+manual.<sha>` | ❌ build-only |
+| Pull request touching the script/workflow | `manual` | — | ❌ build-only |
+| Local editable install (`uv sync`) | — | `<next-patch>.dev<N>` from git | n/a |
+
+On a tagged commit setuptools-scm derives the version straight from the tag. For
+the two synthetic modes, `scripts/package.py` computes the version and hands it
+to setuptools-scm via `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SAMUDRA` — it never
+edits a tracked file. A nightly's base is one patch above the most recent `v*`
+tag (or `fallback_version` before the first tag), and its UTC timestamp keeps
+every nightly unique and PEP 440-ordered *above* the last release, so `--pre`
+resolves them.
+
+### Cutting a stable release
+
+```bash
+# Just tag and push — no version bump anywhere:
+git tag v1.1.0
+git push origin v1.1.0
+```
+
+The tag push runs `resolve → build → publish`, uploading `samudra 1.1.0` to
+PyPI. To dry-run first, use **Actions → Release → Run workflow → mode: manual**;
+that builds and runs `twine check` without publishing.
+
+!!! note "Before the first tag"
+    The repository has no `v*` tags yet, so builds fall back to `1.0.0`
+    (`fallback_version` in `[tool.setuptools_scm]`, mirrored by `FALLBACK_VERSION`
+    in `scripts/package.py` — keep the two in sync). Cutting `v1.0.0` makes the
+    tag the single source of truth from then on.
+
+## One-time trusted-publisher setup
+
+Before the first publish, register the repository as a trusted publisher on
+PyPI (a maintainer with project-owner rights does this once):
+
+1. Create the project on PyPI, or use [pending publishers](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
+   to reserve the name `samudra` before the first upload.
+2. On the project's **Settings → Publishing** page, add a GitHub Actions
+   publisher with:
+     - **Owner**: `Open-Athena`
+     - **Repository**: `Samudra`
+     - **Workflow name**: `release.yml`
+     - **Environment**: `pypi-publish`
+3. In the GitHub repo, create an environment named `pypi-publish`
+   (**Settings → Environments**). Optionally add required reviewers so stable
+   releases need an approval before the publish job runs.
+
+No secrets are needed — the publish job mints a short-lived OIDC token per run.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: CC-BY-4.0
 # Releasing to PyPI
 
 Samudra is published to [PyPI](https://pypi.org/project/samudra/) as a single
-pure-Python wheel by the [`Release`](https://github.com/Open-Athena/Samudra/actions/workflows/release.yml)
+pure-Python wheel by the [`Release`](https://github.com/m2lines/Samudra/actions/workflows/release.yml)
 workflow. It authenticates with [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/),
 so no API token is stored anywhere.
 
@@ -91,7 +91,7 @@ PyPI (a maintainer with project-owner rights does this once):
    to reserve the name `samudra` before the first upload.
 2. On the project's **Settings → Publishing** page, add a GitHub Actions
    publisher with:
-     - **Owner**: `Open-Athena`
+     - **Owner**: `m2lines`
      - **Repository**: `Samudra`
      - **Workflow name**: `release.yml`
      - **Environment**: `pypi-publish`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -75,10 +75,12 @@ PyPI. To dry-run first, use **Actions → Release → Run workflow → mode: man
 that builds and runs `twine check` without publishing.
 
 !!! note "Before the first tag"
-    The repository has no `v*` tags yet, so builds fall back to `1.0.0`
-    (`fallback_version` in `[tool.setuptools_scm]`, mirrored by `FALLBACK_VERSION`
-    in `scripts/package.py` — keep the two in sync). Cutting `v1.0.0` makes the
-    tag the single source of truth from then on.
+    The repository has no `v*` tags yet, so the "last release" falls back to
+    `0.0.0` (`fallback_version` in `[tool.setuptools_scm]`, mirrored by
+    `FALLBACK_VERSION` in `scripts/package.py` — keep the two in sync). Builds
+    therefore target `0.0.1` (e.g. a nightly is `0.0.1.dev<stamp>`). Cutting the
+    first tag, **`v0.0.1`**, makes the tag the single source of truth from then
+    on.
 
 ## One-time trusted-publisher setup
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -37,6 +37,19 @@ matching `torch` already present. With `uv` the `[tool.uv]` build settings in
 `pip install --no-build-isolation "samudra[cuda]"` in an environment that
 already has `torch`.
 
+Installing exposes a `samudra` console command that mirrors the module entry
+points, so you don't need a checkout to run a task against your own config:
+
+```bash
+samudra train path/to/train.yaml --experiment.data_root $DATA_PATH
+samudra eval  path/to/eval.yaml  --ckpt_path path/to/checkpoint
+samudra viz   path/to/viz.yaml
+```
+
+The example configs under `configs/` are not yet shipped in the wheel — pass a
+path to your own YAML (or one from a checkout). Packaging the presets so
+`samudra train samudra_om4/train.yaml` resolves them is planned as a follow-up.
+
 ## How versions are cut
 
 The version is owned by [setuptools-scm](https://setuptools-scm.readthedocs.io/):
@@ -48,11 +61,17 @@ the build:
 | Trigger | Mode | Version | Published? |
 | --- | --- | --- | --- |
 | Push a `v*` tag | `stable` | the tag, e.g. `v1.0.0` → `1.0.0` (setuptools-scm) | ✅ PyPI |
-| Daily `schedule` (06:00 UTC) | `nightly` | `<next-patch>.dev<YYYYMMDDhhmm>` | ✅ PyPI |
+| Weekly `schedule` (Mon 06:00 UTC) | `nightly` | `<next-patch>.dev<YYYYMMDDhhmm>` | ✅ PyPI |
 | `workflow_dispatch` → `nightly`/`stable` | as chosen | as above | ✅ PyPI |
-| `workflow_dispatch` → `manual` | `manual` | `<next-patch>+manual.<sha>` | ❌ build-only |
-| Pull request touching the script/workflow | `manual` | — | ❌ build-only |
+| `workflow_dispatch` → `smoke` | `smoke` | `<next-patch>+smoke.<sha>` | ❌ build-only |
+| Pull request touching the script/workflow | `smoke` | — | ❌ build-only |
 | Local editable install (`uv sync`) | — | `<next-patch>.dev<N>` from git | n/a |
+
+The scheduled dev release is weekly rather than daily — Samudra doesn't turn over
+enough in a day to warrant one, and the timestamp still makes each build unique.
+The `smoke` mode is build-only: it names what the build *does* (a no-publish
+check), not how it's triggered — every mode, `smoke` included, can be started by
+hand from **Actions → Release → Run workflow**.
 
 On a tagged commit setuptools-scm derives the version straight from the tag. For
 the two synthetic modes, `scripts/package.py` computes the version and hands it
@@ -62,6 +81,11 @@ tag (or `fallback_version` before the first tag), and its UTC timestamp keeps
 every nightly unique and PEP 440-ordered *above* the last release, so `--pre`
 resolves them.
 
+Every publish (stable **and** nightly) waits on the CPU test suite: the release
+workflow calls `test.yml` as a required `test` job, so a red suite blocks the
+upload. A tag push doesn't otherwise run the tests, which is why the release
+workflow invokes them itself.
+
 ### Cutting a stable release
 
 ```bash
@@ -70,8 +94,8 @@ git tag v1.1.0
 git push origin v1.1.0
 ```
 
-The tag push runs `resolve → build → publish`, uploading `samudra 1.1.0` to
-PyPI. To dry-run first, use **Actions → Release → Run workflow → mode: manual**;
+The tag push runs `resolve → test → build → publish`, uploading `samudra 1.1.0`
+to PyPI. To dry-run first, use **Actions → Release → Run workflow → mode: smoke**;
 that builds and runs `twine check` without publishing.
 
 !!! note "Before the first tag"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
       - Torch: torch.md
   - Development:
       - Contributing: contributing.md
+      - Releasing: releasing.md
   - API Reference:
       - Models:
           - Base Model: models/base.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,10 @@
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools", "wheel" ]
+requires = [ "setuptools", "setuptools-scm>=8", "wheel" ]
 
 [project]
 name = "samudra"
-version = "1.0"
 description = "Train and evaluate ocean model emulators"
 readme = "README.md"
 keywords = [ "climate", "emulation", "machine learning", "ocean" ]
@@ -23,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
+dynamic = [ "version" ] # derived from git tags by setuptools-scm
 dependencies = [
   "aiohttp>=3.11.13",
   "cftime>=1.6.4.post1",
@@ -57,6 +57,11 @@ optional-dependencies.cuda = [
   "torchvision>=0.24.0a0",
 ]
 
+urls.Documentation = "https://m2lines.github.io/Samudra/docs/"
+urls.Homepage = "https://m2lines.github.io/Samudra/"
+urls.Issues = "https://github.com/Open-Athena/Samudra/issues"
+urls.Repository = "https://github.com/Open-Athena/Samudra"
+
 [dependency-groups]
 dev = [
   "beartype>=0.20",
@@ -90,6 +95,24 @@ docs = [
   "mkdocstrings[python]>=0.27",
   "zensical",
 ]
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+package-data = { samudra = [ "py.typed" ] }
+
+# Pin discovery to src/ so setuptools auto-discovery can't sweep stray
+# top-level dirs (e.g. a stale build/lib/) into the wheel.
+[tool.setuptools.packages.find]
+where = [ "src" ]
+
+# The version comes from git tags (v1.2.3 -> 1.2.3); commits past a tag get a
+# `.devN` suffix. no-local-version drops the `+g<sha>` segment PyPI rejects.
+# fallback_version applies before the first tag exists -- keep it in sync with
+# FALLBACK_VERSION in scripts/package.py.
+
+[tool.setuptools_scm]
+local_scheme = "no-local-version"
+fallback_version = "1.0.0"
 
 [tool.ruff]
 lint.select = [ "B006", "D", "E", "F", "I", "UP", "W" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,8 @@ optional-dependencies.cuda = [
 
 urls.Documentation = "https://m2lines.github.io/Samudra/docs/"
 urls.Homepage = "https://m2lines.github.io/Samudra/"
-urls.Issues = "https://github.com/Open-Athena/Samudra/issues"
-urls.Repository = "https://github.com/Open-Athena/Samudra"
+urls.Issues = "https://github.com/m2lines/Samudra/issues"
+urls.Repository = "https://github.com/m2lines/Samudra"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,12 +107,13 @@ where = [ "src" ]
 
 # The version comes from git tags (v1.2.3 -> 1.2.3); commits past a tag get a
 # `.devN` suffix. no-local-version drops the `+g<sha>` segment PyPI rejects.
-# fallback_version applies before the first tag exists -- keep it in sync with
-# FALLBACK_VERSION in scripts/package.py.
+# fallback_version is the last released version before the first tag exists
+# (0.0.0 = none yet, so builds target 0.0.1); guess-next-dev bumps it. Keep it
+# in sync with FALLBACK_VERSION in scripts/package.py.
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
-fallback_version = "1.0.0"
+fallback_version = "0.0.0"
 
 [tool.ruff]
 lint.select = [ "B006", "D", "E", "F", "I", "UP", "W" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ urls.Documentation = "https://m2lines.github.io/Samudra/docs/"
 urls.Homepage = "https://m2lines.github.io/Samudra/"
 urls.Issues = "https://github.com/m2lines/Samudra/issues"
 urls.Repository = "https://github.com/m2lines/Samudra"
+# `samudra train|eval|viz CONFIG` for installed users; mirrors `python -m samudra.train`.
+scripts.samudra = "samudra.cli:main"
 
 [dependency-groups]
 dev = [

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -212,9 +212,10 @@ def main() -> None:
         "--version",
         default=None,
         help=(
-            "Explicit version. Required for --mode stable; when set for any mode it "
-            "is used verbatim. CI's resolve job computes the version once and passes "
-            "it here so the build job stamps the identical value."
+            "Explicit version, used verbatim. Required for --mode stable. CI's resolve "
+            "job computes the version once and passes it here so the build job stamps "
+            "the identical value; for nightly/manual it must be a value this script "
+            "would itself produce (a bare release version is rejected for those modes)."
         ),
     )
     parser.add_argument(
@@ -228,6 +229,22 @@ def main() -> None:
     # value the resolve job advertised (a nightly straddling midnight UTC would
     # otherwise recompute a different timestamp here).
     version = args.version if args.version else resolve_version(args.mode, args.version)
+
+    # Defense in depth: nightly and manual are publishing (or would-be
+    # publishing) modes whose versions must carry their synthetic marker. Refuse
+    # a bare release version passed in verbatim -- e.g. an operator leaving a
+    # value in the dispatch version field while selecting nightly -- so it can
+    # never be stamped and published as a bogus release. Only stable stamps a
+    # plain release version.
+    if args.mode == "nightly" and ".dev" not in version:
+        raise SystemExit(
+            f"refusing to build a nightly without a .dev suffix: {version!r}"
+        )
+    if args.mode == "manual" and "+manual" not in version:
+        raise SystemExit(
+            f"refusing to build a manual smoke without a +manual segment: {version!r}"
+        )
+
     print(f"Mode:    {args.mode}\nVersion: {version}")
     _emit_github_output("version", version)
 

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -61,9 +61,11 @@ PYPI_PACKAGE = "samudra"
 # with non-alphanumerics collapsed to underscores) and skips git entirely.
 SCM_ENV_VAR = "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SAMUDRA"
 
-# Base used before the first v* tag exists. Keep in sync with `fallback_version`
-# under [tool.setuptools_scm] so tagless dev installs and nightlies agree.
-FALLBACK_VERSION = "1.0.0"
+# Stands in for the last released version before the first v* tag exists (0.0.0
+# = nothing released yet); dev builds then target 0.0.1. Keep in sync with
+# `fallback_version` under [tool.setuptools_scm] so tagless dev installs and
+# nightlies resolve to the same base.
+FALLBACK_VERSION = "0.0.0"
 
 
 # ---------- helpers ----------------------------------------------------------
@@ -105,13 +107,11 @@ def _bump_patch(version: str) -> str:
     return f"{major}.{minor}.{patch + 1}"
 
 
-def _release_base() -> str:
-    """Next patch above the most recent v* tag; FALLBACK_VERSION when untagged.
+def _last_release() -> str:
+    """Most recent v* tag (without the leading 'v'), or FALLBACK_VERSION.
 
-    This is the release setuptools-scm would guess for the next version, computed
-    locally from git so the script carries no build-time dependency. It anchors
-    the synthetic nightly/manual versions to the real release line without ever
-    needing a hand-maintained version field.
+    FALLBACK_VERSION (0.0.0) stands in when no v* tag exists yet, so the first
+    release the tree builds toward is 0.0.1.
     """
     try:
         tag = subprocess.check_output(
@@ -121,8 +121,19 @@ def _release_base() -> str:
             stderr=subprocess.DEVNULL,
         ).strip()
     except subprocess.CalledProcessError:
-        return FALLBACK_VERSION  # no v* tag yet: build toward the first release
-    return _bump_patch(tag.lstrip("v"))
+        return FALLBACK_VERSION
+    return tag.lstrip("v")
+
+
+def _release_base() -> str:
+    """Next patch above the last release -- the version dev builds work toward.
+
+    Mirrors setuptools-scm's guess-next-dev (one patch above the most recent
+    tag), computed locally from git so the script carries no build-time
+    dependency. It anchors the synthetic nightly/manual versions to the real
+    release line without ever needing a hand-maintained version field.
+    """
+    return _bump_patch(_last_release())
 
 
 def resolve_version(mode: str, explicit: str | None) -> str:

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = []  # stdlib + git only; the build itself shells out to `uv`.
+# ///
+"""Build the samudra wheel + sdist for PyPI publication.
+
+Samudra is pure Python, so the build produces a single universal
+``samudra-<version>-py3-none-any.whl`` that serves both CPU and GPU users. The
+GPU custom kernels (flash-attn, flash-perceiver, torchvision) live in the
+``cuda`` optional extra and compile on the user's machine at install time --
+nothing GPU-specific goes into this wheel. That means there is exactly one
+artifact per build regardless of hardware.
+
+Versioning is owned by setuptools-scm (see ``[tool.setuptools_scm]`` in
+pyproject.toml): a plain build derives the version from git tags. This script
+only steps in for the two synthetic modes below, which it feeds to the build
+via ``SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SAMUDRA`` -- so nothing here ever
+mutates a tracked file.
+
+Publication to PyPI is done by the release workflow
+(.github/workflows/release.yml) via ``pypa/gh-action-pypi-publish`` with OIDC
+trusted publishing -- this script never uploads anything and never needs a
+token.
+
+Three modes:
+    nightly  -- version becomes <base>.dev<YYYYMMDDhhmm> (UTC), where <base> is
+                one patch above the most recent v* tag. PEP 440 orders the dev
+                release above that stable, so `pip install --pre samudra` / `uv`
+                prefer it. The timestamp guarantees every nightly is unique even
+                on days with no new commits.
+    stable   -- version is taken verbatim from --version (the release workflow
+                extracts it from the v<version> tag; setuptools-scm would derive
+                the identical value from that same tag).
+    manual   -- version becomes <base>+manual.<sha>; a build-only smoke. PyPI
+                rejects local-version identifiers, so the workflow's publish job
+                declines to run in this mode.
+
+Usage:
+    python scripts/package.py --mode nightly
+    python scripts/package.py --mode stable --version 1.0.0
+    python scripts/package.py --mode nightly --resolve-only
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DIST_DIR = REPO_ROOT / "dist"
+PYPI_PACKAGE = "samudra"
+
+# setuptools-scm reads the build version from this env var (dist name uppercased
+# with non-alphanumerics collapsed to underscores) and skips git entirely.
+SCM_ENV_VAR = "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SAMUDRA"
+
+# Base used before the first v* tag exists. Keep in sync with `fallback_version`
+# under [tool.setuptools_scm] so tagless dev installs and nightlies agree.
+FALLBACK_VERSION = "1.0.0"
+
+
+# ---------- helpers ----------------------------------------------------------
+
+
+def _check_tool(name: str, install_hint: str) -> None:
+    if shutil.which(name) is None:
+        print(
+            f"ERROR: '{name}' not found. Install with: {install_hint}", file=sys.stderr
+        )
+        sys.exit(1)
+
+
+def _git_short_sha() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "--short", "HEAD"], text=True, cwd=REPO_ROOT
+    ).strip()
+
+
+def _emit_github_output(key: str, value: str) -> None:
+    """Append `key=value` to $GITHUB_OUTPUT when running under GitHub Actions."""
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"{key}={value}\n")
+
+
+# ---------- version resolution -----------------------------------------------
+
+
+def _bump_patch(version: str) -> str:
+    """Return one patch above `version` (e.g. 1.0.0 -> 1.0.1)."""
+    import re
+
+    parts = [int(p) for p in re.split(r"[.\-+]", version) if p.isdigit()][:3]
+    parts += [0] * (3 - len(parts))
+    major, minor, patch = parts
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _release_base() -> str:
+    """Next patch above the most recent v* tag; FALLBACK_VERSION when untagged.
+
+    This is the release setuptools-scm would guess for the next version, computed
+    locally from git so the script carries no build-time dependency. It anchors
+    the synthetic nightly/manual versions to the real release line without ever
+    needing a hand-maintained version field.
+    """
+    try:
+        tag = subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0", "--match=v*"],
+            text=True,
+            cwd=REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except subprocess.CalledProcessError:
+        return FALLBACK_VERSION  # no v* tag yet: build toward the first release
+    return _bump_patch(tag.lstrip("v"))
+
+
+def resolve_version(mode: str, explicit: str | None) -> str:
+    """Return the build version for the requested mode.
+
+    nightly -> <base>.dev<YYYYMMDDhhmm>
+    stable  -> <explicit>
+    manual  -> <base>+manual.<sha>
+    """
+    if mode == "stable":
+        if not explicit:
+            raise SystemExit("--version is required for --mode stable")
+        return explicit
+    if mode == "nightly":
+        stamp = datetime.now(UTC).strftime("%Y%m%d%H%M")
+        return f"{_release_base()}.dev{stamp}"
+    if mode == "manual":
+        return f"{_release_base()}+manual.{_git_short_sha()}"
+    raise SystemExit(f"Unknown mode: {mode}")
+
+
+# ---------- build ------------------------------------------------------------
+
+
+def build_dist(version: str) -> None:
+    """Build the samudra wheel + sdist into DIST_DIR, pinning setuptools-scm to `version`."""
+    _check_tool("uv", "https://docs.astral.sh/uv/")
+
+    # Start from a clean dist/ so stale artifacts never reach the publish step.
+    if DIST_DIR.exists():
+        shutil.rmtree(DIST_DIR)
+    DIST_DIR.mkdir()
+
+    # Hand the resolved version to setuptools-scm via env so it never touches
+    # git (and no tracked file is mutated). Local, untagged dev builds that do
+    # NOT set this fall back to setuptools-scm's own git-derived version.
+    env = {**os.environ, SCM_ENV_VAR: version}
+    print(f"\n--- Building {PYPI_PACKAGE} ({version}) ---")
+    subprocess.run(
+        [
+            "uv",
+            "build",
+            "--wheel",
+            "--sdist",
+            "--out-dir",
+            str(DIST_DIR),
+            str(REPO_ROOT),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+    wheels = sorted(DIST_DIR.glob("*.whl"))
+    sdists = sorted(DIST_DIR.glob("*.tar.gz"))
+    print(f"\nBuilt {len(wheels)} wheel(s) and {len(sdists)} sdist(s):")
+    for f in (*wheels, *sdists):
+        print(f"  {f.name}")
+    if len(wheels) != 1:
+        raise RuntimeError(f"Expected exactly 1 wheel, got {len(wheels)}")
+    if len(sdists) != 1:
+        raise RuntimeError(f"Expected exactly 1 sdist, got {len(sdists)}")
+
+
+# ---------- main -------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--mode", choices=["nightly", "stable", "manual"], default="nightly"
+    )
+    parser.add_argument(
+        "--version",
+        default=None,
+        help=(
+            "Explicit version. Required for --mode stable; when set for any mode it "
+            "is used verbatim. CI's resolve job computes the version once and passes "
+            "it here so the build job stamps the identical value."
+        ),
+    )
+    parser.add_argument(
+        "--resolve-only",
+        action="store_true",
+        help="Print the resolved version and emit it to $GITHUB_OUTPUT; do not build.",
+    )
+    args = parser.parse_args()
+
+    # A passed --version wins for every mode so the build job reuses the exact
+    # value the resolve job advertised (a nightly straddling midnight UTC would
+    # otherwise recompute a different timestamp here).
+    version = args.version if args.version else resolve_version(args.mode, args.version)
+    print(f"Mode:    {args.mode}\nVersion: {version}")
+    _emit_github_output("version", version)
+
+    if args.resolve_only:
+        return
+
+    build_dist(version)
+    print(f"\nBuild complete. Wheel + sdist in {DIST_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -35,9 +35,10 @@ Three modes:
     stable   -- version is taken verbatim from --version (the release workflow
                 extracts it from the v<version> tag; setuptools-scm would derive
                 the identical value from that same tag).
-    manual   -- version becomes <base>+manual.<sha>; a build-only smoke. PyPI
+    smoke    -- version becomes <base>+smoke.<sha>; a build-only check. PyPI
                 rejects local-version identifiers, so the workflow's publish job
-                declines to run in this mode.
+                declines to run in this mode. ("smoke" names what it does, not
+                how it starts -- every mode can be hand-triggered.)
 
 Usage:
     python scripts/package.py --mode nightly
@@ -141,7 +142,7 @@ def resolve_version(mode: str, explicit: str | None) -> str:
 
     nightly -> <base>.dev<YYYYMMDDhhmm>
     stable  -> <explicit>
-    manual  -> <base>+manual.<sha>
+    smoke   -> <base>+smoke.<sha>
     """
     if mode == "stable":
         if not explicit:
@@ -150,8 +151,8 @@ def resolve_version(mode: str, explicit: str | None) -> str:
     if mode == "nightly":
         stamp = datetime.now(UTC).strftime("%Y%m%d%H%M")
         return f"{_release_base()}.dev{stamp}"
-    if mode == "manual":
-        return f"{_release_base()}+manual.{_git_short_sha()}"
+    if mode == "smoke":
+        return f"{_release_base()}+smoke.{_git_short_sha()}"
     raise SystemExit(f"Unknown mode: {mode}")
 
 
@@ -206,7 +207,7 @@ def main() -> None:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "--mode", choices=["nightly", "stable", "manual"], default="nightly"
+        "--mode", choices=["nightly", "stable", "smoke"], default="nightly"
     )
     parser.add_argument(
         "--version",
@@ -230,7 +231,7 @@ def main() -> None:
     # otherwise recompute a different timestamp here).
     version = args.version if args.version else resolve_version(args.mode, args.version)
 
-    # Defense in depth: nightly and manual are publishing (or would-be
+    # Defense in depth: nightly and smoke are publishing (or would-be
     # publishing) modes whose versions must carry their synthetic marker. Refuse
     # a bare release version passed in verbatim -- e.g. an operator leaving a
     # value in the dispatch version field while selecting nightly -- so it can
@@ -240,9 +241,9 @@ def main() -> None:
         raise SystemExit(
             f"refusing to build a nightly without a .dev suffix: {version!r}"
         )
-    if args.mode == "manual" and "+manual" not in version:
+    if args.mode == "smoke" and "+smoke" not in version:
         raise SystemExit(
-            f"refusing to build a manual smoke without a +manual segment: {version!r}"
+            f"refusing to build a smoke without a +smoke segment: {version!r}"
         )
 
     print(f"Mode:    {args.mode}\nVersion: {version}")

--- a/src/samudra/__init__.py
+++ b/src/samudra/__init__.py
@@ -1,3 +1,12 @@
 # SPDX-FileCopyrightText: 2026 Samudra Authors
 #
 # SPDX-License-Identifier: Apache-2.0
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("samudra")
+except PackageNotFoundError:  # not installed (e.g. running from a bare source tree)
+    __version__ = "0.0.0+unknown"
+
+__all__ = ["__version__"]

--- a/src/samudra/cli.py
+++ b/src/samudra/cli.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Console-script entry point: ``samudra <train|eval|viz> CONFIG [OVERRIDES...]``.
+
+Installed as the ``samudra`` command (see ``[project.scripts]`` in
+pyproject.toml), so a user who ``pip install samudra`` can run
+``samudra train path/to/config.yaml`` without cloning the repo. Each
+subcommand forwards to the same ``main`` the module entry points use
+(``python -m samudra.train`` etc.), so behaviour is identical.
+"""
+
+import sys
+
+_COMMANDS = ("train", "eval", "viz")
+
+
+def main() -> None:
+    """Dispatch ``samudra <command> ...`` to the matching task entry point."""
+    argv = sys.argv[1:]
+    if not argv or argv[0] not in _COMMANDS:
+        sys.stderr.write(
+            f"usage: samudra {{{'|'.join(_COMMANDS)}}} CONFIG [OVERRIDES...]\n"
+        )
+        raise SystemExit(2)
+
+    command, rest = argv[0], argv[1:]
+    # The config loaders parse sys.argv directly, so strip the subcommand token
+    # and leave them an argv of `CONFIG [OVERRIDES...]`.
+    sys.argv = [f"samudra {command}", *rest]
+
+    if command == "train":
+        from samudra.train import main as train_main
+
+        train_main()
+    elif command == "eval":
+        from samudra.eval import main as eval_main
+
+        eval_main()
+    else:  # viz
+        from samudra.viz.config import VizConfig
+        from samudra.viz.config import main as viz_main
+
+        viz_main(VizConfig.from_yaml_and_cli())
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -3536,7 +3536,6 @@ wheels = [
 
 [[package]]
 name = "samudra"
-version = "1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Publishes `samudra` to [PyPI](https://pypi.org/project/samudra/) as a single pure-Python wheel via a new **Release** workflow, modeled on [marin's release workflow](https://github.com/marin-community/marin/blob/main/.github/workflows/marin-release-libs-wheels.yaml) (`resolve → build → publish`) and adapted to a single-package repo. Publishing is **gated on the CPU test suite**.

### Release channels

| Trigger | Mode | Version | Published? |
| --- | --- | --- | --- |
| Push a `v*` tag | stable | the tag, e.g. `v0.0.1` → `0.0.1` | ✅ PyPI |
| `schedule` (Mon 06:00 UTC, weekly) | nightly | `<next-patch>.dev<YYYYMMDDhhmm>` | ✅ PyPI |
| `workflow_dispatch` | nightly / stable / smoke | computed (nightly/smoke) or the version input (stable only) | ✅ (not smoke) |
| Pull request touching the script/workflow | smoke | — | ❌ build-only |

The scheduled dev release is **weekly** rather than daily — the repo doesn't turn over enough in a day to warrant one, and the timestamp still makes each build unique. A hand-triggered **nightly** is supported: choose `mode: nightly` and leave the version field blank to build and publish a real `0.0.1.dev<stamp>`. The `smoke` mode is a build-only check (no publish); it names what the build *does*, not how it's triggered — every mode can be started by hand from **Actions → Release → Run workflow**.

### Test-gated publishing

Every publish (stable **and** nightly) waits on the CPU test suite. `test.yml` was made reusable (`workflow_call`), and the release workflow's `publish` job `needs` a `test` job that invokes it — so a red suite blocks the upload. A tag push doesn't otherwise run `test.yml`, which is why the release workflow calls it itself. (Branch-protection required-checks are intentionally left untouched; the in-workflow gate covers the release path.)

### `samudra` console script

Installing now exposes a `samudra` command (`[project.scripts]` → `samudra.cli:main`) that dispatches `samudra train|eval|viz CONFIG ...` to the same entry points as `python -m samudra.train`, so an installed user can run a task against **their own** config without a checkout. The example presets under `configs/` are **not yet shipped** in the wheel (our src-layout only packages files under `src/samudra/`); relocating the `configs/` tree so `samudra train samudra_om4/train.yaml` resolves *by name* is a self-contained refactor left as a documented follow-up.

### Versioning (setuptools-scm, hybrid)

Version is delegated to **setuptools-scm**: a git tag *is* the version, so there's no `version =` field to maintain and `samudra.__version__` works at runtime. `scripts/package.py` only computes the two synthetic versions (timestamped nightly, `+smoke` build) and injects them through scm's own `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_SAMUDRA` override — it never mutates a tracked file.

The timestamped nightly guarantees a unique, PEP 440-ordered dev release **even on weeks with no new commits**, which setuptools-scm's commit-distance schemes cannot provide. (Cutting the timestamp logic *into* a custom `version_scheme` would either reintroduce same-commit collisions or break scm's same-commit-→-same-version determinism, so it stays in the script.)

Before the first tag, the "last release" falls back to `0.0.0` (`fallback_version` in `[tool.setuptools_scm]`, mirrored by `FALLBACK_VERSION` in the script), so builds target `0.0.1`.

### Publish safety

A dispatched **nightly**/**smoke** run ignores the version input field — only a stable cut consumes it. This closes a footgun where a stray value left in the field would otherwise be stamped verbatim and published as a bogus non-dev release, permanently burning a PyPI version. As a backstop, the script also refuses to build a nightly without a `.dev` suffix or a smoke without a `+smoke` segment, failing loudly before anything is emitted or published.

### CPU vs GPU

Samudra is pure Python, so **one universal `py3-none-any` wheel serves everyone**. CPU is the default (`pip install samudra`); the GPU custom kernels (flash-attn, flash-perceiver, torchvision) stay in the existing `cuda` extra and compile on the user's machine — nothing GPU-specific enters the wheel.

## Security / hardening (per #766)

- **OIDC trusted publishing** — no PyPI token stored; publish job scoped to the `pypi-publish` environment.
- All actions **pinned to full commit SHAs**.
- Top-level `permissions: contents: read`; `id-token: write` scoped **only** to the publish job.

## Also included

- Pin package discovery to `src/` so setuptools auto-discovery can't sweep a stale `build/lib/` into the wheel (this was really happening in local builds); ship `py.typed`; add `[project.urls]`.
- Docs: new `docs/releasing.md` (process, CPU/GPU install, `samudra` CLI, one-time trusted-publisher setup) and a PyPI install section in `docs/getting-started/installation.md`.

## Verification

- `resolve` for all modes, real builds (nightly/stable/smoke), and a plain untagged build — all produce a single `samudra` wheel, `twine check` PASSED, no stray `ocean_emulators`.
- Console script: `samudra` with no/unknown command exits 2 with usage; `samudra train --help` routes through the real `TrainConfig` parser; the built wheel registers `samudra = samudra.cli:main`.
- Publish-safety: a nightly/smoke run with a stray version input is rejected (exit 1, nothing emitted); a blank-version nightly dispatch resolves to `0.0.1.dev<stamp>`.
- Local editable install derives `0.0.1.dev<N>` from git automatically.
- `pre-commit` passes on all changed files (`ruff`, `ruff-format`, `mypy`, `check-yaml`, `pyproject-fmt`, schemas).

## Follow-up

- **Ship example configs in the wheel** so `samudra train samudra_om4/train.yaml` resolves presets by name (relocate `configs/` under `src/samudra/`) — separate PR.

### Before first publish (maintainer, one-time)

1. Register the repo as a PyPI **trusted publisher** (Owner `m2lines`, Repo `Samudra`, Workflow `release.yml`, Environment `pypi-publish`) — use the pending-publisher flow to reserve the free `samudra` name.
2. Create the `pypi-publish` GitHub environment (optionally with required reviewers).
3. Tag `v0.0.1` to cut the first stable release. Steps documented in `docs/releasing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9qeRacC2ZdJ4DCbs6SM8t
