### PR TITLE
Fix freshwater donor CLI routing

### DIFF
--- a/data/ocean_preprocessing/__main__.py
+++ b/data/ocean_preprocessing/__main__.py
@@ -195,6 +195,9 @@ class CLI:
         write_retries: Number of times the distributed scheduler retries a failed task
             during the final Zarr write. Guards against transient failures. Only applies
              when running on a cluster. Default 5.
+        wfo_source_path: Optional OM4 Zarr store containing five-day-mean ``wfo``
+            on the primary source's native grid and intervals. Its end-of-interval
+            time labels are validated before transplantation.
         cluster: Type of Dask cluster to use for distributed computation. Options are:
             'off' (no cluster, single-threaded), 'local' (LocalCluster), 'kube'
             (KubeCluster), 'slurm' (SlurmCluster), 'coiled' (Coiled cluster).
@@ -214,6 +217,7 @@ class CLI:
         dry_run: bool = False,
         small_run: bool = False,
         write_retries: int = 5,
+        wfo_source_path: str | None = None,
         cluster: Cluster = "off",
         **cluster_opts,
     ):
@@ -227,6 +231,7 @@ class CLI:
         self.dry_run = dry_run
         self.small_run = small_run
         self.write_retries = write_retries
+        self.wfo_source_path = wfo_source_path
         self.dask_client = init_cluster(cluster, **cluster_opts)
 
     def _collect(self, ds: xr.Dataset):
@@ -280,7 +285,6 @@ class CLI:
         nc_mosaic_path: str,
         target_grid_path: str,
         spatial_filter_scale: None | int = None,
-        wfo_source_path: str | None = None,
     ) -> None:
         """Process the OM4 oceans dataset (the ocean component of CMIP).
 
@@ -326,16 +330,13 @@ class CLI:
                 scale determination. When spatial filtering is performed (not --skip-spatial-filtering),
                 this value will be used instead of the scale inferred from the target grid name.
                 By default (None), the scale is automatically estimated from the target grid basename.
-            wfo_source_path: Optional OM4 Zarr store containing five-day-mean ``wfo``
-                on the recipient's native grid and intervals. Its end-of-interval time
-                labels are validated against ``zarr_data_path`` before transplantation.
         """
         logger.info("preprocessing.")
         ds_processed = om4_preprocessing(
             zarr_data_path,
             native_grid_path,
             nc_mosaic_path,
-            wfo_source_path=wfo_source_path,
+            wfo_source_path=self.wfo_source_path,
         )
         # This publication-specific invariant must run even when expensive
         # schema/deep validation is disabled. Shared validators remain backward

--- a/data/tests/test_main.py
+++ b/data/tests/test_main.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from unittest.mock import sentinel
 
 import numpy as np
+import ocean_preprocessing.__main__ as main
 import xarray as xr
 from ocean_preprocessing.__main__ import CLI
 
@@ -27,3 +29,24 @@ def test_collect_explicitly_writes_zarr_v2(tmp_path):
 
     metadata = json.loads((output / ".zgroup").read_text(encoding="utf-8"))
     assert metadata["zarr_format"] == 2
+
+
+def test_wfo_source_path_is_not_forwarded_to_cluster(monkeypatch, tmp_path):
+    cluster_calls = []
+
+    def fake_init_cluster(cluster, **cluster_opts):
+        cluster_calls.append((cluster, cluster_opts))
+        return sentinel.client
+
+    monkeypatch.setattr(main, "init_cluster", fake_init_cluster)
+
+    pipeline = CLI(
+        output_path=str(tmp_path / "unused.zarr"),
+        cluster="local",
+        wfo_source_path="s3://example/wfo.zarr",
+        n_workers=4,
+    )
+
+    assert pipeline.wfo_source_path == "s3://example/wfo.zarr"
+    assert pipeline.dask_client is sentinel.client
+    assert cluster_calls == [("local", {"n_workers": 4})]

--- a/scripts/slurm_preprocess_om4.sbatch
+++ b/scripts/slurm_preprocess_om4.sbatch
@@ -17,7 +17,8 @@
 # raw data is streamed directly from the OSN pod via s3fs (no local staging).
 #
 # --- Required env vars -------------------------------------------------------
