### PR TITLE
Add Empire AI section to doc index.

### DIFF
--- a/docs/empire-ai.md
+++ b/docs/empire-ai.md
@@ -63,6 +63,7 @@ For NYU, use this layout:
 ├── .apptainer-cache/
 ├── .apptainer-images/
 ├── .data_cache/
+├── code/
 ├── data/
 │   └── om4_onedeg/
 ├── logs/
@@ -166,10 +167,8 @@ Exit the transfer node after the copy and verification finish.
 ## Build and publish the exact container
 
 The container workflow is `.github/workflows/container-physicsnemo.yml`.
-Source/config-only changes can normally use the code-overlay workflow described
-in [the Torch guide](torch.md), but dependency or lockfile changes require an
-exact container rebuild. PR 842 changes `uv.lock`, so dispatch its container
-workflow before using it:
+Dependency or lockfile changes require an exact container rebuild. PR 842
+changes `uv.lock`, so dispatch its container workflow before using it:
 
 ```bash
 gh workflow run container-physicsnemo.yml \
@@ -244,71 +243,67 @@ tail "$SCRATCH/logs/pull-sif-JOB_ID.out"
 ls -lh "$SIF_PATH"
 ```
 
-## Build a code overlay on a compute node
+## Choose a reproducible code source
 
-For source or configuration changes that leave `uv.lock` and `pyproject.toml`
-unchanged, use a small code overlay instead of rebuilding the 12 GiB SIF. The
-Torch guide's default overlay directory is `/scratch/$USER`, which is not the
-Empire AI scratch path. Set `CODE_LAYER_DIR` explicitly.
+Use one of these supported paths on Alpha:
 
-Do not run the builder on the login or transfer nodes. It invokes Apptainer
-several times, and those hosts do not provide a working `squashfuse` setup.
-Submit the build to a compute node. Alpha's `test` QoS currently requires a GPU
-GRES even though the overlay build itself is CPU-only:
+1. Build and use an exact SIF for the experiment commit. This is required when
+   `uv.lock` or `pyproject.toml` changes and is the strongest isolation.
+2. For source/config-only changes, mount a clean, commit-pinned Git checkout
+   read-only with the harness's `CODE_DIR` support.
+
+Do **not** use the Torch EXT3 `CODE_LAYER` mechanism on Alpha. `apptainer
+overlay create` can succeed, which is misleading, but the later `apptainer exec
+--overlay` fails for ordinary users while attaching `/dev/loop0`:
+
+```text
+failed to find loop device
+could not open /dev/loop0: permission denied
+```
+
+This limitation applies on Alpha compute nodes as well as login nodes.
+
+To prepare the read-only-bind option, resolve a pushed ref to a full commit and
+create a detached worktree. Do not edit this checkout after submitting jobs:
 
 ```bash
 ssh eai
-cd ~/Samudra
-
-git fetch origin feature/native-sdpa-perceiver
-export CODE_REF="$(git rev-parse FETCH_HEAD)"
 export SCRATCH="/mnt/lustre/nyu/$USER"
-export SIF_PATH="$SCRATCH/.apptainer-images/physicsnemo-26.05-native-sdpa.sif"
-export CODE_LAYER_DIR="$SCRATCH/.apptainer-code-layers"
-export CODE_LAYER="$CODE_LAYER_DIR/samudra-code-${CODE_REF}.img"
-export APPTAINER_CACHEDIR="$SCRATCH/.apptainer-cache"
-export APPTAINER_TMPDIR=/tmp
-mkdir -p "$CODE_LAYER_DIR" "$APPTAINER_CACHEDIR" "$SCRATCH/logs"
+export CODE_REF=feature/native-sdpa-perceiver
 
-BUILD_JOB_ID="$(sbatch --parsable \
-  --account=nyu \
-  --partition=nyu \
-  --qos=test \
-  --constraint=h100 \
-  --nodes=1 \
-  --ntasks=1 \
-  --cpus-per-task=8 \
-  --mem=64G \
-  --gres=gpu:nvidia_h100_80gb_hbm3:1 \
-  --time=00:30:00 \
-  --chdir="$SCRATCH" \
-  --output="$SCRATCH/logs/code-layer-%j.out" \
-  --error="$SCRATCH/logs/code-layer-%j.err" \
-  --export=ALL \
-  --wrap='source /etc/profile.d/modules.sh; module load apptainer; bash "$HOME/Samudra/scripts/build_apptainer_code_layer.sh" "$CODE_REF" "$SIF_PATH"')"
-echo "Overlay build job: $BUILD_JOB_ID"
+git -C ~/Samudra fetch origin "$CODE_REF"
+export CODE_COMMIT="$(git -C ~/Samudra rev-parse FETCH_HEAD)"
+export CODE_DIR="$SCRATCH/code/Samudra-$CODE_COMMIT"
+mkdir -p "$SCRATCH/code"
+if [[ ! -d "$CODE_DIR" ]]; then
+  git -C ~/Samudra worktree add --detach "$CODE_DIR" "$CODE_COMMIT"
+fi
+
+test "$(git -C "$CODE_DIR" rev-parse HEAD)" = "$CODE_COMMIT"
+test -z "$(git -C "$CODE_DIR" status --porcelain)"
 ```
 
-Use a full pushed commit for `CODE_REF`, as above. This makes the expected
-`CODE_LAYER` path known before the build finishes, which allows later jobs to
-depend on it. The builder verifies dependency-file equality, the overlay
-checksum, and a `samudra` import before publishing the layer atomically. If the
-dependency files differ, rebuild the container; do not bypass that check.
-
-Each Apptainer invocation currently expands the SIF into a node-local temporary
-sandbox because Alpha compute nodes lack `squashfuse` and `fuse2fs`. Several
-minutes of startup time and related warnings are therefore expected. A
-30-minute `test` allocation leaves reasonable margin. Confirm `COMPLETED`
-before using the layer when submitting jobs manually:
+Export both `CODE_DIR` and `CODE_COMMIT` when submitting training and eval.
+The shared harness repeats those two Git checks on the compute node, requires
+a full 40-character commit, and mounts the checkout at
+`/opt/samudra-code:ro`. In the same container preflight used to read image
+metadata, it verifies:
 
 ```bash
-sacct -j "$BUILD_JOB_ID" --format=JobID,State,Elapsed,ExitCode
-tail "$SCRATCH/logs/code-layer-$BUILD_JOB_ID.out"
-ls -lh "$CODE_LAYER" "$CODE_LAYER.sha256" "$CODE_LAYER.json"
+cmp -s /opt/samudra-code/uv.lock /workspace/uv.lock
+cmp -s /opt/samudra-code/pyproject.toml /workspace/pyproject.toml
 ```
 
-Set `CODE_LAYER` for training and evaluation jobs. Both harnesses verify and
-mount it read-only, and record its commit and checksum in run provenance.
+A mismatch fails before creating the run directory. Successful jobs pass the
+code commit and repository to W&B and record the bind path, commit, dependency
+hashes, container identity, and SIF path in `source-manifest.json` and
+`run-provenance.json`.
+
+Alpha lacks `squashfuse` and `fuse2fs`, so every `apptainer exec` may unpack the
+12 GiB SIF into a temporary sandbox. The harness combines container metadata
+and `CODE_DIR` compatibility into one preflight, followed by the actual run,
+instead of using a separate invocation for every check. Startup can still take
+several minutes.
 
 ## Shell conveniences and secrets
 
@@ -424,9 +419,10 @@ The pilot above was validated on 2026-08-21 with these results:
 
 Alpha currently lacks `squashfuse` and `fuse2fs` on compute nodes. Apptainer
 therefore prints warnings and expands the SIF to node-local temporary
-sandboxes. The shared harness performs three container invocations during
-startup, adding roughly two minutes in this pilot. The warnings are non-fatal;
-the final job state and exit code are the authoritative result.
+sandboxes. The original harness performed three container invocations during
+startup, adding roughly two minutes in this pilot; the current harness combines
+metadata and compatibility checks into one preflight. The warnings are
+non-fatal; the final job state and exit code are the authoritative result.
 
 ## Compare queue-aware resource shapes
 
@@ -454,10 +450,11 @@ for shape in 1:16:200G 4:48:800G 8:96:1600G; do
 done
 ```
 
-The projected start time is a transient scheduler estimate, not a reservation
-or guarantee. Balance it against the expected scaling efficiency and runtime;
-four GPUs can finish sooner than eight when the smaller request starts much
-earlier.
+The projected start time is a volatile scheduler snapshot, not a reservation
+or guarantee; it can move by hours within minutes. A submitted job may also
+temporarily report `StartTime=Unknown`. Balance queue state against expected
+scaling efficiency and runtime: four GPUs can finish sooner than eight when the
+smaller request starts much earlier.
 
 `sbatch --test-only` prints job-like IDs as part of its estimate, but it does
 **not** enqueue those jobs. Confirm with `squeue -u "$USER"` if there is any
@@ -477,16 +474,7 @@ export WANDB_MODE=online
 export ARGS='--data.loading.num_workers=2 --preemptible=true'
 export REQUEUE_ON_USR1=1
 
-dependency_args=()
-if [[ -n "${BUILD_JOB_ID:-}" ]]; then
-  dependency_args=(
-    --dependency="afterok:$BUILD_JOB_ID"
-    --kill-on-invalid-dep=yes
-  )
-fi
-
 TRAIN_JOB_ID="$(sbatch --parsable \
-  "${dependency_args[@]}" \
   --account="$ACCOUNT" \
   --partition="$ACCOUNT" \
   --qos=long \
@@ -528,7 +516,7 @@ To target H200 instead, replace the constraint and GRES:
 For normal experiments, submit the stages as one failure-safe dependency chain:
 
 ```text
-overlay build ──afterok──> training ──afterok──> evaluation ──afterok──> visualization
+training ──afterok──> evaluation ──afterok──> visualization
 ```
 
 Use `--kill-on-invalid-dep=yes` at every edge. If an upstream job fails or is
@@ -573,7 +561,8 @@ echo "Evaluation job: $EVAL_JOB_ID"
 ```
 
 Visualization does not yet have a dedicated Slurm harness, so invoke the same
