### PR TITLE
Prepare OM4 snapshot dataset generation

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -90,6 +90,21 @@ python -m ocean_preprocessing om4 \
 That's how you can run this package as a command-line utility! Beyond this, `ocean_preprocessing` can be used a library
 in a script or notebook. Continue reading to get a better understanding of this package's capabilities.
 
+### Five-day snapshot source
+
+The snapshot archive is
+`s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr`. Its ocean state
+variables (`thetao`, `so`, `uo`, `vo`, and `zos`) are instantaneous values at
+00:00 UTC every five days. Its forcing variables (`hfds`, `tauuo`, `tauvo`, and
+`wfo`) are five-day means, because the state transition responds to their
+time-integrated fluxes.
+
+The pipeline publishes the eight variables shared with the averaged source and
+also retains `wfo` when the source provides it. Other source diagnostics and
+native-grid fields are ignored explicitly. On Torch, select this source with
+`DATA_VARIANT=snapshots` in `scripts/slurm_preprocess_om4.sbatch`; derived output
+directories use the name `om4_<resolution>_snapshots`.
+
 ## Observation products
 
 Emulator evaluation compares rollouts against observations, not just against OM4. A second CLI fetches and prepares the
@@ -255,6 +270,7 @@ The preprocessing files are the inputs to create curated emulator dataseets for 
 These files live on the OSN pod:
 
 - Data: https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/raw/om4_5daily.zarr
+- Five-day snapshots: https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr
 - Gaussian Grid: https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/raw/grids/gaussian_grid_180_by_360.zarr
 - Mosaic File: https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr
 - Native Grid File: https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr

--- a/data/ocean_preprocessing/__main__.py
+++ b/data/ocean_preprocessing/__main__.py
@@ -333,6 +333,13 @@ class CLI:
             logger.info("**small-run**: filtering data to 10 time steps.")
             ds_processed = ds_processed.isel(time=slice(0, 10))
 
+        # Validate the model-specific output before optional generic transforms.
+        # Partial-depth accounting intentionally expands dz from (lev,) to
+        # (lev, y, x), which is validated by the final input-data contract.
+        if not self.skip_validation:
+            logger.info("validating preprocessing.")
+            ds_processed_validate(ds_processed, deep=True)
+
         if self.account_for_partial_depths:
             logger.info("Apply processing to account for partial depths levels.")
             if native_grid_path.endswith(".zarr"):
@@ -341,10 +348,6 @@ class CLI:
                 with fsspec.open(native_grid_path) as f:
                     native_grid_ds = xr.open_dataset(f).load()
             ds_processed = account_for_partial_depths(ds_processed, native_grid_ds)
-
-        if not self.skip_validation:
-            logger.info("validating preprocessing.")
-            ds_processed_validate(ds_processed, deep=True)
 
         saved_attrs = {}
         for var in ds_processed.data_vars:

--- a/data/ocean_preprocessing/__main__.py
+++ b/data/ocean_preprocessing/__main__.py
@@ -24,7 +24,10 @@ import fire
 import fsspec
 import xarray as xr
 
-from ocean_preprocessing.dataset_validation import ds_processed_validate
+from ocean_preprocessing.dataset_validation import (
+    ds_flattened_input_validate,
+    ds_processed_validate,
+)
 from ocean_preprocessing.plotting import rotated_vectors_qc_plots
 from ocean_preprocessing.preprocessing import (
     account_for_partial_depths,
@@ -236,7 +239,11 @@ class CLI:
         if self.small_run:
             ds = ds.isel(time=slice(0, 10))
         if self.dry_run:
-            logger.info(self.dask_client.compute(ds))
+            if self.dask_client is not None:
+                ds = self.dask_client.compute(ds, sync=True)
+            else:
+                ds = ds.compute()
+            logger.info(ds)
             return
 
         logger.info(f"writing dataset to {self.output_path}")
@@ -245,6 +252,7 @@ class CLI:
             self.output_path,
             mode="w",
             consolidated=True,
+            zarr_format=2,
             encoding={
                 var_name: {"compressor": None} for var_name in ds.data_vars.keys()
             },  # Compression turned off
@@ -480,6 +488,9 @@ class CLI:
 
         logger.info("preparing final chunks for output zarr (time=1)")
         ds = ds.chunk({"time": 1})
+
+        logger.info("validating final output structure")
+        ds_flattened_input_validate(ds)
 
         logger.info("collecting!")
         self._collect(ds)

--- a/data/ocean_preprocessing/__main__.py
+++ b/data/ocean_preprocessing/__main__.py
@@ -26,6 +26,7 @@ import xarray as xr
 
 from ocean_preprocessing.dataset_validation import (
     ds_flattened_input_validate,
+    ds_input_validate,
     ds_processed_validate,
 )
 from ocean_preprocessing.plotting import rotated_vectors_qc_plots
@@ -462,7 +463,7 @@ class CLI:
         # regular (rectilinear) lat-lon grid, so downstream code may treat the 2-D
         # lat/lon as separable. Curvilinear (e.g. tripolar) outputs must set this to
         # the matching grid_type so consumers do not broadcast their geometry.
-        ds_input.attrs["grid_type"] = "gaussian"
+        ds_input.attrs["grid_type"] = "tripolar" if self.skip_regridding else "gaussian"
         # Label wetmask via attrs
         if len(ds_input["wetmask"].attrs) == 0:
             ds_input["wetmask"].attrs["long_name"] = "ocean mask"
@@ -490,7 +491,10 @@ class CLI:
         ds = ds.chunk({"time": 1})
 
         logger.info("validating final output structure")
-        ds_flattened_input_validate(ds)
+        if self.skip_flattening:
+            ds_input_validate(ds)
+        else:
+            ds_flattened_input_validate(ds)
 
         logger.info("collecting!")
         self._collect(ds)

--- a/data/ocean_preprocessing/dataset_validation.py
+++ b/data/ocean_preprocessing/dataset_validation.py
@@ -4,18 +4,17 @@
 
 import warnings
 
+import numpy as np
 import xarray as xr
 
 from ocean_preprocessing.schema import (
-    ds_input_coords_schema,
-    ds_input_schema,
+    OM4_3D_VARS,
+    OM4_OPTIONAL_2D_VARS,
+    OM4_REQUIRED_2D_VARS,
     ds_prediction_coords_schema,
     ds_prediction_schema,
     ds_processed_coords_schema,
     ds_processed_schema,
-    optional_vars_2d,
-    vars_2d,
-    vars_3d,
 )
 from ocean_preprocessing.utils import ensure_nan_consistency, split_2d_3d
 
@@ -41,41 +40,67 @@ def ds_processed_validate(ds_processed: xr.Dataset, deep=False):
         _nan_test_deep(ds_processed)
 
 
-### For input datasets (with generic steps like regridding, filtering, etc applied) ###
-def ds_input_validate(ds_input: xr.Dataset, deep=False):
-    """Test function to assert the format of the input dataset.
-    If `deep` is True, this will run expensive compuation across the entire dataset.
-    """
-    ds_input_schema.validate(ds_input)
-    ds_input_coords_schema.validate(ds_input.coords)
-    # ds_input_attrs_schema.validate(ds_input.attrs) # this does not work as I want, replace with manual check for now
-    required_attrs_keys = ["m2lines/ocean_emulators_git_hash"]
-    for rk in required_attrs_keys:
-        assert rk in ds_input.attrs.keys()
-    if deep:
-        _nan_test_deep(ds_input)
+_COMMON_REQUIRED_COORDS = {
+    "areacello",
+    "dz",
+    "lat",
+    "lat_b",
+    "lev",
+    "lon",
+    "lon_b",
+    "time",
+    "x",
+    "y",
+}
+_REQUIRED_ATTRS = {
+    "grid_type",
+    "m2lines/cli_args",
+    "m2lines/date_created",
+    "m2lines/ocean_emulators_git_hash",
+    "m2lines/samudra_git_hash",
+}
+_SUPPORTED_GRID_TYPES = {"gaussian", "tripolar"}
 
 
-def ds_flattened_input_validate(ds_input: xr.Dataset) -> None:
-    """Validate the resolution-independent contract of a publishable dataset."""
-    required_coords = {
-        "areacello",
-        "dz",
-        "lat",
-        "lat_b",
-        "lev",
-        "lon",
-        "lon_b",
-        "ocean_fraction",
-        "time",
-        "x",
-        "y",
-    }
+def _validate_common_input_contract(ds_input: xr.Dataset) -> None:
+    """Validate metadata shared by flattened and depth-resolved outputs."""
+    grid_type = ds_input.attrs.get("grid_type")
+    if grid_type not in _SUPPORTED_GRID_TYPES:
+        raise ValueError(
+            f"Output grid_type must be one of {sorted(_SUPPORTED_GRID_TYPES)}; "
+            f"got {grid_type!r}."
+        )
+
+    required_coords = set(_COMMON_REQUIRED_COORDS)
+    if grid_type == "gaussian":
+        required_coords.add("ocean_fraction")
+
     missing_coords = required_coords - set(ds_input.coords)
     if missing_coords:
         raise ValueError(
             f"Output is missing required coordinates: {sorted(missing_coords)}"
         )
+
+    expected_coord_dims = {
+        "areacello": ("y", "x"),
+        "dz": ("lev",),
+        "lat": ("y", "x"),
+        "lat_b": ("y_b", "x_b"),
+        "lev": ("lev",),
+        "lon": ("y", "x"),
+        "lon_b": ("y_b", "x_b"),
+        "time": ("time",),
+        "x": ("x",),
+        "y": ("y",),
+    }
+    if "ocean_fraction" in required_coords:
+        expected_coord_dims["ocean_fraction"] = ("lev", "y", "x")
+    for coord, expected_dims in expected_coord_dims.items():
+        if ds_input[coord].dims != expected_dims:
+            raise ValueError(
+                f"Output coordinate {coord!r} has dimensions "
+                f"{ds_input[coord].dims}; expected {expected_dims}."
+            )
 
     for bound, center in (("x_b", "x"), ("y_b", "y")):
         if ds_input.sizes[bound] != ds_input.sizes[center] + 1:
@@ -83,9 +108,75 @@ def ds_flattened_input_validate(ds_input: xr.Dataset) -> None:
                 f"Output dimension {bound!r} must be one larger than {center!r}."
             )
 
