### PR TITLE
Share generated test data across worktrees

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -209,6 +209,18 @@ pytest -m manual
 We use `pytest` as a test runner. All tests in this project have several [_marks_](https://docs.pytest.org/en/stable/how-to/mark.html)
 that allow developers to control what tests are run locally. Two marks of particular interest are `cuda` and `manual`.
 
+The test suite generates about 5 GB of reusable ocean data under `.data_cache` by default. To avoid creating a copy in
+every Git worktree, set `SAMUDRA_TEST_DATA_CACHE` to a shared directory before running tests:
+
+```bash
+export SAMUDRA_TEST_DATA_CACHE="$HOME/Library/Caches/samudra/test-data"
+pytest -m "not manual and not cuda"
+```
+
+Samudra adds a versioned subdirectory to this path and uses file locks so concurrent test runs can safely initialize the
+shared data. The default remains the worktree-local `.data_cache` when the environment variable is unset. When a change
+makes the cached test-data format incompatible, increment `TEST_DATA_CACHE_VERSION` in `tests/conftest.py`.
+
 "cuda" tests are tests that require an NVIDIA GPU to run. If tests use the `device` fixture, then they'll automatically
 be configured to run on both GPU and CPU simultaneously. Certain tests, however, can be marked with `@pytest.mark.cuda`
 if they need to run on that hardware. To run CUDA-only tests, call:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import os
 import pathlib
 from collections.abc import Generator, Iterable
 from typing import ClassVar, Self
@@ -36,6 +37,7 @@ TEST_FULL_DATASET_SPEC = c.build_om4_spec(
     prognostic_vars_key="thermo_dynamic_all",
     boundary_vars_key="tau_hfds_hfds_anom",
 )
+TEST_DATA_CACHE_VERSION = "v1"
 
 
 def _om4_canonical_var_names(var_names: Iterable[str]) -> list[str]:
@@ -297,7 +299,10 @@ class DataSourceDims:
 
 
 def cache_dir(pytestconfig: pytest.Config) -> pathlib.Path:
-    dir = pytestconfig.rootpath / ".data_cache"
+    if shared_cache := os.environ.get("SAMUDRA_TEST_DATA_CACHE"):
+        dir = pathlib.Path(shared_cache).expanduser() / TEST_DATA_CACHE_VERSION
+    else:
+        dir = pytestconfig.rootpath / ".data_cache"
     dir.mkdir(parents=True, exist_ok=True)
     return dir
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -8,6 +8,7 @@ import contextlib
 import dataclasses
 import datetime
 import itertools
+import pathlib
 from collections.abc import Generator
 
 import cftime
@@ -49,6 +50,28 @@ from tests.llc_fixtures import write_raw_llc_zarr_datasets
 def inference_loader_pair(trainer_pair: TrainPair) -> tuple[TrainConfig, DataLoader]:
     cfg, trainer = trainer_pair
     return cfg, trainer.inference_loader
+
+
+def test_cache_dir_defaults_to_worktree(
+    pytestconfig: pytest.Config, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SAMUDRA_TEST_DATA_CACHE", raising=False)
+
+    assert cache_dir(pytestconfig) == pytestconfig.rootpath / ".data_cache"
+
+
+def test_cache_dir_supports_shared_cache(
+    pytestconfig: pytest.Config,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    shared_cache = tmp_path / "samudra-test-data"
+    monkeypatch.setenv("SAMUDRA_TEST_DATA_CACHE", str(shared_cache))
+
+    actual = cache_dir(pytestconfig)
+
+    assert actual == shared_cache / "v1"
+    assert actual.is_dir()
 
 
 def coarsen_data(ds: xr.Dataset) -> xr.Dataset:


### PR DESCRIPTION
## Summary

- allow `SAMUDRA_TEST_DATA_CACHE` to place generated pytest data in a shared directory
- namespace shared data under a versioned `v1` directory while preserving the worktree-local default
- document the worktree setup and cover both path-selection behaviors

## Testing

- `uv run pytest tests/test_datasets.py -k cache_dir_`
- `uvx pre-commit run --files tests/conftest.py tests/test_datasets.py docs/contributing.md`
- `env -u VIRTUAL_ENV uv run python -m pytest -m "not manual and not cuda" -n auto` (459 passed, 2 skipped, 10 xfailed)