### PR TITLE
Add reproducible OM4 freshwater flux surgery

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -105,6 +105,38 @@ native-grid fields are ignored explicitly. On Torch, select this source with
 `DATA_VARIANT=snapshots` in `scripts/slurm_preprocess_om4.sbatch`; derived output
 directories use the name `om4_<resolution>_snapshots`.
 
+### Adding freshwater flux to the averaged source
+
+The original averaged archive does not contain `wfo`. To build an averaged-state
+dataset with freshwater forcing, use
+`s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr` as a supplemental
+`wfo` source:
+
+```bash
+python -m ocean_preprocessing om4 \
+   "s3://m2lines-pubs/Samudra/raw/om4_5daily.zarr" \
+   "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr" \
+   "s3://m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr" \
+   "s3://m2lines-pubs/Samudra/raw/grids/gaussian_grid_180_by_360.zarr" \
+   --wfo_source_path="s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr" \
+   --output_path="./om4_onedeg_with_wfo/OM4.zarr" \
+   --skip_spatial_filtering
+```
+
+This is not a positional merge. The averaged archive labels intervals at their
+midpoints, whereas the donor labels the same intervals at their upper bounds.
+Before relabeling `wfo` with the recipient timestamps, the pipeline requires:
+
+- exact equality between donor times and recipient `time_bnds` upper bounds;
+- identical native `xh` and `yh` coordinates;
+- `wfo(time, yh, xh)` with `cell_methods` identifying `time: mean`; and
+- no existing `wfo` in the recipient.
+
+The output records the donor path and alignment rule in
+`m2lines/wfo_surgery_source` and `m2lines/wfo_surgery_alignment`. On Torch,
+`DATA_VARIANT=averaged_with_wfo` configures the donor automatically and writes
+to `om4_<resolution>_with_wfo`.
+
 ## Observation products
 
 Emulator evaluation compares rollouts against observations, not just against OM4. A second CLI fetches and prepares the

--- a/data/README.md
+++ b/data/README.md
@@ -52,6 +52,7 @@ python -m ocean_preprocessing om4 \
    "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/gaussian_grid_360_by_720.zarr" \
+    --wfo_source_path="s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr" \
     --output_path="./local_om4_test.zarr" \
     --dry_run \
     --small_run
@@ -82,6 +83,7 @@ python -m ocean_preprocessing om4 \
    "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/gaussian_grid_360_by_720.zarr" \
+    --wfo_source_path="s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr" \
     --output_path="s3://m2lines-pubs/Samudra/v$(date "+%Y-%m")/om4_halfdeg/OM4.zarr" \
     --cluster="coiled" \
     --wait_for_workers=True
@@ -99,9 +101,9 @@ variables (`thetao`, `so`, `uo`, `vo`, and `zos`) are instantaneous values at
 `wfo`) are five-day means, because the state transition responds to their
 time-integrated fluxes.
 
-The pipeline publishes the eight variables shared with the averaged source and
-also retains `wfo` when the source provides it. Other source diagnostics and
-native-grid fields are ignored explicitly. On Torch, select this source with
+The pipeline publishes the nine required emulator inputs, including `wfo`.
+Other source diagnostics and native-grid fields are ignored explicitly. On
+Torch, select this source with
 `DATA_VARIANT=snapshots` in `scripts/slurm_preprocess_om4.sbatch`; derived output
 directories use the name `om4_<resolution>_snapshots`.
 
@@ -119,7 +121,7 @@ python -m ocean_preprocessing om4 \
    "s3://m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/gaussian_grid_180_by_360.zarr" \
    --wfo_source_path="s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr" \