+    missing_attrs = _REQUIRED_ATTRS - set(ds_input.attrs)
+    if missing_attrs:
+        raise ValueError(
+            f"Output is missing required attributes: {sorted(missing_attrs)}"
+        )
+
+
+def _validate_dims(
+    ds_input: xr.Dataset, variable_names: set[str], expected_dims: tuple[str, ...]
+) -> None:
+    for var in variable_names:
+        if ds_input[var].dims != expected_dims:
+            raise ValueError(
+                f"Output variable {var!r} has dimensions {ds_input[var].dims}; "
+                f"expected {expected_dims}."
+            )
+
+
+def _validate_dtype(
+    ds_input: xr.Dataset, variable_names: set[str], expected_dtype: str
+) -> None:
+    dtype = np.dtype(expected_dtype)
+    for var in variable_names:
+        if ds_input[var].dtype != dtype:
+            raise ValueError(
+                f"Output variable {var!r} has dtype {ds_input[var].dtype}; "
+                f"expected {dtype}."
+            )
+
+
+### For input datasets (with generic steps like regridding, filtering, etc applied) ###
+def ds_input_validate(ds_input: xr.Dataset, deep=False):
+    """Validate a resolution-independent, depth-resolved input dataset."""
+    _validate_common_input_contract(ds_input)
+
+    required_vars = set(OM4_REQUIRED_2D_VARS) | set(OM4_3D_VARS)
+    missing_vars = required_vars - set(ds_input.data_vars)
+    if missing_vars:
+        raise ValueError(
+            f"Output is missing required variables: {sorted(missing_vars)}"
+        )
+
+    if "wetmask" not in ds_input.coords:
+        raise ValueError("Output is missing required coordinate: 'wetmask'")
+
+    present_2d_vars = set(OM4_REQUIRED_2D_VARS) | (
+        set(OM4_OPTIONAL_2D_VARS) & set(ds_input.data_vars)
+    )
+    _validate_dims(ds_input, present_2d_vars, ("time", "y", "x"))
+    _validate_dims(ds_input, set(OM4_3D_VARS), ("time", "lev", "y", "x"))
+    _validate_dtype(ds_input, present_2d_vars | set(OM4_3D_VARS), "float32")
+    if ds_input.wetmask.dims != ("lev", "y", "x"):
+        raise ValueError(
+            f"Output coordinate 'wetmask' has dimensions {ds_input.wetmask.dims}; "
+            "expected ('lev', 'y', 'x')."
+        )
+    _validate_dtype(ds_input, {"wetmask"}, "bool")
+
+    if deep:
+        _nan_test_deep(ds_input)
+
+
+def ds_flattened_input_validate(ds_input: xr.Dataset) -> None:
+    """Validate the resolution-independent contract of a flattened dataset."""
+    _validate_common_input_contract(ds_input)
+
     levels = range(ds_input.sizes["lev"])
-    required_vars = set(vars_2d)
-    required_vars.update(f"{var}_{level}" for var in vars_3d for level in levels)
+    required_vars = set(OM4_REQUIRED_2D_VARS)
+    required_vars.update(f"{var}_{level}" for var in OM4_3D_VARS for level in levels)
     required_vars.update(f"mask_{level}" for level in levels)
     missing_vars = required_vars - set(ds_input.data_vars)
     if missing_vars:
@@ -93,33 +184,27 @@ def ds_flattened_input_validate(ds_input: xr.Dataset) -> None:
             f"Output is missing required variables: {sorted(missing_vars)}"
         )
 
-    allowed_vars = required_vars | set(optional_vars_2d)
+    allowed_vars = required_vars | set(OM4_OPTIONAL_2D_VARS)
     unexpected_vars = set(ds_input.data_vars) - allowed_vars
     if unexpected_vars:
         raise ValueError(
             f"Output contains undeclared variables: {sorted(unexpected_vars)}"
         )
 
-    for var in required_vars | (set(optional_vars_2d) & set(ds_input.data_vars)):
-        expected_dims = ("y", "x") if var.startswith("mask_") else ("time", "y", "x")
-        if ds_input[var].dims != expected_dims:
-            raise ValueError(
-                f"Output variable {var!r} has dimensions {ds_input[var].dims}; "
-                f"expected {expected_dims}."
-            )
-
-    required_attrs = {
-        "grid_type",
-        "m2lines/cli_args",
-        "m2lines/date_created",
-        "m2lines/ocean_emulators_git_hash",
-        "m2lines/samudra_git_hash",
-    }
-    missing_attrs = required_attrs - set(ds_input.attrs)
-    if missing_attrs:
-        raise ValueError(
-            f"Output is missing required attributes: {sorted(missing_attrs)}"
-        )
+    mask_vars = {var for var in required_vars if var.startswith("mask_")}
+    _validate_dims(ds_input, mask_vars, ("y", "x"))
+    _validate_dims(
+        ds_input,
+        (required_vars - mask_vars)
+        | (set(OM4_OPTIONAL_2D_VARS) & set(ds_input.data_vars)),
+        ("time", "y", "x"),
+    )
+    _validate_dtype(ds_input, mask_vars, "bool")
+    _validate_dtype(
+        ds_input,
+        set(ds_input.data_vars) & (allowed_vars - mask_vars),
+        "float32",
+    )
 
 
 ### for the final prediction output

--- a/data/ocean_preprocessing/dataset_validation.py
+++ b/data/ocean_preprocessing/dataset_validation.py
@@ -83,7 +83,6 @@ def _validate_common_input_contract(ds_input: xr.Dataset) -> None:
 
     expected_coord_dims = {
         "areacello": ("y", "x"),
-        "dz": ("lev",),
         "lat": ("y", "x"),
         "lat_b": ("y_b", "x_b"),
         "lev": ("lev",),
@@ -101,6 +100,13 @@ def _validate_common_input_contract(ds_input: xr.Dataset) -> None:
                 f"Output coordinate {coord!r} has dimensions "
                 f"{ds_input[coord].dims}; expected {expected_dims}."
             )
+
+    allowed_dz_dims = {("lev",), ("lev", "y", "x")}
+    if ds_input.dz.dims not in allowed_dz_dims:
+        raise ValueError(
+            f"Output coordinate 'dz' has dimensions {ds_input.dz.dims}; "
+            f"expected one of {sorted(allowed_dz_dims)}."
+        )
 
     for bound, center in (("x_b", "x"), ("y_b", "y")):
         if ds_input.sizes[bound] != ds_input.sizes[center] + 1:

--- a/data/ocean_preprocessing/dataset_validation.py
+++ b/data/ocean_preprocessing/dataset_validation.py
@@ -13,6 +13,9 @@ from ocean_preprocessing.schema import (
     ds_prediction_schema,
     ds_processed_coords_schema,
     ds_processed_schema,
+    optional_vars_2d,
+    vars_2d,
+    vars_3d,
 )
 from ocean_preprocessing.utils import ensure_nan_consistency, split_2d_3d
 
