### PR TITLE
Publish team Torch experiments to OSN by default

### DIFF
--- a/docs/torch.md
+++ b/docs/torch.md
@@ -85,6 +85,8 @@ It expects environment variables:
   team Torch harness defaults to `1` and publishes it to the public OSN archive
 - `ARCHIVE_BASE` (optional): authenticated rclone destination used when
   publishing (default: `nyu-osn:m2lines-pubs/Samudra/experiments`)
+- `ARCHIVE_OWNER` (optional): owner namespace below `ARCHIVE_BASE` (default:
+  the current Torch `$USER`)
 - `ARCHIVE_INTERVAL_SECONDS` (optional): seconds between incremental copies
   while training runs (default: `900`, minimum: `60`)
 - `ARCHIVE_TOOL` (optional): host path to `scripts/experiment_archive.py`;
@@ -136,7 +138,9 @@ The team Torch harness publishes experiments by default. Training continues to
 write to `/scratch/$USER/runs`; publication copies only the current run
 directory to OSN. This default is scoped to the Torch harness and does not
 change Samudra's generic training configuration, SkyPilot, or third-party
-workflows.
+workflows. Published runs are stored under
+`s3://m2lines-pubs/Samudra/experiments/<owner>/<run-name>`; owner defaults to
+the current Torch user and can be overridden with `ARCHIVE_OWNER`.
 
 Configure an authenticated OSN rclone remote without storing credentials in the
 repository:
@@ -167,9 +171,10 @@ sbatch scripts/slurm_apptainer_train.sbatch
 The harness performs an initial copy before starting training, starts
 an incremental copy every 15 minutes, and performs a final verified copy for
 successful, failed, and requeued runs. `archive-status.json` in each published
-run records its lifecycle state, timestamps, Slurm identity, restart count, and
-final exit code. A successful training process with a failed final publication
-returns nonzero; a failed training process retains its original exit code.
+run records its owner, lifecycle state, timestamps, Slurm identity, restart
+count, and final exit code. A successful training process with a failed final
+publication returns nonzero; a failed training process retains its original
+exit code.
 
 The archive is public. Review new artifact types before adding them to the run
 directory, and never write secrets there. Local W&B state, common credential and

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -75,7 +75,8 @@ It expects environment variables:
 - `CONFIG` (required): config path inside the container image. Relative paths are
   resolved under `/workspace/`, e.g. `src/samudra/configs/samudra_om4/train.yaml`.
 - `NAME_SUFFIX` (required): populates the run name by prepending the current date;
-  you can also set `NAME` directly if you prefer.
+  you can also set `NAME` directly if you prefer. `NAME` must be a single path
+  segment, not a nested path.
 - `DATA_ROOT` (optional): host data path passed to
   `--experiment.data_root` (default:
   `/scratch/<current_user>/data/om4_onedeg_v3`)
@@ -108,6 +109,8 @@ Key behavior:
 
 - Refuses to run if `${OUTPUT_BASE}/$NAME` already exists, except when
   `SLURM_RESTART_COUNT` indicates that Slurm restarted the same requeued job.
+- Refuses to start a new run if its owner/name archive destination already has
+  objects. A Slurm requeue is allowed to resume the same destination.
 - Fails early if either `${DATA_ROOT}` or `${OUTPUT_BASE}` does not exist, with
   instructions to set the corresponding env var.
 - Uses the container venv explicitly (`/workspace/.venv/bin/python`) to avoid missing deps.
@@ -176,9 +179,17 @@ count, and final exit code. A successful training process with a failed final
 publication returns nonzero; a failed training process retains its original
 exit code.
 
+If archive preflight fails before a fresh run starts, the local run metadata is
+moved aside under an adjacent
+`<run-name>.archive-preflight-failed-<job>-<timestamp>` directory. No experiment
+data is deleted, and the original name can be retried after archive access is
+fixed. If a partial remote destination was created, choose a new run name or
+have the partial archive reviewed before retrying.
+
 The archive is public. Review new artifact types before adding them to the run
 directory, and never write secrets there. Local W&B state, common credential and
-key filenames, and incomplete temporary files are excluded from publication.
+key filenames, and incomplete temporary files (including atomic checkpoint
+temps under `saved_nets/`) are excluded from publication.
 
 ## Fast Iteration With Ref-Built Code Overlays
 

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -81,6 +81,15 @@ It expects environment variables:
   `/scratch/<current_user>/data/om4_onedeg_v3`)
 - `OUTPUT_BASE` (optional): host output base dir passed to
   `--experiment.base_output_dir` (default: `/scratch/<current_user>/runs`)
+- `PUBLISH_TO_OSN` (optional): set to `1` to publish the current run directory
+  to the public OSN experiment archive; default `0` leaves existing behavior
+  unchanged
+- `ARCHIVE_BASE` (optional): authenticated rclone destination used when
+  publishing (default: `nyu-osn:m2lines-pubs/FOMO/experiments`)
+- `ARCHIVE_INTERVAL_SECONDS` (optional): seconds between incremental copies
+  while training runs (default: `900`, minimum: `60`)
+- `ARCHIVE_TOOL` (optional): host path to `scripts/experiment_archive.py`;
+  defaults to the file next to the training harness
 - `ARGS` (optional): extra CLI overrides, e.g. `--batch_size=1`
 - `NSYS_ARGS` (optional): if set, wrap the training launch with `nsys profile`
 - `SCRATCH_DIR` (optional): host scratch/work directory for default SIF and data
@@ -112,11 +121,51 @@ Key behavior:
   these locations to `/scratch/$USER` so large files do not consume home quota.
 - If `NSYS_ARGS` is set and does not include `-o`/`--output`, reports are written under
   `${OUTPUT_BASE}/${NAME}/nsys/`.
+- Public archive publication is opt-in. Enabled runs still write to fast local
+  scratch, then copy the run directory at startup, periodically, on failure or
+  requeue, and at successful completion. The final copy is size-verified.
 
 When `preemptible: true`, training detects the latest checkpoint in an existing
 run directory and resumes from it after a Slurm requeue. The requeue hook does
 not create a checkpoint at signal time, so checkpoint frequently enough that
 restarting from the most recent completed epoch is acceptable.
+
+## Publish Current and Future Torch Experiments
+
+Source the public archive profile before submitting a team experiment. Training
+continues to write to `/scratch/$USER/runs`; publication copies only the current
+run directory to OSN. Ordinary users who do not source the profile retain the
+existing scratch-only behavior.
+
+Configure an authenticated OSN rclone remote without storing credentials in the
+repository:
+
+```bash
+rclone config create nyu-osn s3 \
+  provider=AWS \
+  env_auth=true \
+  endpoint=https://nyu1.osn.mghpcc.org/
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+```bash
+source scripts/torch_public_archive.sh
+export CONFIG=src/samudra/configs/samudra_om4/train.yaml
+export NAME_SUFFIX=public-baseline
+sbatch scripts/slurm_apptainer_train.sbatch
+```
+
+The harness performs an initial copy before starting training, starts
+an incremental copy every 15 minutes, and performs a final verified copy for
+successful, failed, and requeued runs. `archive-status.json` in each published
+run records its lifecycle state, timestamps, Slurm identity, restart count, and
+final exit code. A successful training process with a failed final publication
+returns nonzero; a failed training process retains its original exit code.
+
+The archive is public. Review new artifact types before adding them to the run
+directory, and never write secrets there. Local W&B state, common credential and
+key filenames, and incomplete temporary files are excluded from publication.
 
 ## Fast Iteration With Ref-Built Code Overlays
 
@@ -130,6 +179,8 @@ Copy the builder and harnesses to Torch:
 scp scripts/slurm_apptainer_pull.sbatch torch:~/slurm_apptainer_pull.sbatch
 scp scripts/build_apptainer_code_layer.sh torch:~/build_apptainer_code_layer.sh
 scp scripts/slurm_apptainer_train.sbatch torch:~/slurm_apptainer_train.sbatch
+scp scripts/experiment_archive.py torch:~/experiment_archive.py
+scp scripts/torch_public_archive.sh torch:~/torch_public_archive.sh
 ```
 
 Prepare a stable container SIF, then build the layer on Torch:

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -191,6 +191,12 @@ directory, and never write secrets there. Local W&B state, common credential and
 key filenames, and incomplete temporary files (including atomic checkpoint
 temps under `saved_nets/`) are excluded from publication.
 
+If `CODE_REPO_URL` contains authentication information, the builder uses the
+original URL only for `git fetch`. Repository URL user information, query
+parameters, and fragments are removed from logs, code-layer manifests, W&B
+metadata, and public run provenance. The training harness also sanitizes
+metadata from existing code layers and container images before publication.
+
 ## Fast Iteration With Ref-Built Code Overlays
 
 The code-layer builder fetches a pushed Git ref, resolves it to a full commit,
@@ -204,6 +210,7 @@ scp scripts/slurm_apptainer_pull.sbatch torch:~/slurm_apptainer_pull.sbatch
 scp scripts/build_apptainer_code_layer.sh torch:~/build_apptainer_code_layer.sh
 scp scripts/slurm_apptainer_train.sbatch torch:~/slurm_apptainer_train.sbatch
 scp scripts/experiment_archive.py torch:~/experiment_archive.py