-#   RESOLUTION   one of: twodeg | twodeg_filter | onedeg | onedeg_filter | halfdeg | quarterdeg
+#   RESOLUTION   one of: twodeg | twodeg_filter | onedeg | onedeg_filter |
+#                halfdeg | halfdeg_filter | quarterdeg | quarterdeg_filter
 #   OUTPUT_PATH  full s3 zarr path for the result, OR set OUTPUT_BASE (below).
 #
 # --- Common env vars ---------------------------------------------------------
@@ -63,8 +64,8 @@
 # directives below):
 #   twodeg / twodeg_filter : --cpus-per-task=32  --mem=240G --time=08:00:00  (coarsest, fastest)
 #   onedeg / onedeg_filter : --cpus-per-task=64  --mem=480G --time=12:00:00
-#   halfdeg                : --cpus-per-task=128 --mem=490G --time=1-00:00:00
-#   quarterdeg             : --cpus-per-task=128 --mem=490G --time=2-00:00:00 \
+#   halfdeg / halfdeg_filter : --cpus-per-task=128 --mem=490G --time=1-00:00:00
+#   quarterdeg / quarterdeg_filter : --cpus-per-task=128 --mem=490G --time=2-00:00:00 \
 #                            (also set N_WORKERS=16 to cap peak memory; if it
 #                             still OOMs, fall back to --partition=cl for a
 #                             3 TB node -- but that partition queues for days)
@@ -99,7 +100,7 @@ source "${VARIANT_SCRIPT}"
 # --- Resolve inputs ----------------------------------------------------------
 RESOLUTION="${RESOLUTION:-}"
 if [[ -z "${RESOLUTION}" ]]; then
-  echo "ERROR: RESOLUTION is required (twodeg | twodeg_filter | onedeg | onedeg_filter | halfdeg | quarterdeg)." >&2
+  echo "ERROR: RESOLUTION is required (twodeg | twodeg_filter | onedeg | onedeg_filter | halfdeg | halfdeg_filter | quarterdeg | quarterdeg_filter)." >&2
   exit 2
 fi
 
@@ -111,10 +112,12 @@ case "${RESOLUTION}" in
   onedeg)        GRID="gaussian_grid_180_by_360";  FILTER_FLAG="--skip_spatial_filtering" ;;
   onedeg_filter) GRID="gaussian_grid_180_by_360";  FILTER_FLAG="" ;;   # filtering ON (scale 18)
   halfdeg)       GRID="gaussian_grid_360_by_720";  FILTER_FLAG="--skip_spatial_filtering" ;;
+  halfdeg_filter) GRID="gaussian_grid_360_by_720"; FILTER_FLAG="" ;;   # filtering ON (scale 9)
   quarterdeg)    GRID="gaussian_grid_720_by_1440"; FILTER_FLAG="--skip_spatial_filtering" ;;
+  quarterdeg_filter) GRID="gaussian_grid_720_by_1440"; FILTER_FLAG="" ;; # filtering ON (scale 1)
   *)
     echo "ERROR: unknown RESOLUTION='${RESOLUTION}'." >&2
-    echo "Expected one of: twodeg | twodeg_filter | onedeg | onedeg_filter | halfdeg | quarterdeg." >&2
+    echo "Expected one of: twodeg | twodeg_filter | onedeg | onedeg_filter | halfdeg | halfdeg_filter | quarterdeg | quarterdeg_filter." >&2
     exit 2 ;;
 esac
 


### PR DESCRIPTION
## Summary

- make `wfo_source_path` an explicit top-level preprocessing CLI option
- keep it out of arbitrary Dask `cluster_opts`
- use the stored option when running the OM4 subcommand
- add a regression test proving the donor path is not forwarded to `LocalCluster`

## Context

The September data-release smoke job caught this before any output was written. Python Fire routed the OM4 method flag into the class constructor's `**cluster_opts`, causing Dask workers to fail with `Server.__init__() got an unexpected keyword argument 'wfo_source_path'`.

## Tests

- `PYTHONPATH=data pytest -q data/tests/test_main.py data/tests/test_simulation_preprocessing.py data/tests/test_slurm_harness.py`
- `uvx pre-commit run --all-files`