-SIF and optional code overlay explicitly. The `samudra_om4/viz.yaml` preset
+SIF and optional read-only code checkout explicitly. The
+`samudra_om4/viz.yaml` preset
 reads its basin mask anonymously from public OSN:
 
 ```bash
@@ -602,23 +591,32 @@ VIZ_JOB_ID="$(sbatch --parsable \
     source /etc/profile.d/modules.sh
     module load apptainer
     code_root=/workspace
-    overlay_args=()
-    if [[ -n "${CODE_LAYER:-}" ]]; then
+    code_bind_args=()
+    if [[ -n "${CODE_DIR:-}" ]]; then
+      test "$(git -C "$CODE_DIR" rev-parse HEAD)" = "$CODE_COMMIT"
+      test -z "$(git -C "$CODE_DIR" status --porcelain)"
       code_root=/opt/samudra-code
-      overlay_args=(--overlay "$CODE_LAYER:ro")
+      code_bind_args=(--bind "$CODE_DIR:$code_root:ro")
     fi
     apptainer exec --nv \
-      "${overlay_args[@]}" \
+      "${code_bind_args[@]}" \
       --bind "$DATA_ROOT:$DATA_ROOT,$OUTPUT_BASE:$OUTPUT_BASE" \
       --pwd "$code_root" \
       "$SIF_PATH" \
-      env PYTHONPATH="$code_root/src" \
-      /workspace/.venv/bin/python -m samudra.viz \
-      "$code_root/$VIZ_CONFIG" \
-      --data_root="$DATA_ROOT" \
-      --base_output_dir="$OUTPUT_BASE" \
-      --name="$VIZ_NAME" \
-      --runs="$RUNS"')"
+      bash -c "
+        set -euo pipefail
+        if [[ \"\$1\" == /opt/samudra-code ]]; then
+          cmp -s /opt/samudra-code/uv.lock /workspace/uv.lock
+          cmp -s /opt/samudra-code/pyproject.toml /workspace/pyproject.toml
+        fi
+        export PYTHONPATH=\"\$1/src\"
+        exec /workspace/.venv/bin/python -m samudra.viz \
+          \"\$1/\$2\" \
+          --data_root=\"\$3\" \
+          --base_output_dir=\"\$4\" \
+          --name=\"\$5\" \
+          --runs=\"\$6\"
+      " bash "$code_root" "$VIZ_CONFIG" "$DATA_ROOT" "$OUTPUT_BASE" "$VIZ_NAME" "$RUNS"')"
 echo "Visualization job: $VIZ_JOB_ID"
 ```
 
@@ -626,7 +624,14 @@ Although visualization is CPU-oriented, an otherwise valid CPU-only Alpha
 request currently fails with `QOSMinGRES`. The practical Alpha workaround is
 to reserve one H100 as above. Alternatives are running visualization on
 another compatible system, or maintaining a separate `arm64` environment for
-the CPU-only Grace system. Do not reuse an Alpha x86 SIF or overlay on Grace.
+the CPU-only Grace system. Do not reuse an Alpha x86 SIF or checkout artifacts
+on Grace.
+
+The dependency policy has been validated in failure as well as success: when
+an earlier EXT3 overlay-preparation experiment failed, `afterok` with
+`--kill-on-invalid-dep=yes` cancelled its training, evaluation, and
+visualization dependents immediately. No downstream stage ran with incorrect
+code or stale artifacts.
 
 ## Monitor and diagnose
 
@@ -651,9 +656,11 @@ Common failures:
   the directory containing `OM4.zarr`, `OM4_means.zarr`, and `OM4_stds.zarr`.
 - Architecture or `exec format` errors: confirm `uname -m` is `x86_64` and use
   the x86 image on Alpha, not an arm64 image intended for Grace.
-- An import or lockfile mismatch with a code overlay: rebuild the container
-  when `uv.lock` or `pyproject.toml` changes; do not bypass the overlay
-  builder's dependency check.
+- `/dev/loop0: permission denied`: an EXT3 `CODE_LAYER` was selected. It is not
+  supported on Alpha; use an exact SIF or the clean `CODE_DIR` read-only bind.
+- A `CODE_DIR` commit, cleanliness, or lockfile failure: recreate the detached
+  checkout from the pushed commit. Rebuild the container if `uv.lock` or
+  `pyproject.toml` changed.
 - A run name already exists: choose a new `NAME`. The harness refuses to mix a
   new job with an existing run except for a Slurm requeue.
 

--- a/docs/empire-ai.md
+++ b/docs/empire-ai.md
@@ -177,11 +177,20 @@ gh workflow run container-physicsnemo.yml \
   --ref feature/native-sdpa-perceiver
 ```
 
-After the workflow succeeds, its manual x86 image tag is:
+After the workflow's `build-and-smoke` job completes its `Publish x86_64
+image` step, its manual x86 image tag is:
 
 ```text
 ghcr.io/m2lines/ocean-emulator-physicsnemo:26.05-manual-feature-native-sdpa-perceiver
 ```
+
+Check the x86 build and publication jobs directly rather than relying only on
+the workflow's overall conclusion: architecture-specific builds and later test
+jobs can fail independently. During the 2026-08-21 validation, the x86 image
+published successfully, while a later container CPU-test job failed collection
+because `scripts.build_quickstart_notebook` was not present in the image. That
+packaging issue did not affect training; the published image completed the EAI
+pilot below.
 
 For other refs, replace slashes in the branch name with hyphens. A production
 run should prefer the immutable SHA tag when the same image has been published
@@ -190,36 +199,96 @@ from `main`.
 ## Pull the SIF once
 
 The training harness can pull an absent SIF, but doing this once before a GPU
-job makes startup predictable. The SIF is shared through Lustre, so it can be
-prepared on a transfer node without waiting for an Alpha CPU allocation:
+job makes startup predictable. Do not do this on a transfer node: although an
+Apptainer module is visible there, its global configuration is not usable. The
+Alpha CPU partition can also have a long queue. Use a short, one-GPU `test` QoS
+job and the repository's atomic pull helper. The resulting SIF is shared
+through Lustre and reused by later jobs:
 
 ```bash
 ssh eai
-ssh alpha-dtn1
-
-source /etc/profile.d/modules.sh
-module load apptainer
-
 SCRATCH="/mnt/lustre/nyu/$USER"
 export APPTAINER_CACHEDIR="$SCRATCH/.apptainer-cache"
-export APPTAINER_TMPDIR=/tmp
-mkdir -p "$APPTAINER_CACHEDIR" "$SCRATCH/.apptainer-images"
+export SCRATCH_DIR="$SCRATCH"
+export SIF_DIR="$SCRATCH/.apptainer-images"
+export SIF_PATH="$SIF_DIR/physicsnemo-26.05-native-sdpa.sif"
+export IMAGE_REF=ghcr.io/m2lines/ocean-emulator-physicsnemo:26.05-manual-feature-native-sdpa-perceiver
+mkdir -p "$APPTAINER_CACHEDIR" "$SIF_DIR" "$SCRATCH/logs"
 
-IMAGE_REF=ghcr.io/m2lines/ocean-emulator-physicsnemo:26.05-manual-feature-native-sdpa-perceiver
-SIF_PATH="$SCRATCH/.apptainer-images/physicsnemo-26.05-native-sdpa.sif"
-apptainer pull "$SIF_PATH" "docker://$IMAGE_REF"
-chmod 0444 "$SIF_PATH"
+sbatch \
+  --account=nyu \
+  --partition=nyu \
+  --qos=test \
+  --constraint=h100 \
+  --nodes=1 \
+  --ntasks=1 \
+  --cpus-per-task=8 \
+  --mem=64G \
+  --gres=gpu:nvidia_h100_80gb_hbm3:1 \
+  --time=00:30:00 \
+  --chdir="$SCRATCH" \
+  --output="$SCRATCH/logs/pull-sif-%j.out" \
+  --error="$SCRATCH/logs/pull-sif-%j.err" \
+  --export=ALL \
+  ~/Samudra/scripts/slurm_apptainer_pull.sbatch
 ```
 
-`APPTAINER_TMPDIR=/tmp` is intentional: image conversion uses node-local space
-and avoids filesystem feature mismatches on shared scratch. Alpha's transfer
-nodes had more than 800 GB free in `/tmp` during validation.
+The helper uses node-local `/tmp` for conversion, avoiding filesystem feature
+mismatches on shared scratch. Wait for `COMPLETED` and inspect the log before
+submitting training:
+
+```bash
+squeue -u "$USER"
+sacct -j JOB_ID --format=JobID,State,Elapsed,ExitCode
+tail "$SCRATCH/logs/pull-sif-JOB_ID.out"
+ls -lh "$SIF_PATH"
+```
+
+## Shell conveniences and secrets
+
+It is reasonable to add non-secret cluster paths to `~/.bashrc`:
+
+```bash
+export EAI_ACCOUNT=nyu
+export EAI_SCRATCH="/mnt/lustre/nyu/$USER"
+export PATH="$HOME/software/alpha-x86/rclone/bin:$PATH"
+```
+
+If every process in the account is trusted and experiment-related, keeping
+`WANDB_API_KEY` in `~/.bashrc` is convenient because `--export=ALL` forwards it
+to Slurm jobs. Set `chmod 600 ~/.bashrc`, and never print or commit the file:
+
+```bash
+export WANDB_API_KEY='...'
+```
+
+For narrower exposure, use `wandb login`, which stores the credential in a
+mode-600 `~/.netrc`, or keep project secrets in a dedicated file:
+
+```bash
+mkdir -p ~/.config/samudra
+chmod 700 ~/.config/samudra
+# Create ~/.config/samudra/secrets.env without committing it:
+# export WANDB_API_KEY='...'
+chmod 600 ~/.config/samudra/secrets.env
+```
+
+Source that file only before an online W&B submission:
+
+```bash
+source ~/.config/samudra/secrets.env
+export WANDB_MODE=online
+```
+
+Slurm receives exported submission-shell variables through `--export=ALL`.
+The pilot below disables W&B so it does not require a credential.
 
 ## Submit the 1° SamudraMini pilot
 
-Use Alpha H100 and the `test` QoS for the first end-to-end validation. This
-performs a real one-epoch training run but uses only one GPU and keeps W&B
-disabled unless a key is deliberately supplied.
+Use Alpha H100 and the `test` QoS for the first end-to-end validation. Debug
+mode performs four real training batches and four validation batches, then
+exits cleanly. This exercises data loading, native SDPA forward/backward,
+metrics, checkpointing, and output writing without spending a full epoch.
 
 ```bash
 ssh eai
@@ -238,9 +307,10 @@ export OUTPUT_BASE="$SCRATCH/runs"
 export SCRATCH_DIR="$SCRATCH"
 export SIF_DIR="$SCRATCH/.apptainer-images"
 export SIF_PATH="$SIF_DIR/physicsnemo-26.05-native-sdpa.sif"
+export IMAGE_REF=ghcr.io/m2lines/ocean-emulator-physicsnemo:26.05-manual-feature-native-sdpa-perceiver
 export DATA_CACHE_DIR="$SCRATCH/.data_cache/$NAME"
 export WANDB_MODE=disabled
-export ARGS='--epochs=1 --save_freq=1 --batch_size=1 --data.loading.num_workers=2'
+export ARGS='--debug=true --epochs=1 --save_freq=1 --batch_size=1 --data.loading.num_workers=2'
 
 sbatch \
   --account="$ACCOUNT" \