-   --output_path="./om4_onedeg_with_wfo/OM4.zarr" \
+   --output_path="./om4_onedeg/OM4.zarr" \
    --skip_spatial_filtering
 ```
 
@@ -134,8 +136,8 @@ Before relabeling `wfo` with the recipient timestamps, the pipeline requires:
 
 The output records the donor path and alignment rule in
 `m2lines/wfo_surgery_source` and `m2lines/wfo_surgery_alignment`. On Torch,
-`DATA_VARIANT=averaged_with_wfo` configures the donor automatically and writes
-to `om4_<resolution>_with_wfo`.
+the default `DATA_VARIANT=averaged` configures the donor automatically. All
+new canonical `om4_<resolution>` datasets therefore include `wfo`.
 
 ## Observation products
 

--- a/data/ocean_preprocessing/__main__.py
+++ b/data/ocean_preprocessing/__main__.py
@@ -28,6 +28,7 @@ from ocean_preprocessing.dataset_validation import (
     ds_flattened_input_validate,
     ds_input_validate,
     ds_processed_validate,
+    require_om4_publication_freshwater_flux,
 )
 from ocean_preprocessing.plotting import rotated_vectors_qc_plots
 from ocean_preprocessing.preprocessing import (
@@ -336,6 +337,10 @@ class CLI:
             nc_mosaic_path,
             wfo_source_path=wfo_source_path,
         )
+        # This publication-specific invariant must run even when expensive
+        # schema/deep validation is disabled. Shared validators remain backward
+        # compatible with legacy OM4 and CM4 datasets that predate wfo.
+        require_om4_publication_freshwater_flux(ds_processed)
         if self.small_run:
             logger.info("**small-run**: filtering data to 10 time steps.")
             ds_processed = ds_processed.isel(time=slice(0, 10))

--- a/data/ocean_preprocessing/__main__.py
+++ b/data/ocean_preprocessing/__main__.py
@@ -279,6 +279,7 @@ class CLI:
         nc_mosaic_path: str,
         target_grid_path: str,
         spatial_filter_scale: None | int = None,
+        wfo_source_path: str | None = None,
     ) -> None:
         """Process the OM4 oceans dataset (the ocean component of CMIP).
 
@@ -324,10 +325,16 @@ class CLI:
                 scale determination. When spatial filtering is performed (not --skip-spatial-filtering),
                 this value will be used instead of the scale inferred from the target grid name.
                 By default (None), the scale is automatically estimated from the target grid basename.
+            wfo_source_path: Optional OM4 Zarr store containing five-day-mean ``wfo``
+                on the recipient's native grid and intervals. Its end-of-interval time
+                labels are validated against ``zarr_data_path`` before transplantation.
         """
         logger.info("preprocessing.")
         ds_processed = om4_preprocessing(
-            zarr_data_path, native_grid_path, nc_mosaic_path
+            zarr_data_path,
+            native_grid_path,
+            nc_mosaic_path,
+            wfo_source_path=wfo_source_path,
         )
         if self.small_run:
             logger.info("**small-run**: filtering data to 10 time steps.")
@@ -462,6 +469,12 @@ class CLI:
         ds_input.attrs["m2lines/samudra_git_hash"] = git_hash
         ds_input.attrs["m2lines/date_created"] = datetime.datetime.now().isoformat()
         ds_input.attrs["m2lines/cli_args"] = " ".join(sys.argv)
+        for attr in (
+            "m2lines/wfo_surgery_source",
+            "m2lines/wfo_surgery_alignment",
+        ):
+            if attr in ds_processed.attrs:
+                ds_input.attrs[attr] = ds_processed.attrs[attr]
         # Horizontal grid geometry: this pipeline conservatively regrids onto a
         # regular (rectilinear) lat-lon grid, so downstream code may treat the 2-D
         # lat/lon as separable. Curvilinear (e.g. tripolar) outputs must set this to

--- a/data/ocean_preprocessing/dataset_validation.py
+++ b/data/ocean_preprocessing/dataset_validation.py
@@ -45,11 +45,14 @@ def require_om4_publication_freshwater_flux(ds: xr.Dataset) -> None:
 
     Shared input validators intentionally accept legacy OM4 and CM4 datasets
     without freshwater flux. New OM4 publications use this narrower invariant.
+    The primary raw source may provide ``wfo`` itself; otherwise callers must
+    supplement it before reaching this boundary.
     """
     if "wfo" not in ds.data_vars:
         raise ValueError(
             "New OM4 publications require freshwater flux variable 'wfo'; "
-            "provide --wfo_source_path when the primary source lacks it"
+            "use a primary raw source that contains it or provide "
+            "--wfo_source_path when the primary source lacks it"
         )
 
 

--- a/data/ocean_preprocessing/dataset_validation.py
+++ b/data/ocean_preprocessing/dataset_validation.py
@@ -40,6 +40,19 @@ def ds_processed_validate(ds_processed: xr.Dataset, deep=False):
         _nan_test_deep(ds_processed)
 
 
+def require_om4_publication_freshwater_flux(ds: xr.Dataset) -> None:
+    """Require ``wfo`` at the new-OM4-publication boundary.
+
+    Shared input validators intentionally accept legacy OM4 and CM4 datasets
+    without freshwater flux. New OM4 publications use this narrower invariant.
+    """
+    if "wfo" not in ds.data_vars:
+        raise ValueError(
+            "New OM4 publications require freshwater flux variable 'wfo'; "
+            "provide --wfo_source_path when the primary source lacks it"
+        )
+
+
 _COMMON_REQUIRED_COORDS = {
     "areacello",
     "dz",

--- a/data/ocean_preprocessing/schema.py
+++ b/data/ocean_preprocessing/schema.py
@@ -5,8 +5,10 @@
 from xarrera import CoordsSchema, DataArraySchema, DatasetSchema  # noqa: E402
 
 OM4_3D_VARS = ("so", "thetao", "uo", "vo")
-OM4_REQUIRED_2D_VARS = ("hfds", "tauuo", "tauvo", "wfo", "zos")
-OM4_OPTIONAL_2D_VARS = ()
+OM4_REQUIRED_2D_VARS = ("hfds", "tauuo", "tauvo", "zos")
+# Legacy averaged OM4 and CM4 datasets do not contain freshwater flux. Keep wfo
+# optional in shared validators; the OM4 publication CLI enforces it separately.
+OM4_OPTIONAL_2D_VARS = ("wfo",)
 
 
 ### Preprocessing Stage

--- a/data/ocean_preprocessing/schema.py
+++ b/data/ocean_preprocessing/schema.py
@@ -5,10 +5,8 @@
 from xarrera import CoordsSchema, DataArraySchema, DatasetSchema  # noqa: E402
 
 OM4_3D_VARS = ("so", "thetao", "uo", "vo")
-OM4_REQUIRED_2D_VARS = ("hfds", "tauuo", "tauvo", "zos")
-# Raw snapshot sources provide wfo directly. Raw averaged sources can acquire it
-# through the validated supplemental-source surgery in gfdl_om4.transplant_wfo.
-OM4_OPTIONAL_2D_VARS = ("wfo",)
+OM4_REQUIRED_2D_VARS = ("hfds", "tauuo", "tauvo", "wfo", "zos")
+OM4_OPTIONAL_2D_VARS = ()
 
 
 ### Preprocessing Stage

--- a/data/ocean_preprocessing/schema.py
+++ b/data/ocean_preprocessing/schema.py
@@ -6,8 +6,8 @@ from xarrera import CoordsSchema, DataArraySchema, DatasetSchema  # noqa: E402
 
 OM4_3D_VARS = ("so", "thetao", "uo", "vo")
 OM4_REQUIRED_2D_VARS = ("hfds", "tauuo", "tauvo", "zos")
-# Keep this policy explicit until the matching averaged-run wfo source in #838
-# is identified. Snapshot sources currently provide wfo; averaged sources do not.
+# Raw snapshot sources provide wfo directly. Raw averaged sources can acquire it
+# through the validated supplemental-source surgery in gfdl_om4.transplant_wfo.
 OM4_OPTIONAL_2D_VARS = ("wfo",)
 
 

--- a/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
+++ b/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
@@ -75,8 +75,8 @@ def select_om4_variables(ds: xr.Dataset) -> xr.Dataset:
     Snapshot archives also contain diagnostic and native-grid fields that the
     averaged archive does not. Passing every compatible source variable through
     would make the published dataset depend accidentally on the source archive's
-    contents. ``wfo`` is retained when available because it is an intentional
-    five-day-mean forcing in the snapshot product.
+    contents. ``wfo`` is required: snapshot archives provide it directly, while
+    averaged archives must first acquire it through :func:`transplant_wfo`.
     """
     available = set(ds.data_vars)
     missing = OM4_REQUIRED_DATA_VARS - available

--- a/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
+++ b/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
@@ -23,6 +23,12 @@ logger = logging.getLogger(__name__)
 
 OM4_REQUIRED_DATA_VARS = frozenset(OM4_3D_VARS + OM4_REQUIRED_2D_VARS)
 OM4_OPTIONAL_DATA_VARS = frozenset(OM4_OPTIONAL_2D_VARS)
+WFO_DIMS = ("time", "yh", "xh")
+FIVE_DAYS_SECONDS = 5 * 24 * 60 * 60
+WFO_SURGERY_ALIGNMENT = (
+    "donor time == recipient time_bnds upper bound; "
+    "donor wfo relabeled to recipient interval-midpoint time"
+)
 
 
 # load supergrid and extract the angles
@@ -82,6 +88,110 @@ def select_om4_variables(ds: xr.Dataset) -> xr.Dataset:
     if ignored:
         logger.info("ignoring undeclared OM4 source variables: %s", sorted(ignored))
     return ds[sorted(selected)]
+
+
+def transplant_wfo(
+    recipient: xr.Dataset, donor: xr.Dataset, *, donor_path: str
+) -> xr.Dataset:
+    """Add five-day-mean ``wfo`` to an averaged OM4 source.
+
+    The averaged archive labels each five-day interval at its midpoint, while
+    the combined snapshot archive labels the same interval at its upper bound.
+    Validate that relationship and the native tracer grid before relabeling the
+    donor data with the recipient's timestamps. The operation remains lazy;
+    data chunks are read only when the preprocessing result is computed.
+    """
+    if "wfo" in recipient:
+        raise ValueError(
+            "OM4 recipient already contains 'wfo'; refusing to overwrite it"
+        )
+    if "wfo" not in donor:
+        raise ValueError("OM4 freshwater-flux donor is missing required variable 'wfo'")
+    if "time_bnds" not in recipient:
+        raise ValueError(
+            "OM4 recipient must provide time_bnds to validate freshwater-flux alignment"
+        )
+
+    wfo = donor["wfo"]
+    if wfo.dims != WFO_DIMS:
+        raise ValueError(f"Donor 'wfo' has dimensions {wfo.dims}; expected {WFO_DIMS}")
+    if "time" not in donor.coords:
+        raise ValueError("OM4 freshwater-flux donor has no time coordinate")
+
+    bounds = recipient["time_bnds"]
+    if bounds.dims != ("time", "nv") or bounds.sizes["nv"] != 2:
+        raise ValueError(
+            "OM4 recipient time_bnds must have dimensions ('time', 'nv') with nv=2"
+        )
+
+    def timedelta_seconds(value) -> float:
+        if hasattr(value, "total_seconds"):
+            return value.total_seconds()
+        return float(value / np.timedelta64(1, "s"))
+
+    starts = bounds.isel(nv=0).values
+    ends = bounds.isel(nv=1).values
+    midpoints = recipient["time"].values
+    interval_seconds = np.array(
+        [timedelta_seconds(end - start) for start, end in zip(starts, ends)]
+    )
+    left_seconds = np.array(
+        [
+            timedelta_seconds(midpoint - start)
+            for midpoint, start in zip(midpoints, starts)
+        ]
+    )
+    right_seconds = np.array(
+        [timedelta_seconds(end - midpoint) for end, midpoint in zip(ends, midpoints)]
+    )
+    if not (
+        np.all(interval_seconds == FIVE_DAYS_SECONDS)
+        and np.array_equal(left_seconds, right_seconds)
+    ):
+        raise ValueError(
+            "OM4 recipient time_bnds must describe centered five-day intervals"
+        )
+
+    for coord in ("xh", "yh"):
+        if coord not in recipient.coords or coord not in donor.coords:
+            raise ValueError(f"Both OM4 stores must provide the {coord!r} coordinate")
+        try:
+            xr.testing.assert_identical(recipient[coord], donor[coord])
+        except AssertionError as error:
+            raise ValueError(
+                f"OM4 freshwater-flux donor {coord!r} grid does not match recipient"
+            ) from error
+
+    interval_ends = bounds.isel(nv=1, drop=True)
+    if not np.array_equal(donor["time"].values, interval_ends.values):
+        raise ValueError(
+            "OM4 freshwater-flux donor timestamps must exactly match the upper "
+            "bounds of the recipient's five-day intervals"
+        )
+
+    if "time: mean" not in wfo.attrs.get("cell_methods", ""):
+        raise ValueError(
+            "Donor 'wfo' is not identified as a time mean in its cell_methods attribute"
+        )
+    expected_attrs = {
+        "standard_name": "water_flux_into_sea_water",
+        "units": "kg m-2 s-1",
+    }
+    for attr, expected in expected_attrs.items():
+        if wfo.attrs.get(attr) != expected:
+            raise ValueError(
+                f"Donor 'wfo' {attr} must be {expected!r}; got {wfo.attrs.get(attr)!r}"
+            )
+
+    transplanted = wfo.assign_coords(time=recipient["time"])
+    result = recipient.assign(wfo=transplanted)
+    result.attrs.update(
+        {
+            "m2lines/wfo_surgery_source": donor_path,
+            "m2lines/wfo_surgery_alignment": WFO_SURGERY_ALIGNMENT,
+        }
+    )
+    return result
 
 
 def vertical_cell_metadata(ds: xr.Dataset) -> tuple[xr.DataArray, xr.DataArray]:
@@ -148,12 +258,26 @@ def vertical_cell_metadata(ds: xr.Dataset) -> tuple[xr.DataArray, xr.DataArray]:
 
 
 def om4_preprocessing(
-    zarr_data_path, nc_grid_path, nc_mosaic_path, fs=fsspec, backend_kwargs=None
+    zarr_data_path,
+    nc_grid_path,
+    nc_mosaic_path,
+    fs=fsspec,
+    backend_kwargs=None,
+    wfo_source_path=None,
 ):
     """OM4 specific preprocessing."""
     ds = xr.open_dataset(
         zarr_data_path, engine="zarr", chunks={}, backend_kwargs=backend_kwargs
     )
+
+    if wfo_source_path is not None:
+        donor = xr.open_dataset(
+            wfo_source_path,
+            engine="zarr",
+            chunks={},
+            backend_kwargs=backend_kwargs,
+        )
+        ds = transplant_wfo(ds, donor, donor_path=wfo_source_path)
 
     ds = select_om4_variables(ds)
     ds = normalize_vertical_coords(ds)
@@ -234,5 +358,12 @@ def om4_preprocessing(
     ds = ds.astype(np.float32)
     # higher precision for the area
     ds = ds.assign_coords(areacello=ds.areacello.astype("float64"))
+    if wfo_source_path is not None:
+        ds.attrs.update(
+            {
+                "m2lines/wfo_surgery_source": wfo_source_path,
+                "m2lines/wfo_surgery_alignment": WFO_SURGERY_ALIGNMENT,
+            }
+        )
     ds_processed_validate(ds)
     return ds

--- a/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
+++ b/data/ocean_preprocessing/simulation_preprocessing/gfdl_om4.py
@@ -75,8 +75,8 @@ def select_om4_variables(ds: xr.Dataset) -> xr.Dataset:
     Snapshot archives also contain diagnostic and native-grid fields that the
     averaged archive does not. Passing every compatible source variable through
     would make the published dataset depend accidentally on the source archive's
-    contents. ``wfo`` is required: snapshot archives provide it directly, while
-    averaged archives must first acquire it through :func:`transplant_wfo`.
+    contents. ``wfo`` is retained when available. The OM4 publication CLI
+    requires it, while this lower-level helper remains usable by legacy CM4.
     """
     available = set(ds.data_vars)
     missing = OM4_REQUIRED_DATA_VARS - available

--- a/data/tests/data.py
+++ b/data/tests/data.py
@@ -102,7 +102,7 @@ def processed_data():
                 ),
                 dims=["time", "y", "x"],
             )
-            for v in ["hfds", "tauuo", "tauvo", "wfo", "zos"]
+            for v in ["hfds", "tauuo", "tauvo", "zos"]
         }
         | {
             v: xr.DataArray(
@@ -223,7 +223,6 @@ def input_data():
                 "hfds",
                 "tauuo",
                 "tauvo",
-                "wfo",
                 "sithick",
                 "siconc",
             ]

--- a/data/tests/data.py
+++ b/data/tests/data.py
@@ -102,7 +102,7 @@ def processed_data():
                 ),
                 dims=["time", "y", "x"],
             )
-            for v in ["hfds", "tauuo", "tauvo", "zos"]
+            for v in ["hfds", "tauuo", "tauvo", "wfo", "zos"]
         }
         | {
             v: xr.DataArray(
@@ -223,6 +223,7 @@ def input_data():
                 "hfds",
                 "tauuo",
                 "tauvo",
+                "wfo",
                 "sithick",
                 "siconc",
             ]

--- a/data/tests/test_data.py
+++ b/data/tests/test_data.py
@@ -12,8 +12,8 @@ from ocean_preprocessing.dataset_validation import (
     ds_input_validate,
     ds_prediction_validate,
     ds_processed_validate,
+    require_om4_publication_freshwater_flux,
 )
-from xarrera import SchemaError
 
 from tests.data import input_data, prediction_data, processed_data  # noqa
 
@@ -22,9 +22,17 @@ def test_processed_data(processed_data):
     ds_processed_validate(processed_data)
 
 
-def test_processed_data_requires_freshwater_flux(processed_data):
-    with pytest.raises(SchemaError, match="wfo"):
-        ds_processed_validate(processed_data.drop_vars("wfo"))
+def test_processed_data_allows_snapshot_water_flux(processed_data):
+    processed_data["wfo"] = processed_data["hfds"]
+    ds_processed_validate(processed_data)
+
+
+def test_new_om4_publication_requires_freshwater_flux(processed_data):
+    with pytest.raises(ValueError, match="publications require.*wfo"):
+        require_om4_publication_freshwater_flux(processed_data)
+
+    processed_data["wfo"] = processed_data["hfds"]
+    require_om4_publication_freshwater_flux(processed_data)
 
 
 def test_input_data(input_data):
@@ -90,13 +98,9 @@ def _flattened_input(*, include_wfo: bool = True) -> xr.Dataset:
     )
 
 
-def test_flattened_input_contract_is_resolution_independent():
-    ds_flattened_input_validate(_flattened_input())
-
-
-def test_flattened_input_contract_requires_freshwater_flux():
-    with pytest.raises(ValueError, match="missing required variables.*wfo"):
-        ds_flattened_input_validate(_flattened_input(include_wfo=False))
+@pytest.mark.parametrize("include_wfo", [False, True])
+def test_flattened_input_contract_is_resolution_independent(include_wfo):
+    ds_flattened_input_validate(_flattened_input(include_wfo=include_wfo))
 
 
 def test_flattened_input_contract_rejects_undeclared_variable():

--- a/data/tests/test_data.py
+++ b/data/tests/test_data.py
@@ -13,6 +13,7 @@ from ocean_preprocessing.dataset_validation import (
     ds_prediction_validate,
     ds_processed_validate,
 )
+from xarrera import SchemaError
 
 from tests.data import input_data, prediction_data, processed_data  # noqa
 
@@ -21,9 +22,9 @@ def test_processed_data(processed_data):
     ds_processed_validate(processed_data)
 
 
-def test_processed_data_allows_snapshot_water_flux(processed_data):
-    processed_data["wfo"] = processed_data["hfds"]
-    ds_processed_validate(processed_data)
+def test_processed_data_requires_freshwater_flux(processed_data):
+    with pytest.raises(SchemaError, match="wfo"):
+        ds_processed_validate(processed_data.drop_vars("wfo"))
 
 
 def test_input_data(input_data):
@@ -89,9 +90,13 @@ def _flattened_input(*, include_wfo: bool = True) -> xr.Dataset:
     )
 
 
-@pytest.mark.parametrize("include_wfo", [False, True])
-def test_flattened_input_contract_is_resolution_independent(include_wfo):
-    ds_flattened_input_validate(_flattened_input(include_wfo=include_wfo))
+def test_flattened_input_contract_is_resolution_independent():
+    ds_flattened_input_validate(_flattened_input())
+
+
+def test_flattened_input_contract_requires_freshwater_flux():
+    with pytest.raises(ValueError, match="missing required variables.*wfo"):
+        ds_flattened_input_validate(_flattened_input(include_wfo=False))
 
 
 def test_flattened_input_contract_rejects_undeclared_variable():

--- a/data/tests/test_data.py
+++ b/data/tests/test_data.py
@@ -28,7 +28,10 @@ def test_processed_data_allows_snapshot_water_flux(processed_data):
 
 
 def test_new_om4_publication_requires_freshwater_flux(processed_data):
-    with pytest.raises(ValueError, match="publications require.*wfo"):
+    with pytest.raises(
+        ValueError,
+        match="publications require.*wfo.*primary raw source.*wfo_source_path",
+    ):
         require_om4_publication_freshwater_flux(processed_data)
 
     processed_data["wfo"] = processed_data["hfds"]

--- a/data/tests/test_simulation_preprocessing.py
+++ b/data/tests/test_simulation_preprocessing.py
@@ -8,6 +8,7 @@ import xarray as xr
 from ocean_preprocessing.simulation_preprocessing.gfdl_om4 import (
     normalize_vertical_coords,
     select_om4_variables,
+    transplant_wfo,
     vertical_cell_metadata,
 )
 
@@ -87,3 +88,101 @@ def test_select_om4_variables_rejects_incomplete_source():
 
     with pytest.raises(ValueError, match="missing required variables.*thetao"):
         select_om4_variables(source)
+
+
+def _wfo_surgery_sources():
+    midpoint = np.array(["1958-01-03T12:00", "1958-01-08T12:00"], dtype="datetime64[m]")
+    interval_end = np.array(
+        ["1958-01-06T00:00", "1958-01-11T00:00"], dtype="datetime64[m]"
+    )
+    xh = [0.25, 0.75]
+    yh = [-0.25, 0.25]
+    recipient = xr.Dataset(
+        {
+            "hfds": (("time", "yh", "xh"), np.ones((2, 2, 2))),
+            "time_bnds": (
+                ("time", "nv"),
+                np.column_stack(
+                    [
+                        np.array(["1958-01-01", "1958-01-06"], dtype="datetime64[m]"),
+                        interval_end,
+                    ]
+                ),
+            ),
+        },
+        coords={"time": midpoint, "xh": xh, "yh": yh},
+    )
+    donor = xr.Dataset(
+        {
+            "wfo": (
+                ("time", "yh", "xh"),
+                np.arange(8, dtype="float32").reshape(2, 2, 2),
+                {
+                    "cell_methods": "area:mean time: mean",
+                    "standard_name": "water_flux_into_sea_water",
+                    "units": "kg m-2 s-1",
+                },
+            )
+        },
+        coords={"time": interval_end, "xh": xh, "yh": yh},
+    )
+    return recipient, donor
+
+
+def test_transplant_wfo_relabels_matching_intervals_and_records_provenance():
+    recipient, donor = _wfo_surgery_sources()
+
+    out = transplant_wfo(recipient, donor, donor_path="s3://example/donor.zarr")
+
+    xr.testing.assert_equal(out.wfo, donor.wfo.assign_coords(time=recipient.time))
+    assert out.time.identical(recipient.time)
+    assert out.attrs["m2lines/wfo_surgery_source"] == "s3://example/donor.zarr"
+    assert "upper bound" in out.attrs["m2lines/wfo_surgery_alignment"]
+
+
+def test_transplant_wfo_rejects_misaligned_intervals():
+    recipient, donor = _wfo_surgery_sources()
+    donor = donor.assign_coords(time=donor.time + np.timedelta64(5, "D"))
+
+    with pytest.raises(ValueError, match="timestamps must exactly match"):
+        transplant_wfo(recipient, donor, donor_path="donor.zarr")
+
+
+def test_transplant_wfo_requires_centered_five_day_recipient_intervals():
+    recipient, donor = _wfo_surgery_sources()
+    recipient["time_bnds"][0, 0] = np.datetime64("1958-01-02")
+
+    with pytest.raises(ValueError, match="centered five-day intervals"):
+        transplant_wfo(recipient, donor, donor_path="donor.zarr")
+
+
+def test_transplant_wfo_rejects_different_native_grid():
+    recipient, donor = _wfo_surgery_sources()
+    donor = donor.assign_coords(xh=[0.5, 1.0])
+
+    with pytest.raises(ValueError, match="'xh' grid does not match"):
+        transplant_wfo(recipient, donor, donor_path="donor.zarr")
+
+
+def test_transplant_wfo_requires_time_mean_metadata():
+    recipient, donor = _wfo_surgery_sources()
+    donor.wfo.attrs["cell_methods"] = "area:mean time: point"
+
+    with pytest.raises(ValueError, match="not identified as a time mean"):
+        transplant_wfo(recipient, donor, donor_path="donor.zarr")
+
+
+def test_transplant_wfo_requires_cf_identity_metadata():
+    recipient, donor = _wfo_surgery_sources()
+    donor.wfo.attrs["units"] = "m s-1"
+
+    with pytest.raises(ValueError, match="units must be 'kg m-2 s-1'"):
+        transplant_wfo(recipient, donor, donor_path="donor.zarr")
+
+
+def test_transplant_wfo_refuses_to_overwrite_existing_data():
+    recipient, donor = _wfo_surgery_sources()
+    recipient["wfo"] = recipient.hfds
+
+    with pytest.raises(ValueError, match="refusing to overwrite"):
+        transplant_wfo(recipient, donor, donor_path="donor.zarr")

--- a/data/tests/test_simulation_preprocessing.py
+++ b/data/tests/test_simulation_preprocessing.py
@@ -60,7 +60,17 @@ def test_averaged_vertical_cell_metadata_matches_processed_schema_dtype():
 
 
 def _om4_source(*extra_vars: str) -> xr.Dataset:
-    required = ["hfds", "so", "tauuo", "tauvo", "thetao", "uo", "vo", "zos"]
+    required = [
+        "hfds",
+        "so",
+        "tauuo",
+        "tauvo",
+        "thetao",
+        "uo",
+        "vo",
+        "wfo",
+        "zos",
+    ]
     return xr.Dataset(
         {name: ("time", np.ones(2)) for name in [*required, *extra_vars]},
         coords={"time": [0, 1]},
@@ -68,7 +78,7 @@ def _om4_source(*extra_vars: str) -> xr.Dataset:
 
 
 def test_select_om4_variables_retains_declared_snapshot_forcing():
-    out = select_om4_variables(_om4_source("wfo", "hfgeou", "wet"))
+    out = select_om4_variables(_om4_source("hfgeou", "wet"))
 
     assert set(out.data_vars) == {
         "hfds",
@@ -90,7 +100,8 @@ def test_select_om4_variables_rejects_incomplete_source():
         select_om4_variables(source)
 
 
-def _wfo_surgery_sources():
+@pytest.fixture
+def wfo_surgery_sources():
     midpoint = np.array(["1958-01-03T12:00", "1958-01-08T12:00"], dtype="datetime64[m]")
     interval_end = np.array(
         ["1958-01-06T00:00", "1958-01-11T00:00"], dtype="datetime64[m]"
@@ -129,8 +140,10 @@ def _wfo_surgery_sources():
     return recipient, donor
 
 
-def test_transplant_wfo_relabels_matching_intervals_and_records_provenance():
-    recipient, donor = _wfo_surgery_sources()
+def test_transplant_wfo_relabels_matching_intervals_and_records_provenance(
+    wfo_surgery_sources,
+):
+    recipient, donor = wfo_surgery_sources
 
     out = transplant_wfo(recipient, donor, donor_path="s3://example/donor.zarr")
 
@@ -140,48 +153,50 @@ def test_transplant_wfo_relabels_matching_intervals_and_records_provenance():
     assert "upper bound" in out.attrs["m2lines/wfo_surgery_alignment"]
 
 
-def test_transplant_wfo_rejects_misaligned_intervals():
-    recipient, donor = _wfo_surgery_sources()
+def test_transplant_wfo_rejects_misaligned_intervals(wfo_surgery_sources):
+    recipient, donor = wfo_surgery_sources
     donor = donor.assign_coords(time=donor.time + np.timedelta64(5, "D"))
 
     with pytest.raises(ValueError, match="timestamps must exactly match"):
         transplant_wfo(recipient, donor, donor_path="donor.zarr")
 
 
-def test_transplant_wfo_requires_centered_five_day_recipient_intervals():
-    recipient, donor = _wfo_surgery_sources()
+def test_transplant_wfo_requires_centered_five_day_recipient_intervals(
+    wfo_surgery_sources,
+):
+    recipient, donor = wfo_surgery_sources
     recipient["time_bnds"][0, 0] = np.datetime64("1958-01-02")
 
     with pytest.raises(ValueError, match="centered five-day intervals"):
         transplant_wfo(recipient, donor, donor_path="donor.zarr")
 
 
-def test_transplant_wfo_rejects_different_native_grid():
-    recipient, donor = _wfo_surgery_sources()
+def test_transplant_wfo_rejects_different_native_grid(wfo_surgery_sources):
+    recipient, donor = wfo_surgery_sources
     donor = donor.assign_coords(xh=[0.5, 1.0])
 
     with pytest.raises(ValueError, match="'xh' grid does not match"):
         transplant_wfo(recipient, donor, donor_path="donor.zarr")
 
 
-def test_transplant_wfo_requires_time_mean_metadata():
-    recipient, donor = _wfo_surgery_sources()
+def test_transplant_wfo_requires_time_mean_metadata(wfo_surgery_sources):
+    recipient, donor = wfo_surgery_sources
     donor.wfo.attrs["cell_methods"] = "area:mean time: point"
 
     with pytest.raises(ValueError, match="not identified as a time mean"):
         transplant_wfo(recipient, donor, donor_path="donor.zarr")
 
 
-def test_transplant_wfo_requires_cf_identity_metadata():
-    recipient, donor = _wfo_surgery_sources()
+def test_transplant_wfo_requires_cf_identity_metadata(wfo_surgery_sources):
+    recipient, donor = wfo_surgery_sources
     donor.wfo.attrs["units"] = "m s-1"
 
     with pytest.raises(ValueError, match="units must be 'kg m-2 s-1'"):
         transplant_wfo(recipient, donor, donor_path="donor.zarr")
 
 
-def test_transplant_wfo_refuses_to_overwrite_existing_data():
-    recipient, donor = _wfo_surgery_sources()
+def test_transplant_wfo_refuses_to_overwrite_existing_data(wfo_surgery_sources):
+    recipient, donor = wfo_surgery_sources
     recipient["wfo"] = recipient.hfds
 
     with pytest.raises(ValueError, match="refusing to overwrite"):

--- a/data/tests/test_slurm_harness.py
+++ b/data/tests/test_slurm_harness.py
@@ -22,8 +22,8 @@ def _resolve_variant(variant: str) -> subprocess.CompletedProcess[str]:
             "bash",
             "-c",
             'source "$1"; resolve_om4_data_variant || exit $?; '
-            'printf "%s|%s|%s" "$DATA_VARIANT" "$OM4_SOURCE_STORE" '
-            '"$OM4_OUTPUT_SUFFIX"',
+            'printf "%s|%s|%s|%s" "$DATA_VARIANT" "$OM4_SOURCE_STORE" '
+            '"$OM4_OUTPUT_SUFFIX" "$OM4_WFO_SOURCE_STORE"',
             "bash",
             str(VARIANT_SCRIPT),
         ],
@@ -37,8 +37,12 @@ def _resolve_variant(variant: str) -> subprocess.CompletedProcess[str]:
 @pytest.mark.parametrize(
     ("variant", "expected"),
     [
-        ("averaged", "averaged|om4_5daily.zarr|"),
-        ("snapshots", "snapshots|om4_5daily_snapshots.zarr|_snapshots"),
+        ("averaged", "averaged|om4_5daily.zarr||"),
+        (
+            "averaged_with_wfo",
+            "averaged_with_wfo|om4_5daily.zarr|_with_wfo|om4_5daily_snapshots.zarr",
+        ),
+        ("snapshots", "snapshots|om4_5daily_snapshots.zarr|_snapshots|"),
     ],
 )
 def test_om4_data_variant(variant, expected):

--- a/data/tests/test_slurm_harness.py
+++ b/data/tests/test_slurm_harness.py
@@ -37,10 +37,9 @@ def _resolve_variant(variant: str) -> subprocess.CompletedProcess[str]:
 @pytest.mark.parametrize(
     ("variant", "expected"),
     [
-        ("averaged", "averaged|om4_5daily.zarr||"),
         (
-            "averaged_with_wfo",
-            "averaged_with_wfo|om4_5daily.zarr|_with_wfo|om4_5daily_snapshots.zarr",
+            "averaged",
+            "averaged|om4_5daily.zarr||om4_5daily_snapshots.zarr",
         ),
         ("snapshots", "snapshots|om4_5daily_snapshots.zarr|_snapshots|"),
     ],

--- a/docs/data.md
+++ b/docs/data.md
@@ -505,6 +505,7 @@ output-directory suffix:
 | `DATA_VARIANT` | raw source | derived output directory |
 | --- | --- | --- |
 | `averaged` (default) | `om4_5daily.zarr` | `om4_<resolution>/` |
+| `averaged_with_wfo` | `om4_5daily.zarr` + snapshot-source `wfo` | `om4_<resolution>_with_wfo/` |
 | `snapshots` | `om4_5daily_snapshots.zarr` | `om4_<resolution>_snapshots/` |
 
 For the snapshot source, `thetao`, `so`, `uo`, `vo`, and `zos` are instantaneous
@@ -512,6 +513,15 @@ values at 00:00 UTC every five days. The forcings `hfds`, `tauuo`, `tauvo`, and
 `wfo` are five-day means; this is intentional because the ocean state integrates
 their fluxes over the transition. The processed snapshot datasets retain `wfo`
 and the standard emulator inputs, while ignoring undeclared source diagnostics.
+
+The `averaged_with_wfo` variant performs the freshwater-flux surgery without
+creating a duplicate raw archive. It preserves the state and forcing variables
+from `om4_5daily.zarr`, then lazily transplants only the five-day-mean `wfo` from
+`om4_5daily_snapshots.zarr`. Before relabeling the donor values with the
+recipient's midpoint timestamps, the job requires identical native grids and
+requires each donor timestamp to equal the upper bound of its recipient
+interval. The published store records the donor and alignment rule in
+`m2lines/wfo_surgery_source` and `m2lines/wfo_surgery_alignment`.
 
 ```bash
 export OUTPUT_BASE="s3://m2lines-pubs/Samudra/v$(date +%Y-%m)"