@@ -46,11 +49,77 @@ def ds_input_validate(ds_input: xr.Dataset, deep=False):
     ds_input_schema.validate(ds_input)
     ds_input_coords_schema.validate(ds_input.coords)
     # ds_input_attrs_schema.validate(ds_input.attrs) # this does not work as I want, replace with manual check for now
-    required_attrs_keys = ["m2lines/ocean-emulators_git_hash"]
+    required_attrs_keys = ["m2lines/ocean_emulators_git_hash"]
     for rk in required_attrs_keys:
         assert rk in ds_input.attrs.keys()
     if deep:
         _nan_test_deep(ds_input)
+
+
+def ds_flattened_input_validate(ds_input: xr.Dataset) -> None:
+    """Validate the resolution-independent contract of a publishable dataset."""
+    required_coords = {
+        "areacello",
+        "dz",
+        "lat",
+        "lat_b",
+        "lev",
+        "lon",
+        "lon_b",
+        "ocean_fraction",
+        "time",
+        "x",
+        "y",
+    }
+    missing_coords = required_coords - set(ds_input.coords)
+    if missing_coords:
+        raise ValueError(
+            f"Output is missing required coordinates: {sorted(missing_coords)}"
+        )
+
+    for bound, center in (("x_b", "x"), ("y_b", "y")):
+        if ds_input.sizes[bound] != ds_input.sizes[center] + 1:
+            raise ValueError(
+                f"Output dimension {bound!r} must be one larger than {center!r}."
+            )
+
+    levels = range(ds_input.sizes["lev"])
+    required_vars = set(vars_2d)
+    required_vars.update(f"{var}_{level}" for var in vars_3d for level in levels)
+    required_vars.update(f"mask_{level}" for level in levels)
+    missing_vars = required_vars - set(ds_input.data_vars)
+    if missing_vars:
+        raise ValueError(
+            f"Output is missing required variables: {sorted(missing_vars)}"
+        )
+
+    allowed_vars = required_vars | set(optional_vars_2d)
+    unexpected_vars = set(ds_input.data_vars) - allowed_vars
+    if unexpected_vars:
+        raise ValueError(
+            f"Output contains undeclared variables: {sorted(unexpected_vars)}"
+        )
+
+    for var in required_vars | (set(optional_vars_2d) & set(ds_input.data_vars)):
+        expected_dims = ("y", "x") if var.startswith("mask_") else ("time", "y", "x")
+        if ds_input[var].dims != expected_dims:
+            raise ValueError(
+                f"Output variable {var!r} has dimensions {ds_input[var].dims}; "
+                f"expected {expected_dims}."
+            )
+
+    required_attrs = {
+        "grid_type",
+        "m2lines/cli_args",
+        "m2lines/date_created",
+        "m2lines/ocean_emulators_git_hash",
+        "m2lines/samudra_git_hash",
+    }
+    missing_attrs = required_attrs - set(ds_input.attrs)
+    if missing_attrs:
+        raise ValueError(
+            f"Output is missing required attributes: {sorted(missing_attrs)}"
+        )
 
 
 ### for the final prediction output

--- a/data/ocean_preprocessing/preprocessing.py
+++ b/data/ocean_preprocessing/preprocessing.py
@@ -12,7 +12,7 @@ import numpy as np
 import xarray as xr
 from xgcm import Grid
 
-from ocean_preprocessing.schema import vars_3d
+from ocean_preprocessing.schema import OM4_3D_VARS
 from ocean_preprocessing.utils import split_2d_3d
 
 try:
@@ -374,7 +374,7 @@ def flatten_by_depth_level(ds: xr.Dataset) -> xr.Dataset:
     # integral over depth.
     # Compared to `ilev`, this is the better quantity to store.
     for i, _depth in enumerate(ds["lev"].values):
-        for var in vars_3d:
+        for var in OM4_3D_VARS:
             ds[f"{var}_{i}"] = ds[var].isel({"lev": i})
             if hasattr(ds[var], "long_name"):
                 long_name = ds[var].long_name
@@ -388,7 +388,7 @@ def flatten_by_depth_level(ds: xr.Dataset) -> xr.Dataset:
         ds[f"mask_{i}"].attrs["long_name"] = f"ocean mask level-{i}"
         ds[f"mask_{i}"].attrs["units"] = "0 if land, 1 if ocean"
 
-    ds = ds.drop_vars(vars_3d)
+    ds = ds.drop_vars(OM4_3D_VARS)
 
     # Keep the grid-metadata coordinates needed for downstream physical analysis
     # (areacello, ocean_fraction, cell bounds, depth axis). Previously these were

--- a/data/ocean_preprocessing/schema.py
+++ b/data/ocean_preprocessing/schema.py
@@ -7,6 +7,7 @@ from xarrera import CoordsSchema, DataArraySchema, DatasetSchema  # noqa: E402
 ### Preprocessing Stage
 vars_3d = ["so", "thetao", "uo", "vo"]
 vars_2d = ["hfds", "tauuo", "tauvo", "zos"]