@@ -252,7 +322,7 @@ sbatch \
   --cpus-per-task=16 \
   --mem=128G \
   --gres=gpu:nvidia_h100_80gb_hbm3:1 \
-  --time=02:00:00 \
+  --time=00:30:00 \
   --chdir="$SCRATCH" \
   --output="$SCRATCH/logs/samudra-eai-%j.out" \
   --error="$SCRATCH/logs/samudra-eai-%j.err" \
@@ -264,6 +334,27 @@ Command-line `sbatch` options override the Torch-specific defaults embedded in
 the shared harness. Keep every resource override above: in particular, the
 account, GRES, CPU count, memory, working directory, and logs must not fall
 back to Torch values.
+
+### Validated result
+
+The pilot above was validated on 2026-08-21 with these results:
+
+- source/container commit
+  `b7f94a312a0d261ce9f65ea2d1d0d86654b1155e` from PR 842;
+- public dataset copy: 91.639 GiB and 380,460 matching files according to
+  `rclone check --size-only --one-way`;
+- SIF preparation job `40324`: `COMPLETED` with exit code `0:0` in 16m49s;
+- H100 debug training job `40380`: `COMPLETED` with exit code `0:0` in 5m26s;
+- internal train/validation work: 54 seconds, train loss 2.420, validation loss
+  0.636, and about 2.35 GB peak GPU memory during training;
+- four checkpoints written: best validation, latest, epoch 1, and EMA; and
+- `run-provenance.json` recorded the same commit for source and container.
+
+Alpha currently lacks `squashfuse` and `fuse2fs` on compute nodes. Apptainer
+therefore prints warnings and expands the SIF to node-local temporary
+sandboxes. The shared harness performs three container invocations during
+startup, adding roughly two minutes in this pilot. The warnings are non-fatal;
+the final job state and exit code are the authoritative result.
 
 ## Scale to a full H100 node
 
@@ -321,7 +412,7 @@ squeue -u "$USER" -o '%.18i %.12q %.9T %.10M %.6D %R'
 sacct -u "$USER" -S today \
   --format=JobID,JobName,QOS,AllocTRES,Elapsed,State,ExitCode
 sprio -j JOB_ID
-ssh alpha-dtn1 tail -f "/mnt/lustre/nyu/$USER/logs/samudra-eai-JOB_ID.out"
+tail -f "/mnt/lustre/nyu/$USER/logs/samudra-eai-JOB_ID.out"
 ```
 
 The run output is under `$OUTPUT_BASE/$NAME`. The harness also records

--- a/docs/empire-ai.md
+++ b/docs/empire-ai.md
@@ -244,6 +244,72 @@ tail "$SCRATCH/logs/pull-sif-JOB_ID.out"
 ls -lh "$SIF_PATH"
 ```
 
+## Build a code overlay on a compute node
+
+For source or configuration changes that leave `uv.lock` and `pyproject.toml`
+unchanged, use a small code overlay instead of rebuilding the 12 GiB SIF. The
+Torch guide's default overlay directory is `/scratch/$USER`, which is not the
+Empire AI scratch path. Set `CODE_LAYER_DIR` explicitly.
+
+Do not run the builder on the login or transfer nodes. It invokes Apptainer
+several times, and those hosts do not provide a working `squashfuse` setup.
+Submit the build to a compute node. Alpha's `test` QoS currently requires a GPU
+GRES even though the overlay build itself is CPU-only:
+
+```bash
+ssh eai
+cd ~/Samudra
+
+git fetch origin feature/native-sdpa-perceiver
+export CODE_REF="$(git rev-parse FETCH_HEAD)"
+export SCRATCH="/mnt/lustre/nyu/$USER"
+export SIF_PATH="$SCRATCH/.apptainer-images/physicsnemo-26.05-native-sdpa.sif"
+export CODE_LAYER_DIR="$SCRATCH/.apptainer-code-layers"
+export CODE_LAYER="$CODE_LAYER_DIR/samudra-code-${CODE_REF}.img"
+export APPTAINER_CACHEDIR="$SCRATCH/.apptainer-cache"
+export APPTAINER_TMPDIR=/tmp
+mkdir -p "$CODE_LAYER_DIR" "$APPTAINER_CACHEDIR" "$SCRATCH/logs"
+
+BUILD_JOB_ID="$(sbatch --parsable \
+  --account=nyu \
+  --partition=nyu \
+  --qos=test \
+  --constraint=h100 \
+  --nodes=1 \
+  --ntasks=1 \
+  --cpus-per-task=8 \
+  --mem=64G \
+  --gres=gpu:nvidia_h100_80gb_hbm3:1 \
+  --time=00:30:00 \
+  --chdir="$SCRATCH" \
+  --output="$SCRATCH/logs/code-layer-%j.out" \
+  --error="$SCRATCH/logs/code-layer-%j.err" \
+  --export=ALL \
+  --wrap='source /etc/profile.d/modules.sh; module load apptainer; bash "$HOME/Samudra/scripts/build_apptainer_code_layer.sh" "$CODE_REF" "$SIF_PATH"')"
+echo "Overlay build job: $BUILD_JOB_ID"
+```
+
+Use a full pushed commit for `CODE_REF`, as above. This makes the expected
+`CODE_LAYER` path known before the build finishes, which allows later jobs to
+depend on it. The builder verifies dependency-file equality, the overlay
+checksum, and a `samudra` import before publishing the layer atomically. If the
+dependency files differ, rebuild the container; do not bypass that check.
+
+Each Apptainer invocation currently expands the SIF into a node-local temporary
+sandbox because Alpha compute nodes lack `squashfuse` and `fuse2fs`. Several
+minutes of startup time and related warnings are therefore expected. A
+30-minute `test` allocation leaves reasonable margin. Confirm `COMPLETED`
+before using the layer when submitting jobs manually:
+
+```bash
+sacct -j "$BUILD_JOB_ID" --format=JobID,State,Elapsed,ExitCode
+tail "$SCRATCH/logs/code-layer-$BUILD_JOB_ID.out"
+ls -lh "$CODE_LAYER" "$CODE_LAYER.sha256" "$CODE_LAYER.json"
+```
+
+Set `CODE_LAYER` for training and evaluation jobs. Both harnesses verify and
+mount it read-only, and record its commit and checksum in run provenance.
+
 ## Shell conveniences and secrets
 
 It is reasonable to add non-secret cluster paths to `~/.bashrc`:
@@ -255,15 +321,16 @@ export PATH="$HOME/software/alpha-x86/rclone/bin:$PATH"
 ```
 
 If every process in the account is trusted and experiment-related, keeping
-`WANDB_API_KEY` in `~/.bashrc` is convenient because `--export=ALL` forwards it
-to Slurm jobs. Set `chmod 600 ~/.bashrc`, and never print or commit the file:
+`WANDB_API_KEY` in `~/.bashrc` is convenient for interactive shells. Set
+`chmod 600 ~/.bashrc`, and never print or commit the file:
 
 ```bash
 export WANDB_API_KEY='...'
 ```
 
-For narrower exposure, use `wandb login`, which stores the credential in a
-mode-600 `~/.netrc`, or keep project secrets in a dedicated file:
+Do not assume that `ssh eai 'command'`, a non-interactive shell, or a future
+shell configuration will source `.bashrc`. For automation, a dedicated secret
+file is a clearer interface:
 
 ```bash
 mkdir -p ~/.config/samudra
@@ -273,15 +340,20 @@ chmod 700 ~/.config/samudra
 chmod 600 ~/.config/samudra/secrets.env
 ```
 
-Source that file only before an online W&B submission:
+Source that file explicitly before an online W&B submission and test that the
+key exists without printing it:
 
 ```bash
 source ~/.config/samudra/secrets.env
+test -n "${WANDB_API_KEY:-}"
 export WANDB_MODE=online
 ```
 
-Slurm receives exported submission-shell variables through `--export=ALL`.
-The pilot below disables W&B so it does not require a credential.
+If the key is kept only in `.bashrc`, explicitly run `source "$HOME/.bashrc"`
+and the same `test -n` check instead. Place the export before any
+interactive-shell early return in that file. Slurm receives exported
+submission-shell variables through `--export=ALL`. The pilot below disables
+W&B so it does not require a credential.
 
 ## Submit the 1° SamudraMini pilot
 
@@ -356,6 +428,41 @@ sandboxes. The shared harness performs three container invocations during
 startup, adding roughly two minutes in this pilot. The warnings are non-fatal;
 the final job state and exit code are the authoritative result.
 
+## Compare queue-aware resource shapes
+
+A full node has the greatest instantaneous throughput, but it may wait longer
+than a smaller request. Before a production submission, compare several valid
+shapes with `sbatch --test-only` using the same QoS, wall time, constraints, and
+roughly proportional CPU and memory requests as the real job:
+
+```bash
+for shape in 1:16:200G 4:48:800G 8:96:1600G; do
+  IFS=: read -r gpus cpus memory <<<"$shape"
+  echo "--- ${gpus}x H100 ---"
+  sbatch --test-only \
+    --account=nyu \
+    --partition=nyu \
+    --qos=standard \
+    --constraint=h100 \
+    --nodes=1 \
+    --ntasks=1 \
+    --cpus-per-task="$cpus" \
+    --mem="$memory" \
+    --gres="gpu:nvidia_h100_80gb_hbm3:$gpus" \
+    --time=2-00:00:00 \
+    --wrap=true
+done
+```
+
+The projected start time is a transient scheduler estimate, not a reservation
+or guarantee. Balance it against the expected scaling efficiency and runtime;
+four GPUs can finish sooner than eight when the smaller request starts much
+earlier.
+
+`sbatch --test-only` prints job-like IDs as part of its estimate, but it does
+**not** enqueue those jobs. Confirm with `squeue -u "$USER"` if there is any
+doubt. A `QOSMinGRES` result is a rejected shape, not a queued job.
+
 ## Scale to a full H100 node
 
 After the pilot succeeds, a full-node 8-GPU run uses all 96 CPU cores. Do not
@@ -363,13 +470,23 @@ copy Torch's 128-CPU request; Alpha GPU nodes expose 96 schedulable CPU cores.
 For example:
 
 ```bash
-export NAME="$(date +%F)-samudra-mini-onedeg-eai-8gpu"
+export NAME="$(date +%F)-samudra-onedeg-eai-8gpu"
 export DATA_CACHE_DIR="$SCRATCH/.data_cache/$NAME"
+export CONFIG=src/samudra/configs/samudra_om4/train.yaml
 export WANDB_MODE=online
 export ARGS='--data.loading.num_workers=2 --preemptible=true'
 export REQUEUE_ON_USR1=1
 
