### PR TITLE
Parallelize search across local and allocated GPUs

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -89,6 +89,15 @@ visible at the same paths on every node. Alpha is x86_64; an environment built
 for Alpha must not be reused on Empire's ARM systems. Use an architecture-
 appropriate environment or multi-architecture container for those systems.
 
+Before relying on allocation-wide pooling, verify that the target cluster
+admits concurrent exclusive job steps. Some Slurm installations serialize
+nested `srun` steps even when their GPU, CPU, and memory requests do not
+overlap. From an interactive allocation, a useful smoke check is to start two
+exclusive one-GPU `srun` commands concurrently and confirm with `squeue --steps`
+that both enter `RUNNING`. This scheduler policy cannot be inferred from the
+allocation environment. On a single node where the batch shell sees every
+allocated GPU, use the `local` executor if concurrent job steps are unavailable.
+
 The Slurm-allocation executor is synchronous: the allocation remains active
 through every rung, and a worker failure stops promotion after the other
 running workers have exited. For separately queued, resumable jobs and

--- a/docs/search.md
+++ b/docs/search.md
@@ -36,11 +36,50 @@ python -m samudra.search path/to/search.yaml
 
 The runner submits the first rung and fixed baselines. On Slurm, dependent
 controller jobs automatically rank completed candidates and submit each later
