### PR TITLE
Support Python 3.6 in Slurm provenance writers

### DIFF
--- a/scripts/slurm_apptainer_eval.sbatch
+++ b/scripts/slurm_apptainer_eval.sbatch
@@ -356,7 +356,9 @@ keys = (
     "SAMUDRA_CONTAINER_IMAGE_REF",
     "SAMUDRA_CONTAINER_SIF_PATH",
 )
-provenance = {key.removeprefix("SAMUDRA_").lower(): os.environ[key] for key in keys}
+# Keep this compatible with the host Python 3.6 available on ORCD.
+prefix = "SAMUDRA_"
+provenance = {key[len(prefix) :].lower(): os.environ[key] for key in keys}
 with open(os.environ["SAMUDRA_PROVENANCE_PATH"], "w", encoding="utf-8") as stream:
     json.dump(provenance, stream, indent=2, sort_keys=True)
     stream.write("\n")

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -396,7 +396,9 @@ keys = (
     "SAMUDRA_CONTAINER_IMAGE_REF",
     "SAMUDRA_CONTAINER_SIF_PATH",
 )
-provenance = {key.removeprefix("SAMUDRA_").lower(): os.environ[key] for key in keys}
+# Keep this compatible with the host Python 3.6 available on ORCD.
+prefix = "SAMUDRA_"
+provenance = {key[len(prefix) :].lower(): os.environ[key] for key in keys}
 with open(os.environ["SAMUDRA_PROVENANCE_PATH"], "w", encoding="utf-8") as stream:
     json.dump(provenance, stream, indent=2, sort_keys=True)
     stream.write("\n")


### PR DESCRIPTION
## Summary

- keep the Apptainer train and eval provenance writers compatible with ORCD's host Python 3.6
- replace `str.removeprefix` with equivalent prefix slicing in both Slurm harnesses
- document why the older-Python-compatible form is required

## Root cause

The Slurm harness writes `run-provenance.json` with the host `python3` before launching Apptainer. ORCD currently provides Python 3.6.8 on the host, where `str.removeprefix` is unavailable. As a result, H200 smoke-test job `18753331` pulled the correct container successfully but exited before `srun` launched training.

## Impact

Training and evaluation jobs can now write provenance metadata and proceed to their container launch on ORCD's host Python.

## Checks

- `bash -n scripts/slurm_apptainer_train.sbatch scripts/slurm_apptainer_eval.sbatch`
- executed each harness's embedded provenance writer with ORCD host Python 3.6.8 and verified the expected JSON keys
- `git diff --check`