-sbatch \
+dependency_args=()
+if [[ -n "${BUILD_JOB_ID:-}" ]]; then
+  dependency_args=(
+    --dependency="afterok:$BUILD_JOB_ID"
+    --kill-on-invalid-dep=yes
+  )
+fi
+
+TRAIN_JOB_ID="$(sbatch --parsable \
+  "${dependency_args[@]}" \
   --account="$ACCOUNT" \
   --partition="$ACCOUNT" \
   --qos=long \
@@ -386,7 +503,8 @@ sbatch \
   --output="$SCRATCH/logs/samudra-eai-%j.out" \
   --error="$SCRATCH/logs/samudra-eai-%j.err" \
   --export=ALL \
-  ~/Samudra/scripts/slurm_apptainer_train.sbatch
+  ~/Samudra/scripts/slurm_apptainer_train.sbatch)"
+echo "Training job: $TRAIN_JOB_ID"
 ```
 
 The harness traps `USR1`, requeues the job, and resumes from the latest
@@ -404,6 +522,111 @@ To target H200 instead, replace the constraint and GRES:
 ```bash
 --constraint=h200 --gres=gpu:nvidia_h200:8
 ```
+
+## Chain evaluation and visualization
+
+For normal experiments, submit the stages as one failure-safe dependency chain:
+
+```text
+overlay build ──afterok──> training ──afterok──> evaluation ──afterok──> visualization
+```
+
+Use `--kill-on-invalid-dep=yes` at every edge. If an upstream job fails or is
+cancelled, Slurm then cancels the dependent job instead of leaving it pending
+forever or producing artifacts from stale inputs.
+
+The validated `samudra_mini_om4` pilot does not currently ship a matching eval
+preset. The concrete example below applies when training with
+`samudra_om4/train.yaml`; use the matching eval and visualization configs for
+any other model.
+
+After submitting the training command above, submit a one-GPU evaluation:
+
+```bash
+export TRAIN_NAME="$NAME"
+export EVAL_NAME="${TRAIN_NAME}-eval"
+export CONFIG=src/samudra/configs/samudra_om4/eval.yaml
+export NAME="$EVAL_NAME"
+export TARGET_CHECKPOINT="$TRAIN_NAME/saved_nets/ema_ckpt.pt"
+export ARGS='--num_model_steps_forward=25'
+export DATA_CACHE_DIR="$SCRATCH/.data_cache/$EVAL_NAME"
+
+EVAL_JOB_ID="$(sbatch --parsable \
+  --dependency="afterok:$TRAIN_JOB_ID" \
+  --kill-on-invalid-dep=yes \
+  --account="$ACCOUNT" \
+  --partition="$ACCOUNT" \
+  --qos=standard \
+  --constraint=h100 \
+  --nodes=1 \
+  --ntasks-per-node=1 \
+  --cpus-per-task=16 \
+  --mem=128G \
+  --gres=gpu:nvidia_h100_80gb_hbm3:1 \
+  --time=04:00:00 \
+  --chdir="$SCRATCH" \
+  --output="$SCRATCH/logs/samudra-eval-%j.out" \
+  --error="$SCRATCH/logs/samudra-eval-%j.err" \
+  --export=ALL \
+  ~/Samudra/scripts/slurm_apptainer_eval.sbatch)"
+echo "Evaluation job: $EVAL_JOB_ID"
+```
+
+Visualization does not yet have a dedicated Slurm harness, so invoke the same
+SIF and optional code overlay explicitly. The `samudra_om4/viz.yaml` preset
+reads its basin mask anonymously from public OSN:
+
+```bash
+export VIZ_CONFIG=src/samudra/configs/samudra_om4/viz.yaml
+export VIZ_NAME="${TRAIN_NAME}-viz"
+export RUNS="[{\"name\":\"$EVAL_NAME\",\"location\":\"$OUTPUT_BASE/$EVAL_NAME/predictions.zarr\"}]"
+
+VIZ_JOB_ID="$(sbatch --parsable \
+  --dependency="afterok:$EVAL_JOB_ID" \
+  --kill-on-invalid-dep=yes \
+  --account="$ACCOUNT" \
+  --partition="$ACCOUNT" \
+  --qos=standard \
+  --constraint=h100 \
+  --nodes=1 \
+  --ntasks=1 \
+  --cpus-per-task=16 \
+  --mem=128G \
+  --gres=gpu:nvidia_h100_80gb_hbm3:1 \
+  --time=04:00:00 \
+  --chdir="$SCRATCH" \
+  --output="$SCRATCH/logs/samudra-viz-%j.out" \
+  --error="$SCRATCH/logs/samudra-viz-%j.err" \
+  --export=ALL \
+  --wrap='set -euo pipefail
+    source /etc/profile.d/modules.sh
+    module load apptainer
+    code_root=/workspace
+    overlay_args=()
+    if [[ -n "${CODE_LAYER:-}" ]]; then
+      code_root=/opt/samudra-code
+      overlay_args=(--overlay "$CODE_LAYER:ro")
+    fi
+    apptainer exec --nv \
+      "${overlay_args[@]}" \
+      --bind "$DATA_ROOT:$DATA_ROOT,$OUTPUT_BASE:$OUTPUT_BASE" \
+      --pwd "$code_root" \
+      "$SIF_PATH" \
+      env PYTHONPATH="$code_root/src" \
+      /workspace/.venv/bin/python -m samudra.viz \
+      "$code_root/$VIZ_CONFIG" \
+      --data_root="$DATA_ROOT" \
+      --base_output_dir="$OUTPUT_BASE" \
+      --name="$VIZ_NAME" \
+      --runs="$RUNS"')"
+echo "Visualization job: $VIZ_JOB_ID"
+```
+
+Although visualization is CPU-oriented, an otherwise valid CPU-only Alpha
+request currently fails with `QOSMinGRES`. The practical Alpha workaround is
+to reserve one H100 as above. Alternatives are running visualization on
+another compatible system, or maintaining a separate `arm64` environment for
+the CPU-only Grace system. Do not reuse an Alpha x86 SIF or overlay on Grace.
 
 ## Monitor and diagnose
 

--- a/docs/empire-ai.md
+++ b/docs/empire-ai.md
@@ -1,0 +1,353 @@
+<!--
+SPDX-FileCopyrightText: 2026 Samudra Authors
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Empire AI Alpha Slurm Training With Apptainer
+
+This is the project runbook for training Samudra on Empire AI Alpha. It uses
+the repository's existing Slurm/Apptainer harness, stages the public OSN data
+on Lustre, and keeps images, caches, runs, and large logs out of the home
+filesystem.
+
+The commands below were validated on Alpha with the NYU account and the public
+1° OM4 dataset. Replace `nyu` with the account reported for your user.
+
+## Choose Alpha, Grace, or Beta
+
+- Use **Alpha H100** as the default for Samudra development and training. Alpha
+  is `x86_64`; an H100 node has eight 80 GB GPUs, 96 CPU cores, and about 1.9 TB
+  of host memory.
+- Use **Alpha H200** when the additional GPU memory is useful. An H200 has
+  141 GB. Request it by its full GRES name.
+- Do not submit GPU training to **Grace**. Grace is CPU-only `arm64` and is
+  intended for CPU-heavy work. It needs separate environments and compiled
+  artifacts.
+- **Beta NVL72/B200** uses a separate Slurm environment and is outside this
+  Alpha guide.
+
+An arm64 Samudra image is therefore not needed for Alpha. Use the repository's
+`x86_64` PhysicsNeMo image.
+
+Useful live checks:
+
+```bash
+uname -m
+sacctmgr show assoc user="$USER" format=User,Account,Partition,QOS
+sinfo -o '%P|%a|%l|%D|%G|%f'
+scontrol show node alphagpu01
+```
+
+Empire AI is transitioning from institutional Alpha partitions to an `alpha`
+hardware-tier partition. Always trust the live association and `sinfo` output
+over a copied command. At the time of validation, the account and partition
+were both `nyu`.
+
+## Filesystem layout
+
+Home is mounted at `/mnt/home/$USER`. Keep the repository, small scripts, and
+small configuration files there. Do not put datasets or container images in
+home.
+
+Alpha Lustre scratch is mounted at:
+
+```text
+/mnt/lustre/<institution>/$USER
+```
+
+For NYU, use this layout:
+
+```text
+/mnt/lustre/nyu/$USER/
+├── .apptainer-cache/
+├── .apptainer-images/
+├── .data_cache/
+├── data/
+│   └── om4_onedeg/
+├── logs/
+└── runs/
+```
+
+Scratch is high-performance, transient storage. Empire AI may introduce a
+purge policy, so copy important checkpoints and results elsewhere.
+
+## Get the code
+
+Use a pushed commit or branch so the source is reproducible. For the native
+SDPA Perceiver work in PR 842:
+
+```bash
+ssh eai
+git clone --branch feature/native-sdpa-perceiver --single-branch \
+  https://github.com/m2lines/Samudra.git ~/Samudra
+cd ~/Samudra
+git rev-parse HEAD
+```
+
+The native implementation uses PyTorch
+`scaled_dot_product_attention`; it does not require external `flash-attn` or
+`flash-perceiver` wheels. `perceiver_implementation: auto` lets PyTorch select
+an available SDPA backend, including its FlashAttention kernel when eligible.
+
+## Stage public OSN data through a transfer node
+
+Alpha has two data-transfer nodes, `alpha-dtn1` and `alpha-dtn2`. Start bulk
+transfers there rather than on a login or GPU node:
+
+```bash
+ssh eai
+ssh alpha-dtn1
+```
+
+At the time of validation, rclone was not installed system-wide. Install the
+official static `x86_64` binary once in an architecture-labeled home path:
+
+```bash
+install_root="$HOME/software/alpha-x86/rclone"
+tmp_dir="$(mktemp -d)"
+curl --fail --location --silent --show-error \
+  https://downloads.rclone.org/rclone-current-linux-amd64.zip \
+  --output "$tmp_dir/rclone.zip"
+unzip -q "$tmp_dir/rclone.zip" -d "$tmp_dir/unpacked"
+rclone_src="$(find "$tmp_dir/unpacked" -type f -name rclone -perm -u+x -print -quit)"
+mkdir -p "$install_root/bin"
+install -m 0755 "$rclone_src" "$install_root/bin/rclone"
+rm -rf "$tmp_dir"
+```
+
+Configure anonymous access to the public NYU OSN pod:
+
+```bash
+RCLONE="$HOME/software/alpha-x86/rclone/bin/rclone"
+"$RCLONE" config create nyu-osn-public s3 \
+  provider Other \
+  endpoint https://nyu1.osn.mghpcc.org/ \
+  env_auth false
+```
+
+Copy the complete 1° dataset, including the mean and standard-deviation Zarr
+stores required by training:
+
+```bash
+SCRATCH="/mnt/lustre/nyu/$USER"
+mkdir -p "$SCRATCH/data/om4_onedeg" "$SCRATCH/logs"
+
+nohup "$RCLONE" copy \
+  nyu-osn-public:m2lines-pubs/Samudra/v2026-07/om4_onedeg \
+  "$SCRATCH/data/om4_onedeg" \
+  --ignore-existing \
+  --transfers=32 \
+  --checkers=64 \
+  --stats=1m \
+  --stats-one-line \
+  --log-level NOTICE \
+  --stats-log-level NOTICE \
+  >"$SCRATCH/logs/rclone-om4-onedeg.log" 2>&1 </dev/null &
+```
+
+The source is about 92 GiB. The command is restart-safe: rerunning it with
+`--ignore-existing` fills in missing objects without replacing completed ones.
+Monitor and verify it on the transfer node:
+
+```bash
+tail -f "$SCRATCH/logs/rclone-om4-onedeg.log"
+pgrep -a -u "$USER" -f '[r]clone copy.*om4_onedeg'
+du -sh "$SCRATCH/data/om4_onedeg"
+
+"$RCLONE" check \
+  nyu-osn-public:m2lines-pubs/Samudra/v2026-07/om4_onedeg \
+  "$SCRATCH/data/om4_onedeg" \
+  --size-only --one-way
+```
+
+Exit the transfer node after the copy and verification finish.
+
+## Build and publish the exact container
+
+The container workflow is `.github/workflows/container-physicsnemo.yml`.
+Source/config-only changes can normally use the code-overlay workflow described
+in [the Torch guide](torch.md), but dependency or lockfile changes require an
+exact container rebuild. PR 842 changes `uv.lock`, so dispatch its container
+workflow before using it:
+
+```bash
+gh workflow run container-physicsnemo.yml \
+  --repo m2lines/Samudra \
+  --ref feature/native-sdpa-perceiver
+```
+
+After the workflow succeeds, its manual x86 image tag is:
+
+```text
+ghcr.io/m2lines/ocean-emulator-physicsnemo:26.05-manual-feature-native-sdpa-perceiver
+```
+
+For other refs, replace slashes in the branch name with hyphens. A production
+run should prefer the immutable SHA tag when the same image has been published
+from `main`.
+
+## Pull the SIF once
+
+The training harness can pull an absent SIF, but doing this once before a GPU
+job makes startup predictable. The SIF is shared through Lustre, so it can be
+prepared on a transfer node without waiting for an Alpha CPU allocation:
+
+```bash
+ssh eai
+ssh alpha-dtn1
+
+source /etc/profile.d/modules.sh
+module load apptainer
+
+SCRATCH="/mnt/lustre/nyu/$USER"
+export APPTAINER_CACHEDIR="$SCRATCH/.apptainer-cache"
+export APPTAINER_TMPDIR=/tmp
+mkdir -p "$APPTAINER_CACHEDIR" "$SCRATCH/.apptainer-images"
+
+IMAGE_REF=ghcr.io/m2lines/ocean-emulator-physicsnemo:26.05-manual-feature-native-sdpa-perceiver
+SIF_PATH="$SCRATCH/.apptainer-images/physicsnemo-26.05-native-sdpa.sif"
+apptainer pull "$SIF_PATH" "docker://$IMAGE_REF"
+chmod 0444 "$SIF_PATH"
+```
+
+`APPTAINER_TMPDIR=/tmp` is intentional: image conversion uses node-local space
+and avoids filesystem feature mismatches on shared scratch. Alpha's transfer
+nodes had more than 800 GB free in `/tmp` during validation.
+
+## Submit the 1° SamudraMini pilot
+
+Use Alpha H100 and the `test` QoS for the first end-to-end validation. This
+performs a real one-epoch training run but uses only one GPU and keeps W&B
+disabled unless a key is deliberately supplied.
+
+```bash
+ssh eai
+cd ~/Samudra
+
+ACCOUNT=nyu
+SCRATCH="/mnt/lustre/$ACCOUNT/$USER"
+NAME="$(date +%F)-samudra-mini-onedeg-eai-pilot"
+
+mkdir -p "$SCRATCH/runs" "$SCRATCH/logs"
+
+export CONFIG=src/samudra/configs/samudra_mini_om4/train.yaml
+export NAME
+export DATA_ROOT="$SCRATCH/data/om4_onedeg"
+export OUTPUT_BASE="$SCRATCH/runs"
+export SCRATCH_DIR="$SCRATCH"
+export SIF_DIR="$SCRATCH/.apptainer-images"
+export SIF_PATH="$SIF_DIR/physicsnemo-26.05-native-sdpa.sif"
+export DATA_CACHE_DIR="$SCRATCH/.data_cache/$NAME"
+export WANDB_MODE=disabled
+export ARGS='--epochs=1 --save_freq=1 --batch_size=1 --data.loading.num_workers=2'
+
+sbatch \
+  --account="$ACCOUNT" \
+  --partition="$ACCOUNT" \
+  --qos=test \
+  --constraint=h100 \
+  --nodes=1 \
+  --ntasks-per-node=1 \
+  --cpus-per-task=16 \
+  --mem=128G \
+  --gres=gpu:nvidia_h100_80gb_hbm3:1 \
+  --time=02:00:00 \
+  --chdir="$SCRATCH" \
+  --output="$SCRATCH/logs/samudra-eai-%j.out" \
+  --error="$SCRATCH/logs/samudra-eai-%j.err" \
+  --export=ALL \
+  ~/Samudra/scripts/slurm_apptainer_train.sbatch
+```
+
+Command-line `sbatch` options override the Torch-specific defaults embedded in
+the shared harness. Keep every resource override above: in particular, the
+account, GRES, CPU count, memory, working directory, and logs must not fall
+back to Torch values.
+
+## Scale to a full H100 node
+
+After the pilot succeeds, a full-node 8-GPU run uses all 96 CPU cores. Do not
+copy Torch's 128-CPU request; Alpha GPU nodes expose 96 schedulable CPU cores.
+For example:
+
+```bash
+export NAME="$(date +%F)-samudra-mini-onedeg-eai-8gpu"
+export DATA_CACHE_DIR="$SCRATCH/.data_cache/$NAME"
+export WANDB_MODE=online
+export ARGS='--data.loading.num_workers=2 --preemptible=true'
+export REQUEUE_ON_USR1=1
+
+sbatch \
+  --account="$ACCOUNT" \
+  --partition="$ACCOUNT" \
+  --qos=long \
+  --constraint=h100 \
+  --nodes=1 \
+  --ntasks-per-node=1 \
+  --cpus-per-task=96 \
+  --mem=1600G \
+  --gres=gpu:nvidia_h100_80gb_hbm3:8 \
+  --time=7-00:00:00 \
+  --requeue \
+  --signal=B:USR1@300 \
+  --chdir="$SCRATCH" \
+  --output="$SCRATCH/logs/samudra-eai-%j.out" \
+  --error="$SCRATCH/logs/samudra-eai-%j.err" \
+  --export=ALL \
+  ~/Samudra/scripts/slurm_apptainer_train.sbatch
+```
+
+The harness traps `USR1`, requeues the job, and resumes from the latest
+completed checkpoint when `preemptible: true`. The signal itself does not
+create a checkpoint, so retain a suitable checkpoint frequency. EAI's
+published `SIGTERM` example is not interchangeable with this harness's `USR1`
+trap.
+
+For a normal run of no more than 48 hours, use `--qos=standard`. The `long` QoS
+allows up to seven days at a lower SU factor but may start more slowly. Check
+the current limits before submitting because scheduler policy can change.
+
+To target H200 instead, replace the constraint and GRES:
+
+```bash
+--constraint=h200 --gres=gpu:nvidia_h200:8
+```
+
+## Monitor and diagnose
+
+```bash
+squeue -u "$USER" -o '%.18i %.12q %.9T %.10M %.6D %R'
+sacct -u "$USER" -S today \
+  --format=JobID,JobName,QOS,AllocTRES,Elapsed,State,ExitCode
+sprio -j JOB_ID
+ssh alpha-dtn1 tail -f "/mnt/lustre/nyu/$USER/logs/samudra-eai-JOB_ID.out"
+```
+
+The run output is under `$OUTPUT_BASE/$NAME`. The harness also records
+`run-provenance.json`, including the exact container commit and SIF path.
+
+Common failures:
+
+- `Invalid account or account/partition combination`: rerun `sacctmgr show
+  assoc` and use the institution associated with your user.
+- `Requested node configuration is not available`: compare the request with
+  `scontrol show node`. A full Alpha GPU node has 96, not 128, CPU cores.
+- `DATA_ROOT directory does not exist`: finish or resume the OSN copy and use
+  the directory containing `OM4.zarr`, `OM4_means.zarr`, and `OM4_stds.zarr`.
+- Architecture or `exec format` errors: confirm `uname -m` is `x86_64` and use
+  the x86 image on Alpha, not an arm64 image intended for Grace.
+- An import or lockfile mismatch with a code overlay: rebuild the container
+  when `uv.lock` or `pyproject.toml` changes; do not bypass the overlay
+  builder's dependency check.
+- A run name already exists: choose a new `NAME`. The harness refuses to mix a
+  new job with an existing run except for a Slurm requeue.
+
+## Empire AI references
+
+- [Getting Started: Alpha, Grace, and Beta](https://empireai.freshdesk.com/support/solutions/articles/157000374441-empire-ai-getting-started-alpha-grace-beta-)
+- [Alpha job submission and QoS](https://empireai.freshdesk.com/support/solutions/articles/157000374474-alpha-job-submission-and-qos-overview)
+- [Submitting jobs](https://empireai.freshdesk.com/support/solutions/articles/157000010768-how-do-i-submit-jobs-)
+- [Alpha storage](https://empireai.freshdesk.com/support/solutions/articles/157000175046-empire-ai-alpha-storage)
+- [Alpha hardware](https://empireai.freshdesk.com/support/solutions/articles/157000007946-alpha-hardware)
+- [Alpha and Grace mixed-architecture guidance](https://empireai.freshdesk.com/support/solutions/articles/157000373787-alpha-and-grace-mixed-architecture-guidance)

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -70,6 +70,11 @@ The overlay is checksum-verified and mounted read-only under
 `/opt/samudra-code`; it is not a live checkout, so later host edits cannot alter
 a queued, running, requeued, or resumed job.
 
+`CODE_DIR` is a second, mutually exclusive option for systems where EXT3
+overlays are unavailable. It mounts a clean Git checkout read-only and requires
+`CODE_COMMIT` to match its full `HEAD`. The harness also rejects untracked
+files and verifies that `uv.lock` and `pyproject.toml` match the SIF.
+
 It expects environment variables:
 
 - `CONFIG` (required): config path inside the container image. Relative paths are
@@ -87,6 +92,10 @@ It expects environment variables:
   caches (default: `/scratch/<current_user>`)
 - `CODE_LAYER` (optional): absolute path to a code overlay produced by
   `scripts/build_apptainer_code_layer.sh`
+- `CODE_DIR` (optional): clean Git checkout to mount read-only; mutually
+  exclusive with `CODE_LAYER`
+- `CODE_COMMIT` (required with `CODE_DIR`): full 40-character commit expected
+  at the checkout's `HEAD`
 - `REQUEUE_ON_USR1` (optional): set to `1` when submitting with
   `--requeue --signal=B:USR1@300`; the harness requeues the job when Slurm sends
   the warning signal.
@@ -102,6 +111,8 @@ Key behavior:
   instructions to set the corresponding env var.
 - Uses the container venv explicitly (`/workspace/.venv/bin/python`) to avoid missing deps.
 - Source/config-only changes can use a code overlay without rebuilding the container.
+- Systems without usable EXT3 overlays can use a clean, commit-pinned
+  `CODE_DIR` read-only bind.
 - Dependency changes require a new container because the overlay builder refuses
   any `uv.lock` or `pyproject.toml` mismatch with the container SIF.
 - Caches the pulled SIF under `${SCRATCH_DIR}/.apptainer-images/` by default.
@@ -396,6 +407,10 @@ It expects environment variables:
   caches (default: `/scratch/<current_user>`)
 - `CODE_LAYER` (optional): absolute path to a code overlay produced by
   `scripts/build_apptainer_code_layer.sh`
+- `CODE_DIR` (optional): clean Git checkout mounted read-only; mutually
+  exclusive with `CODE_LAYER`
+- `CODE_COMMIT` (required with `CODE_DIR`): full 40-character commit expected
+  at the checkout's `HEAD`
 - `WANDB_API_KEY` (optional): if set and `WANDB_MODE` unset, defaults to W&B online
 - `WANDB_MODE` (optional): `online` or `disabled` (if unset, defaults based on
   whether `WANDB_API_KEY` is present)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Data: data.md
       - How to Run: run.md
       - Torch: torch.md
+      - Empire AI: empire-ai.md
   - Development:
       - Contributing: contributing.md
       - Releasing: releasing.md

--- a/scripts/slurm_apptainer_eval.sbatch
+++ b/scripts/slurm_apptainer_eval.sbatch
@@ -20,6 +20,9 @@
 #   export CONTAINER_TAG=26.05-latest
 # Optional code layer built by scripts/build_apptainer_code_layer.sh:
 #   export CODE_LAYER=/scratch/$USER/.apptainer-code-layers/samudra-code-<hash>.img
+# Or a clean, commit-pinned checkout mounted read-only:
+#   export CODE_DIR=/path/to/Samudra
+#   export CODE_COMMIT=<full-git-sha>
 #
 # Checkpoint selection (pick one):
 #   export TARGET_CHECKPOINT=<path-relative-to-OUTPUT_BASE>
@@ -41,6 +44,17 @@
 
 set -euo pipefail
 
+if ! command -v apptainer >/dev/null 2>&1 \
+  && ! command -v singularity >/dev/null 2>&1; then
+  if [[ -f /etc/profile.d/modules.sh ]]; then
+    # shellcheck source=/etc/profile.d/modules.sh
+    source /etc/profile.d/modules.sh
+  fi
+  if command -v module >/dev/null 2>&1; then
+    module load "${APPTAINER_MODULE:-apptainer}"
+  fi
+fi
+
 if command -v apptainer >/dev/null 2>&1; then
   APPTAINER_BIN=apptainer
 elif command -v singularity >/dev/null 2>&1; then
@@ -56,6 +70,12 @@ NAME_SUFFIX="${NAME_SUFFIX:-}"
 ARGS="${ARGS:-}"
 BACKEND="${BACKEND:-cuda}"
 CODE_LAYER="${CODE_LAYER:-}"
+CODE_DIR="${CODE_DIR:-}"
+CODE_COMMIT="${CODE_COMMIT:-}"
+if [[ -n "${CODE_LAYER}" && -n "${CODE_DIR}" ]]; then
+  echo "Specify only one of CODE_LAYER or CODE_DIR." >&2
+  exit 2
+fi
 if [[ -z "${NAME}" && -n "${NAME_SUFFIX}" ]]; then
   NAME="$(date +%Y-%m-%d)-${NAME_SUFFIX}"
 fi
@@ -195,20 +215,90 @@ else
   echo "Using existing SIF."
 fi
 
-CONTAINER_GIT_COMMIT="$(
-  "${APPTAINER_BIN}" exec "${SIF_PATH}" \
-    bash -lc 'printf %s "${SAMUDRA_CONTAINER_GIT_COMMIT:-${WANDB_GIT_COMMIT:-unknown}}"'
-)"
-CONTAINER_GIT_REMOTE_URL="$(
-  "${APPTAINER_BIN}" exec "${SIF_PATH}" \
-    bash -lc 'printf %s "${SAMUDRA_CONTAINER_GIT_REMOTE_URL:-${WANDB_GIT_REMOTE_URL:-unknown}}"'
-)"
 CODE_ROOT=/workspace
-CODE_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
-CODE_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
+CODE_GIT_COMMIT=""
+CODE_GIT_REMOTE_URL=""
 CODE_LAYER_SHA256=""
 CODE_LAYER_MANIFEST=""
 OVERLAY_ARGS=()
+CODE_BIND_ARGS=()
+if [[ -n "${CODE_DIR}" ]]; then
+  if [[ -z "${CODE_COMMIT}" ]]; then
+    echo "CODE_COMMIT is required when CODE_DIR is set." >&2
+    exit 9
+  fi
+  if [[ ! "${CODE_COMMIT}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "CODE_COMMIT must be a full 40-character Git commit: ${CODE_COMMIT}" >&2
+    exit 9
+  fi
+  if [[ ! -d "${CODE_DIR}" ]]; then
+    echo "CODE_DIR does not exist or is not a directory: ${CODE_DIR}" >&2
+    exit 9
+  fi
+  CODE_DIR="$(realpath "${CODE_DIR}")"
+  if ! CODE_GIT_COMMIT="$(git -C "${CODE_DIR}" rev-parse --verify HEAD^{commit})"; then
+    echo "CODE_DIR is not a Git checkout: ${CODE_DIR}" >&2
+    exit 9
+  fi
+  CODE_GIT_COMMIT="${CODE_GIT_COMMIT,,}"
+  if [[ "${CODE_GIT_COMMIT}" != "${CODE_COMMIT,,}" ]]; then
+    echo "CODE_DIR HEAD does not match CODE_COMMIT." >&2
+    echo "CODE_DIR HEAD: ${CODE_GIT_COMMIT}" >&2
+    echo "CODE_COMMIT:    ${CODE_COMMIT,,}" >&2
+    exit 9
+  fi
+  if [[ -n "$(git -C "${CODE_DIR}" status --porcelain)" ]]; then
+    echo "CODE_DIR must be clean, including untracked files: ${CODE_DIR}" >&2
+    exit 9
+  fi
+  for source_path in src pyproject.toml uv.lock; do
+    if [[ ! -e "${CODE_DIR}/${source_path}" ]]; then
+      echo "Required source path is absent from CODE_DIR: ${source_path}" >&2
+      exit 9
+    fi
+  done
+  CODE_GIT_REMOTE_URL="$(git -C "${CODE_DIR}" config --get remote.origin.url || true)"
+  if [[ -z "${CODE_GIT_REMOTE_URL}" ]]; then
+    echo "CODE_DIR does not have a remote.origin.url: ${CODE_DIR}" >&2
+    exit 9
+  fi
+  CODE_ROOT=/opt/samudra-code
+  CODE_BIND_ARGS=(--bind "${CODE_DIR}:${CODE_ROOT}:ro")
+  export APPTAINERENV_SAMUDRA_CODE_DIR_PREFLIGHT=1
+fi
+
+if ! CONTAINER_METADATA_TEXT="$(
+  "${APPTAINER_BIN}" exec \
+    "${CODE_BIND_ARGS[@]}" \
+    "${SIF_PATH}" \
+    bash -lc '
+      set -euo pipefail
+      if [[ "${SAMUDRA_CODE_DIR_PREFLIGHT:-0}" == "1" ]]; then
+        cmp -s /opt/samudra-code/uv.lock /workspace/uv.lock
+        cmp -s /opt/samudra-code/pyproject.toml /workspace/pyproject.toml
+      fi
+      printf "%s\n%s\n" \
+        "${SAMUDRA_CONTAINER_GIT_COMMIT:-${WANDB_GIT_COMMIT:-unknown}}" \
+        "${SAMUDRA_CONTAINER_GIT_REMOTE_URL:-${WANDB_GIT_REMOTE_URL:-unknown}}"
+    '
+)"; then
+  echo "Container metadata or CODE_DIR dependency compatibility check failed." >&2
+  echo "CODE_DIR uv.lock and pyproject.toml must match the container SIF." >&2
+  exit 9
+fi
+unset APPTAINERENV_SAMUDRA_CODE_DIR_PREFLIGHT
+readarray -t CONTAINER_METADATA <<<"${CONTAINER_METADATA_TEXT}"
+if [[ "${#CONTAINER_METADATA[@]}" -ne 2 ]]; then
+  echo "Container has invalid commit/repository metadata: ${SIF_PATH}" >&2
+  exit 9
+fi
+CONTAINER_GIT_COMMIT="${CONTAINER_METADATA[0]}"
+CONTAINER_GIT_REMOTE_URL="${CONTAINER_METADATA[1]}"
+if [[ -z "${CODE_DIR}" ]]; then
+  CODE_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
+  CODE_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
+fi
+
 if [[ -n "${CODE_LAYER}" ]]; then
   if [[ ! -s "${CODE_LAYER}" ]]; then
     echo "CODE_LAYER does not exist or is empty: ${CODE_LAYER}" >&2
@@ -274,8 +364,10 @@ echo "Code commit:     ${CODE_GIT_COMMIT}"
 if [[ -n "${CODE_LAYER}" ]]; then
   echo "Code layer:      ${CODE_LAYER}"
   echo "Code layer SHA:  ${CODE_LAYER_SHA256}"
+elif [[ -n "${CODE_DIR}" ]]; then
+  echo "Code directory:  ${CODE_DIR} (read-only bind)"
 else
-  echo "Code layer:      none (using source baked into container SIF)"
+  echo "Code source:     container SIF"
 fi
 
 export APPTAINERENV_WANDB_GIT_COMMIT="${CODE_GIT_COMMIT}"
@@ -283,6 +375,7 @@ export APPTAINERENV_WANDB_GIT_REMOTE_URL="${CODE_GIT_REMOTE_URL}"
 export APPTAINERENV_SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}"
 export APPTAINERENV_SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}"
 export APPTAINERENV_SAMUDRA_CODE_LAYER_SHA256="${CODE_LAYER_SHA256}"
+export APPTAINERENV_SAMUDRA_CODE_DIR="${CODE_DIR}"
 export APPTAINERENV_SAMUDRA_CONTAINER_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
 export APPTAINERENV_SAMUDRA_CONTAINER_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
 export APPTAINERENV_SAMUDRA_CONTAINER_IMAGE_REF="${CONTAINER_IMAGE_REF}"
@@ -292,6 +385,7 @@ export SINGULARITYENV_WANDB_GIT_REMOTE_URL="${CODE_GIT_REMOTE_URL}"
 export SINGULARITYENV_SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}"
 export SINGULARITYENV_SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}"
 export SINGULARITYENV_SAMUDRA_CODE_LAYER_SHA256="${CODE_LAYER_SHA256}"
+export SINGULARITYENV_SAMUDRA_CODE_DIR="${CODE_DIR}"
 export SINGULARITYENV_SAMUDRA_CONTAINER_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
 export SINGULARITYENV_SAMUDRA_CONTAINER_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
 export SINGULARITYENV_SAMUDRA_CONTAINER_IMAGE_REF="${CONTAINER_IMAGE_REF}"
@@ -334,11 +428,40 @@ BIND_ARG="$(IFS=,; echo "${binds[*]}")"
 mkdir -p "${RUN_DIR}"
 if [[ -n "${CODE_LAYER_MANIFEST}" ]]; then
   cp "${CODE_LAYER_MANIFEST}" "${RUN_DIR}/source-manifest.json"
+elif [[ -n "${CODE_DIR}" ]]; then
+  SAMUDRA_SOURCE_MANIFEST_PATH="${RUN_DIR}/source-manifest.json" \
+  SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}" \
+  SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}" \
+  SAMUDRA_CODE_DIR="${CODE_DIR}" \
+  SAMUDRA_UV_LOCK_SHA256="$(sha256sum "${CODE_DIR}/uv.lock" | awk '{print $1}')" \
+  SAMUDRA_PYPROJECT_SHA256="$(sha256sum "${CODE_DIR}/pyproject.toml" | awk '{print $1}')" \
+  python3 - <<'PY'
+import datetime
+import json
+import os
+
+manifest = {
+    "schema_version": 1,
+    "source_mode": "read_only_bind",
+    "source_root": "/opt/samudra-code",
+    "host_source_path": os.environ["SAMUDRA_CODE_DIR"],
+    "code_commit": os.environ["SAMUDRA_CODE_COMMIT"],
+    "code_repo_url": os.environ["SAMUDRA_CODE_REPO_URL"],
+    "uv_lock_sha256": os.environ["SAMUDRA_UV_LOCK_SHA256"],
+    "pyproject_sha256": os.environ["SAMUDRA_PYPROJECT_SHA256"],
+    "included_paths": ["src", "pyproject.toml", "uv.lock"],
+    "recorded_at_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+}
+with open(os.environ["SAMUDRA_SOURCE_MANIFEST_PATH"], "w", encoding="utf-8") as stream:
+    json.dump(manifest, stream, indent=2, sort_keys=True)
+    stream.write("\n")
+PY
 fi
 SAMUDRA_PROVENANCE_PATH="${RUN_DIR}/run-provenance.json" \
 SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}" \
 SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}" \
 SAMUDRA_CODE_LAYER_SHA256="${CODE_LAYER_SHA256}" \
+SAMUDRA_CODE_DIR="${CODE_DIR}" \
 SAMUDRA_CONTAINER_GIT_COMMIT="${CONTAINER_GIT_COMMIT}" \
 SAMUDRA_CONTAINER_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}" \
 SAMUDRA_CONTAINER_IMAGE_REF="${CONTAINER_IMAGE_REF}" \
@@ -351,6 +474,7 @@ keys = (
     "SAMUDRA_CODE_COMMIT",
     "SAMUDRA_CODE_REPO_URL",
     "SAMUDRA_CODE_LAYER_SHA256",
+    "SAMUDRA_CODE_DIR",
     "SAMUDRA_CONTAINER_GIT_COMMIT",
     "SAMUDRA_CONTAINER_GIT_REMOTE_URL",
     "SAMUDRA_CONTAINER_IMAGE_REF",
@@ -367,6 +491,7 @@ PY
 srun --ntasks=1 --ntasks-per-node=1 \
   "${APPTAINER_BIN}" exec --nv \
     "${OVERLAY_ARGS[@]}" \
+    "${CODE_BIND_ARGS[@]}" \
     --bind "${BIND_ARG}" \
     --pwd "${CODE_ROOT}" \
     "${SIF_PATH}" \
@@ -380,7 +505,7 @@ srun --ntasks=1 --ntasks-per-node=1 \
       fi
       if [[ ! -f \"${CONFIG_IN_CONTAINER}\" ]]; then
         echo \"ERROR: config not found inside container: ${CONFIG_IN_CONTAINER}\" >&2
-        echo \"Hint: verify CONFIG and the selected code layer.\" >&2
+        echo \"Hint: verify CONFIG and the selected code source.\" >&2
         exit 2
       fi
       /workspace/.venv/bin/python -m samudra.eval \"${CONFIG_IN_CONTAINER}\" \

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -22,6 +22,9 @@
 #   export CONTAINER_TAG=26.05-latest
 # Optional code layer built by scripts/build_apptainer_code_layer.sh:
 #   export CODE_LAYER=/scratch/$USER/.apptainer-code-layers/samudra-code-<hash>.img
+# Or a clean, commit-pinned checkout mounted read-only:
+#   export CODE_DIR=/path/to/Samudra
+#   export CODE_COMMIT=<full-git-sha>
 #
 # Private GHCR pulls (if needed):
 #   export GHCR_USERNAME=...
@@ -73,6 +76,12 @@ ARGS="${ARGS:-}"
 NSYS_ARGS="${NSYS_ARGS:-}"
 REQUEUE_ON_USR1="${REQUEUE_ON_USR1:-0}"
 CODE_LAYER="${CODE_LAYER:-}"
+CODE_DIR="${CODE_DIR:-}"
+CODE_COMMIT="${CODE_COMMIT:-}"
+if [[ -n "${CODE_LAYER}" && -n "${CODE_DIR}" ]]; then
+  echo "Specify only one of CODE_LAYER or CODE_DIR." >&2
+  exit 2
+fi
 if [[ -z "${NAME}" && -n "${NAME_SUFFIX}" ]]; then
   NAME="$(date +%Y-%m-%d)-${NAME_SUFFIX}"
 fi
@@ -201,22 +210,95 @@ else
   echo "Using existing SIF."
 fi
 
-# The SIF supplies the heavyweight Python/CUDA environment. An optional code
-# overlay supplies source/configs from a separately pinned git commit.
-CONTAINER_GIT_COMMIT="$(
-  "${APPTAINER_BIN}" exec "${SIF_PATH}" \
-    bash -lc 'printf %s "${SAMUDRA_CONTAINER_GIT_COMMIT:-${WANDB_GIT_COMMIT:-unknown}}"'
-)"
-CONTAINER_GIT_REMOTE_URL="$(
-  "${APPTAINER_BIN}" exec "${SIF_PATH}" \
-    bash -lc 'printf %s "${SAMUDRA_CONTAINER_GIT_REMOTE_URL:-${WANDB_GIT_REMOTE_URL:-unknown}}"'
-)"
+# The SIF supplies the heavyweight Python/CUDA environment. Optional code can
+# come from an EXT3 overlay or a clean, commit-pinned checkout mounted read-only.
 CODE_ROOT=/workspace
-CODE_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
-CODE_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
+CODE_GIT_COMMIT=""
+CODE_GIT_REMOTE_URL=""
 CODE_LAYER_SHA256=""
 CODE_LAYER_MANIFEST=""
 OVERLAY_ARGS=()
+CODE_BIND_ARGS=()
+if [[ -n "${CODE_DIR}" ]]; then
+  if [[ -z "${CODE_COMMIT}" ]]; then
+    echo "CODE_COMMIT is required when CODE_DIR is set." >&2
+    exit 7
+  fi
+  if [[ ! "${CODE_COMMIT}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    echo "CODE_COMMIT must be a full 40-character Git commit: ${CODE_COMMIT}" >&2
+    exit 7
+  fi
+  if [[ ! -d "${CODE_DIR}" ]]; then
+    echo "CODE_DIR does not exist or is not a directory: ${CODE_DIR}" >&2
+    exit 7
+  fi
+  CODE_DIR="$(realpath "${CODE_DIR}")"
+  if ! CODE_GIT_COMMIT="$(git -C "${CODE_DIR}" rev-parse --verify HEAD^{commit})"; then
+    echo "CODE_DIR is not a Git checkout: ${CODE_DIR}" >&2
+    exit 7
+  fi
+  CODE_GIT_COMMIT="${CODE_GIT_COMMIT,,}"
+  if [[ "${CODE_GIT_COMMIT}" != "${CODE_COMMIT,,}" ]]; then
+    echo "CODE_DIR HEAD does not match CODE_COMMIT." >&2
+    echo "CODE_DIR HEAD: ${CODE_GIT_COMMIT}" >&2
+    echo "CODE_COMMIT:    ${CODE_COMMIT,,}" >&2
+    exit 7
+  fi
+  if [[ -n "$(git -C "${CODE_DIR}" status --porcelain)" ]]; then
+    echo "CODE_DIR must be clean, including untracked files: ${CODE_DIR}" >&2
+    exit 7
+  fi
+  for source_path in src pyproject.toml uv.lock; do
+    if [[ ! -e "${CODE_DIR}/${source_path}" ]]; then
+      echo "Required source path is absent from CODE_DIR: ${source_path}" >&2
+      exit 7
+    fi
+  done
+  CODE_GIT_REMOTE_URL="$(git -C "${CODE_DIR}" config --get remote.origin.url || true)"
+  if [[ -z "${CODE_GIT_REMOTE_URL}" ]]; then
+    echo "CODE_DIR does not have a remote.origin.url: ${CODE_DIR}" >&2
+    exit 7
+  fi
+  CODE_ROOT=/opt/samudra-code
+  CODE_BIND_ARGS=(--bind "${CODE_DIR}:${CODE_ROOT}:ro")
+  export APPTAINERENV_SAMUDRA_CODE_DIR_PREFLIGHT=1
+fi
+
+# Read container identity and, for CODE_DIR, compare dependency files in one
+# invocation. This avoids an additional expensive SIF expansion on systems
+# without FUSE helpers.
+if ! CONTAINER_METADATA_TEXT="$(
+  "${APPTAINER_BIN}" exec \
+    "${CODE_BIND_ARGS[@]}" \
+    "${SIF_PATH}" \
+    bash -lc '
+      set -euo pipefail
+      if [[ "${SAMUDRA_CODE_DIR_PREFLIGHT:-0}" == "1" ]]; then
+        cmp -s /opt/samudra-code/uv.lock /workspace/uv.lock
+        cmp -s /opt/samudra-code/pyproject.toml /workspace/pyproject.toml
+      fi
+      printf "%s\n%s\n" \
+        "${SAMUDRA_CONTAINER_GIT_COMMIT:-${WANDB_GIT_COMMIT:-unknown}}" \
+        "${SAMUDRA_CONTAINER_GIT_REMOTE_URL:-${WANDB_GIT_REMOTE_URL:-unknown}}"
+    '
+)"; then
+  echo "Container metadata or CODE_DIR dependency compatibility check failed." >&2
+  echo "CODE_DIR uv.lock and pyproject.toml must match the container SIF." >&2
+  exit 7
+fi
+unset APPTAINERENV_SAMUDRA_CODE_DIR_PREFLIGHT
+readarray -t CONTAINER_METADATA <<<"${CONTAINER_METADATA_TEXT}"
+if [[ "${#CONTAINER_METADATA[@]}" -ne 2 ]]; then
+  echo "Container has invalid commit/repository metadata: ${SIF_PATH}" >&2
+  exit 7
+fi
+CONTAINER_GIT_COMMIT="${CONTAINER_METADATA[0]}"
+CONTAINER_GIT_REMOTE_URL="${CONTAINER_METADATA[1]}"
+if [[ -z "${CODE_DIR}" ]]; then
+  CODE_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
+  CODE_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
+fi
+
 if [[ -n "${CODE_LAYER}" ]]; then
   if [[ ! -s "${CODE_LAYER}" ]]; then
     echo "CODE_LAYER does not exist or is empty: ${CODE_LAYER}" >&2
@@ -282,8 +364,10 @@ echo "Code commit:    ${CODE_GIT_COMMIT}"
 if [[ -n "${CODE_LAYER}" ]]; then
   echo "Code layer:     ${CODE_LAYER}"
   echo "Code layer SHA: ${CODE_LAYER_SHA256}"
+elif [[ -n "${CODE_DIR}" ]]; then
+  echo "Code directory: ${CODE_DIR} (read-only bind)"
 else
-  echo "Code layer:     none (using source baked into container SIF)"
+  echo "Code source:    container SIF"
 fi
 
 # W&B's git panel must describe the code being executed, not the commit that
@@ -293,6 +377,7 @@ export APPTAINERENV_WANDB_GIT_REMOTE_URL="${CODE_GIT_REMOTE_URL}"
 export APPTAINERENV_SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}"
 export APPTAINERENV_SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}"
 export APPTAINERENV_SAMUDRA_CODE_LAYER_SHA256="${CODE_LAYER_SHA256}"
+export APPTAINERENV_SAMUDRA_CODE_DIR="${CODE_DIR}"
 export APPTAINERENV_SAMUDRA_CONTAINER_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
 export APPTAINERENV_SAMUDRA_CONTAINER_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
 export APPTAINERENV_SAMUDRA_CONTAINER_IMAGE_REF="${CONTAINER_IMAGE_REF}"
@@ -302,6 +387,7 @@ export SINGULARITYENV_WANDB_GIT_REMOTE_URL="${CODE_GIT_REMOTE_URL}"
 export SINGULARITYENV_SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}"
 export SINGULARITYENV_SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}"
 export SINGULARITYENV_SAMUDRA_CODE_LAYER_SHA256="${CODE_LAYER_SHA256}"
+export SINGULARITYENV_SAMUDRA_CODE_DIR="${CODE_DIR}"
 export SINGULARITYENV_SAMUDRA_CONTAINER_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
 export SINGULARITYENV_SAMUDRA_CONTAINER_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
 export SINGULARITYENV_SAMUDRA_CONTAINER_IMAGE_REF="${CONTAINER_IMAGE_REF}"
@@ -374,11 +460,40 @@ BIND_ARG="$(IFS=,; echo "${binds[*]}")"
 mkdir -p "${RUN_DIR}"
 if [[ -n "${CODE_LAYER_MANIFEST}" ]]; then
   cp "${CODE_LAYER_MANIFEST}" "${RUN_DIR}/source-manifest.json"
+elif [[ -n "${CODE_DIR}" ]]; then
+  SAMUDRA_SOURCE_MANIFEST_PATH="${RUN_DIR}/source-manifest.json" \
+  SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}" \
+  SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}" \
+  SAMUDRA_CODE_DIR="${CODE_DIR}" \
+  SAMUDRA_UV_LOCK_SHA256="$(sha256sum "${CODE_DIR}/uv.lock" | awk '{print $1}')" \
+  SAMUDRA_PYPROJECT_SHA256="$(sha256sum "${CODE_DIR}/pyproject.toml" | awk '{print $1}')" \
+  python3 - <<'PY'
+import datetime
+import json
+import os
+
+manifest = {
+    "schema_version": 1,
+    "source_mode": "read_only_bind",
+    "source_root": "/opt/samudra-code",
+    "host_source_path": os.environ["SAMUDRA_CODE_DIR"],
+    "code_commit": os.environ["SAMUDRA_CODE_COMMIT"],
+    "code_repo_url": os.environ["SAMUDRA_CODE_REPO_URL"],
+    "uv_lock_sha256": os.environ["SAMUDRA_UV_LOCK_SHA256"],
+    "pyproject_sha256": os.environ["SAMUDRA_PYPROJECT_SHA256"],
+    "included_paths": ["src", "pyproject.toml", "uv.lock"],
+    "recorded_at_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+}
+with open(os.environ["SAMUDRA_SOURCE_MANIFEST_PATH"], "w", encoding="utf-8") as stream:
+    json.dump(manifest, stream, indent=2, sort_keys=True)
+    stream.write("\n")
+PY
 fi
 SAMUDRA_PROVENANCE_PATH="${RUN_DIR}/run-provenance.json" \
 SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}" \
 SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}" \
 SAMUDRA_CODE_LAYER_SHA256="${CODE_LAYER_SHA256}" \
+SAMUDRA_CODE_DIR="${CODE_DIR}" \
 SAMUDRA_CONTAINER_GIT_COMMIT="${CONTAINER_GIT_COMMIT}" \
 SAMUDRA_CONTAINER_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}" \
 SAMUDRA_CONTAINER_IMAGE_REF="${CONTAINER_IMAGE_REF}" \
@@ -391,6 +506,7 @@ keys = (
     "SAMUDRA_CODE_COMMIT",
     "SAMUDRA_CODE_REPO_URL",
     "SAMUDRA_CODE_LAYER_SHA256",
+    "SAMUDRA_CODE_DIR",
     "SAMUDRA_CONTAINER_GIT_COMMIT",
     "SAMUDRA_CONTAINER_GIT_REMOTE_URL",
     "SAMUDRA_CONTAINER_IMAGE_REF",
@@ -413,6 +529,7 @@ export OE_NSYS_OUTPUT_DIR="${NSYS_OUTPUT_DIR}"
 srun --ntasks="${SLURM_NNODES}" --ntasks-per-node=1 \
   "${APPTAINER_BIN}" exec --nv \
     "${OVERLAY_ARGS[@]}" \
+    "${CODE_BIND_ARGS[@]}" \
     --bind "${BIND_ARG}" \
     --pwd "${CODE_ROOT}" \
     "${SIF_PATH}" \
@@ -426,7 +543,7 @@ srun --ntasks="${SLURM_NNODES}" --ntasks-per-node=1 \
       fi
       if [[ ! -f \"${CONFIG_IN_CONTAINER}\" ]]; then
         echo \"ERROR: config not found inside container: ${CONFIG_IN_CONTAINER}\" >&2
-        echo \"Hint: verify CONFIG and the selected code layer.\" >&2
+        echo \"Hint: verify CONFIG and the selected code source.\" >&2
         exit 2
       fi
       torchrun_args=(


### PR DESCRIPTION
## Summary

- add an Empire AI Alpha training runbook and include it in the documentation navigation
- document the live Alpha architecture, storage layout, Slurm account/QoS selection, and H100/H200 requests
- provide a restart-safe rclone workflow for staging the public 1° OM4 dataset from OSN through an Alpha transfer node
- document exact-container publication and one-time Apptainer SIF preparation
- add an Empire-specific, compute-node code-overlay recipe with the required Lustre paths and expected SIF expansion cost
- include a bounded one-GPU pilot, queue-aware 1/4/8-GPU comparisons, and a checkpoint-aware production run
- document a failure-safe `overlay -> training -> evaluation -> visualization` chain using `afterok` and `--kill-on-invalid-dep=yes`
- cover the current visualization `QOSMinGRES` constraint and its one-H100 workaround
- make automated W&B secret loading explicit and verifiable without printing the key

## Empirical validation

Validated on Empire AI Alpha on 2026-08-21 using PR #842 commit `b7f94a312a0d261ce9f65ea2d1d0d86654b1155e`:

- copied 91.639 GiB of public 1° OM4 data and verified 380,460 files with `rclone check --size-only --one-way`
- confirmed Alpha is x86_64, so the ARM/Grace image is not required
- published and converted the matching PhysicsNeMo image into a reusable 12 GiB SIF
- SIF preparation job `40324` completed with exit code `0:0`
- H100 debug training job `40380` completed with exit code `0:0`
- completed four training and four validation batches with train loss 2.420, validation loss 0.636, and about 2.35 GiB peak GPU memory
- wrote best-validation, latest, epoch, and EMA checkpoints plus run provenance
- confirmed CPU-only Alpha requests currently fail with `QOSMinGRES`, while 1-, 4-, and 8-H100 shapes pass `sbatch --test-only`
- confirmed `--test-only` prints estimated job IDs without adding jobs to the queue

## Verification

- syntax-checked every fenced Bash example with `bash -n`
- `git diff --check`
- `uvx pre-commit run trailing-whitespace --all-files`
- `uvx pre-commit run check-yaml --all-files`
- `uvx pre-commit run detect-secrets --all-files`
- `uvx pre-commit run reuse --all-files`
- `uv run --group docs zensical build --clean`

## Known issue observed during validation

The manual container workflow published the x86_64 image successfully, and that image completed the EAI pilot. A later container CPU-test job failed during collection because `scripts.build_quickstart_notebook` was not present in the image. The guide calls this out explicitly so that the unrelated packaging failure is not confused with an Empire AI or native-SDPA training failure.