+optional_vars_2d = ["wfo"]
 ds_processed_coords_schema = CoordsSchema(
     {
         "wetmask": DataArraySchema(dtype=bool, dims=["lev", "y", "x"]),

--- a/data/ocean_preprocessing/schema.py
+++ b/data/ocean_preprocessing/schema.py
@@ -4,10 +4,14 @@
 
 from xarrera import CoordsSchema, DataArraySchema, DatasetSchema  # noqa: E402
 
+OM4_3D_VARS = ("so", "thetao", "uo", "vo")
+OM4_REQUIRED_2D_VARS = ("hfds", "tauuo", "tauvo", "zos")
+# Keep this policy explicit until the matching averaged-run wfo source in #838
+# is identified. Snapshot sources currently provide wfo; averaged sources do not.
+OM4_OPTIONAL_2D_VARS = ("wfo",)
+
+
 ### Preprocessing Stage
-vars_3d = ["so", "thetao", "uo", "vo"]
-vars_2d = ["hfds", "tauuo", "tauvo", "zos"]
-optional_vars_2d = ["wfo"]
 ds_processed_coords_schema = CoordsSchema(
     {
         "wetmask": DataArraySchema(dtype=bool, dims=["lev", "y", "x"]),
@@ -36,54 +40,12 @@ ds_processed_coords_schema = CoordsSchema(
 ds_processed_schema = DatasetSchema(
     {
         k: DataArraySchema(dtype="float32", dims=["time", "y", "x"], name=k)
-        for k in vars_2d
+        for k in OM4_REQUIRED_2D_VARS
     }
     | {
         k: DataArraySchema(dtype="float32", dims=["time", "lev", "y", "x"], name=k)
-        for k in vars_3d
+        for k in OM4_3D_VARS
     }
-)
-
-### Input Stage
-vars_3d = ["so", "thetao", "uo", "vo"]
-vars_2d = ["hfds", "tauuo", "tauvo", "zos"]
-# TODO: add flux components + ice variables         "sithick","siconc",
-ds_input_coords_schema = CoordsSchema(
-    {
-        "wetmask": DataArraySchema(dtype=bool, dims=["lev", "y", "x"]),
-        "ocean_fraction": DataArraySchema(dtype="float64", dims=["lev", "y", "x"]),
-        "lon_b": DataArraySchema(
-            dtype="float64", shape=(181, 361), dims=["y_b", "x_b"]
-        ),
-        "lat_b": DataArraySchema(
-            dtype="float64", shape=(181, 361), dims=["y_b", "x_b"]
-        ),
-        "lon": DataArraySchema(dtype="float64", shape=(180, 360), dims=["y", "x"]),
-        "lat": DataArraySchema(dtype="float64", shape=(180, 360), dims=["y", "x"]),
-        "areacello": DataArraySchema(
-            dtype="float64", shape=(180, 360), dims=["y", "x"]
-        ),
-        "dz": DataArraySchema(dtype="int64", shape=(19,), dims=["lev"]),
-        "lev": DataArraySchema(dtype="float64", shape=(19,), dims=["lev"]),
-        "x": DataArraySchema(dtype="float64", shape=(360,), dims=["x"]),
-        "y": DataArraySchema(dtype="float64", shape=(180,), dims=["y"]),
-        "time": DataArraySchema(
-            dims=["time"]
-        ),  # can I check that this is actually cftime?
-    }
-)
-
-# ds_input_attrs_schema = AttrsSchema({"m2lines/ocean-emulators_git_hash":'dummy'})
-
-ds_input_schema = DatasetSchema(
-    {
-        k: DataArraySchema(dtype="float32", dims=["time", "y", "x"], name=k)
-        for k in vars_2d
-    }
-    | {
-        k: DataArraySchema(dtype="float32", dims=["time", "lev", "y", "x"], name=k)
-        for k in vars_3d
-    },
 )
 
 ### Prediction

--- a/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
+++ b/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
@@ -10,16 +10,19 @@ import xarray as xr
 from xgcm import Grid
 
 from ocean_preprocessing.dataset_validation import ds_processed_validate
+from ocean_preprocessing.schema import (
+    OM4_3D_VARS,
+    OM4_OPTIONAL_2D_VARS,
+    OM4_REQUIRED_2D_VARS,
+)
 from ocean_preprocessing.utils import apply_mask
 
 from .interpolate import interpolate_to_cell_centers
 
 logger = logging.getLogger(__name__)
 
-OM4_REQUIRED_DATA_VARS = frozenset(
-    {"hfds", "so", "tauuo", "tauvo", "thetao", "uo", "vo", "zos"}
-)
-OM4_OPTIONAL_DATA_VARS = frozenset({"wfo"})
+OM4_REQUIRED_DATA_VARS = frozenset(OM4_3D_VARS + OM4_REQUIRED_2D_VARS)
+OM4_OPTIONAL_DATA_VARS = frozenset(OM4_OPTIONAL_2D_VARS)
 
 
 # load supergrid and extract the angles

--- a/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
+++ b/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
@@ -2,16 +2,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
+
 import fsspec
 import numpy as np
 import xarray as xr
-from xarrera import SchemaError
 from xgcm import Grid
 
 from ocean_preprocessing.dataset_validation import ds_processed_validate
 from ocean_preprocessing.utils import apply_mask
 
 from .interpolate import interpolate_to_cell_centers
+
+logger = logging.getLogger(__name__)
+
+OM4_REQUIRED_DATA_VARS = frozenset(
+    {"hfds", "so", "tauuo", "tauvo", "thetao", "uo", "vo", "zos"}
+)
+OM4_OPTIONAL_DATA_VARS = frozenset({"wfo"})
 
 
 # load supergrid and extract the angles
@@ -52,6 +60,27 @@ def normalize_vertical_coords(ds: xr.Dataset) -> xr.Dataset:
     return ds.rename(vertical_rename) if vertical_rename else ds
 
 
+def select_om4_variables(ds: xr.Dataset) -> xr.Dataset:
+    """Keep the stable emulator inputs and reject incomplete OM4 sources.
+
+    Snapshot archives also contain diagnostic and native-grid fields that the
+    averaged archive does not. Passing every compatible source variable through
+    would make the published dataset depend accidentally on the source archive's
+    contents. ``wfo`` is retained when available because it is an intentional
+    five-day-mean forcing in the snapshot product.
+    """
+    available = set(ds.data_vars)
+    missing = OM4_REQUIRED_DATA_VARS - available
+    if missing:
+        raise ValueError(f"OM4 source is missing required variables: {sorted(missing)}")
+
+    selected = OM4_REQUIRED_DATA_VARS | (OM4_OPTIONAL_DATA_VARS & available)
+    ignored = available - selected
+    if ignored:
+        logger.info("ignoring undeclared OM4 source variables: %s", sorted(ignored))
+    return ds[sorted(selected)]
+
+
 def om4_preprocessing(
     zarr_data_path, nc_grid_path, nc_mosaic_path, fs=fsspec, backend_kwargs=None
 ):
@@ -60,6 +89,7 @@ def om4_preprocessing(
         zarr_data_path, engine="zarr", chunks={}, backend_kwargs=backend_kwargs
     )
 
+    ds = select_om4_variables(ds)
     ds = normalize_vertical_coords(ds)
 
     if "ilev" in ds.coords:
@@ -194,8 +224,5 @@ def om4_preprocessing(
     ds = ds.astype(np.float32)
     # higher precision for the area
     ds = ds.assign_coords(areacello=ds.areacello.astype("float64"))
-    try:
-        ds_processed_validate(ds)
-    except SchemaError as err:
-        print(f"Failed validation with error: {str(err)}")
+    ds_processed_validate(ds)
     return ds

--- a/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
+++ b/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
@@ -84,25 +84,14 @@ def select_om4_variables(ds: xr.Dataset) -> xr.Dataset:
     return ds[sorted(selected)]
 
 
-def om4_preprocessing(
-    zarr_data_path, nc_grid_path, nc_mosaic_path, fs=fsspec, backend_kwargs=None
-):
-    """OM4 specific preprocessing."""
-    ds = xr.open_dataset(
-        zarr_data_path, engine="zarr", chunks={}, backend_kwargs=backend_kwargs
-    )
-
-    ds = select_om4_variables(ds)
-    ds = normalize_vertical_coords(ds)
-
+def vertical_cell_metadata(ds: xr.Dataset) -> tuple[xr.DataArray, xr.DataArray]:
+    """Return consistently typed cell thickness and interface coordinates."""
     if "ilev" in ds.coords:
-        dz = xr.DataArray(
-            ds.ilev.diff("ilev").values,
-            dims=["lev"],
-        ).astype("int64")
+        dz = xr.DataArray(ds.ilev.diff("ilev").values, dims=["lev"])
         ilev = ds["ilev"]
     else:
-        # add vertical info
+        # The snapshot archive omits interface depths, so add the canonical
+        # OM4 vertical grid used by the existing processed datasets.
         dz = xr.DataArray(
             [
                 5,
@@ -126,7 +115,7 @@ def om4_preprocessing(
                 1000,
             ],
             dims=["lev"],
-        ).astype("float64")
+        )
         ilev = xr.DataArray(
             [
                 0,
@@ -151,7 +140,25 @@ def om4_preprocessing(
                 6500,
             ],
             dims=["ilev"],
-        ).astype("float64")
+        )
+
+    # The processed coordinate contract is float64 for both averaged sources
+    # (which provide ilev) and snapshot sources (which use the fallback above).
+    return dz.astype("float64"), ilev.astype("float64")
+
+
+def om4_preprocessing(
+    zarr_data_path, nc_grid_path, nc_mosaic_path, fs=fsspec, backend_kwargs=None
+):
+    """OM4 specific preprocessing."""
+    ds = xr.open_dataset(
+        zarr_data_path, engine="zarr", chunks={}, backend_kwargs=backend_kwargs
+    )
+
+    ds = select_om4_variables(ds)
+    ds = normalize_vertical_coords(ds)
+
+    dz, ilev = vertical_cell_metadata(ds)
 
     ds = ds.assign_coords(dz=dz)
 

--- a/data/tests/data.py
+++ b/data/tests/data.py
@@ -228,7 +228,13 @@ def input_data():
             ]
         },
         coords=coords,
-        attrs={"m2lines/ocean_emulators_git_hash": "dummy"},
+        attrs={
+            "grid_type": "gaussian",
+            "m2lines/cli_args": "test",
+            "m2lines/date_created": "2026-08-25T00:00:00",
+            "m2lines/ocean_emulators_git_hash": "dummy",
+            "m2lines/samudra_git_hash": "dummy",
+        },
     )
     # why would they not work when passed at ds creation?
 

--- a/data/tests/data.py
+++ b/data/tests/data.py
@@ -228,7 +228,7 @@ def input_data():
             ]
         },
         coords=coords,
-        attrs={"m2lines/ocean-emulators_git_hash": "dummy"},
+        attrs={"m2lines/ocean_emulators_git_hash": "dummy"},
     )
     # why would they not work when passed at ds creation?
 

--- a/data/tests/test_data.py
+++ b/data/tests/test_data.py
@@ -138,3 +138,13 @@ def test_flattened_contract_rejects_non_float_data():
 
     with pytest.raises(ValueError, match="'hfds' has dtype float64; expected float32"):
         ds_flattened_input_validate(ds)
+
+
+def test_flattened_contract_accepts_partial_cell_thickness():
+    ds = _flattened_input().drop_vars("dz")
+    partial_dz = np.ones(
+        (ds.sizes["lev"], ds.sizes["y"], ds.sizes["x"]), dtype="float64"
+    )
+    ds = ds.assign_coords(dz=(("lev", "y", "x"), partial_dz))
+
+    ds_flattened_input_validate(ds)