@@ -533,6 +543,20 @@ RESOLUTION=quarterdeg N_WORKERS=16 \
 for R in twodeg onedeg onedeg_filter halfdeg quarterdeg; do
   RESOLUTION=$R sbatch scripts/slurm_make_norm_om4.sbatch
 done
+```
+
+To produce freshwater-augmented averaged datasets, set the variant for both
+preprocessing and normalization jobs:
+
+```bash
+export OUTPUT_BASE="s3://m2lines-pubs/Samudra/v$(date +%Y-%m)"
+export DATA_VARIANT=averaged_with_wfo
+
+RESOLUTION=onedeg EXTRA_ARGS="--small_run --dry_run" \
+  sbatch --cpus-per-task=16 --mem=64G --time=00:30:00 scripts/slurm_preprocess_om4.sbatch
+
+RESOLUTION=onedeg \
+  sbatch --cpus-per-task=64 --mem=480G --time=12:00:00 scripts/slurm_preprocess_om4.sbatch
 ```
 
 To produce the four unfiltered snapshot scales in a new monthly namespace, keep

--- a/docs/data.md
+++ b/docs/data.md
@@ -353,6 +353,7 @@ python -m ocean_preprocessing om4 \
    "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/gaussian_grid_180_by_360.zarr" \
+    --wfo_source_path="s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr" \
     --output_path="s3://m2lines-pubs/Samudra/v$(date "+%Y-%m")/om4_onedeg/OM4.zarr" \
     --skip_spatial_filtering \
     --skip_validation \
@@ -378,6 +379,7 @@ python -m ocean_preprocessing om4 \
    "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/gaussian_grid_180_by_360.zarr" \
+    --wfo_source_path="s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr" \
     --output_path="s3://m2lines-pubs/Samudra/v$(date '+%Y-%m')/om4_onedeg_filter/OM4.zarr" \
     --skip_validation \
     --cluster="coiled" \
@@ -401,6 +403,7 @@ python -m ocean_preprocessing om4 \
    "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/gaussian_grid_360_by_720.zarr" \
+    --wfo_source_path="s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr" \
     --output_path="s3://m2lines-pubs/Samudra/v$(date '+%Y-%m')/om4_halfdeg/OM4.zarr" \
     --skip_spatial_filtering \
     --skip_validation \
@@ -425,6 +428,7 @@ python -m ocean_preprocessing om4 \
    "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/ocean_hgrid.zarr" \
    "s3://m2lines-pubs/Samudra/raw/grids/gaussian_grid_720_by_1440.zarr" \
+    --wfo_source_path="s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr" \
     --output_path="s3://m2lines-pubs/Samudra/v$(date '+%Y-%m')/om4_quarterdeg/OM4.zarr" \
     --skip_spatial_filtering \
     --skip_validation \
@@ -504,8 +508,7 @@ output-directory suffix:
 
 | `DATA_VARIANT` | raw source | derived output directory |
 | --- | --- | --- |
-| `averaged` (default) | `om4_5daily.zarr` | `om4_<resolution>/` |
-| `averaged_with_wfo` | `om4_5daily.zarr` + snapshot-source `wfo` | `om4_<resolution>_with_wfo/` |
+| `averaged` (default) | `om4_5daily.zarr` + snapshot-source `wfo` | `om4_<resolution>/` |
 | `snapshots` | `om4_5daily_snapshots.zarr` | `om4_<resolution>_snapshots/` |
 
 For the snapshot source, `thetao`, `so`, `uo`, `vo`, and `zos` are instantaneous
@@ -514,10 +517,11 @@ values at 00:00 UTC every five days. The forcings `hfds`, `tauuo`, `tauvo`, and
 their fluxes over the transition. The processed snapshot datasets retain `wfo`
 and the standard emulator inputs, while ignoring undeclared source diagnostics.
 
-The `averaged_with_wfo` variant performs the freshwater-flux surgery without
+The default `averaged` variant performs the freshwater-flux surgery without
 creating a duplicate raw archive. It preserves the state and forcing variables
 from `om4_5daily.zarr`, then lazily transplants only the five-day-mean `wfo` from
-`om4_5daily_snapshots.zarr`. Before relabeling the donor values with the
+`om4_5daily_snapshots.zarr`. Thus, new canonical averaged datasets always
+contain freshwater forcing. Before relabeling the donor values with the
 recipient's midpoint timestamps, the job requires identical native grids and
 requires each donor timestamp to equal the upper bound of its recipient
 interval. The published store records the donor and alignment rule in
@@ -545,12 +549,12 @@ for R in twodeg onedeg onedeg_filter halfdeg quarterdeg; do
 done
 ```
 