+scp scripts/sanitize_repository_url.py torch:~/sanitize_repository_url.py
 ```
 
 Prepare a stable container SIF, then build the layer on Torch:

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -85,7 +85,7 @@ It expects environment variables:
   to the public OSN experiment archive; default `0` leaves existing behavior
   unchanged
 - `ARCHIVE_BASE` (optional): authenticated rclone destination used when
-  publishing (default: `nyu-osn:m2lines-pubs/FOMO/experiments`)
+  publishing (default: `nyu-osn:m2lines-pubs/Samudra/experiments`)
 - `ARCHIVE_INTERVAL_SECONDS` (optional): seconds between incremental copies
   while training runs (default: `900`, minimum: `60`)
 - `ARCHIVE_TOOL` (optional): host path to `scripts/experiment_archive.py`;

--- a/docs/torch.md
+++ b/docs/torch.md
@@ -81,9 +81,8 @@ It expects environment variables:
   `/scratch/<current_user>/data/om4_onedeg_v3`)
 - `OUTPUT_BASE` (optional): host output base dir passed to
   `--experiment.base_output_dir` (default: `/scratch/<current_user>/runs`)
-- `PUBLISH_TO_OSN` (optional): set to `1` to publish the current run directory
-  to the public OSN experiment archive; default `0` leaves existing behavior
-  unchanged
+- `PUBLISH_TO_OSN` (optional): set to `0` to keep the current run private; the
+  team Torch harness defaults to `1` and publishes it to the public OSN archive
 - `ARCHIVE_BASE` (optional): authenticated rclone destination used when
   publishing (default: `nyu-osn:m2lines-pubs/Samudra/experiments`)
 - `ARCHIVE_INTERVAL_SECONDS` (optional): seconds between incremental copies
@@ -121,9 +120,10 @@ Key behavior:
   these locations to `/scratch/$USER` so large files do not consume home quota.
 - If `NSYS_ARGS` is set and does not include `-o`/`--output`, reports are written under
   `${OUTPUT_BASE}/${NAME}/nsys/`.
-- Public archive publication is opt-in. Enabled runs still write to fast local
-  scratch, then copy the run directory at startup, periodically, on failure or
-  requeue, and at successful completion. The final copy is size-verified.
+- The team Torch harness publishes to the public archive by default. Runs still
+  write to fast local scratch, then copy the run directory at startup,
+  periodically, on failure or requeue, and at successful completion. Set
+  `PUBLISH_TO_OSN=0` to opt out. The final copy is size-verified.
 
 When `preemptible: true`, training detects the latest checkpoint in an existing
 run directory and resumes from it after a Slurm requeue. The requeue hook does
@@ -132,10 +132,11 @@ restarting from the most recent completed epoch is acceptable.
 
 ## Publish Current and Future Torch Experiments
 
-Source the public archive profile before submitting a team experiment. Training
-continues to write to `/scratch/$USER/runs`; publication copies only the current
-run directory to OSN. Ordinary users who do not source the profile retain the
-existing scratch-only behavior.
+The team Torch harness publishes experiments by default. Training continues to
+write to `/scratch/$USER/runs`; publication copies only the current run
+directory to OSN. This default is scoped to the Torch harness and does not
+change Samudra's generic training configuration, SkyPilot, or third-party
+workflows.
 
 Configure an authenticated OSN rclone remote without storing credentials in the
 repository:
@@ -150,9 +151,16 @@ export AWS_SECRET_ACCESS_KEY=...
 ```
 
 ```bash
-source scripts/torch_public_archive.sh
 export CONFIG=src/samudra/configs/samudra_om4/train.yaml
 export NAME_SUFFIX=public-baseline
+sbatch scripts/slurm_apptainer_train.sbatch
+```
+
+To keep a particular run private, explicitly disable publication before
+submitting it. OSN credentials are not required for an opted-out run.
+
+```bash
+export PUBLISH_TO_OSN=0
 sbatch scripts/slurm_apptainer_train.sbatch
 ```
 
@@ -180,7 +188,6 @@ scp scripts/slurm_apptainer_pull.sbatch torch:~/slurm_apptainer_pull.sbatch
 scp scripts/build_apptainer_code_layer.sh torch:~/build_apptainer_code_layer.sh
 scp scripts/slurm_apptainer_train.sbatch torch:~/slurm_apptainer_train.sbatch
 scp scripts/experiment_archive.py torch:~/experiment_archive.py