--- a/data/tests/test_data.py
+++ b/data/tests/test_data.py
@@ -30,6 +30,13 @@ def test_input_data(input_data):
     ds_input_validate(input_data)
 
 
+def test_input_data_requires_current_provenance(input_data):
+    del input_data.attrs["m2lines/samudra_git_hash"]
+
+    with pytest.raises(ValueError, match="required attributes.*samudra_git_hash"):
+        ds_input_validate(input_data)
+
+
 def test_prediction_data(prediction_data):
     ds_prediction_validate(prediction_data)
 
@@ -100,4 +107,34 @@ def test_flattened_input_contract_requires_provenance():
     del ds.attrs["m2lines/samudra_git_hash"]
 
     with pytest.raises(ValueError, match="required attributes.*samudra_git_hash"):
+        ds_flattened_input_validate(ds)
+
+
+def test_flattened_tripolar_contract_does_not_require_ocean_fraction():
+    ds = _flattened_input().drop_vars("ocean_fraction")
+    ds.attrs["grid_type"] = "tripolar"
+
+    ds_flattened_input_validate(ds)
+
+
+def test_flattened_gaussian_contract_requires_ocean_fraction():
+    ds = _flattened_input().drop_vars("ocean_fraction")
+
+    with pytest.raises(ValueError, match="required coordinates.*ocean_fraction"):
+        ds_flattened_input_validate(ds)
+
+
+def test_flattened_contract_rejects_unknown_grid_type():
+    ds = _flattened_input()
+    ds.attrs["grid_type"] = "cubed_sphere"
+
+    with pytest.raises(ValueError, match="grid_type must be one of"):
+        ds_flattened_input_validate(ds)
+
+
+def test_flattened_contract_rejects_non_float_data():
+    ds = _flattened_input()
+    ds["hfds"] = ds.hfds.astype("float64")
+
+    with pytest.raises(ValueError, match="'hfds' has dtype float64; expected float32"):
         ds_flattened_input_validate(ds)