-To produce freshwater-augmented averaged datasets, set the variant for both
-preprocessing and normalization jobs:
+The default commands above produce freshwater-augmented averaged datasets. The
+variant may also be set explicitly for preprocessing and normalization jobs:
 
 ```bash
 export OUTPUT_BASE="s3://m2lines-pubs/Samudra/v$(date +%Y-%m)"
-export DATA_VARIANT=averaged_with_wfo
+export DATA_VARIANT=averaged
 
 RESOLUTION=onedeg EXTRA_ARGS="--small_run --dry_run" \
   sbatch --cpus-per-task=16 --mem=64G --time=00:30:00 scripts/slurm_preprocess_om4.sbatch

--- a/scripts/om4_data_variant.sh
+++ b/scripts/om4_data_variant.sh
@@ -13,11 +13,6 @@ resolve_om4_data_variant() {
     averaged)
       OM4_SOURCE_STORE="om4_5daily.zarr"
       OM4_OUTPUT_SUFFIX=""
-      OM4_WFO_SOURCE_STORE=""
-      ;;
-    averaged_with_wfo)
-      OM4_SOURCE_STORE="om4_5daily.zarr"
-      OM4_OUTPUT_SUFFIX="_with_wfo"
       OM4_WFO_SOURCE_STORE="om4_5daily_snapshots.zarr"
       ;;
     snapshots)
@@ -27,7 +22,7 @@ resolve_om4_data_variant() {
       ;;
     *)
       echo "ERROR: unknown DATA_VARIANT='${DATA_VARIANT}'." >&2
-      echo "Expected one of: averaged | averaged_with_wfo | snapshots." >&2
+      echo "Expected one of: averaged | snapshots." >&2
       return 2
       ;;
   esac

--- a/scripts/om4_data_variant.sh
+++ b/scripts/om4_data_variant.sh
@@ -13,14 +13,21 @@ resolve_om4_data_variant() {
     averaged)
       OM4_SOURCE_STORE="om4_5daily.zarr"
       OM4_OUTPUT_SUFFIX=""
+      OM4_WFO_SOURCE_STORE=""
+      ;;
+    averaged_with_wfo)
+      OM4_SOURCE_STORE="om4_5daily.zarr"
+      OM4_OUTPUT_SUFFIX="_with_wfo"
+      OM4_WFO_SOURCE_STORE="om4_5daily_snapshots.zarr"
       ;;
     snapshots)
       OM4_SOURCE_STORE="om4_5daily_snapshots.zarr"
       OM4_OUTPUT_SUFFIX="_snapshots"
+      OM4_WFO_SOURCE_STORE=""
       ;;
     *)
       echo "ERROR: unknown DATA_VARIANT='${DATA_VARIANT}'." >&2
-      echo "Expected one of: averaged | snapshots." >&2
+      echo "Expected one of: averaged | averaged_with_wfo | snapshots." >&2
       return 2
       ;;
   esac

--- a/scripts/slurm_preprocess_om4.sbatch
+++ b/scripts/slurm_preprocess_om4.sbatch
@@ -25,9 +25,13 @@
 #                  ${OUTPUT_BASE}/om4_${RESOLUTION}${variant_suffix}/OM4.zarr
 #                e.g. export OUTPUT_BASE="s3://m2lines-pubs/Samudra/v$(date +%Y-%m)"
 #   RAW_ROOT     source prefix (default: s3://m2lines-pubs/Samudra/raw)
-#   DATA_VARIANT averaged (default) | snapshots; selects the raw store and adds
-#                `_snapshots` to derived output directories for snapshot data.
+#   DATA_VARIANT averaged (default) | averaged_with_wfo | snapshots; selects
+#                the raw store and derived output-directory suffix. The
+#                averaged_with_wfo variant transplants the five-day-mean wfo
+#                from the combined snapshot source after strict alignment QC.
 #   DATA_PATH    exact raw OM4 source; overrides DATA_VARIANT's source selection.
+#   WFO_SOURCE_PATH exact supplemental wfo store; defaults to the combined
+#                snapshot source for DATA_VARIANT=averaged_with_wfo.
 #   PREPROC_ENV  conda env name (default: ocean_preprocessing)
 #   CONDA_SH     path to conda.sh (autodetected from $CONDA_EXE / common dirs)
 #   REPO_DIR     repo checkout (default: $SLURM_SUBMIT_DIR); we cd here so the
@@ -117,6 +121,10 @@ esac
 RAW_ROOT="${RAW_ROOT:-s3://m2lines-pubs/Samudra/raw}"
 resolve_om4_data_variant
 DATA_PATH="${DATA_PATH:-${RAW_ROOT}/${OM4_SOURCE_STORE}}"
+WFO_SOURCE_PATH="${WFO_SOURCE_PATH:-}"
+if [[ -z "${WFO_SOURCE_PATH}" && -n "${OM4_WFO_SOURCE_STORE}" ]]; then
+  WFO_SOURCE_PATH="${RAW_ROOT}/${OM4_WFO_SOURCE_STORE}"
+fi
 NATIVE_GRID_PATH="${RAW_ROOT}/ocean_static_no_mask_table.zarr"
 MOSAIC_PATH="${RAW_ROOT}/grids/ocean_hgrid.zarr"
 TARGET_GRID_PATH="${RAW_ROOT}/grids/${GRID}.zarr"
@@ -192,6 +200,9 @@ fi
 if [[ "${SKIP_VALIDATION:-1}" == "1" ]]; then
   pipeline_flags+=(--skip_validation)
 fi
+if [[ -n "${WFO_SOURCE_PATH}" ]]; then
+  pipeline_flags+=(--wfo_source_path="${WFO_SOURCE_PATH}")
+fi
 
 # --- Run ---------------------------------------------------------------------
 # Enter the selected data subproject before invoking Python. The conda env is
@@ -203,6 +214,7 @@ cd "${REPO_DIR}/data"
 echo "Resolution:   ${RESOLUTION}"
 echo "Data variant: ${DATA_VARIANT}"
 echo "Data path:    ${DATA_PATH}"
+echo "wfo source:   ${WFO_SOURCE_PATH:-none}"
 echo "Target grid:  ${GRID}  (filter: ${FILTER_FLAG:-on})"
 echo "Raw root:     ${RAW_ROOT}"
 echo "Output path:  ${OUTPUT_PATH}"

--- a/scripts/slurm_preprocess_om4.sbatch
+++ b/scripts/slurm_preprocess_om4.sbatch
@@ -25,13 +25,13 @@
 #                  ${OUTPUT_BASE}/om4_${RESOLUTION}${variant_suffix}/OM4.zarr
 #                e.g. export OUTPUT_BASE="s3://m2lines-pubs/Samudra/v$(date +%Y-%m)"
 #   RAW_ROOT     source prefix (default: s3://m2lines-pubs/Samudra/raw)
-#   DATA_VARIANT averaged (default) | averaged_with_wfo | snapshots; selects
-#                the raw store and derived output-directory suffix. The
-#                averaged_with_wfo variant transplants the five-day-mean wfo
-#                from the combined snapshot source after strict alignment QC.
+#   DATA_VARIANT averaged (default) | snapshots; selects the raw store and
+#                derived output-directory suffix. The averaged variant adds
+#                five-day-mean wfo from the combined snapshot source after
+#                strict alignment QC.
 #   DATA_PATH    exact raw OM4 source; overrides DATA_VARIANT's source selection.
 #   WFO_SOURCE_PATH exact supplemental wfo store; defaults to the combined
-#                snapshot source for DATA_VARIANT=averaged_with_wfo.
+#                snapshot source for DATA_VARIANT=averaged.
 #   PREPROC_ENV  conda env name (default: ocean_preprocessing)
 #   CONDA_SH     path to conda.sh (autodetected from $CONDA_EXE / common dirs)
 #   REPO_DIR     repo checkout (default: $SLURM_SUBMIT_DIR); we cd here so the


### PR DESCRIPTION
## Summary

- add a lazy `wfo` transplant from the combined snapshot archive into the averaged OM4 source
- validate five-day interval alignment, midpoint/end timestamp semantics, native grid identity, CF variable identity, and non-overwrite behavior before merging
- make `wfo` required by the OM4 processed-data contract, so a pipeline can no longer publish new data without freshwater forcing
- make the canonical `averaged` Torch variant perform the transplant automatically while retaining the standard `om4_<resolution>` output namespace
- preserve donor and alignment provenance in processed stores and document local/Torch reproduction

## Scientific validation

Will Gregory's proposed `hfds` comparison was run over all 4,745 records using the public 2-degree derivatives. The 65-year climatologies correlate at 0.99979, mean bias is -0.0017 W/m2, and longitudinal wavenumber-1 amplitude is 0.0106 W/m2. The difference does not show the fixed day/night pattern expected from instantaneous forcing.

The code's alignment contract was also exercised directly against:

- `s3://m2lines-pubs/Samudra/raw/om4_5daily.zarr`
- `s3://m2lines-pubs/Samudra/raw/om4_5daily_snapshots.zarr`

All 4,745 donor timestamps match the recipient interval upper bounds, and the native tracer grids match exactly.

## Tests

- `PYTHONPATH=data pytest -q data/tests` (51 passed, 1 skipped)
- `uvx pre-commit run --all-files`
- live public-OSN metadata/alignment smoke test