-scp scripts/torch_public_archive.sh torch:~/torch_public_archive.sh
 ```
 
 Prepare a stable container SIF, then build the layer on Torch:

--- a/scripts/build_apptainer_code_layer.sh
+++ b/scripts/build_apptainer_code_layer.sh
@@ -10,6 +10,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY_URL_SANITIZER="${SCRIPT_DIR}/sanitize_repository_url.py"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -64,9 +67,16 @@ for command_name in git python3 sha256sum flock; do
     exit 4
   fi
 done
+if [[ ! -f "${REPOSITORY_URL_SANITIZER}" ]]; then
+  echo "Repository URL sanitizer not found: ${REPOSITORY_URL_SANITIZER}" >&2
+  exit 4
+fi
 
 CURRENT_USER="${USER:-$(id -un)}"
 CODE_REPO_URL="${CODE_REPO_URL:-https://github.com/m2lines/Samudra.git}"
+CODE_REPO_PUBLIC_URL="$(
+  printf %s "${CODE_REPO_URL}" | python3 "${REPOSITORY_URL_SANITIZER}"
+)"
 CODE_LAYER_DIR="${CODE_LAYER_DIR:-/scratch/${CURRENT_USER}/.apptainer-code-layers}"
 CODE_LAYER_SIZE_MB="${CODE_LAYER_SIZE_MB:-128}"
 if [[ ! "${CODE_LAYER_SIZE_MB}" =~ ^[1-9][0-9]*$ ]]; then
@@ -86,11 +96,14 @@ trap cleanup EXIT
 CHECKOUT_DIR="${BUILD_DIR}/repo"
 git init --quiet "${CHECKOUT_DIR}"
 git -C "${CHECKOUT_DIR}" remote add origin "${CODE_REPO_URL}"
-echo "Fetching pushed ref ${CODE_REF} from ${CODE_REPO_URL}"
-if ! git -C "${CHECKOUT_DIR}" fetch --quiet --no-tags --depth=1 origin "${CODE_REF}"; then
+echo "Fetching pushed ref ${CODE_REF} from ${CODE_REPO_PUBLIC_URL}"
+if ! git -C "${CHECKOUT_DIR}" fetch \
+  --quiet --no-tags --depth=1 origin "${CODE_REF}" \
+  2>"${BUILD_DIR}/git-fetch-error.log"; then
   echo "Could not fetch ${CODE_REF}; ensure the ref has been pushed and is reachable." >&2
   exit 5
 fi
+unset CODE_REPO_URL
 RESOLVED_COMMIT="$(git -C "${CHECKOUT_DIR}" rev-parse --verify FETCH_HEAD^{commit})"
 CODE_COMMIT="${RESOLVED_COMMIT,,}"
 echo "Resolved ${CODE_REF} to ${CODE_COMMIT}."
@@ -147,7 +160,8 @@ verify_existing_layer() {
   local manifest_commit manifest_repo_url
   manifest_commit="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["code_commit"])' "${MANIFEST_PATH}")"
   manifest_repo_url="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["code_repo_url"])' "${MANIFEST_PATH}")"
-  [[ "${manifest_commit}" == "${CODE_COMMIT}" && "${manifest_repo_url}" == "${CODE_REPO_URL}" ]]
+  [[ "${manifest_commit}" == "${CODE_COMMIT}" \
+    && "${manifest_repo_url}" == "${CODE_REPO_PUBLIC_URL}" ]]
 }
 
 if verify_existing_layer; then
@@ -168,7 +182,7 @@ SOURCE_PYPROJECT_SHA256="$(sha256sum "${CHECKOUT_DIR}/pyproject.toml" | awk '{pr
 BUILD_MANIFEST="${BUILD_DIR}/source-manifest.json"
 CODE_COMMIT="${CODE_COMMIT}" \
 CODE_REF="${CODE_REF}" \
-CODE_REPO_URL="${CODE_REPO_URL}" \
+CODE_REPO_PUBLIC_URL="${CODE_REPO_PUBLIC_URL}" \
 BUILD_TIMESTAMP="${BUILD_TIMESTAMP}" \
 SOURCE_UV_LOCK_SHA256="${SOURCE_UV_LOCK_SHA256}" \
 SOURCE_PYPROJECT_SHA256="${SOURCE_PYPROJECT_SHA256}" \
@@ -181,7 +195,7 @@ manifest = {
     "schema_version": 1,
     "code_commit": os.environ["CODE_COMMIT"],
     "requested_code_ref": os.environ["CODE_REF"],
-    "code_repo_url": os.environ["CODE_REPO_URL"],
+    "code_repo_url": os.environ["CODE_REPO_PUBLIC_URL"],
     "built_at_utc": os.environ["BUILD_TIMESTAMP"],
     "source_root": "/opt/samudra-code",
     "uv_lock_sha256": os.environ["SOURCE_UV_LOCK_SHA256"],

--- a/scripts/experiment_archive.py
+++ b/scripts/experiment_archive.py
@@ -42,6 +42,7 @@ EXCLUDE_PATTERNS = (
     "**/*.pem",
     "**/*.part",
     "**/*.tmp",
+    "/saved_nets/tmp*",
     "**/.nfs*",
     "**/wandb/**",
 )
@@ -112,6 +113,10 @@ def check_command(
     ]
 
 
+def list_command(destination: str, rclone_bin: str = "rclone") -> List[str]:
+    return [rclone_bin, "lsf", destination, "--max-depth", "1"]
+
+
 def validate_run_dir(run_dir: Path) -> Path:
     if run_dir.is_symlink():
         raise ArchiveError(f"refusing symlinked run directory: {run_dir}")
@@ -121,6 +126,43 @@ def validate_run_dir(run_dir: Path) -> Path:
     if resolved == Path("/"):
         raise ArchiveError("refusing to publish filesystem root")
     return resolved
+
+
+def preflight_destination(
+    run_dir: Path,
+    archive_base: str,
+    owner: str,
+    apply: bool,
+    rclone_bin: str = "rclone",
+) -> Dict[str, object]:
+    """Verify that a new run's archive destination has no existing objects."""
+    run_dir = validate_run_dir(run_dir)
+    destination = archive_destination(archive_base, owner, run_dir.name)
+    command = list_command(destination, rclone_bin)
+    print(_display_command(command), flush=True)
+
+    if not apply:
+        return {
+            "destination": destination,
+            "owner": owner,
+            "status": "planned",
+        }
+
+    result = subprocess.run(
+        command,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    if result.stdout.strip():
+        raise ArchiveError(
+            f"archive destination already contains objects: {destination}; "
+            "choose a unique run name"
+        )
+    return {
+        "destination": destination,
+        "owner": owner,
+        "status": "available",
+    }
 
 
 def publish_run(
@@ -277,6 +319,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--no-verify", action="store_true", help="skip rclone's size verification"
     )
 
+    preflight_parser = subparsers.add_parser(
+        "preflight", help="require an unused archive destination for a new run"
+    )
+    preflight_parser.add_argument("run_dir", type=Path)
+    preflight_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="query the destination; without this flag only print the command",
+    )
+
     watch_parser = subparsers.add_parser(
         "watch", help="periodically publish one active run until signaled"
     )
@@ -311,6 +363,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 args.owner,
                 apply=args.apply,
                 verify=not args.no_verify,
+                rclone_bin=args.rclone_bin,
+            )
+            return 0
+        if args.command == "preflight":
+            preflight_destination(
+                args.run_dir,
+                args.archive_base,
+                args.owner,
+                apply=args.apply,
                 rclone_bin=args.rclone_bin,
             )
             return 0

--- a/scripts/experiment_archive.py
+++ b/scripts/experiment_archive.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publish Samudra experiment run directories to an rclone archive.
+
+The CLI is deliberately dry-run by default.  ``--apply`` is required before it
+will invoke rclone, and publication only copies files: it never deletes source
+or destination objects.
+"""
+
+# The Torch host may provide Python 3.6 even though Samudra itself requires a
+# newer interpreter inside its container.
+# ruff: noqa: UP006, UP007, UP017, UP035, UP045
+
+import argparse
+import json
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+
+DEFAULT_ARCHIVE_BASE = "nyu-osn:m2lines-pubs/FOMO/experiments"
+STATUS_FILENAME = "archive-status.json"
+VALID_STATES = ("running", "requeued", "completed", "failed")
+
+# A run directory is public after publication.  Keep credentials, local W&B
+# state, and files that may still be in the middle of an atomic write out of it.
+EXCLUDE_PATTERNS = (
+    "**/.env",
+    "**/.env.*",
+    "**/.netrc",
+    "**/*credentials*",
+    "**/*.key",
+    "**/*.pem",
+    "**/*.part",
+    "**/*.tmp",
+    "**/.nfs*",
+    "**/wandb/**",
+)
+
+
+class ArchiveError(RuntimeError):
+    pass
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _display_command(command: Sequence[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def _exclusion_args() -> List[str]:
+    args = []  # type: List[str]
+    for pattern in EXCLUDE_PATTERNS:
+        args.extend(("--exclude", pattern))
+    return args
+
+
+def archive_destination(archive_base: str, run_name: str) -> str:
+    if not archive_base.strip():
+        raise ArchiveError("archive base must not be empty")
+    if run_name in ("", ".", "..") or "/" in run_name or "\\" in run_name:
+        raise ArchiveError(f"invalid run name: {run_name!r}")
+    return f"{archive_base.rstrip('/')}/{run_name}"
+
+
+def copy_command(
+    run_dir: Path, destination: str, rclone_bin: str = "rclone"
+) -> List[str]:
+    return [
+        rclone_bin,
+        "copy",
+        str(run_dir),
+        destination,
+        "--stats=30s",
+        *_exclusion_args(),
+    ]
+
+
+def check_command(
+    run_dir: Path, destination: str, rclone_bin: str = "rclone"
+) -> List[str]:
+    return [
+        rclone_bin,
+        "check",
+        str(run_dir),
+        destination,
+        "--one-way",
+        "--size-only",
+        *_exclusion_args(),
+    ]
+
+
+def validate_run_dir(run_dir: Path) -> Path:
+    if run_dir.is_symlink():
+        raise ArchiveError(f"refusing symlinked run directory: {run_dir}")
+    if not run_dir.is_dir():
+        raise ArchiveError(f"run directory does not exist: {run_dir}")
+    resolved = run_dir.resolve()
+    if resolved == Path("/"):
+        raise ArchiveError("refusing to publish filesystem root")
+    return resolved
+
+
+def publish_run(
+    run_dir: Path,
+    archive_base: str,
+    apply: bool,
+    verify: bool = True,
+    rclone_bin: str = "rclone",
+) -> Dict[str, object]:
+    run_dir = validate_run_dir(run_dir)
+    destination = archive_destination(archive_base, run_dir.name)
+    commands = [copy_command(run_dir, destination, rclone_bin)]
+    if verify:
+        commands.append(check_command(run_dir, destination, rclone_bin))
+
+    for command in commands:
+        print(_display_command(command), flush=True)
+        if apply:
+            subprocess.run(command, check=True)
+
+    return {
+        "source": str(run_dir),
+        "destination": destination,
+        "status": "verified" if apply and verify else "copied" if apply else "planned",
+        "verified": bool(apply and verify),
+    }
+
+
+def _write_json_atomic(path: Path, payload: Dict[str, object]) -> None:
+    path = path.resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp.{os.getpid()}")
+    with temporary.open("w", encoding="utf-8") as stream:
+        json.dump(payload, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    os.replace(str(temporary), str(path))
+
+
+def write_status(run_dir: Path, state: str, exit_code: Optional[int] = None) -> Path:
+    run_dir = validate_run_dir(run_dir)
+    if state not in VALID_STATES:
+        raise ArchiveError(f"invalid archive state: {state!r}")
+    status_path = run_dir / STATUS_FILENAME
+    previous = {}  # type: Dict[str, object]
+    if status_path.is_file():
+        try:
+            loaded = json.loads(status_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as error:
+            raise ArchiveError(
+                f"could not read existing status file: {status_path}"
+            ) from error
+        if not isinstance(loaded, dict):
+            raise ArchiveError(f"existing status file is not an object: {status_path}")
+        previous = loaded
+
+    now = utc_now()
+    status = {
+        "schema_version": 1,
+        "run_name": run_dir.name,
+        "state": state,
+        "started_at": previous.get("started_at", now),
+        "updated_at": now,
+    }  # type: Dict[str, object]
+    for environment_name, field_name in (
+        ("SLURM_JOB_ID", "slurm_job_id"),
+        ("SLURM_RESTART_COUNT", "slurm_restart_count"),
+    ):
+        value = os.environ.get(environment_name)
+        if value is not None:
+            status[field_name] = value
+    if exit_code is not None:
+        status["exit_code"] = exit_code
+    if state in ("completed", "failed"):
+        status["finished_at"] = now
+    _write_json_atomic(status_path, status)
+    return status_path
+
+
+def watch_run(
+    run_dir: Path,
+    archive_base: str,
+    interval_seconds: float,
+    apply: bool,
+    rclone_bin: str = "rclone",
+    stop_event: Optional[threading.Event] = None,
+    max_cycles: Optional[int] = None,
+) -> int:
+    if interval_seconds <= 0:
+        raise ArchiveError("archive interval must be positive")
+    stop_event = stop_event or threading.Event()
+    failures = 0
+    cycles = 0
+    while not stop_event.wait(interval_seconds):
+        try:
+            publish_run(
+                run_dir,
+                archive_base,
+                apply=apply,
+                verify=False,
+                rclone_bin=rclone_bin,
+            )
+        except subprocess.CalledProcessError as error:
+            failures += 1
+            print(
+                f"Periodic archive copy failed with exit code {error.returncode}: "
+                f"{_display_command(error.cmd)}",
+                file=sys.stderr,
+                flush=True,
+            )
+        cycles += 1
+        if max_cycles is not None and cycles >= max_cycles:
+            break
+    return 1 if failures else 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-base",
+        default=DEFAULT_ARCHIVE_BASE,
+        help="rclone destination containing one directory per experiment run",
+    )
+    parser.add_argument("--rclone-bin", default="rclone", help=argparse.SUPPRESS)
+    subparsers = parser.add_subparsers(dest="command")
+
+    publish_parser = subparsers.add_parser("publish", help="publish one run directory")
+    publish_parser.add_argument("run_dir", type=Path)
+    publish_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform the copy; without this flag only print the commands",
+    )
+    publish_parser.add_argument(
+        "--no-verify", action="store_true", help="skip rclone's size verification"
+    )
+
+    watch_parser = subparsers.add_parser(
+        "watch", help="periodically publish one active run until signaled"
+    )
+    watch_parser.add_argument("run_dir", type=Path)
+    watch_parser.add_argument("--interval", type=float, default=900.0)
+    watch_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform periodic copies; without this flag only print the plans",
+    )
+
+    status_parser = subparsers.add_parser(
+        "status", help="write public lifecycle metadata into a run directory"
+    )
+    status_parser.add_argument("run_dir", type=Path)
+    status_parser.add_argument("state", choices=VALID_STATES)
+    status_parser.add_argument("--exit-code", type=int)
+
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command is None:
+        parser.error("a command is required")
+    try:
+        if args.command == "publish":
+            publish_run(
+                args.run_dir,
+                args.archive_base,
+                apply=args.apply,
+                verify=not args.no_verify,
+                rclone_bin=args.rclone_bin,
+            )
+            return 0
+        if args.command == "status":
+            write_status(args.run_dir, args.state, args.exit_code)
+            return 0
+        if args.command == "watch":
+            stop_event = threading.Event()
+
+            def request_stop(signum: int, frame: object) -> None:
+                del signum, frame
+                stop_event.set()
+
+            signal.signal(signal.SIGTERM, request_stop)
+            signal.signal(signal.SIGINT, request_stop)
+            return watch_run(
+                args.run_dir,
+                args.archive_base,
+                interval_seconds=args.interval,
+                apply=args.apply,
+                rclone_bin=args.rclone_bin,
+                stop_event=stop_event,
+            )
+    except ArchiveError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/experiment_archive.py
+++ b/scripts/experiment_archive.py
@@ -66,12 +66,23 @@ def _exclusion_args() -> List[str]:
     return args
 
 
-def archive_destination(archive_base: str, run_name: str) -> str:
+def _validate_archive_segment(value: str, label: str) -> str:
+    if (
+        value in ("", ".", "..")
+        or value != value.strip()
+        or "/" in value
+        or "\\" in value
+    ):
+        raise ArchiveError(f"invalid {label}: {value!r}")
+    return value
+
+
+def archive_destination(archive_base: str, owner: str, run_name: str) -> str:
     if not archive_base.strip():
         raise ArchiveError("archive base must not be empty")
-    if run_name in ("", ".", "..") or "/" in run_name or "\\" in run_name:
-        raise ArchiveError(f"invalid run name: {run_name!r}")
-    return f"{archive_base.rstrip('/')}/{run_name}"
+    owner = _validate_archive_segment(owner, "archive owner")
+    run_name = _validate_archive_segment(run_name, "run name")
+    return f"{archive_base.rstrip('/')}/{owner}/{run_name}"
 
 
 def copy_command(
@@ -115,12 +126,13 @@ def validate_run_dir(run_dir: Path) -> Path:
 def publish_run(
     run_dir: Path,
     archive_base: str,
+    owner: str,
     apply: bool,
     verify: bool = True,
     rclone_bin: str = "rclone",
 ) -> Dict[str, object]:
     run_dir = validate_run_dir(run_dir)
-    destination = archive_destination(archive_base, run_dir.name)
+    destination = archive_destination(archive_base, owner, run_dir.name)
     commands = [copy_command(run_dir, destination, rclone_bin)]
     if verify:
         commands.append(check_command(run_dir, destination, rclone_bin))
@@ -133,6 +145,7 @@ def publish_run(
     return {
         "source": str(run_dir),
         "destination": destination,
+        "owner": owner,
         "status": "verified" if apply and verify else "copied" if apply else "planned",
         "verified": bool(apply and verify),
     }
@@ -148,8 +161,11 @@ def _write_json_atomic(path: Path, payload: Dict[str, object]) -> None:
     os.replace(str(temporary), str(path))
 
 
-def write_status(run_dir: Path, state: str, exit_code: Optional[int] = None) -> Path:
+def write_status(
+    run_dir: Path, owner: str, state: str, exit_code: Optional[int] = None
+) -> Path:
     run_dir = validate_run_dir(run_dir)
+    owner = _validate_archive_segment(owner, "archive owner")
     if state not in VALID_STATES:
         raise ArchiveError(f"invalid archive state: {state!r}")
     status_path = run_dir / STATUS_FILENAME
@@ -164,10 +180,16 @@ def write_status(run_dir: Path, state: str, exit_code: Optional[int] = None) -> 
         if not isinstance(loaded, dict):
             raise ArchiveError(f"existing status file is not an object: {status_path}")
         previous = loaded
+        previous_owner = previous.get("owner")
+        if previous_owner is not None and previous_owner != owner:
+            raise ArchiveError(
+                f"archive owner changed from {previous_owner!r} to {owner!r}"
+            )
 
     now = utc_now()
     status = {
         "schema_version": 1,
+        "owner": owner,
         "run_name": run_dir.name,
         "state": state,
         "started_at": previous.get("started_at", now),
@@ -191,6 +213,7 @@ def write_status(run_dir: Path, state: str, exit_code: Optional[int] = None) -> 
 def watch_run(
     run_dir: Path,
     archive_base: str,
+    owner: str,
     interval_seconds: float,
     apply: bool,
     rclone_bin: str = "rclone",
@@ -199,6 +222,8 @@ def watch_run(
 ) -> int:
     if interval_seconds <= 0:
         raise ArchiveError("archive interval must be positive")
+    owner = _validate_archive_segment(owner, "archive owner")
+    validate_run_dir(run_dir)
     stop_event = stop_event or threading.Event()
     failures = 0
     cycles = 0
@@ -207,6 +232,7 @@ def watch_run(
             publish_run(
                 run_dir,
                 archive_base,
+                owner,
                 apply=apply,
                 verify=False,
                 rclone_bin=rclone_bin,
@@ -230,7 +256,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--archive-base",
         default=DEFAULT_ARCHIVE_BASE,
-        help="rclone destination containing one directory per experiment run",
+        help="rclone destination containing owner and experiment directories",
+    )
+    parser.add_argument(
+        "--owner",
+        required=True,
+        help="archive namespace for the user or team that owns the experiment",
     )
     parser.add_argument("--rclone-bin", default="rclone", help=argparse.SUPPRESS)
     subparsers = parser.add_subparsers(dest="command")
@@ -277,13 +308,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             publish_run(
                 args.run_dir,
                 args.archive_base,
+                args.owner,
                 apply=args.apply,
                 verify=not args.no_verify,
                 rclone_bin=args.rclone_bin,
             )
             return 0
         if args.command == "status":
-            write_status(args.run_dir, args.state, args.exit_code)
+            write_status(args.run_dir, args.owner, args.state, args.exit_code)
             return 0
         if args.command == "watch":
             stop_event = threading.Event()
@@ -297,6 +329,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             return watch_run(
                 args.run_dir,
                 args.archive_base,
+                args.owner,
                 interval_seconds=args.interval,
                 apply=args.apply,
                 rclone_bin=args.rclone_bin,

--- a/scripts/experiment_archive.py
+++ b/scripts/experiment_archive.py
@@ -27,7 +27,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 
-DEFAULT_ARCHIVE_BASE = "nyu-osn:m2lines-pubs/FOMO/experiments"
+DEFAULT_ARCHIVE_BASE = "nyu-osn:m2lines-pubs/Samudra/experiments"
 STATUS_FILENAME = "archive-status.json"
 VALID_STATES = ("running", "requeued", "completed", "failed")
 

--- a/scripts/sanitize_repository_url.py
+++ b/scripts/sanitize_repository_url.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Remove credentials from repository URLs before recording provenance."""
+
+# The Torch host may provide Python 3.6 even though Samudra itself requires a
+# newer interpreter inside its container.
+
+import re
+import sys
+from urllib.parse import urlsplit, urlunsplit
+
+SCP_STYLE_URL = re.compile(
+    r"^(?P<user>[^/@:\s]+)@(?P<host>(?:\[[^\]]+\])|(?:[^/:\s]+)):(?P<path>.+)$"
+)
+
+
+def sanitize_repository_url(value: str) -> str:
+    """Return a repository identity without URL credentials or query secrets."""
+    if (
+        not value
+        or value != value.strip()
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+    ):
+        raise ValueError("repository URL must be a non-empty single-line value")
+
+    scp_match = SCP_STYLE_URL.match(value)
+    if scp_match:
+        host = scp_match.group("host")
+        path = scp_match.group("path").lstrip("/")
+        return f"ssh://{host}/{path}"
+
+    parsed = urlsplit(value)
+    if not parsed.netloc:
+        if parsed.scheme and "@" in parsed.path:
+            raise ValueError("repository URL has malformed user information")
+        if parsed.scheme:
+            return urlunsplit((parsed.scheme, "", parsed.path, "", ""))
+        return value
+
+    hostname = parsed.hostname
+    if hostname is None:
+        raise ValueError("repository URL has no hostname")
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    port = parsed.port
+    netloc = f"{host}:{port}" if port is not None else host
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+
+
+def main() -> int:
+    try:
+        sanitized = sanitize_repository_url(sys.stdin.read())
+    except ValueError:
+        print("ERROR: could not sanitize repository URL", file=sys.stderr)
+        return 2
+    sys.stdout.write(sanitized)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -11,6 +11,7 @@
 #   export NAME_SUFFIX=om4_samudra_baseline   # NAME becomes YYYY-MM-DD-<suffix>
 #   export ARGS="--epochs=2 --batch_size=1"
 #   export WANDB_API_KEY=...   # optional; if unset, wandb is disabled
+#   export PUBLISH_TO_OSN=0     # optional; team Torch jobs publish by default
 #   sbatch --nodes=1 --gres=gpu:rtx6000:8 scripts/slurm_apptainer_train.sbatch
 #
 # Multi-node example (requires enough nodes available):
@@ -75,7 +76,7 @@ ARGS="${ARGS:-}"
 NSYS_ARGS="${NSYS_ARGS:-}"
 REQUEUE_ON_USR1="${REQUEUE_ON_USR1:-0}"
 CODE_LAYER="${CODE_LAYER:-}"
-PUBLISH_TO_OSN="${PUBLISH_TO_OSN:-0}"
+PUBLISH_TO_OSN="${PUBLISH_TO_OSN:-1}"
 ARCHIVE_BASE="${ARCHIVE_BASE:-nyu-osn:m2lines-pubs/Samudra/experiments}"
 ARCHIVE_INTERVAL_SECONDS="${ARCHIVE_INTERVAL_SECONDS:-900}"
 ARCHIVE_TOOL="${ARCHIVE_TOOL:-${SCRIPT_DIR}/experiment_archive.py}"

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -76,7 +76,7 @@ NSYS_ARGS="${NSYS_ARGS:-}"
 REQUEUE_ON_USR1="${REQUEUE_ON_USR1:-0}"
 CODE_LAYER="${CODE_LAYER:-}"
 PUBLISH_TO_OSN="${PUBLISH_TO_OSN:-0}"
-ARCHIVE_BASE="${ARCHIVE_BASE:-nyu-osn:m2lines-pubs/FOMO/experiments}"
+ARCHIVE_BASE="${ARCHIVE_BASE:-nyu-osn:m2lines-pubs/Samudra/experiments}"
 ARCHIVE_INTERVAL_SECONDS="${ARCHIVE_INTERVAL_SECONDS:-900}"
 ARCHIVE_TOOL="${ARCHIVE_TOOL:-${SCRIPT_DIR}/experiment_archive.py}"
 if [[ -z "${NAME}" && -n "${NAME_SUFFIX}" ]]; then

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -48,6 +48,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPOSITORY_URL_SANITIZER="${SCRIPT_DIR}/sanitize_repository_url.py"
 
 if ! command -v apptainer >/dev/null 2>&1 \
   && ! command -v singularity >/dev/null 2>&1; then
@@ -104,6 +105,15 @@ case "${PUBLISH_TO_OSN}" in
     exit 2
     ;;
 esac
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "The training harness requires python3 on the host PATH." >&2
+  exit 2
+fi
+if [[ ! -f "${REPOSITORY_URL_SANITIZER}" ]]; then
+  echo "Repository URL sanitizer not found: ${REPOSITORY_URL_SANITIZER}" >&2
+  echo "Copy scripts/sanitize_repository_url.py next to this harness." >&2
+  exit 2
+fi
 if [[ "${PUBLISH_TO_OSN}" == "1" ]]; then
   if [[ ! "${ARCHIVE_INTERVAL_SECONDS}" =~ ^[0-9]+$ ]] \
     || (( ARCHIVE_INTERVAL_SECONDS < 60 )); then
@@ -114,16 +124,16 @@ if [[ "${PUBLISH_TO_OSN}" == "1" ]]; then
     echo "PUBLISH_TO_OSN=1 requires rclone on the host PATH." >&2
     exit 2
   fi
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "PUBLISH_TO_OSN=1 requires python3 on the host PATH." >&2
-    exit 2
-  fi
   if [[ ! -f "${ARCHIVE_TOOL}" ]]; then
     echo "Experiment archive tool not found: ${ARCHIVE_TOOL}" >&2
     echo "Copy scripts/experiment_archive.py next to this harness or set ARCHIVE_TOOL." >&2
     exit 2
   fi
 fi
+
+sanitize_repository_url() {
+  printf %s "$1" | python3 "${REPOSITORY_URL_SANITIZER}"
+}
 
 if [[ "${REQUEUE_ON_USR1}" == "1" ]]; then
   handle_requeue() {
@@ -258,6 +268,12 @@ CONTAINER_GIT_REMOTE_URL="$(
   "${APPTAINER_BIN}" exec "${SIF_PATH}" \
     bash -lc 'printf %s "${SAMUDRA_CONTAINER_GIT_REMOTE_URL:-${WANDB_GIT_REMOTE_URL:-unknown}}"'
 )"
+if ! CONTAINER_GIT_REMOTE_URL="$(
+  sanitize_repository_url "${CONTAINER_GIT_REMOTE_URL}"
+)"; then
+  echo "Container repository URL metadata is invalid." >&2
+  exit 7
+fi
 CODE_ROOT=/workspace
 CODE_GIT_COMMIT="${CONTAINER_GIT_COMMIT}"
 CODE_GIT_REMOTE_URL="${CONTAINER_GIT_REMOTE_URL}"
@@ -292,13 +308,22 @@ print(manifest["code_repo_url"])
     echo "Could not parse code-layer manifest: ${CODE_LAYER_MANIFEST}" >&2
     exit 7
   fi
-  readarray -t CODE_METADATA <<<"${CODE_METADATA_TEXT}"
-  if [[ "${#CODE_METADATA[@]}" -ne 2 ]]; then
+  if [[ "${CODE_METADATA_TEXT}" != *$'\n'* ]]; then
     echo "Code-layer manifest has invalid commit/repository metadata: ${CODE_LAYER_MANIFEST}" >&2
     exit 7
   fi
-  CODE_GIT_COMMIT="${CODE_METADATA[0]}"
-  CODE_GIT_REMOTE_URL="${CODE_METADATA[1]}"
+  CODE_GIT_COMMIT="${CODE_METADATA_TEXT%%$'\n'*}"
+  CODE_LAYER_REPO_URL="${CODE_METADATA_TEXT#*$'\n'}"
+  if [[ -z "${CODE_GIT_COMMIT}" || "${CODE_LAYER_REPO_URL}" == *$'\n'* ]]; then
+    echo "Code-layer manifest has invalid commit/repository metadata: ${CODE_LAYER_MANIFEST}" >&2
+    exit 7
+  fi
+  if ! CODE_GIT_REMOTE_URL="$(
+    sanitize_repository_url "${CODE_LAYER_REPO_URL}"
+  )"; then
+    echo "Code-layer repository URL metadata is invalid." >&2
+    exit 7
+  fi
   CODE_LAYER_SHA256="$(awk 'NR == 1 {print $1}' "${CODE_LAYER_SHA_FILE}")"
   CODE_ROOT=/opt/samudra-code
   OVERLAY_ARGS=(--overlay "${CODE_LAYER}:ro")
@@ -419,10 +444,9 @@ BIND_ARG="$(IFS=,; echo "${binds[*]}")"
 # Create the run directory after preflight validation so early failures are
 # retryable with the same NAME.
 mkdir -p "${RUN_DIR}"
-if [[ -n "${CODE_LAYER_MANIFEST}" ]]; then
-  cp "${CODE_LAYER_MANIFEST}" "${RUN_DIR}/source-manifest.json"
-fi
 SAMUDRA_PROVENANCE_PATH="${RUN_DIR}/run-provenance.json" \
+SAMUDRA_PUBLIC_SOURCE_MANIFEST_PATH="${RUN_DIR}/source-manifest.json" \
+SAMUDRA_CODE_LAYER_MANIFEST="${CODE_LAYER_MANIFEST}" \
 SAMUDRA_CODE_COMMIT="${CODE_GIT_COMMIT}" \
 SAMUDRA_CODE_REPO_URL="${CODE_GIT_REMOTE_URL}" \
 SAMUDRA_CODE_LAYER_SHA256="${CODE_LAYER_SHA256}" \
@@ -433,6 +457,17 @@ SAMUDRA_CONTAINER_SIF_PATH="${SIF_PATH}" \
 python3 - <<'PY'
 import json
 import os
+
+source_manifest = os.environ["SAMUDRA_CODE_LAYER_MANIFEST"]
+if source_manifest:
+    with open(source_manifest, encoding="utf-8") as stream:
+        public_manifest = json.load(stream)
+    public_manifest["code_repo_url"] = os.environ["SAMUDRA_CODE_REPO_URL"]
+    with open(
+        os.environ["SAMUDRA_PUBLIC_SOURCE_MANIFEST_PATH"], "w", encoding="utf-8"
+    ) as stream:
+        json.dump(public_manifest, stream, indent=2, sort_keys=True)
+        stream.write("\n")
 
 keys = (
     "SAMUDRA_CODE_COMMIT",

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -46,6 +46,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if ! command -v apptainer >/dev/null 2>&1 \
   && ! command -v singularity >/dev/null 2>&1; then
   if [[ -f /etc/profile.d/modules.sh ]]; then
@@ -73,6 +75,10 @@ ARGS="${ARGS:-}"
 NSYS_ARGS="${NSYS_ARGS:-}"
 REQUEUE_ON_USR1="${REQUEUE_ON_USR1:-0}"
 CODE_LAYER="${CODE_LAYER:-}"
+PUBLISH_TO_OSN="${PUBLISH_TO_OSN:-0}"
+ARCHIVE_BASE="${ARCHIVE_BASE:-nyu-osn:m2lines-pubs/FOMO/experiments}"
+ARCHIVE_INTERVAL_SECONDS="${ARCHIVE_INTERVAL_SECONDS:-900}"
+ARCHIVE_TOOL="${ARCHIVE_TOOL:-${SCRIPT_DIR}/experiment_archive.py}"
 if [[ -z "${NAME}" && -n "${NAME_SUFFIX}" ]]; then
   NAME="$(date +%Y-%m-%d)-${NAME_SUFFIX}"
 fi
@@ -82,9 +88,37 @@ if [[ -z "${CONFIG}" || -z "${NAME}" ]]; then
   echo "Example: export NAME_SUFFIX=om4_samudra_baseline" >&2
   exit 2
 fi
+case "${PUBLISH_TO_OSN}" in
+  0|1) ;;
+  *)
+    echo "PUBLISH_TO_OSN must be 0 or 1, got: ${PUBLISH_TO_OSN}" >&2
+    exit 2
+    ;;
+esac
+if [[ "${PUBLISH_TO_OSN}" == "1" ]]; then
+  if [[ ! "${ARCHIVE_INTERVAL_SECONDS}" =~ ^[0-9]+$ ]] \
+    || (( ARCHIVE_INTERVAL_SECONDS < 60 )); then
+    echo "ARCHIVE_INTERVAL_SECONDS must be an integer of at least 60 seconds." >&2
+    exit 2
+  fi
+  if ! command -v rclone >/dev/null 2>&1; then
+    echo "PUBLISH_TO_OSN=1 requires rclone on the host PATH." >&2
+    exit 2
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "PUBLISH_TO_OSN=1 requires python3 on the host PATH." >&2
+    exit 2
+  fi
+  if [[ ! -f "${ARCHIVE_TOOL}" ]]; then
+    echo "Experiment archive tool not found: ${ARCHIVE_TOOL}" >&2
+    echo "Copy scripts/experiment_archive.py next to this harness or set ARCHIVE_TOOL." >&2
+    exit 2
+  fi
+fi
 
 if [[ "${REQUEUE_ON_USR1}" == "1" ]]; then
   handle_requeue() {
+    ARCHIVE_FINAL_STATE="requeued"
     echo "Received USR1; requeueing Slurm job ${SLURM_JOB_ID}."
     scontrol requeue "${SLURM_JOB_ID}"
     exit 0
@@ -186,6 +220,11 @@ echo "Config:     ${CONFIG}"
 echo "Name:       ${NAME}"
 echo "Data root:  ${DATA_ROOT}"
 echo "Outputs:    ${OUTPUT_BASE}"
+if [[ "${PUBLISH_TO_OSN}" == "1" ]]; then
+  echo "Archive:    ${ARCHIVE_BASE}/${NAME} (every ${ARCHIVE_INTERVAL_SECONDS}s)"
+else
+  echo "Archive:    disabled"
+fi
 echo "W&B mode:   ${WANDB_MODE}"
 echo "Image ref:  ${IMAGE_REF}"
 echo "SIF path:   ${SIF_PATH}"
@@ -403,6 +442,77 @@ with open(os.environ["SAMUDRA_PROVENANCE_PATH"], "w", encoding="utf-8") as strea
     json.dump(provenance, stream, indent=2, sort_keys=True)
     stream.write("\n")
 PY
+
+ARCHIVE_WATCH_PID=""
+ARCHIVE_FINAL_STATE="failed"
+TRAIN_EXIT_CODE=1
+
+run_archive_tool() {
+  python3 "${ARCHIVE_TOOL}" --archive-base "${ARCHIVE_BASE}" "$@"
+}
+
+stop_archive_watch() {
+  if [[ -z "${ARCHIVE_WATCH_PID}" ]]; then
+    return 0
+  fi
+  if kill -0 "${ARCHIVE_WATCH_PID}" 2>/dev/null; then
+    kill -TERM "${ARCHIVE_WATCH_PID}" 2>/dev/null || true
+  fi
+  if ! wait "${ARCHIVE_WATCH_PID}"; then
+    echo "A periodic archive copy failed; the final copy will retry it." >&2
+  fi
+  ARCHIVE_WATCH_PID=""
+}
+
+finalize_archive() {
+  local status_args=(status "${RUN_DIR}" "${ARCHIVE_FINAL_STATE}")
+  local archive_exit_code=0
+  stop_archive_watch
+  if [[ "${ARCHIVE_FINAL_STATE}" == "completed" \
+    || "${ARCHIVE_FINAL_STATE}" == "failed" ]]; then
+    status_args+=(--exit-code "${TRAIN_EXIT_CODE}")
+  fi
+  if ! run_archive_tool "${status_args[@]}"; then
+    echo "Could not write final experiment archive status." >&2
+    archive_exit_code=8
+  fi
+  if ! run_archive_tool publish "${RUN_DIR}" --apply; then
+    echo "Final experiment archive publication failed." >&2
+    archive_exit_code=8
+  fi
+  return "${archive_exit_code}"
+}
+
+handle_archive_exit() {
+  local process_exit_code=$?
+  local archive_exit_code=0
+  trap - EXIT
+  if finalize_archive; then
+    archive_exit_code=0
+  else
+    archive_exit_code=$?
+  fi
+  if (( process_exit_code != 0 )); then
+    exit "${process_exit_code}"
+  fi
+  if (( archive_exit_code != 0 )); then
+    exit "${archive_exit_code}"
+  fi
+  exit 0
+}
+
+if [[ "${PUBLISH_TO_OSN}" == "1" ]]; then
+  run_archive_tool status "${RUN_DIR}" running
+  if ! run_archive_tool publish "${RUN_DIR}" --apply; then
+    echo "Initial public archive preflight failed; training will not start." >&2
+    exit 8
+  fi
+  run_archive_tool watch "${RUN_DIR}" \
+    --interval "${ARCHIVE_INTERVAL_SECONDS}" \
+    --apply &
+  ARCHIVE_WATCH_PID=$!
+  trap handle_archive_exit EXIT
+fi
 if [[ -n "${NSYS_ARGS}" ]]; then
   mkdir -p "${NSYS_OUTPUT_DIR}"
 fi
@@ -410,6 +520,7 @@ fi
 export OE_NSYS_ARGS="${NSYS_ARGS}"
 export OE_NSYS_OUTPUT_DIR="${NSYS_OUTPUT_DIR}"
 
+set +e
 srun --ntasks="${SLURM_NNODES}" --ntasks-per-node=1 \
   "${APPTAINER_BIN}" exec --nv \
     "${OVERLAY_ARGS[@]}" \
@@ -476,3 +587,11 @@ srun --ntasks="${SLURM_NNODES}" --ntasks-per-node=1 \
         --backend=\"nccl\" \
         ${ARGS}
     "
+TRAIN_EXIT_CODE=$?
+set -e
+if (( TRAIN_EXIT_CODE == 0 )); then
+  ARCHIVE_FINAL_STATE="completed"
+else
+  ARCHIVE_FINAL_STATE="failed"
+fi
+exit "${TRAIN_EXIT_CODE}"

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -70,6 +70,7 @@ else
 fi
 
 CONFIG="${CONFIG:-}"
+CURRENT_USER="${USER:-$(id -un)}"
 NAME="${NAME:-}"
 NAME_SUFFIX="${NAME_SUFFIX:-}"
 ARGS="${ARGS:-}"
@@ -78,6 +79,7 @@ REQUEUE_ON_USR1="${REQUEUE_ON_USR1:-0}"
 CODE_LAYER="${CODE_LAYER:-}"
 PUBLISH_TO_OSN="${PUBLISH_TO_OSN:-1}"
 ARCHIVE_BASE="${ARCHIVE_BASE:-nyu-osn:m2lines-pubs/Samudra/experiments}"
+ARCHIVE_OWNER="${ARCHIVE_OWNER:-${CURRENT_USER}}"
 ARCHIVE_INTERVAL_SECONDS="${ARCHIVE_INTERVAL_SECONDS:-900}"
 ARCHIVE_TOOL="${ARCHIVE_TOOL:-${SCRIPT_DIR}/experiment_archive.py}"
 if [[ -z "${NAME}" && -n "${NAME_SUFFIX}" ]]; then
@@ -128,7 +130,6 @@ if [[ "${REQUEUE_ON_USR1}" == "1" ]]; then
 fi
 
 # Data + outputs (host paths; will be bind-mounted into the container at same paths).
-CURRENT_USER="${USER:-$(id -un)}"
 DATA_ROOT_DEFAULT="/scratch/${CURRENT_USER}/data/om4_onedeg_v3"
 OUTPUT_BASE_DEFAULT="/scratch/${CURRENT_USER}/runs"
 DATA_ROOT="${DATA_ROOT:-${DATA_ROOT_DEFAULT}}"
@@ -222,7 +223,7 @@ echo "Name:       ${NAME}"
 echo "Data root:  ${DATA_ROOT}"
 echo "Outputs:    ${OUTPUT_BASE}"
 if [[ "${PUBLISH_TO_OSN}" == "1" ]]; then
-  echo "Archive:    ${ARCHIVE_BASE}/${NAME} (every ${ARCHIVE_INTERVAL_SECONDS}s)"
+  echo "Archive:    ${ARCHIVE_BASE}/${ARCHIVE_OWNER}/${NAME} (every ${ARCHIVE_INTERVAL_SECONDS}s)"
 else
   echo "Archive:    disabled"
 fi
@@ -449,7 +450,10 @@ ARCHIVE_FINAL_STATE="failed"
 TRAIN_EXIT_CODE=1
 
 run_archive_tool() {
-  python3 "${ARCHIVE_TOOL}" --archive-base "${ARCHIVE_BASE}" "$@"
+  python3 "${ARCHIVE_TOOL}" \
+    --archive-base "${ARCHIVE_BASE}" \
+    --owner "${ARCHIVE_OWNER}" \
+    "$@"
 }
 
 stop_archive_watch() {

--- a/scripts/slurm_apptainer_train.sbatch
+++ b/scripts/slurm_apptainer_train.sbatch
@@ -91,6 +91,12 @@ if [[ -z "${CONFIG}" || -z "${NAME}" ]]; then
   echo "Example: export NAME_SUFFIX=om4_samudra_baseline" >&2
   exit 2
 fi
+case "${NAME}" in
+  .|..|[[:space:]]*|*[[:space:]]|*/*|*\\*)
+    echo "NAME must be one path segment without leading/trailing whitespace: ${NAME}" >&2
+    exit 2
+    ;;
+esac
 case "${PUBLISH_TO_OSN}" in
   0|1) ;;
   *)
@@ -456,6 +462,26 @@ run_archive_tool() {
     "$@"
 }
 
+quarantine_unstarted_run() {
+  local quarantine_path
+  quarantine_path="${RUN_DIR}.archive-preflight-failed-${SLURM_JOB_ID:-$$}-$(date +%s)"
+  if mv -- "${RUN_DIR}" "${quarantine_path}"; then
+    echo "Unstarted run retained at: ${quarantine_path}" >&2
+    echo "The original NAME can be retried after fixing archive access." >&2
+    return 0
+  fi
+  echo "Could not quarantine ${RUN_DIR}; move it manually before retrying NAME." >&2
+  return 1
+}
+
+initialize_archive() {
+  run_archive_tool status "${RUN_DIR}" running || return
+  if (( ${SLURM_RESTART_COUNT:-0} == 0 )); then
+    run_archive_tool preflight "${RUN_DIR}" --apply || return
+  fi
+  run_archive_tool publish "${RUN_DIR}" --apply || return
+}
+
 stop_archive_watch() {
   if [[ -z "${ARCHIVE_WATCH_PID}" ]]; then
     return 0
@@ -507,9 +533,14 @@ handle_archive_exit() {
 }
 
 if [[ "${PUBLISH_TO_OSN}" == "1" ]]; then
-  run_archive_tool status "${RUN_DIR}" running
-  if ! run_archive_tool publish "${RUN_DIR}" --apply; then
+  if ! initialize_archive; then
+    run_archive_tool status "${RUN_DIR}" failed --exit-code 8 || true
     echo "Initial public archive preflight failed; training will not start." >&2
+    if (( ${SLURM_RESTART_COUNT:-0} == 0 )); then
+      quarantine_unstarted_run || true
+    else
+      echo "Requeued run retained at its existing path: ${RUN_DIR}" >&2
+    fi
     exit 8
   fi
   run_archive_tool watch "${RUN_DIR}" \

--- a/scripts/torch_public_archive.sh
+++ b/scripts/torch_public_archive.sh
@@ -5,5 +5,5 @@
 # Source this profile before submitting a Torch training job to opt in to the
 # public experiment archive.
 export PUBLISH_TO_OSN=1
-export ARCHIVE_BASE="nyu-osn:m2lines-pubs/FOMO/experiments"
+export ARCHIVE_BASE="nyu-osn:m2lines-pubs/Samudra/experiments"
 export ARCHIVE_INTERVAL_SECONDS=900

--- a/scripts/torch_public_archive.sh
+++ b/scripts/torch_public_archive.sh
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Source this profile before submitting a Torch training job to opt in to the
+# public experiment archive.
+export PUBLISH_TO_OSN=1
+export ARCHIVE_BASE="nyu-osn:m2lines-pubs/FOMO/experiments"
+export ARCHIVE_INTERVAL_SECONDS=900

--- a/scripts/torch_public_archive.sh
+++ b/scripts/torch_public_archive.sh
@@ -1,9 +1,0 @@
-# SPDX-FileCopyrightText: 2026 Samudra Authors
-#
-# SPDX-License-Identifier: Apache-2.0
-
-# Source this profile before submitting a Torch training job to opt in to the
-# public experiment archive.
-export PUBLISH_TO_OSN=1
-export ARCHIVE_BASE="nyu-osn:m2lines-pubs/Samudra/experiments"
-export ARCHIVE_INTERVAL_SECONDS=900

--- a/tests/test_experiment_archive.py
+++ b/tests/test_experiment_archive.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 import subprocess
 import threading
 from pathlib import Path
@@ -12,12 +13,145 @@ import pytest
 from scripts import experiment_archive
 
 
+def _write_executable(path, contents):
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_harness_to_archive_failure(
+    tmp_path, restart_count, failed_command, name="run-a"
+):
+    repository = Path(__file__).parents[1]
+    harness = repository / "scripts" / "slurm_apptainer_train.sbatch"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "apptainer",
+        """#!/bin/bash
+if [[ "$1" == "exec" ]]; then
+  printf unknown
+fi
+""",
+    )
+    _write_executable(
+        fake_bin / "scontrol",
+        """#!/bin/bash
+printf 'node-a\n'
+""",
+    )
+    _write_executable(
+        fake_bin / "rclone",
+        """#!/bin/bash
+printf '%s\n' "$*" >> "${RCLONE_LOG}"
+if [[ "$1" == "${RCLONE_FAIL_COMMAND}" ]]; then
+  exit 9
+fi
+""",
+    )
+
+    data_root = tmp_path / "data"
+    output_base = tmp_path / "runs"
+    scratch_dir = tmp_path / "scratch"
+    run_dir = output_base / name
+    data_root.mkdir()
+    output_base.mkdir()
+    scratch_dir.mkdir()
+    image_path = tmp_path / "image.sif"
+    image_path.write_text("image", encoding="utf-8")
+    if restart_count:
+        run_dir.mkdir()
+        (run_dir / "checkpoint").write_text("existing", encoding="utf-8")
+
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{fake_bin}:{environment['PATH']}",
+            "USER": "torch-user",
+            "CONFIG": "config.yaml",
+            "NAME": name,
+            "DATA_ROOT": str(data_root),
+            "OUTPUT_BASE": str(output_base),
+            "SCRATCH_DIR": str(scratch_dir),
+            "SIF_PATH": str(image_path),
+            "PUBLISH_TO_OSN": "1",
+            "ARCHIVE_BASE": "remote:bucket/archive",
+            "ARCHIVE_OWNER": "owner-a",
+            "ARCHIVE_INTERVAL_SECONDS": "60",
+            "ARCHIVE_TOOL": str(repository / "scripts" / "experiment_archive.py"),
+            "SLURM_JOB_ID": "123",
+            "SLURM_JOB_NODELIST": "node-a",
+            "SLURM_NNODES": "1",
+            "SLURM_GPUS_ON_NODE": "1",
+            "SLURM_CPUS_PER_TASK": "1",
+            "SLURM_RESTART_COUNT": str(restart_count),
+            "RCLONE_LOG": str(tmp_path / "rclone.log"),
+            "RCLONE_FAIL_COMMAND": failed_command,
+        }
+    )
+    result = subprocess.run(
+        ["bash", str(harness)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    return result, run_dir, tmp_path / "rclone.log"
+
+
 def test_team_torch_harness_publishes_by_default():
     harness = Path(__file__).parents[1] / "scripts" / "slurm_apptainer_train.sbatch"
     contents = harness.read_text(encoding="utf-8")
 
     assert 'PUBLISH_TO_OSN="${PUBLISH_TO_OSN:-1}"' in contents
     assert 'ARCHIVE_OWNER="${ARCHIVE_OWNER:-${CURRENT_USER}}"' in contents
+    assert "*/*|*\\\\*)" in contents
+    assert 'preflight "${RUN_DIR}" --apply' in contents
+    assert 'mv -- "${RUN_DIR}" "${quarantine_path}"' in contents
+
+
+def test_harness_rejects_nested_run_name(tmp_path):
+    result, run_dir, _ = _run_harness_to_archive_failure(
+        tmp_path, restart_count=0, failed_command="none", name="nested/run"
+    )
+
+    assert result.returncode == 2
+    assert "NAME must be one path segment" in result.stderr
+    assert not run_dir.exists()
+
+
+def test_fresh_run_preflight_failure_is_quarantined(tmp_path):
+    result, run_dir, rclone_log = _run_harness_to_archive_failure(
+        tmp_path, restart_count=0, failed_command="lsf"
+    )
+
+    assert result.returncode == 8
+    assert not run_dir.exists()
+    quarantined = list(run_dir.parent.glob("run-a.archive-preflight-failed-123-*"))
+    assert len(quarantined) == 1
+    assert (quarantined[0] / "run-provenance.json").is_file()
+    status = json.loads(
+        (quarantined[0] / experiment_archive.STATUS_FILENAME).read_text(
+            encoding="utf-8"
+        )
+    )
+    assert status["state"] == "failed"
+    assert status["exit_code"] == 8
+    assert "lsf remote:bucket/archive/owner-a/run-a" in rclone_log.read_text(
+        encoding="utf-8"
+    )
+
+
+def test_requeued_run_archive_failure_keeps_existing_directory(tmp_path):
+    result, run_dir, rclone_log = _run_harness_to_archive_failure(
+        tmp_path, restart_count=1, failed_command="copy"
+    )
+
+    assert result.returncode == 8
+    assert (run_dir / "checkpoint").is_file()
+    assert not list(run_dir.parent.glob("run-a.archive-preflight-failed-*"))
+    rclone_calls = rclone_log.read_text(encoding="utf-8")
+    assert "copy " in rclone_calls
+    assert "lsf " not in rclone_calls
 
 
 def test_default_archive_uses_public_samudra_prefix():
@@ -60,6 +194,77 @@ def test_copy_command_is_non_destructive_and_excludes_sensitive_files(tmp_path):
     assert "--delete" not in command
     for pattern in experiment_archive.EXCLUDE_PATTERNS:
         assert pattern in command
+
+
+def test_copy_command_excludes_atomic_checkpoint_temporary_files(tmp_path):
+    command = experiment_archive.copy_command(
+        tmp_path / "run", "remote:bucket/archive/run"
+    )
+
+    assert "/saved_nets/tmp*" in command
+
+
+def test_preflight_is_dry_run_by_default(tmp_path, monkeypatch, capsys):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("dry run must not invoke rclone")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+
+    result = experiment_archive.preflight_destination(
+        run_dir, "remote:bucket/archive", "owner-a", apply=False
+    )
+
+    assert result["status"] == "planned"
+    assert "rclone lsf remote:bucket/archive/owner-a/run-a" in capsys.readouterr().out
+
+
+def test_preflight_accepts_an_empty_destination(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+    commands = []
+
+    def return_empty(command, check, stdout):
+        assert check is True
+        assert stdout == subprocess.PIPE
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout=b"")
+
+    monkeypatch.setattr(subprocess, "run", return_empty)
+
+    result = experiment_archive.preflight_destination(
+        run_dir, "remote:bucket/archive", "owner-a", apply=True
+    )
+
+    assert commands == [
+        [
+            "rclone",
+            "lsf",
+            "remote:bucket/archive/owner-a/run-a",
+            "--max-depth",
+            "1",
+        ]
+    ]
+    assert result["status"] == "available"
+
+
+def test_preflight_rejects_an_existing_destination(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+
+    def return_existing(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout="checkpoint.pt\n")
+
+    monkeypatch.setattr(subprocess, "run", return_existing)
+
+    with pytest.raises(
+        experiment_archive.ArchiveError, match="already contains objects"
+    ):
+        experiment_archive.preflight_destination(
+            run_dir, "remote:bucket/archive", "owner-a", apply=True
+        )
 
 
 def test_publish_is_dry_run_by_default(tmp_path, monkeypatch, capsys):

--- a/tests/test_experiment_archive.py
+++ b/tests/test_experiment_archive.py
@@ -5,10 +5,18 @@
 import json
 import subprocess
 import threading
+from pathlib import Path
 
 import pytest
 
 from scripts import experiment_archive
+
+
+def test_team_torch_harness_publishes_by_default():
+    harness = Path(__file__).parents[1] / "scripts" / "slurm_apptainer_train.sbatch"
+    contents = harness.read_text(encoding="utf-8")
+
+    assert 'PUBLISH_TO_OSN="${PUBLISH_TO_OSN:-1}"' in contents
 
 
 def test_default_archive_uses_public_samudra_prefix():

--- a/tests/test_experiment_archive.py
+++ b/tests/test_experiment_archive.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import json
 import os
 import subprocess
@@ -10,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from scripts import experiment_archive
+from scripts import experiment_archive, sanitize_repository_url
 
 
 def _write_executable(path, contents):
@@ -19,7 +20,12 @@ def _write_executable(path, contents):
 
 
 def _run_harness_to_archive_failure(
-    tmp_path, restart_count, failed_command, name="run-a"
+    tmp_path,
+    restart_count,
+    failed_command,
+    name="run-a",
+    code_layer_repo_url=None,
+    container_repo_url="unknown",
 ):
     repository = Path(__file__).parents[1]
     harness = repository / "scripts" / "slurm_apptainer_train.sbatch"
@@ -29,7 +35,11 @@ def _run_harness_to_archive_failure(
         fake_bin / "apptainer",
         """#!/bin/bash
 if [[ "$1" == "exec" ]]; then
-  printf unknown
+  if [[ "$*" == *SAMUDRA_CONTAINER_GIT_REMOTE_URL* ]]; then
+    printf %s "${FAKE_CONTAINER_GIT_REMOTE_URL}"
+  elif [[ "$*" == *SAMUDRA_CONTAINER_GIT_COMMIT* ]]; then
+    printf container-commit
+  fi
 fi
 """,
     )
@@ -58,6 +68,26 @@ fi
     scratch_dir.mkdir()
     image_path = tmp_path / "image.sif"
     image_path.write_text("image", encoding="utf-8")
+    code_layer = ""
+    if code_layer_repo_url is not None:
+        code_layer_path = tmp_path / "code-layer.img"
+        code_layer_path.write_text("code layer", encoding="utf-8")
+        layer_digest = hashlib.sha256(code_layer_path.read_bytes()).hexdigest()
+        Path(f"{code_layer_path}.sha256").write_text(
+            f"{layer_digest}  {code_layer_path.name}\n", encoding="utf-8"
+        )
+        Path(f"{code_layer_path}.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "code_commit": "code-layer-commit",
+                    "code_repo_url": code_layer_repo_url,
+                    "requested_code_ref": "feature",
+                }
+            ),
+            encoding="utf-8",
+        )
+        code_layer = str(code_layer_path)
     if restart_count:
         run_dir.mkdir()
         (run_dir / "checkpoint").write_text("existing", encoding="utf-8")
@@ -73,6 +103,7 @@ fi
             "OUTPUT_BASE": str(output_base),
             "SCRATCH_DIR": str(scratch_dir),
             "SIF_PATH": str(image_path),
+            "CODE_LAYER": code_layer,
             "PUBLISH_TO_OSN": "1",
             "ARCHIVE_BASE": "remote:bucket/archive",
             "ARCHIVE_OWNER": "owner-a",
@@ -86,6 +117,7 @@ fi
             "SLURM_RESTART_COUNT": str(restart_count),
             "RCLONE_LOG": str(tmp_path / "rclone.log"),
             "RCLONE_FAIL_COMMAND": failed_command,
+            "FAKE_CONTAINER_GIT_REMOTE_URL": container_repo_url,
         }
     )
     result = subprocess.run(
@@ -107,6 +139,48 @@ def test_team_torch_harness_publishes_by_default():
     assert "*/*|*\\\\*)" in contents
     assert 'preflight "${RUN_DIR}" --apply' in contents
     assert 'mv -- "${RUN_DIR}" "${quarantine_path}"' in contents
+
+
+def test_repository_url_sanitizer_removes_credentials_and_query_secrets():
+    assert (
+        sanitize_repository_url.sanitize_repository_url(
+            "https://user:token@github.com/m2lines/Samudra.git"  # pragma: allowlist secret
+            "?access_token=other-secret#fragment"
+        )
+        == "https://github.com/m2lines/Samudra.git"
+    )
+    assert (
+        sanitize_repository_url.sanitize_repository_url(
+            "ssh://git@github.com:22/m2lines/Samudra.git"
+        )
+        == "ssh://github.com:22/m2lines/Samudra.git"
+    )
+    assert (
+        sanitize_repository_url.sanitize_repository_url(
+            "git@github.com:m2lines/Samudra.git"
+        )
+        == "ssh://github.com/m2lines/Samudra.git"
+    )
+
+
+@pytest.mark.parametrize(
+    "value", ["", " leading-space", "https:user@host/repo", "https://host/repo\nnext"]
+)
+def test_repository_url_sanitizer_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        sanitize_repository_url.sanitize_repository_url(value)
+
+
+def test_code_layer_builder_records_only_sanitized_repository_url():
+    builder = (
+        Path(__file__).parents[1] / "scripts" / "build_apptainer_code_layer.sh"
+    ).read_text(encoding="utf-8")
+
+    assert "from ${CODE_REPO_PUBLIC_URL}" in builder
+    assert '"code_repo_url": os.environ["CODE_REPO_PUBLIC_URL"]' in builder
+    assert '2>"${BUILD_DIR}/git-fetch-error.log"' in builder
+    assert "unset CODE_REPO_URL" in builder
+    assert "from ${CODE_REPO_URL}" not in builder
 
 
 def test_harness_rejects_nested_run_name(tmp_path):
@@ -139,6 +213,45 @@ def test_fresh_run_preflight_failure_is_quarantined(tmp_path):
     assert "lsf remote:bucket/archive/owner-a/run-a" in rclone_log.read_text(
         encoding="utf-8"
     )
+
+
+def test_public_provenance_strips_repository_credentials(tmp_path):
+    code_layer_url = (
+        "https://layer-user:layer-token@github.com/m2lines/Samudra.git"  # pragma: allowlist secret
+        "?access_token=query-secret"
+    )
+    container_url = "https://container-user:container-token@github.com/m2lines/Samudra.git"  # pragma: allowlist secret
+    result, run_dir, _ = _run_harness_to_archive_failure(
+        tmp_path,
+        restart_count=0,
+        failed_command="lsf",
+        code_layer_repo_url=code_layer_url,
+        container_repo_url=container_url,
+    )
+
+    assert result.returncode == 8
+    quarantined = list(run_dir.parent.glob("run-a.archive-preflight-failed-123-*"))
+    assert len(quarantined) == 1
+    provenance_text = (quarantined[0] / "run-provenance.json").read_text(
+        encoding="utf-8"
+    )
+    source_manifest_text = (quarantined[0] / "source-manifest.json").read_text(
+        encoding="utf-8"
+    )
+    provenance = json.loads(provenance_text)
+    source_manifest = json.loads(source_manifest_text)
+
+    assert provenance["code_repo_url"] == "https://github.com/m2lines/Samudra.git"
+    assert (
+        provenance["container_git_remote_url"]
+        == "https://github.com/m2lines/Samudra.git"
+    )
+    assert source_manifest["code_repo_url"] == (
+        "https://github.com/m2lines/Samudra.git"
+    )
+    for secret in ("layer-token", "query-secret", "container-token"):
+        assert secret not in provenance_text
+        assert secret not in source_manifest_text
 
 
 def test_requeued_run_archive_failure_keeps_existing_directory(tmp_path):

--- a/tests/test_experiment_archive.py
+++ b/tests/test_experiment_archive.py
@@ -11,6 +11,13 @@ import pytest
 from scripts import experiment_archive
 
 
+def test_default_archive_uses_public_samudra_prefix():
+    assert (
+        experiment_archive.DEFAULT_ARCHIVE_BASE
+        == "nyu-osn:m2lines-pubs/Samudra/experiments"
+    )
+
+
 def test_archive_destination_appends_run_name():
     assert (
         experiment_archive.archive_destination("remote:bucket/archive/", "run-42")

--- a/tests/test_experiment_archive.py
+++ b/tests/test_experiment_archive.py
@@ -17,6 +17,7 @@ def test_team_torch_harness_publishes_by_default():
     contents = harness.read_text(encoding="utf-8")
 
     assert 'PUBLISH_TO_OSN="${PUBLISH_TO_OSN:-1}"' in contents
+    assert 'ARCHIVE_OWNER="${ARCHIVE_OWNER:-${CURRENT_USER}}"' in contents
 
 
 def test_default_archive_uses_public_samudra_prefix():
@@ -28,15 +29,25 @@ def test_default_archive_uses_public_samudra_prefix():
 
 def test_archive_destination_appends_run_name():
     assert (
-        experiment_archive.archive_destination("remote:bucket/archive/", "run-42")
-        == "remote:bucket/archive/run-42"
+        experiment_archive.archive_destination(
+            "remote:bucket/archive/", "owner-a", "run-42"
+        )
+        == "remote:bucket/archive/owner-a/run-42"
     )
 
 
 @pytest.mark.parametrize("run_name", ["", ".", "..", "nested/run", "nested\\run"])
 def test_archive_destination_rejects_unsafe_run_name(run_name):
     with pytest.raises(experiment_archive.ArchiveError):
-        experiment_archive.archive_destination("remote:bucket/archive", run_name)
+        experiment_archive.archive_destination(
+            "remote:bucket/archive", "owner-a", run_name
+        )
+
+
+@pytest.mark.parametrize("owner", ["", ".", "..", "team/owner", " team"])
+def test_archive_destination_rejects_unsafe_owner(owner):
+    with pytest.raises(experiment_archive.ArchiveError):
+        experiment_archive.archive_destination("remote:bucket/archive", owner, "run-a")
 
 
 def test_copy_command_is_non_destructive_and_excludes_sensitive_files(tmp_path):
@@ -61,7 +72,7 @@ def test_publish_is_dry_run_by_default(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(subprocess, "run", fail_if_called)
 
     result = experiment_archive.publish_run(
-        run_dir, "remote:bucket/archive", apply=False
+        run_dir, "remote:bucket/archive", "owner-a", apply=False
     )
 
     assert result["status"] == "planned"
@@ -82,7 +93,7 @@ def test_publish_copies_then_verifies(tmp_path, monkeypatch):
     monkeypatch.setattr(subprocess, "run", record)
 
     result = experiment_archive.publish_run(
-        run_dir, "remote:bucket/archive", apply=True
+        run_dir, "remote:bucket/archive", "owner-a", apply=True
     )
 
     assert [command[1] for command in commands] == ["copy", "check"]
@@ -98,12 +109,13 @@ def test_status_tracks_run_lifecycle(tmp_path, monkeypatch):
     timestamps = iter(("start", "finish"))
     monkeypatch.setattr(experiment_archive, "utc_now", lambda: next(timestamps))
 
-    status_path = experiment_archive.write_status(run_dir, "running")
-    experiment_archive.write_status(run_dir, "completed", exit_code=0)
+    status_path = experiment_archive.write_status(run_dir, "owner-a", "running")
+    experiment_archive.write_status(run_dir, "owner-a", "completed", exit_code=0)
 
     status = json.loads(status_path.read_text(encoding="utf-8"))
     assert status == {
         "schema_version": 1,
+        "owner": "owner-a",
         "run_name": "run-a",
         "state": "completed",
         "started_at": "start",
@@ -120,7 +132,16 @@ def test_status_rejects_unknown_state(tmp_path):
     run_dir.mkdir()
 
     with pytest.raises(experiment_archive.ArchiveError, match="invalid archive state"):
-        experiment_archive.write_status(run_dir, "unknown")
+        experiment_archive.write_status(run_dir, "owner-a", "unknown")
+
+
+def test_status_rejects_owner_change(tmp_path):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+    experiment_archive.write_status(run_dir, "owner-a", "running")
+
+    with pytest.raises(experiment_archive.ArchiveError, match="owner changed"):
+        experiment_archive.write_status(run_dir, "owner-b", "running")
 
 
 def test_watch_publishes_without_full_verification(tmp_path, monkeypatch):
@@ -128,14 +149,15 @@ def test_watch_publishes_without_full_verification(tmp_path, monkeypatch):
     run_dir.mkdir()
     calls = []
 
-    def record_publish(run_dir, archive_base, apply, verify, rclone_bin):
-        calls.append((run_dir, archive_base, apply, verify, rclone_bin))
+    def record_publish(run_dir, archive_base, owner, apply, verify, rclone_bin):
+        calls.append((run_dir, archive_base, owner, apply, verify, rclone_bin))
 
     monkeypatch.setattr(experiment_archive, "publish_run", record_publish)
 
     result = experiment_archive.watch_run(
         run_dir,
         "remote:bucket/archive",
+        "owner-a",
         interval_seconds=0.001,
         apply=True,
         stop_event=threading.Event(),
@@ -143,7 +165,9 @@ def test_watch_publishes_without_full_verification(tmp_path, monkeypatch):
     )
 
     assert result == 0
-    assert calls == [(run_dir, "remote:bucket/archive", True, False, "rclone")]
+    assert calls == [
+        (run_dir, "remote:bucket/archive", "owner-a", True, False, "rclone")
+    ]
 
 
 def test_watch_reports_copy_failures(tmp_path, monkeypatch, capsys):
@@ -151,7 +175,12 @@ def test_watch_reports_copy_failures(tmp_path, monkeypatch, capsys):
     run_dir.mkdir()
 
     def fail_publish(*args, **kwargs):
-        command = ["rclone", "copy", str(run_dir), "remote:archive/run-a"]
+        command = [
+            "rclone",
+            "copy",
+            str(run_dir),
+            "remote:archive/owner-a/run-a",
+        ]
         raise subprocess.CalledProcessError(9, command)
 
     monkeypatch.setattr(experiment_archive, "publish_run", fail_publish)
@@ -159,6 +188,7 @@ def test_watch_reports_copy_failures(tmp_path, monkeypatch, capsys):
     result = experiment_archive.watch_run(
         run_dir,
         "remote:bucket/archive",
+        "owner-a",
         interval_seconds=0.001,
         apply=True,
         max_cycles=1,

--- a/tests/test_experiment_archive.py
+++ b/tests/test_experiment_archive.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import subprocess
+import threading
+
+import pytest
+
+from scripts import experiment_archive
+
+
+def test_archive_destination_appends_run_name():
+    assert (
+        experiment_archive.archive_destination("remote:bucket/archive/", "run-42")
+        == "remote:bucket/archive/run-42"
+    )
+
+
+@pytest.mark.parametrize("run_name", ["", ".", "..", "nested/run", "nested\\run"])
+def test_archive_destination_rejects_unsafe_run_name(run_name):
+    with pytest.raises(experiment_archive.ArchiveError):
+        experiment_archive.archive_destination("remote:bucket/archive", run_name)
+
+
+def test_copy_command_is_non_destructive_and_excludes_sensitive_files(tmp_path):
+    command = experiment_archive.copy_command(
+        tmp_path / "run", "remote:bucket/archive/run"
+    )
+
+    assert command[:2] == ["rclone", "copy"]
+    assert "sync" not in command
+    assert "--delete" not in command
+    for pattern in experiment_archive.EXCLUDE_PATTERNS:
+        assert pattern in command
+
+
+def test_publish_is_dry_run_by_default(tmp_path, monkeypatch, capsys):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("dry run must not invoke rclone")
+
+    monkeypatch.setattr(subprocess, "run", fail_if_called)
+
+    result = experiment_archive.publish_run(
+        run_dir, "remote:bucket/archive", apply=False
+    )
+
+    assert result["status"] == "planned"
+    output = capsys.readouterr().out
+    assert "rclone copy" in output
+    assert "rclone check" in output
+
+
+def test_publish_copies_then_verifies(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+    commands = []
+
+    def record(command, check):
+        assert check is True
+        commands.append(command)
+
+    monkeypatch.setattr(subprocess, "run", record)
+
+    result = experiment_archive.publish_run(
+        run_dir, "remote:bucket/archive", apply=True
+    )
+
+    assert [command[1] for command in commands] == ["copy", "check"]
+    assert result["status"] == "verified"
+    assert result["verified"] is True
+
+
+def test_status_tracks_run_lifecycle(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+    monkeypatch.setenv("SLURM_JOB_ID", "1234")
+    monkeypatch.setenv("SLURM_RESTART_COUNT", "2")
+    timestamps = iter(("start", "finish"))
+    monkeypatch.setattr(experiment_archive, "utc_now", lambda: next(timestamps))
+
+    status_path = experiment_archive.write_status(run_dir, "running")
+    experiment_archive.write_status(run_dir, "completed", exit_code=0)
+
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    assert status == {
+        "schema_version": 1,
+        "run_name": "run-a",
+        "state": "completed",
+        "started_at": "start",
+        "updated_at": "finish",
+        "finished_at": "finish",
+        "exit_code": 0,
+        "slurm_job_id": "1234",
+        "slurm_restart_count": "2",
+    }
+
+
+def test_status_rejects_unknown_state(tmp_path):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+
+    with pytest.raises(experiment_archive.ArchiveError, match="invalid archive state"):
+        experiment_archive.write_status(run_dir, "unknown")
+
+
+def test_watch_publishes_without_full_verification(tmp_path, monkeypatch):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+    calls = []
+
+    def record_publish(run_dir, archive_base, apply, verify, rclone_bin):
+        calls.append((run_dir, archive_base, apply, verify, rclone_bin))
+
+    monkeypatch.setattr(experiment_archive, "publish_run", record_publish)
+
+    result = experiment_archive.watch_run(
+        run_dir,
+        "remote:bucket/archive",
+        interval_seconds=0.001,
+        apply=True,
+        stop_event=threading.Event(),
+        max_cycles=1,
+    )
+
+    assert result == 0
+    assert calls == [(run_dir, "remote:bucket/archive", True, False, "rclone")]
+
+
+def test_watch_reports_copy_failures(tmp_path, monkeypatch, capsys):
+    run_dir = tmp_path / "run-a"
+    run_dir.mkdir()
+
+    def fail_publish(*args, **kwargs):
+        command = ["rclone", "copy", str(run_dir), "remote:archive/run-a"]
+        raise subprocess.CalledProcessError(9, command)
+
+    monkeypatch.setattr(experiment_archive, "publish_run", fail_publish)
+
+    result = experiment_archive.watch_run(
+        run_dir,
+        "remote:bucket/archive",
+        interval_seconds=0.001,
+        apply=True,
+        max_cycles=1,
+    )
+
+    assert result == 1
+    assert "Periodic archive copy failed" in capsys.readouterr().err


### PR DESCRIPTION
Part 2 of #711. This PR can be reviewed and merged before the historical backfill work in #858.

## Goal

Keep `/scratch` as the live training filesystem while archiving team Torch experiment runs to the public OSN research archive by default. A user can explicitly opt out for a private run. Samudra generic configuration, SkyPilot, and third-party workflows are unchanged.

## What changed

- add the single-run archive helper used by Torch jobs
- default the team Torch harness to `PUBLISH_TO_OSN=1`; set it to `0` to opt out
- namespace every public run as `<owner>/<run-name>`; owner defaults to the Torch `$USER` and can be overridden with `ARCHIVE_OWNER`
- perform an authenticated, verified archive preflight before training
- incrementally copy only `$RUN_DIR` every 15 minutes
- publish a final verified snapshot for completed, failed, and requeued jobs
- write `archive-status.json` with owner, lifecycle, and Slurm metadata
- reject an owner change when resuming the same run
- preserve the training exit code; fail a successful job if its final publication fails
- document credentials, the explicit opt-out, and public-data safety boundaries

The default destination is `nyu-osn:m2lines-pubs/Samudra/experiments/<owner>/<run-name>` (`s3://m2lines-pubs/Samudra/experiments/<owner>/<run-name>`). The archive uses copy/check operations only. It does not turn OSN into `output_base`, delete scratch data, publish the whole scratch tree, or migrate historical runs.

## Verification

- `uv run pytest tests/test_experiment_archive.py` (21 passed)
- focused pre-commit hooks (all passed)
- `uv run mypy scripts/experiment_archive.py`
- Python 3.6 grammar check for the Torch host-side tool
- `bash -n scripts/slurm_apptainer_train.sbatch`
- `git diff --check`

A credentialed Torch/OSN smoke run remains an operator step after review.