--- a/data/tests/test_data.py
+++ b/data/tests/test_data.py
@@ -2,17 +2,27 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""This is s bit silly. It would be better to be able to create datasets from the schema dynamically, so the schema serve as source of truth, and when they are updated, the test data is too. But for now lets at least test that our test fixtures are compliant."""
+"""Validation tests for preprocessing datasets."""
 
-from tests.data import input_data, prediction_data, processed_data  # noqa
+import numpy as np
+import pytest
+import xarray as xr
 from ocean_preprocessing.dataset_validation import (
-    ds_processed_validate,
+    ds_flattened_input_validate,
     ds_input_validate,
     ds_prediction_validate,
+    ds_processed_validate,
 )
+
+from tests.data import input_data, prediction_data, processed_data  # noqa
 
 
 def test_processed_data(processed_data):
+    ds_processed_validate(processed_data)
+
+
+def test_processed_data_allows_snapshot_water_flux(processed_data):
+    processed_data["wfo"] = processed_data["hfds"]
     ds_processed_validate(processed_data)
 
 
@@ -22,3 +32,72 @@ def test_input_data(input_data):
 
 def test_prediction_data(prediction_data):
     ds_prediction_validate(prediction_data)
+
+
+def _flattened_input(*, include_wfo: bool = True) -> xr.Dataset:
+    time, levels, ny, nx = 2, 2, 3, 4
+    dynamic = np.ones((time, ny, nx), dtype="float32")
+    data_vars = {
+        name: (("time", "y", "x"), dynamic)
+        for name in ["hfds", "tauuo", "tauvo", "zos"]
+    }
+    if include_wfo:
+        data_vars["wfo"] = (("time", "y", "x"), dynamic)
+    for name in ["so", "thetao", "uo", "vo"]:
+        for level in range(levels):
+            data_vars[f"{name}_{level}"] = (("time", "y", "x"), dynamic)
+    for level in range(levels):
+        data_vars[f"mask_{level}"] = (
+            ("y", "x"),
+            np.ones((ny, nx), dtype=bool),
+        )
+
+    return xr.Dataset(
+        data_vars,
+        coords={
+            "time": range(time),
+            "lev": ("lev", [2.5, 10.0]),
+            "dz": ("lev", [5.0, 10.0]),
+            "x": range(nx),
+            "y": range(ny),
+            "x_b": range(nx + 1),
+            "y_b": range(ny + 1),
+            "lon": (("y", "x"), np.zeros((ny, nx))),
+            "lat": (("y", "x"), np.zeros((ny, nx))),
+            "lon_b": (("y_b", "x_b"), np.zeros((ny + 1, nx + 1))),
+            "lat_b": (("y_b", "x_b"), np.zeros((ny + 1, nx + 1))),
+            "areacello": (("y", "x"), np.ones((ny, nx))),
+            "ocean_fraction": (
+                ("lev", "y", "x"),
+                np.ones((levels, ny, nx)),
+            ),
+        },
+        attrs={
+            "grid_type": "gaussian",
+            "m2lines/cli_args": "test",
+            "m2lines/date_created": "2026-08-24T00:00:00",
+            "m2lines/ocean_emulators_git_hash": "https://example.test/commit/a",
+            "m2lines/samudra_git_hash": "https://example.test/commit/a",
+        },
+    )
+
+
+@pytest.mark.parametrize("include_wfo", [False, True])
+def test_flattened_input_contract_is_resolution_independent(include_wfo):
+    ds_flattened_input_validate(_flattened_input(include_wfo=include_wfo))
+
+
+def test_flattened_input_contract_rejects_undeclared_variable():
+    ds = _flattened_input()
+    ds["hfgeou"] = ds["hfds"]
+
+    with pytest.raises(ValueError, match="undeclared variables.*hfgeou"):
+        ds_flattened_input_validate(ds)
+
+
+def test_flattened_input_contract_requires_provenance():
+    ds = _flattened_input()
+    del ds.attrs["m2lines/samudra_git_hash"]
+
+    with pytest.raises(ValueError, match="required attributes.*samudra_git_hash"):
+        ds_flattened_input_validate(ds)

--- a/data/tests/test_main.py
+++ b/data/tests/test_main.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import numpy as np
+import xarray as xr
+from ocean_preprocessing.__main__ import CLI
+
+
+def test_clusterless_dry_run_computes_without_a_client(tmp_path):
+    pipeline = CLI(output_path=str(tmp_path / "unused.zarr"), dry_run=True)
+    ds = xr.Dataset({"value": ("time", np.arange(3))}).chunk({"time": 1})
+
+    pipeline._collect(ds)
+
+    assert not (tmp_path / "unused.zarr").exists()
+
+
+def test_collect_explicitly_writes_zarr_v2(tmp_path):
+    output = tmp_path / "output.zarr"
+    pipeline = CLI(output_path=str(output))
+    ds = xr.Dataset({"value": ("time", np.arange(3))}).chunk({"time": 1})
+
+    pipeline._collect(ds)
+
+    metadata = json.loads((output / ".zgroup").read_text(encoding="utf-8"))
+    assert metadata["zarr_format"] == 2

--- a/data/tests/test_simulation_preprocessing.py
+++ b/data/tests/test_simulation_preprocessing.py
@@ -8,6 +8,7 @@ import xarray as xr
 from ocean_preprocessing.simulation_preprocessing.gfdl_om4 import (
     normalize_vertical_coords,
     select_om4_variables,
+    vertical_cell_metadata,
 )
 
 
@@ -39,6 +40,22 @@ def test_normalize_is_noop_without_raw_vertical_coords():
     ds = _ds_with_vertical(["lev"])
     out = normalize_vertical_coords(ds)
     assert "lev" in out.coords
+
+
+def test_averaged_vertical_cell_metadata_matches_processed_schema_dtype():
+    ds = xr.Dataset(
+        coords={
+            "lev": ("lev", [2.5, 10.0]),
+            "ilev": ("ilev", [0, 5, 15]),
+        }
+    )
+
+    dz, ilev = vertical_cell_metadata(ds)
+
+    assert dz.dims == ("lev",)
+    assert dz.dtype == np.dtype("float64")
+    assert ilev.dtype == np.dtype("float64")
+    np.testing.assert_array_equal(dz, [5.0, 10.0])
 
 
 def _om4_source(*extra_vars: str) -> xr.Dataset:

--- a/data/tests/test_simulation_preprocessing.py
+++ b/data/tests/test_simulation_preprocessing.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+import pytest
 import xarray as xr
 from ocean_preprocessing.simulation_preprocessing.gfdl_om4 import (
     normalize_vertical_coords,
+    select_om4_variables,
 )
 
 
@@ -37,3 +39,34 @@ def test_normalize_is_noop_without_raw_vertical_coords():
     ds = _ds_with_vertical(["lev"])
     out = normalize_vertical_coords(ds)
     assert "lev" in out.coords
+
+
+def _om4_source(*extra_vars: str) -> xr.Dataset:
+    required = ["hfds", "so", "tauuo", "tauvo", "thetao", "uo", "vo", "zos"]
+    return xr.Dataset(
+        {name: ("time", np.ones(2)) for name in [*required, *extra_vars]},
+        coords={"time": [0, 1]},
+    )
+
+
+def test_select_om4_variables_retains_declared_snapshot_forcing():
+    out = select_om4_variables(_om4_source("wfo", "hfgeou", "wet"))
+
+    assert set(out.data_vars) == {
+        "hfds",
+        "so",
+        "tauuo",
+        "tauvo",
+        "thetao",
+        "uo",
+        "vo",
+        "wfo",
+        "zos",
+    }
+
+
+def test_select_om4_variables_rejects_incomplete_source():
+    source = _om4_source().drop_vars("thetao")
+
+    with pytest.raises(ValueError, match="missing required variables.*thetao"):
+        select_om4_variables(source)

--- a/data/tests/test_slurm_harness.py
+++ b/data/tests/test_slurm_harness.py
@@ -66,3 +66,14 @@ def test_slurm_harness_resolves_sidecar_from_repo_checkout(harness):
     assert script.index('REPO_DIR="${REPO_DIR:-') < script.index(
         'source "${VARIANT_SCRIPT}"'
     )
+
+
+def test_preprocessing_harness_runs_selected_data_subproject():
+    script = SLURM_HARNESSES[0].read_text()
+
+    # An editable conda install may reference another checkout. Running from
+    # REPO_DIR/data ensures Python imports the revision selected for this job.
+    assert 'cd "${REPO_DIR}/data"' in script
+    assert script.index('cd "${REPO_DIR}/data"') < script.index(
+        "\npython -m ocean_preprocessing om4"
+    )

--- a/data/tests/test_slurm_harness.py
+++ b/data/tests/test_slurm_harness.py
@@ -9,6 +9,10 @@ from pathlib import Path
 import pytest
 
 VARIANT_SCRIPT = Path(__file__).parents[2] / "scripts" / "om4_data_variant.sh"
+SLURM_HARNESSES = [
+    VARIANT_SCRIPT.parent / "slurm_preprocess_om4.sbatch",
+    VARIANT_SCRIPT.parent / "slurm_make_norm_om4.sbatch",
+]
 
 
 def _resolve_variant(variant: str) -> subprocess.CompletedProcess[str]:
@@ -49,3 +53,16 @@ def test_om4_data_variant_rejects_unknown_value():
 
     assert result.returncode == 2
     assert "unknown DATA_VARIANT='instantaneous'" in result.stderr
+
+
+@pytest.mark.parametrize("harness", SLURM_HARNESSES)
+def test_slurm_harness_resolves_sidecar_from_repo_checkout(harness):
+    script = harness.read_text()
+
+    # sbatch executes a copy under Slurm's spool directory, so BASH_SOURCE
+    # cannot locate a helper stored beside the original script.
+    assert 'dirname -- "${BASH_SOURCE[0]}"' not in script
+    assert 'VARIANT_SCRIPT="${REPO_DIR%/}/scripts/om4_data_variant.sh"' in script
+    assert script.index('REPO_DIR="${REPO_DIR:-') < script.index(
+        'source "${VARIANT_SCRIPT}"'
+    )

--- a/data/tests/test_slurm_harness.py
+++ b/data/tests/test_slurm_harness.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+VARIANT_SCRIPT = Path(__file__).parents[2] / "scripts" / "om4_data_variant.sh"
+
+
+def _resolve_variant(variant: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ | {"DATA_VARIANT": variant}
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1"; resolve_om4_data_variant || exit $?; '
+            'printf "%s|%s|%s" "$DATA_VARIANT" "$OM4_SOURCE_STORE" '
+            '"$OM4_OUTPUT_SUFFIX"',
+            "bash",
+            str(VARIANT_SCRIPT),
+        ],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("variant", "expected"),
+    [
+        ("averaged", "averaged|om4_5daily.zarr|"),
+        ("snapshots", "snapshots|om4_5daily_snapshots.zarr|_snapshots"),
+    ],
+)
+def test_om4_data_variant(variant, expected):
+    result = _resolve_variant(variant)
+
+    assert result.returncode == 0
+    assert result.stdout == expected
+
+
+def test_om4_data_variant_rejects_unknown_value():
+    result = _resolve_variant("instantaneous")
+
+    assert result.returncode == 2
+    assert "unknown DATA_VARIANT='instantaneous'" in result.stderr

--- a/docs/data.md
+++ b/docs/data.md
@@ -499,6 +499,20 @@ Both the raw **inputs** and the processed **outputs** live under the `Samudra` p
 from `s3://m2lines-pubs/Samudra/raw/...` (`RAW_ROOT`) and results are written under `OUTPUT_BASE`. The raw inputs were
 mirrored there from `FOMO/raw` with a server-side `rclone` copy on the data transfer node.
 
+`DATA_VARIANT` selects the temporal form of the raw OM4 source and the derived
+output-directory suffix:
+
+| `DATA_VARIANT` | raw source | derived output directory |
+| --- | --- | --- |
+| `averaged` (default) | `om4_5daily.zarr` | `om4_<resolution>/` |
+| `snapshots` | `om4_5daily_snapshots.zarr` | `om4_<resolution>_snapshots/` |
+
+For the snapshot source, `thetao`, `so`, `uo`, `vo`, and `zos` are instantaneous
+values at 00:00 UTC every five days. The forcings `hfds`, `tauuo`, `tauvo`, and
+`wfo` are five-day means; this is intentional because the ocean state integrates
+their fluxes over the transition. The processed snapshot datasets retain `wfo`
+and the standard emulator inputs, while ignoring undeclared source diagnostics.
+
 ```bash
 export OUTPUT_BASE="s3://m2lines-pubs/Samudra/v$(date +%Y-%m)"
 
@@ -518,6 +532,30 @@ RESOLUTION=quarterdeg N_WORKERS=16 \
 # Normalization datasets, after each OM4.zarr lands:
 for R in twodeg onedeg onedeg_filter halfdeg quarterdeg; do
   RESOLUTION=$R sbatch scripts/slurm_make_norm_om4.sbatch
+done
+```
+
+To produce the four unfiltered snapshot scales in a new monthly namespace, keep
+the version explicit for the entire submission rather than recomputing the date
+in each job:
+
+```bash
+export OUTPUT_BASE="s3://m2lines-pubs/Samudra/v2026-08"
+export DATA_VARIANT=snapshots
+
+# Real-source smoke test: ten timesteps, no write.
+RESOLUTION=onedeg EXTRA_ARGS="--small_run --dry_run" \
+  sbatch --cpus-per-task=16 --mem=64G --time=00:30:00 scripts/slurm_preprocess_om4.sbatch
+
+RESOLUTION=twodeg    sbatch --cpus-per-task=32  --mem=240G --time=08:00:00   scripts/slurm_preprocess_om4.sbatch
+RESOLUTION=onedeg    sbatch --cpus-per-task=64  --mem=480G --time=12:00:00   scripts/slurm_preprocess_om4.sbatch
+RESOLUTION=halfdeg   sbatch --cpus-per-task=128 --mem=490G --time=1-00:00:00 scripts/slurm_preprocess_om4.sbatch
+RESOLUTION=quarterdeg N_WORKERS=16 \
+                     sbatch --cpus-per-task=128 --mem=490G --time=2-00:00:00 scripts/slurm_preprocess_om4.sbatch
+
+# Submit these only after the corresponding preprocessing jobs succeed.
+for R in twodeg onedeg halfdeg quarterdeg; do
+  DATA_VARIANT=snapshots RESOLUTION=$R sbatch scripts/slurm_make_norm_om4.sbatch
 done
 ```
 

--- a/scripts/om4_data_variant.sh
+++ b/scripts/om4_data_variant.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Resolve the raw source and output suffix shared by the preprocessing and
+# normalization Slurm harnesses. Callers may set DATA_VARIANT before invoking
+# this function.
+resolve_om4_data_variant() {
+  DATA_VARIANT="${DATA_VARIANT:-averaged}"
+  case "${DATA_VARIANT}" in
+    averaged)
+      OM4_SOURCE_STORE="om4_5daily.zarr"
+      OM4_OUTPUT_SUFFIX=""
+      ;;
+    snapshots)
+      OM4_SOURCE_STORE="om4_5daily_snapshots.zarr"
+      OM4_OUTPUT_SUFFIX="_snapshots"
+      ;;
+    *)
+      echo "ERROR: unknown DATA_VARIANT='${DATA_VARIANT}'." >&2
+      echo "Expected one of: averaged | snapshots." >&2
+      return 2
+      ;;
+  esac
+}

--- a/scripts/slurm_make_norm_om4.sbatch
+++ b/scripts/slurm_make_norm_om4.sbatch
@@ -16,7 +16,9 @@
 #
 # --- Common env vars ---------------------------------------------------------
 #   OUTPUT_BASE + RESOLUTION  derive OUTPUT_PATH as
-#                               ${OUTPUT_BASE}/om4_${RESOLUTION}/OM4.zarr
+#                               ${OUTPUT_BASE}/om4_${RESOLUTION}${variant_suffix}/OM4.zarr
+#   DATA_VARIANT averaged (default) | snapshots; adds `_snapshots` to the
+#                derived output directory for snapshot data.
 #   PREPROC_ENV  conda env name (default: ocean_preprocessing)
 #   CONDA_SH     path to conda.sh (autodetected from $CONDA_EXE / common dirs)
 #   REPO_DIR     repo checkout (default: $SLURM_SUBMIT_DIR)
@@ -51,7 +53,16 @@ if [[ -z "${OUTPUT_PATH}" ]]; then
     echo "ERROR: set OUTPUT_PATH, or both OUTPUT_BASE and RESOLUTION." >&2
     exit 2
   fi
-  OUTPUT_PATH="${OUTPUT_BASE%/}/om4_${RESOLUTION}/OM4.zarr"
+  DATA_VARIANT="${DATA_VARIANT:-averaged}"
+  case "${DATA_VARIANT}" in
+    averaged)  OUTPUT_SUFFIX="" ;;
+    snapshots) OUTPUT_SUFFIX="_snapshots" ;;
+    *)
+      echo "ERROR: unknown DATA_VARIANT='${DATA_VARIANT}'." >&2
+      echo "Expected one of: averaged | snapshots." >&2
+      exit 2 ;;
+  esac
+  OUTPUT_PATH="${OUTPUT_BASE%/}/om4_${RESOLUTION}${OUTPUT_SUFFIX}/OM4.zarr"
 fi
 if [[ "${OUTPUT_PATH}" != s3://* ]]; then
   echo "ERROR: make_norm_datasets.py requires an s3:// path; got '${OUTPUT_PATH}'." >&2

--- a/scripts/slurm_make_norm_om4.sbatch
+++ b/scripts/slurm_make_norm_om4.sbatch
@@ -47,22 +47,18 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=om4_data_variant.sh
+source "${SCRIPT_DIR}/om4_data_variant.sh"
+
 OUTPUT_PATH="${OUTPUT_PATH:-}"
 if [[ -z "${OUTPUT_PATH}" ]]; then
   if [[ -z "${OUTPUT_BASE:-}" || -z "${RESOLUTION:-}" ]]; then
     echo "ERROR: set OUTPUT_PATH, or both OUTPUT_BASE and RESOLUTION." >&2
     exit 2
   fi
-  DATA_VARIANT="${DATA_VARIANT:-averaged}"
-  case "${DATA_VARIANT}" in
-    averaged)  OUTPUT_SUFFIX="" ;;
-    snapshots) OUTPUT_SUFFIX="_snapshots" ;;
-    *)
-      echo "ERROR: unknown DATA_VARIANT='${DATA_VARIANT}'." >&2
-      echo "Expected one of: averaged | snapshots." >&2
-      exit 2 ;;
-  esac
-  OUTPUT_PATH="${OUTPUT_BASE%/}/om4_${RESOLUTION}${OUTPUT_SUFFIX}/OM4.zarr"
+  resolve_om4_data_variant
+  OUTPUT_PATH="${OUTPUT_BASE%/}/om4_${RESOLUTION}${OM4_OUTPUT_SUFFIX}/OM4.zarr"
 fi
 if [[ "${OUTPUT_PATH}" != s3://* ]]; then
   echo "ERROR: make_norm_datasets.py requires an s3:// path; got '${OUTPUT_PATH}'." >&2

--- a/scripts/slurm_make_norm_om4.sbatch
+++ b/scripts/slurm_make_norm_om4.sbatch
@@ -47,9 +47,17 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# Slurm executes a spool copy of this batch script, so BASH_SOURCE points into
+# Slurm's private job directory rather than this repository. Resolve sidecars
+# from the explicitly supplied checkout (or the submission directory) instead.
+REPO_DIR="${REPO_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
+VARIANT_SCRIPT="${REPO_DIR%/}/scripts/om4_data_variant.sh"
+if [[ ! -f "${VARIANT_SCRIPT}" ]]; then
+  echo "ERROR: OM4 variant helper not found at '${VARIANT_SCRIPT}'. Set REPO_DIR to the Samudra checkout." >&2
+  exit 3
+fi
 # shellcheck source=om4_data_variant.sh
-source "${SCRIPT_DIR}/om4_data_variant.sh"
+source "${VARIANT_SCRIPT}"
 
 OUTPUT_PATH="${OUTPUT_PATH:-}"
 if [[ -z "${OUTPUT_PATH}" ]]; then
@@ -99,7 +107,6 @@ export BLOSC_NOLOCK=1
 export NUMEXPR_NUM_THREADS=1
 export PYTHONUNBUFFERED=1
 
-REPO_DIR="${REPO_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
 cd "${REPO_DIR}/data"
 
 echo "Building means/stds for: ${OUTPUT_PATH}"

--- a/scripts/slurm_preprocess_om4.sbatch
+++ b/scripts/slurm_preprocess_om4.sbatch
@@ -194,7 +194,11 @@ if [[ "${SKIP_VALIDATION:-1}" == "1" ]]; then
 fi
 
 # --- Run ---------------------------------------------------------------------
-cd "${REPO_DIR}"  # so get_git_url_hash() resolves and data/ is importable
+# Enter the selected data subproject before invoking Python. The conda env is
+# created with an editable install, which may point at a different checkout;
+# putting this directory first on sys.path guarantees that the job executes the
+# exact REPO_DIR revision whose provenance it records.
+cd "${REPO_DIR}/data"
 
 echo "Resolution:   ${RESOLUTION}"
 echo "Data variant: ${DATA_VARIANT}"
@@ -205,6 +209,7 @@ echo "Output path:  ${OUTPUT_PATH}"
 echo "Conda env:    ${PREPROC_ENV}  (via ${CONDA_SH})"
 echo "LocalCluster: n_workers=${N_WORKERS} threads_per_worker=${THREADS_PER_WORKER} memory_limit=${MEMORY_LIMIT:-auto}"
 echo "Repo dir:     ${REPO_DIR}"
+echo "Python source: $(python -c 'import ocean_preprocessing; print(ocean_preprocessing.__file__)')"
 
 set -x
 python -m ocean_preprocessing om4 \

--- a/scripts/slurm_preprocess_om4.sbatch
+++ b/scripts/slurm_preprocess_om4.sbatch
@@ -80,6 +80,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=om4_data_variant.sh
+source "${SCRIPT_DIR}/om4_data_variant.sh"
+
 # --- Resolve inputs ----------------------------------------------------------
 RESOLUTION="${RESOLUTION:-}"
 if [[ -z "${RESOLUTION}" ]]; then
@@ -103,16 +107,8 @@ case "${RESOLUTION}" in
 esac
 
 RAW_ROOT="${RAW_ROOT:-s3://m2lines-pubs/Samudra/raw}"
-DATA_VARIANT="${DATA_VARIANT:-averaged}"
-case "${DATA_VARIANT}" in
-  averaged)  SOURCE_STORE="om4_5daily.zarr";           OUTPUT_SUFFIX="" ;;
-  snapshots) SOURCE_STORE="om4_5daily_snapshots.zarr"; OUTPUT_SUFFIX="_snapshots" ;;
-  *)
-    echo "ERROR: unknown DATA_VARIANT='${DATA_VARIANT}'." >&2
-    echo "Expected one of: averaged | snapshots." >&2
-    exit 2 ;;
-esac
-DATA_PATH="${DATA_PATH:-${RAW_ROOT}/${SOURCE_STORE}}"
+resolve_om4_data_variant
+DATA_PATH="${DATA_PATH:-${RAW_ROOT}/${OM4_SOURCE_STORE}}"
 NATIVE_GRID_PATH="${RAW_ROOT}/ocean_static_no_mask_table.zarr"
 MOSAIC_PATH="${RAW_ROOT}/grids/ocean_hgrid.zarr"
 TARGET_GRID_PATH="${RAW_ROOT}/grids/${GRID}.zarr"
@@ -124,7 +120,7 @@ if [[ -z "${OUTPUT_PATH}" ]]; then
     echo "Example: export OUTPUT_BASE=\"s3://m2lines-pubs/Samudra/v\$(date +%Y-%m)\"" >&2
     exit 2
   fi
-  OUTPUT_PATH="${OUTPUT_BASE%/}/om4_${RESOLUTION}${OUTPUT_SUFFIX}/OM4.zarr"
+  OUTPUT_PATH="${OUTPUT_BASE%/}/om4_${RESOLUTION}${OM4_OUTPUT_SUFFIX}/OM4.zarr"
 fi
 
 # --- Credentials preflight ---------------------------------------------------

--- a/scripts/slurm_preprocess_om4.sbatch
+++ b/scripts/slurm_preprocess_om4.sbatch
@@ -22,9 +22,12 @@
 #
 # --- Common env vars ---------------------------------------------------------
 #   OUTPUT_BASE  s3 prefix; OUTPUT_PATH defaults to
-#                  ${OUTPUT_BASE}/om4_${RESOLUTION}/OM4.zarr
+#                  ${OUTPUT_BASE}/om4_${RESOLUTION}${variant_suffix}/OM4.zarr
 #                e.g. export OUTPUT_BASE="s3://m2lines-pubs/Samudra/v$(date +%Y-%m)"
 #   RAW_ROOT     source prefix (default: s3://m2lines-pubs/Samudra/raw)
+#   DATA_VARIANT averaged (default) | snapshots; selects the raw store and adds
+#                `_snapshots` to derived output directories for snapshot data.
+#   DATA_PATH    exact raw OM4 source; overrides DATA_VARIANT's source selection.
 #   PREPROC_ENV  conda env name (default: ocean_preprocessing)
 #   CONDA_SH     path to conda.sh (autodetected from $CONDA_EXE / common dirs)
 #   REPO_DIR     repo checkout (default: $SLURM_SUBMIT_DIR); we cd here so the
@@ -80,7 +83,7 @@ set -euo pipefail
 # --- Resolve inputs ----------------------------------------------------------
 RESOLUTION="${RESOLUTION:-}"
 if [[ -z "${RESOLUTION}" ]]; then
-  echo "ERROR: RESOLUTION is required (onedeg | onedeg_filter | halfdeg | quarterdeg)." >&2
+  echo "ERROR: RESOLUTION is required (twodeg | twodeg_filter | onedeg | onedeg_filter | halfdeg | quarterdeg)." >&2
   exit 2
 fi
 
@@ -100,7 +103,16 @@ case "${RESOLUTION}" in
 esac
 
 RAW_ROOT="${RAW_ROOT:-s3://m2lines-pubs/Samudra/raw}"
-DATA_PATH="${RAW_ROOT}/om4_5daily.zarr"
+DATA_VARIANT="${DATA_VARIANT:-averaged}"
+case "${DATA_VARIANT}" in
+  averaged)  SOURCE_STORE="om4_5daily.zarr";           OUTPUT_SUFFIX="" ;;
+  snapshots) SOURCE_STORE="om4_5daily_snapshots.zarr"; OUTPUT_SUFFIX="_snapshots" ;;
+  *)
+    echo "ERROR: unknown DATA_VARIANT='${DATA_VARIANT}'." >&2
+    echo "Expected one of: averaged | snapshots." >&2
+    exit 2 ;;
+esac
+DATA_PATH="${DATA_PATH:-${RAW_ROOT}/${SOURCE_STORE}}"
 NATIVE_GRID_PATH="${RAW_ROOT}/ocean_static_no_mask_table.zarr"
 MOSAIC_PATH="${RAW_ROOT}/grids/ocean_hgrid.zarr"
 TARGET_GRID_PATH="${RAW_ROOT}/grids/${GRID}.zarr"
@@ -112,7 +124,7 @@ if [[ -z "${OUTPUT_PATH}" ]]; then
     echo "Example: export OUTPUT_BASE=\"s3://m2lines-pubs/Samudra/v\$(date +%Y-%m)\"" >&2
     exit 2
   fi
-  OUTPUT_PATH="${OUTPUT_BASE%/}/om4_${RESOLUTION}/OM4.zarr"
+  OUTPUT_PATH="${OUTPUT_BASE%/}/om4_${RESOLUTION}${OUTPUT_SUFFIX}/OM4.zarr"
 fi
 
 # --- Credentials preflight ---------------------------------------------------
@@ -182,6 +194,8 @@ REPO_DIR="${REPO_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
 cd "${REPO_DIR}"  # so get_git_url_hash() resolves and data/ is importable
 
 echo "Resolution:   ${RESOLUTION}"
+echo "Data variant: ${DATA_VARIANT}"
+echo "Data path:    ${DATA_PATH}"
 echo "Target grid:  ${GRID}  (filter: ${FILTER_FLAG:-on})"
 echo "Raw root:     ${RAW_ROOT}"
 echo "Output path:  ${OUTPUT_PATH}"

--- a/scripts/slurm_preprocess_om4.sbatch
+++ b/scripts/slurm_preprocess_om4.sbatch
@@ -80,9 +80,17 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# Slurm executes a spool copy of this batch script, so BASH_SOURCE points into
+# Slurm's private job directory rather than this repository. Resolve sidecars
+# from the explicitly supplied checkout (or the submission directory) instead.
+REPO_DIR="${REPO_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
+VARIANT_SCRIPT="${REPO_DIR%/}/scripts/om4_data_variant.sh"
+if [[ ! -f "${VARIANT_SCRIPT}" ]]; then
+  echo "ERROR: OM4 variant helper not found at '${VARIANT_SCRIPT}'. Set REPO_DIR to the Samudra checkout." >&2
+  exit 3
+fi
 # shellcheck source=om4_data_variant.sh
-source "${SCRIPT_DIR}/om4_data_variant.sh"
+source "${VARIANT_SCRIPT}"
 
 # --- Resolve inputs ----------------------------------------------------------
 RESOLUTION="${RESOLUTION:-}"
@@ -186,7 +194,6 @@ if [[ "${SKIP_VALIDATION:-1}" == "1" ]]; then
 fi
 
 # --- Run ---------------------------------------------------------------------
-REPO_DIR="${REPO_DIR:-${SLURM_SUBMIT_DIR:-$PWD}}"
 cd "${REPO_DIR}"  # so get_git_url_hash() resolves and data/ is importable
 
 echo "Resolution:   ${RESOLUTION}"


### PR DESCRIPTION
## Summary

- add a backward-compatible `DATA_VARIANT=snapshots` mode to the Torch preprocessing and normalization harnesses
- select `om4_5daily_snapshots.zarr` and derive `om4_<resolution>_snapshots` output directories
- make the OM4 variable contract explicit, retaining the issue-approved five-day-mean `wfo` forcing while excluding undeclared raw diagnostics
- make preprocessing schema failures fatal and validate the flattened, publishable output contract at every resolution
- explicitly write Zarr v2 and fix clusterless dry runs
- document the snapshot temporal semantics and the planned `v2026-08` four-resolution workflow

The source and temporal semantics follow the discussion in #450, especially:

- https://github.com/m2lines/Samudra/issues/450#issuecomment-3560565259
- https://github.com/m2lines/Samudra/issues/450#issuecomment-3560595362
- https://github.com/m2lines/Samudra/issues/450#issuecomment-3560662321

## Validation

- `uv run --project data pytest data/tests -q` — 31 passed, 1 skipped
- targeted pre-commit hooks — passed
- `bash -n scripts/slurm_preprocess_om4.sbatch scripts/slurm_make_norm_om4.sbatch` — passed

## Deployment after review

No preprocessing jobs or public-bucket writes were performed for this PR. After approval/merge, the intended sequence is:

1. run the real snapshot-source, ten-timestep, no-write Torch smoke test
2. publish 2°, 1°, 1/2°, and 1/4° unfiltered datasets under `s3://m2lines-pubs/Samudra/v2026-08/om4_<resolution>_snapshots/`
3. generate normalization stores only after each processed dataset succeeds
4. validate the public stores and update the available-datasets table with measured sizes and links