-rung; users do not manually advance the search. For a local laptop or Colab
-notebook run, include `search/local.yaml` instead of `search/torch.yaml`;
-candidates then run sequentially in the current environment. Each local task
-gets a fresh multiton scope and releases cached CUDA memory before the next
-candidate, so W&B and normalization state cannot leak between models.
+rung; users do not manually advance the search. For a local laptop,
+workstation, Colab notebook, or an already allocated Slurm job, include
+`search/local.yaml` instead of `search/torch.yaml`. The local executor runs one
+isolated candidate process per visible GPU. With no GPU it runs candidates
+sequentially in the controller process. Fixed anchors and rung zero are
+co-scheduled, and each later rung uses up to the same GPU capacity. Set
+`executor.max_concurrent` only when memory, CPU, storage, or service limits
+require using fewer than the available GPUs.
+
+### Use a whole Slurm allocation for independent trials
+
+When `SLURM_JOB_ID` is present, the local executor treats the current job as a
+resource pool. It launches concurrent, exclusive `srun` steps with one task and
+one GPU each. On a homogeneous multi-node allocation it derives total capacity
+from `SLURM_GPUS` or from `SLURM_NNODES * SLURM_GPUS_ON_NODE`; CPU cores are
+divided evenly among GPUs when Slurm exposes `SLURM_CPUS_ON_NODE`.
+
+For example, Empire AI Alpha+ has eight H100 or H200 GPUs per HGX node. A batch
+allocation shaped like the following lets sixteen candidates occupy two nodes:
+
+```bash
+#!/bin/bash
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:8
+#SBATCH --cpus-per-task=<all CPUs on one node>
+#SBATCH --mem=0
+
+module load <modules-needed-by-samudra>
+source <shared-x86-environment>/bin/activate
+python -m samudra.search path/to/search.yaml
+```
+
+Launch the controller directly from the batch script, as above. Do not wrap it
+in `srun`: the executor needs to create its own job steps. The source tree,
+Python executable, candidate configs, data, and output directory must be
+visible at the same paths on every node. Alpha is x86_64; an environment built
+for Alpha must not be reused on Empire's ARM systems. Use an architecture-
+appropriate environment or multi-architecture container for those systems.
+
+The local executor is synchronous: the allocation remains active through every
+rung, and a worker failure stops promotion after the other running workers have
+exited. For separately queued, resumable jobs and controller dependencies, use
+the regular Slurm executor instead.
 
 Clusters that expose the container runtime through environment modules should
 set `executor.apptainer_module` to the exact loadable module name (for example,

--- a/docs/search.md
+++ b/docs/search.md
@@ -45,6 +45,13 @@ rung zero are co-scheduled, and each later rung uses up to the same GPU
 capacity. Set `executor.max_concurrent` only when memory, CPU, storage, or
 service limits require using fewer than the available GPUs.
 
+Every candidate remains a single-GPU experiment in every rung. The executor
+does not assign extra GPUs to survivors as the candidate population shrinks:
+doing so would change global batch size and optimizer steps per epoch midway
+through a resumed training trajectory. Adaptive multi-GPU trials need an
+explicit policy for batch size, learning rate, and epoch accounting rather than
+being inferred from momentarily idle hardware.
+
 ### Use a whole Slurm allocation for independent trials
 
 Include `search/slurm-allocation.yaml` to treat an existing Slurm job as a

--- a/docs/search.md
+++ b/docs/search.md
@@ -59,7 +59,10 @@ resource pool. This distinct executor launches concurrent, exclusive `srun`
 steps with one task and one GPU each. On a homogeneous multi-node allocation it
 derives total capacity from `SLURM_GPUS` or from
 `SLURM_NNODES * SLURM_GPUS_ON_NODE`; CPU cores are divided evenly among GPUs
-when Slurm exposes `SLURM_CPUS_ON_NODE`. It fails loudly outside an allocation.
+when Slurm exposes `SLURM_CPUS_ON_NODE`. Step memory is divided proportionally
+from `SLURM_MEM_PER_NODE` (or `SLURM_MEM_PER_CPU`) so one worker does not reserve
+the entire allocation's memory and serialize the GPU pool. It fails loudly
+outside an allocation.
 
 For example, Empire AI Alpha+ has eight H100 or H200 GPUs per HGX node. A batch
 allocation shaped like the following lets sixteen candidates occupy two nodes:

--- a/docs/search.md
+++ b/docs/search.md
@@ -37,21 +37,22 @@ python -m samudra.search path/to/search.yaml
 The runner submits the first rung and fixed baselines. On Slurm, dependent
 controller jobs automatically rank completed candidates and submit each later
 rung; users do not manually advance the search. For a local laptop,
-workstation, Colab notebook, or an already allocated Slurm job, include
-`search/local.yaml` instead of `search/torch.yaml`. The local executor runs one
-isolated candidate process per visible GPU. With no GPU it runs candidates
-sequentially in the controller process. Fixed anchors and rung zero are
-co-scheduled, and each later rung uses up to the same GPU capacity. Set
-`executor.max_concurrent` only when memory, CPU, storage, or service limits
-require using fewer than the available GPUs.
+workstation, or Colab notebook, include `search/local.yaml` instead of
+`search/torch.yaml`. The local executor runs one isolated candidate process per
+visible GPU and never interprets scheduler environment variables. With no GPU
+it runs candidates sequentially in the controller process. Fixed anchors and
+rung zero are co-scheduled, and each later rung uses up to the same GPU
+capacity. Set `executor.max_concurrent` only when memory, CPU, storage, or
+service limits require using fewer than the available GPUs.
 
 ### Use a whole Slurm allocation for independent trials
 
-When `SLURM_JOB_ID` is present, the local executor treats the current job as a
-resource pool. It launches concurrent, exclusive `srun` steps with one task and
-one GPU each. On a homogeneous multi-node allocation it derives total capacity
-from `SLURM_GPUS` or from `SLURM_NNODES * SLURM_GPUS_ON_NODE`; CPU cores are
-divided evenly among GPUs when Slurm exposes `SLURM_CPUS_ON_NODE`.
+Include `search/slurm-allocation.yaml` to treat an existing Slurm job as a
+resource pool. This distinct executor launches concurrent, exclusive `srun`
+steps with one task and one GPU each. On a homogeneous multi-node allocation it
+derives total capacity from `SLURM_GPUS` or from
+`SLURM_NNODES * SLURM_GPUS_ON_NODE`; CPU cores are divided evenly among GPUs
+when Slurm exposes `SLURM_CPUS_ON_NODE`. It fails loudly outside an allocation.
 
 For example, Empire AI Alpha+ has eight H100 or H200 GPUs per HGX node. A batch
 allocation shaped like the following lets sixteen candidates occupy two nodes:
@@ -76,10 +77,10 @@ visible at the same paths on every node. Alpha is x86_64; an environment built
 for Alpha must not be reused on Empire's ARM systems. Use an architecture-
 appropriate environment or multi-architecture container for those systems.
 
-The local executor is synchronous: the allocation remains active through every
-rung, and a worker failure stops promotion after the other running workers have
-exited. For separately queued, resumable jobs and controller dependencies, use
-the regular Slurm executor instead.
+The Slurm-allocation executor is synchronous: the allocation remains active
+through every rung, and a worker failure stops promotion after the other
+running workers have exited. For separately queued, resumable jobs and
+controller dependencies, use the regular Slurm executor instead.
 
 Clusters that expose the container runtime through environment modules should
 set `executor.apptainer_module` to the exact loadable module name (for example,

--- a/docs/search.md
+++ b/docs/search.md
@@ -317,11 +317,13 @@ boundary with a schema error instead of producing a later key error.
 ## W&B
 
 Each candidate uses the unique search run ID as its W&B group and receives the
-tags `search`, the stable search name, the run ID, and the candidate name. This
-makes repeated trials separately filterable while preserving a stable tag for
-cross-run comparisons. Search identity, rung, objective, epoch budget,
-executor, job ID, parent checkpoint, and the public artifact root are stored
-under `config.experiment.search`.
+tags `search`, the stable search name, and the candidate name. The timestamped
+run ID is deliberately omitted from tags because W&B limits tags to 64
+characters; it remains available as the group and in structured search
+metadata. This makes repeated trials separately filterable while preserving a
+stable tag for cross-run comparisons. Search identity, rung, objective, epoch
+budget, executor, job ID, parent checkpoint, and the public artifact root are
+stored under `config.experiment.search`.
 Promoted rungs resume the same W&B run from the checkpoint, preserving one
 continuous learning curve per candidate.
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -40,10 +40,12 @@ rung; users do not manually advance the search. For a local laptop,
 workstation, or Colab notebook, include `search/local.yaml` instead of
 `search/torch.yaml`. The local executor runs one isolated candidate process per
 visible GPU and never interprets scheduler environment variables. With no GPU
-it runs candidates sequentially in the controller process. Fixed anchors and
-rung zero are co-scheduled, and each later rung uses up to the same GPU
-capacity. Set `executor.max_concurrent` only when memory, CPU, storage, or
-service limits require using fewer than the available GPUs.
+it runs candidates sequentially in the controller process. It is also the
+simplest choice inside a single-node Slurm allocation when the batch shell sees
+all allocated GPUs; use `slurm_allocation` when trials must reach other nodes.
+Fixed anchors and rung zero are co-scheduled, and each later rung uses up to the
+same GPU capacity. Set `executor.max_concurrent` only when memory, CPU, storage,
+or service limits require using fewer than the available GPUs.
 
 Every candidate remains a single-GPU experiment in every rung. The executor
 does not assign extra GPUs to survivors as the candidate population shrinks:
@@ -60,7 +62,7 @@ steps with one task and one GPU each. On a homogeneous multi-node allocation it
 derives total capacity from `SLURM_GPUS` or from
 `SLURM_NNODES * SLURM_GPUS_ON_NODE`; CPU cores are divided evenly among GPUs
 when Slurm exposes `SLURM_CPUS_ON_NODE`. Step memory is divided proportionally
-from `SLURM_MEM_PER_NODE` (or `SLURM_MEM_PER_CPU`) so one worker does not reserve
+from `SLURM_MEM_PER_NODE` when Slurm exposes it, so one worker does not reserve
 the entire allocation's memory and serialize the GPU pool. It fails loudly
 outside an allocation.
 

--- a/src/samudra/backend.py
+++ b/src/samudra/backend.py
@@ -55,15 +55,19 @@ def init_train_backend(
         case "auto" if torch.cuda.is_available():
             logger.info("auto backend detected CUDA")
             device = torch.device("cuda")
-            try:
-                dist_cfg = init_distributed_mode()
-                logger.info("succeeded in initializing distributed mode")
-            except RuntimeError as e:
-                logger.info(
-                    f"Failed to initialize distributed mode, running on single GPU.",
-                    exc_info=e,
-                )
+            if os.environ.get("SAMUDRA_DISABLE_DISTRIBUTED") == "1":
+                logger.info("distributed initialization disabled for this worker")
                 dist_cfg = None
+            else:
+                try:
+                    dist_cfg = init_distributed_mode()
+                    logger.info("succeeded in initializing distributed mode")
+                except RuntimeError as e:
+                    logger.info(
+                        "Failed to initialize distributed mode, running on single GPU.",
+                        exc_info=e,
+                    )
+                    dist_cfg = None
         case "auto":
             logger.warning(
                 "auto backend: cuda not found, using CPU. " + _cuda_diagnostics()

--- a/src/samudra/configs/search/local.yaml
+++ b/src/samudra/configs/search/local.yaml
@@ -4,3 +4,5 @@
 
 type: local
 output_dir: .LOCAL/searches
+# By default, use every visible GPU (including GPUs across a Slurm allocation).
+# max_concurrent: 4

--- a/src/samudra/configs/search/local.yaml
+++ b/src/samudra/configs/search/local.yaml
@@ -4,5 +4,5 @@
 
 type: local
 output_dir: .LOCAL/searches
-# By default, use every visible GPU (including GPUs across a Slurm allocation).
+# By default, use every GPU visible to the current machine.
 # max_concurrent: 4

--- a/src/samudra/configs/search/slurm-allocation.yaml
+++ b/src/samudra/configs/search/slurm-allocation.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+type: slurm_allocation
+output_dir: .LOCAL/searches
+# By default, use every GPU in the current Slurm allocation.
+# max_concurrent: 8

--- a/src/samudra/search/config.py
+++ b/src/samudra/search/config.py
@@ -55,6 +55,7 @@ class SuccessiveHalvingConfig(BaseConfig):
 class LocalExecutorConfig(BaseConfig):
     type: Literal["local"] = "local"
     output_dir: Path
+    max_concurrent: int | None = Field(default=None, ge=1)
     dry_run: bool = False
 
 

--- a/src/samudra/search/config.py
+++ b/src/samudra/search/config.py
@@ -59,6 +59,13 @@ class LocalExecutorConfig(BaseConfig):
     dry_run: bool = False
 
 
+class SlurmAllocationExecutorConfig(BaseConfig):
+    type: Literal["slurm_allocation"] = "slurm_allocation"
+    output_dir: Path
+    max_concurrent: int | None = Field(default=None, ge=1)
+    dry_run: bool = False
+
+
 class SlurmExecutorConfig(BaseConfig):
     type: Literal["slurm"] = "slurm"
     output_dir: Path
@@ -87,7 +94,7 @@ class SlurmExecutorConfig(BaseConfig):
 
 
 ExecutorConfig = Annotated[
-    LocalExecutorConfig | SlurmExecutorConfig,
+    LocalExecutorConfig | SlurmAllocationExecutorConfig | SlurmExecutorConfig,
     Field(discriminator="type"),
 ]
 AlgorithmConfig = SuccessiveHalvingConfig
@@ -152,7 +159,7 @@ class SearchConfig(TopLevelConfig):
             raise ValueError("executor.time_by_rung must have one value per rung")
         if isinstance(self.executor, SlurmExecutorConfig) and self.allow_dirty:
             raise ValueError(
-                "allow_dirty is only supported by the local executor; Slurm "
-                "searches require immutable code provenance"
+                "allow_dirty is not supported by the submitting Slurm executor; "
+                "queued searches require immutable code provenance"
             )
         return self

--- a/src/samudra/search/executors/__init__.py
+++ b/src/samudra/search/executors/__init__.py
@@ -5,5 +5,11 @@
 from samudra.search.executors.base import Executor
 from samudra.search.executors.local import LocalExecutor
 from samudra.search.executors.slurm import SlurmExecutor
+from samudra.search.executors.slurm_allocation import SlurmAllocationExecutor
 
-__all__ = ["Executor", "LocalExecutor", "SlurmExecutor"]
+__all__ = [
+    "Executor",
+    "LocalExecutor",
+    "SlurmAllocationExecutor",
+    "SlurmExecutor",
+]

--- a/src/samudra/search/executors/base.py
+++ b/src/samudra/search/executors/base.py
@@ -17,6 +17,11 @@ class Executor(ABC):
     def __init__(self, search: "SuccessiveHalving") -> None:
         self.search = search
 
+    def submit_initial(self, state: dict[str, Any]) -> None:
+        """Submit fixed anchors and the first successive-halving rung."""
+        self.submit_anchors(state)
+        self.submit_rung(self.search.read_state(), 0)
+
     @abstractmethod
     def submit_anchors(self, state: dict[str, Any]) -> None: ...
 

--- a/src/samudra/search/executors/local.py
+++ b/src/samudra/search/executors/local.py
@@ -2,35 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Resource-aware execution in the current machine or Slurm allocation."""
+"""Run independent search trials on one local machine."""
 
-from __future__ import annotations
-
-import gc
 import os
 import subprocess
-import sys
-from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
 from queue import SimpleQueue
-from typing import Any
 
 import torch
 
 from samudra.search.config import LocalExecutorConfig
-from samudra.search.executors.base import Executor
-from samudra.utils.multiton import MultitonScope
+from samudra.search.executors.pool import PoolExecutor, Task
 
 
-@dataclass(frozen=True)
-class _Task:
-    rung: int
-    task: int
-    anchor: bool
-
-
-def _visible_devices() -> list[str]:
+def visible_devices() -> list[str]:
     """Return CUDA identifiers that can be assigned to child processes."""
     configured = os.environ.get("CUDA_VISIBLE_DEVICES")
     if configured is not None:
@@ -40,40 +24,9 @@ def _visible_devices() -> list[str]:
     return [str(index) for index in range(torch.cuda.device_count())]
 
 
-def _positive_int_environment(name: str) -> int | None:
-    value = os.environ.get(name)
-    if value is None:
-        return None
-    try:
-        parsed = int(value)
-    except ValueError:
-        return None
-    return parsed if parsed > 0 else None
+class LocalExecutor(PoolExecutor):
+    """Use each GPU visible to the current machine as a worker slot."""
 
-
-def _slurm_gpu_count() -> int:
-    """Best available count for a homogeneous Slurm GPU allocation."""
-    total = _positive_int_environment("SLURM_GPUS")
-    if total is not None:
-        return total
-    nodes = _positive_int_environment("SLURM_NNODES") or 1
-    per_node = _positive_int_environment("SLURM_GPUS_ON_NODE")
-    if per_node is None:
-        per_node = len(_visible_devices())
-    if per_node < 1:
-        raise RuntimeError("The Slurm allocation does not expose any GPUs")
-    return nodes * per_node
-
-
-def _slurm_cpus_per_gpu() -> int:
-    cpus = _positive_int_environment("SLURM_CPUS_ON_NODE")
-    gpus = _positive_int_environment("SLURM_GPUS_ON_NODE")
-    if cpus is None or gpus is None:
-        return 1
-    return max(1, cpus // gpus)
-
-
-class LocalExecutor(Executor):
     @property
     def config(self) -> LocalExecutorConfig:
         config = self.search.config.executor
@@ -81,159 +34,34 @@ class LocalExecutor(Executor):
             raise TypeError("LocalExecutor requires a LocalExecutorConfig")
         return config
 
-    def submit_initial(self, state: dict[str, Any]) -> None:
-        """Co-schedule fixed anchors and rung zero across all GPUs."""
-        tasks = [
-            _Task(len(self.search.rungs) - 1, task, True)
-            for task, _ in enumerate(state["anchors"]["candidates"])
-        ]
-        tasks.extend(
-            _Task(0, task, False)
-            for task, _ in enumerate(state["rungs"][0]["candidates"])
-        )
-        state["anchors"]["job_id"] = "local"
-        state["rungs"][0]["job_id"] = "local"
-        state["status"] = "running"
-        self.search.write_state(state)
-        if self.config.dry_run:
-            return
-        self._run_tasks(tasks)
-        self.search.advance(0)
+    @property
+    def job_id(self) -> str:
+        return "local"
 
-    def submit_anchors(self, state: dict[str, Any]) -> None:
-        candidates = state["anchors"]["candidates"]
-        state["anchors"]["job_id"] = "local"
-        self.search.write_state(state)
-        if self.config.dry_run:
-            return
-        self._run_tasks(
-            [
-                _Task(len(self.search.rungs) - 1, task, True)
-                for task, _ in enumerate(candidates)
-            ]
-        )
-
-    def submit_rung(self, state: dict[str, Any], rung: int) -> None:
-        candidates = state["rungs"][rung]["candidates"]
-        state["rungs"][rung]["job_id"] = "local"
-        state["status"] = "running"
-        self.search.write_state(state)
-        if self.config.dry_run:
-            return
-        self._run_tasks([_Task(rung, task, False) for task, _ in enumerate(candidates)])
-        self.search.advance(rung)
-
-    def _run_tasks(self, tasks: list[_Task]) -> None:
+    def _run_tasks(self, tasks: list[Task]) -> None:
         if not tasks:
             return
-        if "SLURM_JOB_ID" in os.environ:
-            step = os.environ.get("SLURM_STEP_ID")
-            if step not in {None, "", "batch", "extern"}:
-                raise RuntimeError(
-                    "Cannot launch local search workers from inside an existing "
-                    "Slurm job step. Run the search directly in an sbatch script "
-                    "or an salloc shell, rather than with `srun python`."
-                )
-            concurrency = _slurm_gpu_count()
-            runner: Callable[[_Task], None] = self._run_slurm_task
-        else:
-            devices = _visible_devices()
-            if not devices:
-                for task in tasks:
-                    self._run_in_process(task)
-                return
-            concurrency = len(devices)
-            available_devices: SimpleQueue[str] = SimpleQueue()
-            for device in devices:
-                available_devices.put(device)
-
-            def run_on_available_device(task: _Task) -> None:
-                device = available_devices.get()
-                try:
-                    self._run_device_task(task, device)
-                finally:
-                    available_devices.put(device)
-
-            self._run_concurrently(
-                tasks,
-                min(self._limit(concurrency), len(tasks)),
-                run_on_available_device,
-            )
+        devices = visible_devices()
+        if not devices:
+            for task in tasks:
+                self._run_in_process(task)
             return
+
+        available_devices: SimpleQueue[str] = SimpleQueue()
+        for device in devices:
+            available_devices.put(device)
+
+        def run_on_available_device(task: Task) -> None:
+            device = available_devices.get()
+            try:
+                environment = self._worker_environment()
+                environment["CUDA_VISIBLE_DEVICES"] = device
+                subprocess.run(self._worker_command(task), check=True, env=environment)
+            finally:
+                available_devices.put(device)
 
         self._run_concurrently(
             tasks,
-            min(self._limit(concurrency), len(tasks)),
-            runner,
+            min(self._limit(len(devices)), len(tasks)),
+            run_on_available_device,
         )
-
-    def _limit(self, available: int) -> int:
-        if self.config.max_concurrent is None:
-            return available
-        return min(available, self.config.max_concurrent)
-
-    @staticmethod
-    def _run_concurrently(
-        items: list[Any], concurrency: int, runner: Callable[[Any], None]
-    ) -> None:
-        errors: list[Exception] = []
-        with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
-            futures = [pool.submit(runner, item) for item in items]
-            for future in as_completed(futures):
-                try:
-                    future.result()
-                except Exception as error:
-                    errors.append(error)
-        if errors:
-            raise errors[0]
-
-    def _worker_command(self, task: _Task) -> list[str]:
-        return [
-            sys.executable,
-            "-m",
-            "samudra.search.worker",
-            "task",
-            str(self.search.config_path),
-            str(self.search.state_path),
-            str(task.rung),
-            str(task.task),
-            *(["--anchor"] if task.anchor else []),
-        ]
-
-    @staticmethod
-    def _worker_environment() -> dict[str, str]:
-        environment = os.environ.copy()
-        environment["SAMUDRA_DISABLE_DISTRIBUTED"] = "1"
-        for name in ("RANK", "LOCAL_RANK", "WORLD_SIZE", "MASTER_ADDR", "MASTER_PORT"):
-            environment.pop(name, None)
-        return environment
-
-    def _run_device_task(self, task: _Task, device: str) -> None:
-        environment = self._worker_environment()
-        environment["CUDA_VISIBLE_DEVICES"] = device
-        subprocess.run(self._worker_command(task), check=True, env=environment)
-
-    def _run_slurm_task(self, task: _Task) -> None:
-        subprocess.run(
-            [
-                "srun",
-                "--exclusive",
-                "--exact",
-                "--nodes=1",
-                "--ntasks=1",
-                f"--cpus-per-task={_slurm_cpus_per_gpu()}",
-                "--gpus-per-task=1",
-                "--gpu-bind=single:1",
-                *self._worker_command(task),
-            ],
-            check=True,
-            env=self._worker_environment(),
-        )
-
-    def _run_in_process(self, task: _Task) -> None:
-        """Keep CPU/notebook execution lightweight and backwards compatible."""
-        try:
-            with MultitonScope():
-                self.search.train_task(task.rung, task.task, anchor=task.anchor)
-        finally:
-            gc.collect()

--- a/src/samudra/search/executors/local.py
+++ b/src/samudra/search/executors/local.py
@@ -2,44 +2,238 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Synchronous local search execution."""
+"""Resource-aware execution in the current machine or Slurm allocation."""
+
+from __future__ import annotations
 
 import gc
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from queue import SimpleQueue
 from typing import Any
 
 import torch
 
+from samudra.search.config import LocalExecutorConfig
 from samudra.search.executors.base import Executor
 from samudra.utils.multiton import MultitonScope
 
 
+@dataclass(frozen=True)
+class _Task:
+    rung: int
+    task: int
+    anchor: bool
+
+
+def _visible_devices() -> list[str]:
+    """Return CUDA identifiers that can be assigned to child processes."""
+    configured = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if configured is not None:
+        if configured.strip() in {"", "-1"}:
+            return []
+        return [value.strip() for value in configured.split(",") if value.strip()]
+    return [str(index) for index in range(torch.cuda.device_count())]
+
+
+def _positive_int_environment(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _slurm_gpu_count() -> int:
+    """Best available count for a homogeneous Slurm GPU allocation."""
+    total = _positive_int_environment("SLURM_GPUS")
+    if total is not None:
+        return total
+    nodes = _positive_int_environment("SLURM_NNODES") or 1
+    per_node = _positive_int_environment("SLURM_GPUS_ON_NODE")
+    if per_node is None:
+        per_node = len(_visible_devices())
+    if per_node < 1:
+        raise RuntimeError("The Slurm allocation does not expose any GPUs")
+    return nodes * per_node
+
+
+def _slurm_cpus_per_gpu() -> int:
+    cpus = _positive_int_environment("SLURM_CPUS_ON_NODE")
+    gpus = _positive_int_environment("SLURM_GPUS_ON_NODE")
+    if cpus is None or gpus is None:
+        return 1
+    return max(1, cpus // gpus)
+
+
 class LocalExecutor(Executor):
+    @property
+    def config(self) -> LocalExecutorConfig:
+        config = self.search.config.executor
+        if not isinstance(config, LocalExecutorConfig):
+            raise TypeError("LocalExecutor requires a LocalExecutorConfig")
+        return config
+
+    def submit_initial(self, state: dict[str, Any]) -> None:
+        """Co-schedule fixed anchors and rung zero across all GPUs."""
+        tasks = [
+            _Task(len(self.search.rungs) - 1, task, True)
+            for task, _ in enumerate(state["anchors"]["candidates"])
+        ]
+        tasks.extend(
+            _Task(0, task, False)
+            for task, _ in enumerate(state["rungs"][0]["candidates"])
+        )
+        state["anchors"]["job_id"] = "local"
+        state["rungs"][0]["job_id"] = "local"
+        state["status"] = "running"
+        self.search.write_state(state)
+        if self.config.dry_run:
+            return
+        self._run_tasks(tasks)
+        self.search.advance(0)
+
     def submit_anchors(self, state: dict[str, Any]) -> None:
         candidates = state["anchors"]["candidates"]
         state["anchors"]["job_id"] = "local"
         self.search.write_state(state)
-        if self.search.config.executor.dry_run:
+        if self.config.dry_run:
             return
-        for task, _ in enumerate(candidates):
-            self._run_task(len(self.search.rungs) - 1, task, anchor=True)
+        self._run_tasks(
+            [
+                _Task(len(self.search.rungs) - 1, task, True)
+                for task, _ in enumerate(candidates)
+            ]
+        )
 
     def submit_rung(self, state: dict[str, Any], rung: int) -> None:
         candidates = state["rungs"][rung]["candidates"]
         state["rungs"][rung]["job_id"] = "local"
         state["status"] = "running"
         self.search.write_state(state)
-        if self.search.config.executor.dry_run:
+        if self.config.dry_run:
             return
-        for task, _ in enumerate(candidates):
-            self._run_task(rung, task, anchor=False)
+        self._run_tasks([_Task(rung, task, False) for task, _ in enumerate(candidates)])
         self.search.advance(rung)
 
-    def _run_task(self, rung: int, task: int, *, anchor: bool) -> None:
-        """Run one candidate with isolated process-global training state."""
+    def _run_tasks(self, tasks: list[_Task]) -> None:
+        if not tasks:
+            return
+        if "SLURM_JOB_ID" in os.environ:
+            step = os.environ.get("SLURM_STEP_ID")
+            if step not in {None, "", "batch", "extern"}:
+                raise RuntimeError(
+                    "Cannot launch local search workers from inside an existing "
+                    "Slurm job step. Run the search directly in an sbatch script "
+                    "or an salloc shell, rather than with `srun python`."
+                )
+            concurrency = _slurm_gpu_count()
+            runner: Callable[[_Task], None] = self._run_slurm_task
+        else:
+            devices = _visible_devices()
+            if not devices:
+                for task in tasks:
+                    self._run_in_process(task)
+                return
+            concurrency = len(devices)
+            available_devices: SimpleQueue[str] = SimpleQueue()
+            for device in devices:
+                available_devices.put(device)
+
+            def run_on_available_device(task: _Task) -> None:
+                device = available_devices.get()
+                try:
+                    self._run_device_task(task, device)
+                finally:
+                    available_devices.put(device)
+
+            self._run_concurrently(
+                tasks,
+                min(self._limit(concurrency), len(tasks)),
+                run_on_available_device,
+            )
+            return
+
+        self._run_concurrently(
+            tasks,
+            min(self._limit(concurrency), len(tasks)),
+            runner,
+        )
+
+    def _limit(self, available: int) -> int:
+        if self.config.max_concurrent is None:
+            return available
+        return min(available, self.config.max_concurrent)
+
+    @staticmethod
+    def _run_concurrently(
+        items: list[Any], concurrency: int, runner: Callable[[Any], None]
+    ) -> None:
+        errors: list[Exception] = []
+        with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+            futures = [pool.submit(runner, item) for item in items]
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception as error:
+                    errors.append(error)
+        if errors:
+            raise errors[0]
+
+    def _worker_command(self, task: _Task) -> list[str]:
+        return [
+            sys.executable,
+            "-m",
+            "samudra.search.worker",
+            "task",
+            str(self.search.config_path),
+            str(self.search.state_path),
+            str(task.rung),
+            str(task.task),
+            *(["--anchor"] if task.anchor else []),
+        ]
+
+    @staticmethod
+    def _worker_environment() -> dict[str, str]:
+        environment = os.environ.copy()
+        environment["SAMUDRA_DISABLE_DISTRIBUTED"] = "1"
+        for name in ("RANK", "LOCAL_RANK", "WORLD_SIZE", "MASTER_ADDR", "MASTER_PORT"):
+            environment.pop(name, None)
+        return environment
+
+    def _run_device_task(self, task: _Task, device: str) -> None:
+        environment = self._worker_environment()
+        environment["CUDA_VISIBLE_DEVICES"] = device
+        subprocess.run(self._worker_command(task), check=True, env=environment)
+
+    def _run_slurm_task(self, task: _Task) -> None:
+        subprocess.run(
+            [
+                "srun",
+                "--exclusive",
+                "--exact",
+                "--nodes=1",
+                "--ntasks=1",
+                f"--cpus-per-task={_slurm_cpus_per_gpu()}",
+                "--gpus-per-task=1",
+                "--gpu-bind=single:1",
+                *self._worker_command(task),
+            ],
+            check=True,
+            env=self._worker_environment(),
+        )
+
+    def _run_in_process(self, task: _Task) -> None:
+        """Keep CPU/notebook execution lightweight and backwards compatible."""
         try:
             with MultitonScope():
-                self.search.train_task(rung, task, anchor=anchor)
+                self.search.train_task(task.rung, task.task, anchor=task.anchor)
         finally:
             gc.collect()
-            if torch.cuda.is_available():
-                torch.cuda.empty_cache()

--- a/src/samudra/search/executors/local.py
+++ b/src/samudra/search/executors/local.py
@@ -4,14 +4,19 @@
 
 """Run independent search trials on one local machine."""
 
+from __future__ import annotations
+
 import os
 import subprocess
 from queue import SimpleQueue
+from typing import TYPE_CHECKING, cast
 
 import torch
 
-from samudra.search.config import LocalExecutorConfig
 from samudra.search.executors.pool import PoolExecutor, Task
+
+if TYPE_CHECKING:
+    from samudra.search.config import LocalExecutorConfig
 
 
 def visible_devices() -> list[str]:
@@ -30,9 +35,9 @@ class LocalExecutor(PoolExecutor):
     @property
     def config(self) -> LocalExecutorConfig:
         config = self.search.config.executor
-        if not isinstance(config, LocalExecutorConfig):
+        if config.type != "local":
             raise TypeError("LocalExecutor requires a LocalExecutorConfig")
-        return config
+        return cast("LocalExecutorConfig", config)
 
     @property
     def job_id(self) -> str:

--- a/src/samudra/search/executors/pool.py
+++ b/src/samudra/search/executors/pool.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared orchestration for executors that pool independent workers."""
+
+from __future__ import annotations
+
+import gc
+import os
+import sys
+from abc import abstractmethod
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from samudra.search.executors.base import Executor
+from samudra.utils.multiton import MultitonScope
+
+
+class PoolConfig(Protocol):
+    max_concurrent: int | None
+    dry_run: bool
+
+
+@dataclass(frozen=True)
+class Task:
+    rung: int
+    task: int
+    anchor: bool
+
+
+class PoolExecutor(Executor):
+    """Run independent trials using slots supplied by a concrete executor."""
+
+    @property
+    @abstractmethod
+    def config(self) -> PoolConfig: ...
+
+    @property
+    @abstractmethod
+    def job_id(self) -> str: ...
+
+    def submit_initial(self, state: dict[str, Any]) -> None:
+        """Co-schedule fixed anchors and rung zero across available slots."""
+        tasks = [
+            Task(len(self.search.rungs) - 1, task, True)
+            for task, _ in enumerate(state["anchors"]["candidates"])
+        ]
+        tasks.extend(
+            Task(0, task, False)
+            for task, _ in enumerate(state["rungs"][0]["candidates"])
+        )
+        state["anchors"]["job_id"] = self.job_id
+        state["rungs"][0]["job_id"] = self.job_id
+        state["status"] = "running"
+        self.search.write_state(state)
+        if self.config.dry_run:
+            return
+        self._run_tasks(tasks)
+        self.search.advance(0)
+
+    def submit_anchors(self, state: dict[str, Any]) -> None:
+        candidates = state["anchors"]["candidates"]
+        state["anchors"]["job_id"] = self.job_id
+        self.search.write_state(state)
+        if self.config.dry_run:
+            return
+        self._run_tasks(
+            [
+                Task(len(self.search.rungs) - 1, task, True)
+                for task, _ in enumerate(candidates)
+            ]
+        )
+
+    def submit_rung(self, state: dict[str, Any], rung: int) -> None:
+        candidates = state["rungs"][rung]["candidates"]
+        state["rungs"][rung]["job_id"] = self.job_id
+        state["status"] = "running"
+        self.search.write_state(state)
+        if self.config.dry_run:
+            return
+        self._run_tasks([Task(rung, task, False) for task, _ in enumerate(candidates)])
+        self.search.advance(rung)
+
+    @abstractmethod
+    def _run_tasks(self, tasks: list[Task]) -> None: ...
+
+    def _limit(self, available: int) -> int:
+        if self.config.max_concurrent is None:
+            return available
+        return min(available, self.config.max_concurrent)
+
+    @staticmethod
+    def _run_concurrently(
+        items: list[Task], concurrency: int, runner: Callable[[Task], None]
+    ) -> None:
+        errors: list[Exception] = []
+        with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
+            futures = [pool.submit(runner, item) for item in items]
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception as error:
+                    errors.append(error)
+        if errors:
+            raise errors[0]
+
+    def _worker_command(self, task: Task) -> list[str]:
+        return [
+            sys.executable,
+            "-m",
+            "samudra.search.worker",
+            "task",
+            str(self.search.config_path),
+            str(self.search.state_path),
+            str(task.rung),
+            str(task.task),
+            *(["--anchor"] if task.anchor else []),
+        ]
+
+    @staticmethod
+    def _worker_environment() -> dict[str, str]:
+        environment = os.environ.copy()
+        environment["SAMUDRA_DISABLE_DISTRIBUTED"] = "1"
+        for name in ("RANK", "LOCAL_RANK", "WORLD_SIZE", "MASTER_ADDR", "MASTER_PORT"):
+            environment.pop(name, None)
+        return environment
+
+    def _run_in_process(self, task: Task) -> None:
+        """Run a CPU task with isolated process-global training state."""
+        try:
+            with MultitonScope():
+                self.search.train_task(task.rung, task.task, anchor=task.anchor)
+        finally:
+            gc.collect()

--- a/src/samudra/search/executors/pool.py
+++ b/src/samudra/search/executors/pool.py
@@ -11,7 +11,7 @@ import os
 import sys
 from abc import abstractmethod
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -97,13 +97,32 @@ class PoolExecutor(Executor):
         items: list[Task], concurrency: int, runner: Callable[[Task], None]
     ) -> None:
         errors: list[Exception] = []
-        with ThreadPoolExecutor(max_workers=max(1, concurrency)) as pool:
-            futures = [pool.submit(runner, item) for item in items]
-            for future in as_completed(futures):
-                try:
-                    future.result()
-                except Exception as error:
-                    errors.append(error)
+        pending_items = iter(items)
+        worker_count = max(1, concurrency)
+        with ThreadPoolExecutor(max_workers=worker_count) as pool:
+            futures: set[Future[None]] = set()
+            for item in pending_items:
+                futures.add(pool.submit(runner, item))
+                if len(futures) == worker_count:
+                    break
+
+            while futures:
+                completed, futures = wait(futures, return_when=FIRST_COMPLETED)
+                for future in completed:
+                    try:
+                        future.result()
+                    except Exception as error:
+                        errors.append(error)
+                if errors:
+                    for future in futures:
+                        future.cancel()
+                    break
+                for _ in completed:
+                    try:
+                        item = next(pending_items)
+                    except StopIteration:
+                        break
+                    futures.add(pool.submit(runner, item))
         if errors:
             raise errors[0]
 

--- a/src/samudra/search/executors/slurm_allocation.py
+++ b/src/samudra/search/executors/slurm_allocation.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run independent search trials inside an existing Slurm allocation."""
+
+import os
+import subprocess
+
+from samudra.search.config import SlurmAllocationExecutorConfig
+from samudra.search.executors.pool import PoolExecutor, Task
+
+
+def _positive_int_environment(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def allocation_gpu_count() -> int:
+    """Return the GPU count for a homogeneous Slurm allocation."""
+    total = _positive_int_environment("SLURM_GPUS")
+    if total is not None:
+        return total
+    nodes = _positive_int_environment("SLURM_NNODES") or 1
+    per_node = _positive_int_environment("SLURM_GPUS_ON_NODE")
+    if per_node is None:
+        raise RuntimeError(
+            "Cannot determine allocation GPU capacity: Slurm did not set "
+            "SLURM_GPUS or SLURM_GPUS_ON_NODE"
+        )
+    return nodes * per_node
+
+
+def cpus_per_gpu() -> int:
+    cpus = _positive_int_environment("SLURM_CPUS_ON_NODE")
+    gpus = _positive_int_environment("SLURM_GPUS_ON_NODE")
+    if cpus is None or gpus is None:
+        return 1
+    return max(1, cpus // gpus)
+
+
+class SlurmAllocationExecutor(PoolExecutor):
+    """Use exclusive one-GPU job steps within the current allocation."""
+
+    @property
+    def config(self) -> SlurmAllocationExecutorConfig:
+        config = self.search.config.executor
+        if not isinstance(config, SlurmAllocationExecutorConfig):
+            raise TypeError(
+                "SlurmAllocationExecutor requires a SlurmAllocationExecutorConfig"
+            )
+        return config
+
+    @property
+    def job_id(self) -> str:
+        return os.environ.get("SLURM_JOB_ID", "slurm-allocation")
+
+    def _run_tasks(self, tasks: list[Task]) -> None:
+        if not tasks:
+            return
+        if "SLURM_JOB_ID" not in os.environ:
+            raise RuntimeError(
+                "The slurm_allocation executor must run inside a Slurm allocation"
+            )
+        step = os.environ.get("SLURM_STEP_ID")
+        if step not in {None, "", "batch", "extern"}:
+            raise RuntimeError(
+                "Cannot launch allocation workers from inside an existing Slurm "
+                "job step. Run the search directly in an sbatch script or an "
+                "salloc shell, rather than with `srun python`."
+            )
+        concurrency = min(self._limit(allocation_gpu_count()), len(tasks))
+        self._run_concurrently(tasks, concurrency, self._run_slurm_task)
+
+    def _run_slurm_task(self, task: Task) -> None:
+        subprocess.run(
+            [
+                "srun",
+                "--exclusive",
+                "--exact",
+                "--nodes=1",
+                "--ntasks=1",
+                f"--cpus-per-task={cpus_per_gpu()}",
+                "--gpus-per-task=1",
+                "--gpu-bind=single:1",
+                *self._worker_command(task),
+            ],
+            check=True,
+            env=self._worker_environment(),
+        )

--- a/src/samudra/search/executors/slurm_allocation.py
+++ b/src/samudra/search/executors/slurm_allocation.py
@@ -4,11 +4,16 @@
 
 """Run independent search trials inside an existing Slurm allocation."""
 
+from __future__ import annotations
+
 import os
 import subprocess
+from typing import TYPE_CHECKING, cast
 
-from samudra.search.config import SlurmAllocationExecutorConfig
 from samudra.search.executors.pool import PoolExecutor, Task
+
+if TYPE_CHECKING:
+    from samudra.search.config import SlurmAllocationExecutorConfig
 
 
 def _positive_int_environment(name: str) -> int | None:
@@ -51,11 +56,11 @@ class SlurmAllocationExecutor(PoolExecutor):
     @property
     def config(self) -> SlurmAllocationExecutorConfig:
         config = self.search.config.executor
-        if not isinstance(config, SlurmAllocationExecutorConfig):
+        if config.type != "slurm_allocation":
             raise TypeError(
                 "SlurmAllocationExecutor requires a SlurmAllocationExecutorConfig"
             )
-        return config
+        return cast("SlurmAllocationExecutorConfig", config)
 
     @property
     def job_id(self) -> str:

--- a/src/samudra/search/executors/slurm_allocation.py
+++ b/src/samudra/search/executors/slurm_allocation.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from typing import TYPE_CHECKING, cast
 
@@ -20,10 +21,10 @@ def _positive_int_environment(name: str) -> int | None:
     value = os.environ.get(name)
     if value is None:
         return None
-    try:
-        parsed = int(value)
-    except ValueError:
+    match = re.fullmatch(r"\s*(\d+)(?:\([^)]*\))?\s*", value)
+    if match is None:
         return None
+    parsed = int(match.group(1))
     return parsed if parsed > 0 else None
 
 

--- a/src/samudra/search/executors/slurm_allocation.py
+++ b/src/samudra/search/executors/slurm_allocation.py
@@ -50,6 +50,21 @@ def cpus_per_gpu() -> int:
     return max(1, cpus // gpus)
 
 
+def step_memory_arguments(*, gpus: int) -> list[str]:
+    """Request the task's proportional share of node memory, when known.
+
+    Without an explicit step memory request, Slurm may assign the entire batch
+    allocation's memory to the first exclusive step and serialize otherwise
+    independent GPU workers.
+    """
+    memory_per_node = _positive_int_environment("SLURM_MEM_PER_NODE")
+    allocated_gpus = _positive_int_environment("SLURM_GPUS_ON_NODE")
+    if memory_per_node is None or allocated_gpus is None:
+        return []
+    memory = max(1, memory_per_node * gpus // allocated_gpus)
+    return [f"--mem={memory}M"]
+
+
 class SlurmAllocationExecutor(PoolExecutor):
     """Use exclusive one-GPU job steps within the current allocation."""
 
@@ -93,6 +108,7 @@ class SlurmAllocationExecutor(PoolExecutor):
                 "--ntasks=1",
                 f"--cpus-per-task={cpus_per_gpu()}",
                 "--gpus-per-task=1",
+                *step_memory_arguments(gpus=1),
                 "--gpu-bind=single:1",
                 *self._worker_command(task),
             ],

--- a/src/samudra/search/successive_halving.py
+++ b/src/samudra/search/successive_halving.py
@@ -201,8 +201,9 @@ class SuccessiveHalving:
                 and self.config.executor.rung0_probe
             )
             if not gate_anchors:
-                self.executor.submit_anchors(state)
-            self.executor.submit_rung(self.read_state(), 0)
+                self.executor.submit_initial(state)
+            else:
+                self.executor.submit_rung(self.read_state(), 0)
         except Exception as error:
             state = self.read_state()
             state["status"] = "failed"

--- a/src/samudra/search/successive_halving.py
+++ b/src/samudra/search/successive_halving.py
@@ -333,9 +333,7 @@ class SuccessiveHalving:
             train_config.experiment.wandb.mode = "disabled"
         tags = train_config.experiment.wandb.tags or []
         train_config.experiment.wandb.tags = list(
-            dict.fromkeys(
-                [*tags, "search", self.slug, self.run_id, resource_slug(name)]
-            )
+            dict.fromkeys([*tags, "search", self.slug, resource_slug(name)])
         )
         train_config.prepare_output_dirs()
         handle_logging(train_config.debug, train_config.experiment.output_dir)

--- a/src/samudra/search/successive_halving.py
+++ b/src/samudra/search/successive_halving.py
@@ -27,7 +27,12 @@ from samudra.search.config import (
     SlurmExecutorConfig,
     resource_slug,
 )
-from samudra.search.executors import Executor, LocalExecutor, SlurmExecutor
+from samudra.search.executors import (
+    Executor,
+    LocalExecutor,
+    SlurmAllocationExecutor,
+    SlurmExecutor,
+)
 from samudra.search.report import write_search_report
 from samudra.search.state import SearchState
 from samudra.train import Trainer
@@ -43,6 +48,7 @@ from samudra.utils.training_summary import (
 CHECKPOINT = Path("saved_nets/ckpt.pt")
 EXECUTORS: dict[str, type[Executor]] = {
     "local": LocalExecutor,
+    "slurm_allocation": SlurmAllocationExecutor,
     "slurm": SlurmExecutor,
 }
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from samudra.backend import init_train_backend
+
+
+def test_search_worker_auto_backend_does_not_initialize_ddp(monkeypatch):
+    monkeypatch.setenv("SAMUDRA_DISABLE_DISTRIBUTED", "1")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        "samudra.backend.init_distributed_mode",
+        lambda: (_ for _ in ()).throw(AssertionError("DDP must remain disabled")),
+    )
+    monkeypatch.setattr("samudra.backend.set_device", lambda device: None)
+
+    device, distributed = init_train_backend("auto")
+
+    assert device == torch.device("cuda")
+    assert distributed is None

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -372,12 +372,11 @@ def test_start_records_and_publishes_submission_failure(tmp_path, monkeypatch):
         },
     )
     search = search_config.build()
-    monkeypatch.setattr(search.executor, "submit_anchors", lambda state: None)
 
-    def fail_submission(state, rung):
+    def fail_submission(state):
         raise RuntimeError("scheduler unavailable")
 
-    monkeypatch.setattr(search.executor, "submit_rung", fail_submission)
+    monkeypatch.setattr(search.executor, "submit_initial", fail_submission)
 
     with pytest.raises(RuntimeError, match="scheduler unavailable"):
         search.start()
@@ -641,6 +640,91 @@ def test_local_executor_runs_tasks_then_advances(tmp_path, monkeypatch):
         ("train", 0, 1, False),
         ("advance", 0),
     ]
+
+
+def test_local_executor_coschedules_anchors_and_first_rung(tmp_path, monkeypatch):
+    search = config(tmp_path).build()
+    search.search_dir.mkdir(parents=True)
+    state = search_state(search, status="prepared")
+    state["anchors"]["candidates"] = ["anchor"]
+    state["rungs"][0]["candidates"] = ["a", "b"]
+    search.write_state(state)
+    batches = []
+    monkeypatch.setattr(
+        search.executor,
+        "_run_tasks",
+        lambda tasks: batches.append(
+            [(task.rung, task.task, task.anchor) for task in tasks]
+        ),
+    )
+    monkeypatch.setattr(search, "advance", lambda rung: batches.append(rung))
+
+    search.executor.submit_initial(state)
+
+    assert batches == [[(1, 0, True), (0, 0, False), (0, 1, False)], 0]
+    saved = search.read_state()
+    assert saved["anchors"]["job_id"] == "local"
+    assert saved["rungs"][0]["job_id"] == "local"
+
+
+def test_local_executor_uses_exclusive_slurm_gpu_steps(tmp_path, monkeypatch):
+    search = config(tmp_path).build()
+    assert isinstance(search.executor, LocalExecutor)
+    search.config.executor.max_concurrent = 2
+    commands = []
+    environments = []
+    monkeypatch.setenv("SLURM_JOB_ID", "123")
+    monkeypatch.setenv("SLURM_NNODES", "2")
+    monkeypatch.setenv("SLURM_GPUS_ON_NODE", "8")
+    monkeypatch.setenv("SLURM_CPUS_ON_NODE", "128")
+    monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("WORLD_SIZE", "16")
+    monkeypatch.delenv("SLURM_STEP_ID", raising=False)
+
+    def run(command, *, check, env):
+        commands.append(command)
+        environments.append(env)
+
+    monkeypatch.setattr("samudra.search.executors.local.subprocess.run", run)
+
+    search.executor._run_tasks(
+        [
+            type("Task", (), {"rung": 0, "task": task, "anchor": False})()
+            for task in range(3)
+        ]
+    )
+
+    assert len(commands) == 3
+    assert all(command[0] == "srun" for command in commands)
+    assert all(
+        "--exclusive" in command and "--exact" in command for command in commands
+    )
+    assert all("--gpus-per-task=1" in command for command in commands)
+    assert all("--cpus-per-task=16" in command for command in commands)
+    assert all(env["SAMUDRA_DISABLE_DISTRIBUTED"] == "1" for env in environments)
+    assert all("RANK" not in env and "WORLD_SIZE" not in env for env in environments)
+
+
+def test_local_executor_preserves_visible_gpu_identifiers(tmp_path, monkeypatch):
+    search = config(tmp_path).build()
+    assert isinstance(search.executor, LocalExecutor)
+    calls = []
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-first,GPU-second")
+
+    def run(command, *, check, env):
+        calls.append((command, env["CUDA_VISIBLE_DEVICES"]))
+
+    monkeypatch.setattr("samudra.search.executors.local.subprocess.run", run)
+    search.executor._run_tasks(
+        [
+            type("Task", (), {"rung": 0, "task": task, "anchor": False})()
+            for task in range(2)
+        ]
+    )
+
+    assert {device for _, device in calls} == {"GPU-first", "GPU-second"}
+    assert all("samudra.search.worker" in command for command, _ in calls)
 
 
 def test_advance_retry_finishes_publication_and_submission(tmp_path, monkeypatch):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -706,6 +706,7 @@ def test_slurm_allocation_executor_uses_exclusive_gpu_steps(tmp_path, monkeypatc
     monkeypatch.setenv("SLURM_NNODES", "2")
     monkeypatch.setenv("SLURM_GPUS_ON_NODE", "8")
     monkeypatch.setenv("SLURM_CPUS_ON_NODE", "128")
+    monkeypatch.setenv("SLURM_MEM_PER_NODE", "1048576")
     monkeypatch.setenv("RANK", "0")
     monkeypatch.setenv("WORLD_SIZE", "16")
     monkeypatch.delenv("SLURM_STEP_ID", raising=False)
@@ -730,6 +731,7 @@ def test_slurm_allocation_executor_uses_exclusive_gpu_steps(tmp_path, monkeypatc
     )
     assert all("--gpus-per-task=1" in command for command in commands)
     assert all("--cpus-per-task=16" in command for command in commands)
+    assert all("--mem=131072M" in command for command in commands)
     assert all(env["SAMUDRA_DISABLE_DISTRIBUTED"] == "1" for env in environments)
     assert all("RANK" not in env and "WORLD_SIZE" not in env for env in environments)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -18,6 +18,7 @@ from samudra.search.executors import (
     SlurmAllocationExecutor,
     SlurmExecutor,
 )
+from samudra.search.executors.pool import PoolExecutor, Task
 from samudra.utils.location import S3Location
 from samudra.utils.schedule import CosineSchedulerConfig
 from samudra.utils.training_summary import (
@@ -676,6 +677,23 @@ def test_local_executor_coschedules_anchors_and_first_rung(tmp_path, monkeypatch
     saved = search.read_state()
     assert saved["anchors"]["job_id"] == "local"
     assert saved["rungs"][0]["job_id"] == "local"
+
+
+def test_pool_stops_launching_queued_tasks_after_worker_failure():
+    started = []
+
+    def run(task: Task) -> None:
+        started.append(task.task)
+        if task.task == 0:
+            raise RuntimeError("candidate failed")
+
+    tasks = [Task(rung=0, task=task, anchor=False) for task in range(5)]
+
+    with pytest.raises(RuntimeError, match="candidate failed"):
+        PoolExecutor._run_concurrently(tasks, concurrency=2, runner=run)
+
+    assert 0 in started
+    assert set(started) <= {0, 1}
 
 
 def test_slurm_allocation_executor_uses_exclusive_gpu_steps(tmp_path, monkeypatch):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -750,6 +750,31 @@ def test_local_executor_preserves_visible_gpu_identifiers(tmp_path, monkeypatch)
     assert all("samudra.search.worker" in command for command, _ in calls)
 
 
+def test_local_executor_keeps_later_rung_trials_on_one_gpu(tmp_path, monkeypatch):
+    search = config(tmp_path).build()
+    assert isinstance(search.executor, LocalExecutor)
+    state = search_state(search)
+    state["rungs"][1]["candidates"] = ["a", "b", "c", "d"]
+    search.search_dir.mkdir(parents=True)
+    search.write_state(state)
+    monkeypatch.setenv(
+        "CUDA_VISIBLE_DEVICES", ",".join(f"GPU-{index}" for index in range(8))
+    )
+    visible_devices = []
+
+    def run(command, *, check, env):
+        visible_devices.append(env["CUDA_VISIBLE_DEVICES"])
+
+    monkeypatch.setattr("samudra.search.executors.local.subprocess.run", run)
+    monkeypatch.setattr(search, "advance", lambda rung: None)
+
+    search.executor.submit_rung(state, 1)
+
+    assert len(visible_devices) == 4
+    assert all("," not in device for device in visible_devices)
+    assert len(set(visible_devices)) == 4
+
+
 def test_advance_retry_finishes_publication_and_submission(tmp_path, monkeypatch):
     search = config(tmp_path).build()
     search.search_dir.mkdir(parents=True)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -704,7 +704,8 @@ def test_slurm_allocation_executor_uses_exclusive_gpu_steps(tmp_path, monkeypatc
     environments = []
     monkeypatch.setenv("SLURM_JOB_ID", "123")
     monkeypatch.setenv("SLURM_NNODES", "2")
-    monkeypatch.setenv("SLURM_GPUS_ON_NODE", "8")
+    # Some Slurm installations append a socket/topology suffix.
+    monkeypatch.setenv("SLURM_GPUS_ON_NODE", "8(S:0-1)")
     monkeypatch.setenv("SLURM_CPUS_ON_NODE", "128")
     monkeypatch.setenv("SLURM_MEM_PER_NODE", "1048576")
     monkeypatch.setenv("RANK", "0")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -978,6 +978,7 @@ def test_task_builds_train_config_and_calls_trainer_directly(tmp_path, monkeypat
     )
     assert train_config.experiment.wandb.group == "test-search--run"
     assert "search" in train_config.experiment.wandb.tags
+    assert "test-search--run" not in train_config.experiment.wandb.tags
     assert received[1] == "run"
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -13,7 +13,11 @@ from pydantic import ValidationError
 from samudra.config import TrainConfig
 from samudra.search import SearchConfig
 from samudra.search.config import ArtifactConfig, SlurmExecutorConfig
-from samudra.search.executors import LocalExecutor, SlurmExecutor
+from samudra.search.executors import (
+    LocalExecutor,
+    SlurmAllocationExecutor,
+    SlurmExecutor,
+)
 from samudra.utils.location import S3Location
 from samudra.utils.schedule import CosineSchedulerConfig
 from samudra.utils.training_summary import (
@@ -25,7 +29,12 @@ from samudra.utils.training_summary import (
 
 def config(tmp_path: Path, *, executor: str = "local") -> SearchConfig:
     executor_config = {"type": "local", "output_dir": tmp_path / "runs"}
-    if executor == "slurm":
+    if executor == "slurm_allocation":
+        executor_config = {
+            "type": "slurm_allocation",
+            "output_dir": tmp_path / "runs",
+        }
+    elif executor == "slurm":
         harness = tmp_path / "train.sbatch"
         harness.touch()
         executor_config = {
@@ -44,7 +53,7 @@ def config(tmp_path: Path, *, executor: str = "local") -> SearchConfig:
             "objective": {"metric": "validation_loss", "mode": "min"},
             "metrics": ["validation_loss", "train_loss"],
             "executor": executor_config,
-            "allow_dirty": executor == "local",
+            "allow_dirty": executor != "slurm",
             "candidates": [
                 {"name": "anchor", "config": "anchor.yaml", "fixed": True},
                 {"name": "a", "config": "a.yaml"},
@@ -112,14 +121,16 @@ def test_slurm_rejects_dirty_worktree_before_submission(tmp_path):
     value = config(tmp_path, executor="slurm").model_dump(mode="json")
     value["allow_dirty"] = True
 
-    with pytest.raises(ValidationError, match="only supported by the local executor"):
+    with pytest.raises(ValidationError, match="not supported by the submitting Slurm"):
         SearchConfig.model_validate(value)
 
 
 def test_executor_dictionary_is_an_explicit_extension_point(tmp_path):
     local = config(tmp_path).build()
+    allocation = config(tmp_path, executor="slurm_allocation").build()
     slurm = config(tmp_path, executor="slurm").build()
     assert isinstance(local.executor, LocalExecutor)
+    assert isinstance(allocation.executor, SlurmAllocationExecutor)
     assert isinstance(slurm.executor, SlurmExecutor)
 
 
@@ -667,9 +678,9 @@ def test_local_executor_coschedules_anchors_and_first_rung(tmp_path, monkeypatch
     assert saved["rungs"][0]["job_id"] == "local"
 
 
-def test_local_executor_uses_exclusive_slurm_gpu_steps(tmp_path, monkeypatch):
-    search = config(tmp_path).build()
-    assert isinstance(search.executor, LocalExecutor)
+def test_slurm_allocation_executor_uses_exclusive_gpu_steps(tmp_path, monkeypatch):
+    search = config(tmp_path, executor="slurm_allocation").build()
+    assert isinstance(search.executor, SlurmAllocationExecutor)
     search.config.executor.max_concurrent = 2
     commands = []
     environments = []
@@ -685,7 +696,7 @@ def test_local_executor_uses_exclusive_slurm_gpu_steps(tmp_path, monkeypatch):
         commands.append(command)
         environments.append(env)
 
-    monkeypatch.setattr("samudra.search.executors.local.subprocess.run", run)
+    monkeypatch.setattr("samudra.search.executors.slurm_allocation.subprocess.run", run)
 
     search.executor._run_tasks(
         [
@@ -705,11 +716,22 @@ def test_local_executor_uses_exclusive_slurm_gpu_steps(tmp_path, monkeypatch):
     assert all("RANK" not in env and "WORLD_SIZE" not in env for env in environments)
 
 
+def test_slurm_allocation_executor_requires_an_allocation(tmp_path, monkeypatch):
+    search = config(tmp_path, executor="slurm_allocation").build()
+    assert isinstance(search.executor, SlurmAllocationExecutor)
+    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="must run inside a Slurm allocation"):
+        search.executor._run_tasks(
+            [type("Task", (), {"rung": 0, "task": 0, "anchor": False})()]
+        )
+
+
 def test_local_executor_preserves_visible_gpu_identifiers(tmp_path, monkeypatch):
     search = config(tmp_path).build()
     assert isinstance(search.executor, LocalExecutor)
     calls = []
-    monkeypatch.delenv("SLURM_JOB_ID", raising=False)
+    monkeypatch.setenv("SLURM_JOB_ID", "ignored-by-local-executor")
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-first,GPU-second")
 
     def run(command, *, check, env):
@@ -724,6 +746,7 @@ def test_local_executor_preserves_visible_gpu_identifiers(tmp_path, monkeypatch)
     )
 
     assert {device for _, device in calls} == {"GPU-first", "GPU-second"}
+    assert all(command[0] != "srun" for command, _ in calls)
     assert all("samudra.search.worker" in command for command, _ in calls)
 
 


### PR DESCRIPTION
## Summary

- keep `local` explicitly single-machine and discover worker slots only through CUDA visibility
- add a distinct `slurm_allocation` executor for independent one-GPU trials inside an existing single- or multi-node Slurm allocation
- allocate CPU and memory TRES proportionally to each exclusive Slurm step so workers can actually run concurrently
- accept Slurm's optional GPU topology suffix in allocation environment values such as `8(S:0-1)`
- share candidate pooling, worker isolation, concurrency limiting, anchor/rung-zero co-scheduling, and fail-fast queue handling between both executors
- retain the existing `slurm` executor for separately queued arrays and dependent controller jobs
- prevent independent search workers from accidentally initializing DDP
- keep W&B search tags within its 64-character limit while retaining the complete run ID in the group and structured search metadata
- document the Empire AI Alpha workflow, including when `local` is sufficient inside a single-node allocation

## Executor roles

- `local`: one isolated process per locally visible GPU; sequential fallback on CPU
- `slurm_allocation`: concurrent exclusive one-GPU `srun` steps in the current allocation
- `slurm`: independently submitted arrays with automatic dependent controllers

`DistributedConfig` remains dedicated to one model distributed across ranks; independent search trials do not create an NCCL process group.

## Resource invariant

Each candidate remains a single-GPU experiment in every rung. Survivors are not automatically changed to 2/4/8-way DDP as the population shrinks, even if that leaves GPUs idle in a retained allocation. Changing world size midway through a resumed trajectory changes global batch size and optimizer steps per epoch. Adaptive multi-GPU promotion therefore needs a separate explicit policy for batch size, learning rate, scheduler behavior, and epoch accounting.

Fixed anchors and rung zero are co-scheduled to maximize utilization during the initial stage. `max_concurrent` can cap the number of simultaneous independent trials. Once a worker fails, queued trials are not launched; already-running workers are allowed to exit before the failure is reported.

## Validation

- `uv run python -m pytest -m "not manual and not cuda" -q` — 469 passed, 2 skipped, 68 deselected, 10 xfailed
- `uv run python -m pytest tests/test_search.py tests/test_backend.py -q` — 40 passed
- `uvx pre-commit run --all-files` — passed

## Deployment note

The `slurm_allocation` controller must be launched directly from an `sbatch` script or `salloc` shell rather than through `srun`, because it creates exclusive `srun` job steps for its workers. The Python environment, source, configs, data, and outputs must be visible at consistent paths on every allocated node. Worker steps explicitly request their proportional share of `SLURM_MEM_PER_NODE`; without that request, Slurm may assign the full allocation memory TRES to the first exclusive step and leave the remaining GPUs idle. Some clusters still serialize nested steps as a site policy, so the docs include a two-step admission smoke check and direct single-node users to the `local` executor when concurrent steps are unavailable.
