### PR TITLE
Add opt-in adaptive data-parallel search trials

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -47,18 +47,48 @@ Fixed anchors and rung zero are co-scheduled, and each later rung uses up to the
 same GPU capacity. Set `executor.max_concurrent` only when memory, CPU, storage,
 or service limits require using fewer than the available GPUs.
 
-Every candidate remains a single-GPU experiment in every rung. The executor
-does not assign extra GPUs to survivors as the candidate population shrinks:
-doing so would change global batch size and optimizer steps per epoch midway
-through a resumed training trajectory. Adaptive multi-GPU trials need an
-explicit policy for batch size, learning rate, and epoch accounting rather than
-being inferred from momentarily idle hardware.
+By default, every candidate remains a single-GPU experiment in every rung. To
+assign newly idle GPUs to survivors without changing the scientific training
+trajectory, opt in to adaptive data parallelism:
+
+```yaml
+resources:
+  strategy: adaptive_data_parallel
+  max_gpus_per_candidate: 16
+  effective_global_batch_size: 64
+  allowed_world_sizes: [1, 2, 4, 8, 16]
+```
+
+For each rung, the executor selects the largest allowed world size that fits
+the allocation and the number of candidates allowed to run concurrently. It
+keeps each candidate's configured `batch_size`, adjusts only
+`gradient_accumulation_steps`, and uses a fixed-global-batch sampler. Thus the
+same shuffled examples form each optimizer update even when a promoted
+candidate moves from one GPU to two, four, or more. Learning-rate and scheduler
+configuration remain unchanged because the effective global batch and number
+of optimizer updates per epoch remain unchanged. The selected plan is recorded
+in `state.json` and reused on retries.
+
+`effective_global_batch_size` must be divisible by
+`batch_size * world_size`. If the requested world size is incompatible, the
+runner warns, preserves the user's batch size, and selects the largest smaller
+compatible world size. The warning recommends a compatible local batch size;
+Samudra never silently overrides that scientific choice. Fixed anchors stay on
+one GPU, using accumulation to preserve the configured effective global batch.
+
+Adaptive data parallelism is supported by the `local` and
+`slurm_allocation` executors. The separately submitted `slurm` executor rejects
+it because its array jobs do not share one allocation. Adaptive candidate
+training configs must use `backend: auto`, allowing the same saved candidate to
+run either as a single process or through the existing distributed
+initialization path.
 
 ### Use a whole Slurm allocation for independent trials
 
 Include `search/slurm-allocation.yaml` to treat an existing Slurm job as a
 resource pool. This distinct executor launches concurrent, exclusive `srun`
-steps with one task and one GPU each. On a homogeneous multi-node allocation it
+steps. A step uses one GPU by default or the planned GPU group when adaptive
+data parallelism is enabled. On a homogeneous multi-node allocation it
 derives total capacity from `SLURM_GPUS` or from
 `SLURM_NNODES * SLURM_GPUS_ON_NODE`; CPU cores are divided evenly among GPUs
 when Slurm exposes `SLURM_CPUS_ON_NODE`. Step memory is divided proportionally

--- a/docs/search.md
+++ b/docs/search.md
@@ -83,6 +83,12 @@ training configs must use `backend: auto`, allowing the same saved candidate to
 run either as a single process or through the existing distributed
 initialization path.
 
+On homogeneous multi-node Slurm allocations, ranks are spread uniformly over
+the smallest number of nodes that can host them. For example, an eight-rank
+trial on two six-GPU nodes runs four ranks per node. If a custom allowed world
+size has no uniform placement, planning warns and selects the next smaller
+placeable size rather than failing after workers are submitted.
+
 ### Use a whole Slurm allocation for independent trials
 
 Include `search/slurm-allocation.yaml` to treat an existing Slurm job as a

--- a/docs/search.md
+++ b/docs/search.md
@@ -69,12 +69,21 @@ configuration remain unchanged because the effective global batch and number
 of optimizer updates per epoch remain unchanged. The selected plan is recorded
 in `state.json` and reused on retries.
 
+Choose `effective_global_batch_size` from the scientific baseline you want to
+preserve: `batch_size * gradient_accumulation_steps * world_size`. For example,
+a prior two-GPU run with local batch 1 and accumulation 16 has an effective
+global batch of 32, even though its single-process configuration alone appears
+to describe a batch of 16.
+
 `effective_global_batch_size` must be divisible by
 `batch_size * world_size`. If the requested world size is incompatible, the
 runner warns, preserves the user's batch size, and selects the largest smaller
 compatible world size. The warning recommends a compatible local batch size;
 Samudra never silently overrides that scientific choice. Fixed anchors stay on
 one GPU, using accumulation to preserve the configured effective global batch.
+Because resource plans are persisted, retry a local run with at least as many
+visible GPUs as its largest planned candidate. The executor fails loudly
+instead of waiting indefinitely if a retry cannot satisfy that plan.
 
 Adaptive data parallelism is supported by the `local` and
 `slurm_allocation` executors. The separately submitted `slurm` executor rejects

--- a/src/samudra/config.py
+++ b/src/samudra/config.py
@@ -1048,6 +1048,11 @@ class SearchRunConfig(BaseConfig):
     artifacts_uri: str | None = None
     job_id: str | None = None
     parent_checkpoint: str | None = None
+    world_size: int = Field(default=1, ge=1)
+    local_batch_size: int = Field(default=1, ge=1)
+    gradient_accumulation_steps: int = Field(default=1, ge=1)
+    effective_global_batch_size: int = Field(default=1, ge=1)
+    adaptive_data_parallel: bool = False
 
 
 class ExperimentConfig(BaseConfig):

--- a/src/samudra/search/config.py
+++ b/src/samudra/search/config.py
@@ -52,6 +52,33 @@ class SuccessiveHalvingConfig(BaseConfig):
         return self
 
 
+class SingleGpuResourceConfig(BaseConfig):
+    strategy: Literal["single_gpu"] = "single_gpu"
+
+
+class AdaptiveDataParallelResourceConfig(BaseConfig):
+    strategy: Literal["adaptive_data_parallel"] = "adaptive_data_parallel"
+    max_gpus_per_candidate: int = Field(ge=2)
+    effective_global_batch_size: int = Field(ge=1)
+    allowed_world_sizes: list[int] = Field(default_factory=lambda: [1, 2, 4, 8, 16])
+
+    @model_validator(mode="after")
+    def _validate_world_sizes(self) -> Self:
+        if self.allowed_world_sizes != sorted(set(self.allowed_world_sizes)):
+            raise ValueError("allowed_world_sizes must be increasing and unique")
+        if not self.allowed_world_sizes or self.allowed_world_sizes[0] != 1:
+            raise ValueError("allowed_world_sizes must start with 1")
+        if any(size < 1 for size in self.allowed_world_sizes):
+            raise ValueError("allowed_world_sizes must contain positive values")
+        return self
+
+
+ResourceConfig = Annotated[
+    SingleGpuResourceConfig | AdaptiveDataParallelResourceConfig,
+    Field(discriminator="strategy"),
+]
+
+
 class LocalExecutorConfig(BaseConfig):
     type: Literal["local"] = "local"
     output_dir: Path
@@ -122,6 +149,7 @@ class SearchConfig(TopLevelConfig):
     algorithm: AlgorithmConfig
     objective: ObjectiveConfig = Field(default_factory=ObjectiveConfig)
     metrics: list[str] = Field(default_factory=lambda: ["validation_loss"])
+    resources: ResourceConfig = Field(default_factory=SingleGpuResourceConfig)
     candidates: list[CandidateConfig] = Field(min_length=1)
     executor: ExecutorConfig
     artifacts: ArtifactConfig | None = None
@@ -161,5 +189,12 @@ class SearchConfig(TopLevelConfig):
             raise ValueError(
                 "allow_dirty is not supported by the submitting Slurm executor; "
                 "queued searches require immutable code provenance"
+            )
+        if isinstance(
+            self.resources, AdaptiveDataParallelResourceConfig
+        ) and isinstance(self.executor, SlurmExecutorConfig):
+            raise ValueError(
+                "adaptive_data_parallel requires the local or slurm_allocation "
+                "executor; submitted Slurm arrays do not share an allocation"
             )
         return self

--- a/src/samudra/search/executors/local.py
+++ b/src/samudra/search/executors/local.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 import subprocess
-from queue import SimpleQueue
+import threading
 from typing import TYPE_CHECKING, cast
 
 import torch
@@ -43,6 +43,10 @@ class LocalExecutor(PoolExecutor):
     def job_id(self) -> str:
         return "local"
 
+    @property
+    def resource_capacity(self) -> int:
+        return max(1, len(visible_devices()))
+
     def _run_tasks(self, tasks: list[Task]) -> None:
         if not tasks:
             return
@@ -52,21 +56,45 @@ class LocalExecutor(PoolExecutor):
                 self._run_in_process(task)
             return
 
-        available_devices: SimpleQueue[str] = SimpleQueue()
-        for device in devices:
-            available_devices.put(device)
+        pool = _DevicePool(devices)
 
         def run_on_available_device(task: Task) -> None:
-            device = available_devices.get()
+            world_size = getattr(task, "world_size", 1)
+            assigned = pool.acquire(world_size)
             try:
-                environment = self._worker_environment()
-                environment["CUDA_VISIBLE_DEVICES"] = device
-                subprocess.run(self._worker_command(task), check=True, env=environment)
+                environment = self._worker_environment(distributed=world_size > 1)
+                environment["CUDA_VISIBLE_DEVICES"] = ",".join(assigned)
+                command = (
+                    self._distributed_worker_command(task)
+                    if world_size > 1
+                    else self._worker_command(task)
+                )
+                subprocess.run(command, check=True, env=environment)
             finally:
-                available_devices.put(device)
+                pool.release(assigned)
 
         self._run_concurrently(
             tasks,
             min(self._limit(len(devices)), len(tasks)),
             run_on_available_device,
         )
+
+
+class _DevicePool:
+    """Atomically reserve groups of CUDA identifiers for concurrent trials."""
+
+    def __init__(self, devices: list[str]) -> None:
+        self._available = list(devices)
+        self._condition = threading.Condition()
+
+    def acquire(self, count: int) -> list[str]:
+        with self._condition:
+            self._condition.wait_for(lambda: len(self._available) >= count)
+            assigned = self._available[:count]
+            del self._available[:count]
+            return assigned
+
+    def release(self, devices: list[str]) -> None:
+        with self._condition:
+            self._available.extend(devices)
+            self._condition.notify_all()

--- a/src/samudra/search/executors/local.py
+++ b/src/samudra/search/executors/local.py
@@ -56,6 +56,15 @@ class LocalExecutor(PoolExecutor):
                 self._run_in_process(task)
             return
 
+        required = max(getattr(task, "world_size", 1) for task in tasks)
+        if required > len(devices):
+            raise RuntimeError(
+                f"A persisted search resource plan requires {required} GPUs for "
+                f"one candidate, but only {len(devices)} are locally visible. "
+                "Retry with at least that many visible GPUs or start a new search "
+                "run so resources can be replanned."
+            )
+
         pool = _DevicePool(devices)
 
         def run_on_available_device(task: Task) -> None:

--- a/src/samudra/search/executors/pool.py
+++ b/src/samudra/search/executors/pool.py
@@ -29,6 +29,7 @@ class Task:
     rung: int
     task: int
     anchor: bool
+    world_size: int = 1
 
 
 class PoolExecutor(Executor):
@@ -44,13 +45,31 @@ class PoolExecutor(Executor):
 
     def submit_initial(self, state: dict[str, Any]) -> None:
         """Co-schedule fixed anchors and rung zero across available slots."""
+        anchors = state["anchors"]["candidates"]
+        competitors = state["rungs"][0]["candidates"]
+        anchor_resources = self._ensure_resource_plan(
+            state["anchors"], anchors, force_single_gpu=True
+        )
+        competitor_resources = self._ensure_resource_plan(
+            state["rungs"][0], competitors
+        )
         tasks = [
-            Task(len(self.search.rungs) - 1, task, True)
-            for task, _ in enumerate(state["anchors"]["candidates"])
+            Task(
+                len(self.search.rungs) - 1,
+                task,
+                True,
+                anchor_resources[name]["world_size"],
+            )
+            for task, name in enumerate(anchors)
         ]
         tasks.extend(
-            Task(0, task, False)
-            for task, _ in enumerate(state["rungs"][0]["candidates"])
+            Task(
+                0,
+                task,
+                False,
+                competitor_resources[name]["world_size"],
+            )
+            for task, name in enumerate(competitors)
         )
         state["anchors"]["job_id"] = self.job_id
         state["rungs"][0]["job_id"] = self.job_id
@@ -63,26 +82,73 @@ class PoolExecutor(Executor):
 
     def submit_anchors(self, state: dict[str, Any]) -> None:
         candidates = state["anchors"]["candidates"]
+        resources = self._ensure_resource_plan(
+            state["anchors"], candidates, force_single_gpu=True
+        )
         state["anchors"]["job_id"] = self.job_id
         self.search.write_state(state)
         if self.config.dry_run:
             return
         self._run_tasks(
             [
-                Task(len(self.search.rungs) - 1, task, True)
-                for task, _ in enumerate(candidates)
+                Task(
+                    len(self.search.rungs) - 1,
+                    task,
+                    True,
+                    resources[name]["world_size"],
+                )
+                for task, name in enumerate(candidates)
             ]
         )
 
     def submit_rung(self, state: dict[str, Any], rung: int) -> None:
         candidates = state["rungs"][rung]["candidates"]
+        resources = self._ensure_resource_plan(state["rungs"][rung], candidates)
         state["rungs"][rung]["job_id"] = self.job_id
         state["status"] = "running"
         self.search.write_state(state)
         if self.config.dry_run:
             return
-        self._run_tasks([Task(rung, task, False) for task, _ in enumerate(candidates)])
+        self._run_tasks(
+            [
+                Task(
+                    rung,
+                    task,
+                    False,
+                    resources[name]["world_size"],
+                )
+                for task, name in enumerate(candidates)
+            ]
+        )
         self.search.advance(rung)
+
+    @property
+    @abstractmethod
+    def resource_capacity(self) -> int: ...
+
+    def _ensure_resource_plan(
+        self,
+        state_section: dict[str, Any],
+        candidates: list[str],
+        *,
+        force_single_gpu: bool = False,
+    ) -> dict[str, dict[str, Any]]:
+        """Persist a plan once so retries keep the same training semantics."""
+        if self.search.config.resources.strategy == "single_gpu":
+            return {name: {"world_size": 1} for name in candidates}
+        existing = state_section.get("resources", {})
+        if set(existing) == set(candidates):
+            return existing
+        resources = self.search.plan_resources(
+            candidates,
+            gpu_capacity=self.resource_capacity,
+            candidate_concurrency=min(
+                len(candidates), self.config.max_concurrent or len(candidates)
+            ),
+            force_single_gpu=force_single_gpu,
+        )
+        state_section["resources"] = resources
+        return resources
 
     @abstractmethod
     def _run_tasks(self, tasks: list[Task]) -> None: ...
@@ -131,6 +197,23 @@ class PoolExecutor(Executor):
             sys.executable,
             "-m",
             "samudra.search.worker",
+            *self._worker_arguments(task),
+        ]
+
+    def _distributed_worker_command(self, task: Task) -> list[str]:
+        return [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--standalone",
+            f"--nproc-per-node={task.world_size}",
+            "--module",
+            "samudra.search.worker",
+            *self._worker_arguments(task),
+        ]
+
+    def _worker_arguments(self, task: Task) -> list[str]:
+        return [
             "task",
             str(self.search.config_path),
             str(self.search.state_path),
@@ -140,9 +223,12 @@ class PoolExecutor(Executor):
         ]
 
     @staticmethod
-    def _worker_environment() -> dict[str, str]:
+    def _worker_environment(*, distributed: bool = False) -> dict[str, str]:
         environment = os.environ.copy()
-        environment["SAMUDRA_DISABLE_DISTRIBUTED"] = "1"
+        if distributed:
+            environment.pop("SAMUDRA_DISABLE_DISTRIBUTED", None)
+        else:
+            environment["SAMUDRA_DISABLE_DISTRIBUTED"] = "1"
         for name in ("RANK", "LOCAL_RANK", "WORLD_SIZE", "MASTER_ADDR", "MASTER_PORT"):
             environment.pop(name, None)
         return environment

--- a/src/samudra/search/executors/pool.py
+++ b/src/samudra/search/executors/pool.py
@@ -126,6 +126,11 @@ class PoolExecutor(Executor):
     @abstractmethod
     def resource_capacity(self) -> int: ...
 
+    @property
+    def placeable_world_sizes(self) -> set[int] | None:
+        """World sizes supported by this executor's hardware topology."""
+        return None
+
     def _ensure_resource_plan(
         self,
         state_section: dict[str, Any],
@@ -145,6 +150,7 @@ class PoolExecutor(Executor):
             candidate_concurrency=min(
                 len(candidates), self.config.max_concurrent or len(candidates)
             ),
+            placeable_world_sizes=self.placeable_world_sizes,
             force_single_gpu=force_single_gpu,
         )
         state_section["resources"] = resources

--- a/src/samudra/search/executors/slurm_allocation.py
+++ b/src/samudra/search/executors/slurm_allocation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 from typing import TYPE_CHECKING, cast
 
 from samudra.search.executors.pool import PoolExecutor, Task
@@ -66,6 +67,13 @@ def step_memory_arguments(*, gpus: int) -> list[str]:
     return [f"--mem={memory}M"]
 
 
+def gpus_per_node() -> int:
+    value = _positive_int_environment("SLURM_GPUS_ON_NODE")
+    if value is None:
+        raise RuntimeError("Slurm did not set SLURM_GPUS_ON_NODE")
+    return value
+
+
 class SlurmAllocationExecutor(PoolExecutor):
     """Use exclusive one-GPU job steps within the current allocation."""
 
@@ -81,6 +89,10 @@ class SlurmAllocationExecutor(PoolExecutor):
     @property
     def job_id(self) -> str:
         return os.environ.get("SLURM_JOB_ID", "slurm-allocation")
+
+    @property
+    def resource_capacity(self) -> int:
+        return allocation_gpu_count()
 
     def _run_tasks(self, tasks: list[Task]) -> None:
         if not tasks:
@@ -100,6 +112,48 @@ class SlurmAllocationExecutor(PoolExecutor):
         self._run_concurrently(tasks, concurrency, self._run_slurm_task)
 
     def _run_slurm_task(self, task: Task) -> None:
+        per_node = gpus_per_node()
+        world_size = getattr(task, "world_size", 1)
+        if world_size <= per_node:
+            self._run_single_node_task(task, world_size=world_size)
+            return
+        if world_size % per_node:
+            raise ValueError(
+                f"world_size={world_size} cannot be placed on homogeneous "
+                f"{per_node}-GPU nodes"
+            )
+        nodes = world_size // per_node
+        subprocess.run(
+            [
+                "srun",
+                "--exclusive",
+                "--exact",
+                f"--nodes={nodes}",
+                f"--ntasks={nodes}",
+                "--ntasks-per-node=1",
+                f"--cpus-per-task={cpus_per_gpu() * per_node}",
+                f"--gpus-per-task={per_node}",
+                *step_memory_arguments(gpus=per_node),
+                "--gpu-bind=none",
+                sys.executable,
+                "-m",
+                "samudra.search.node_launcher",
+                f"--nnodes={nodes}",
+                f"--nproc-per-node={per_node}",
+                f"--master-port={self._master_port(task)}",
+                *self._worker_arguments(task),
+            ],
+            check=True,
+            env=self._worker_environment(distributed=True),
+        )
+
+    def _run_single_node_task(self, task: Task, *, world_size: int) -> None:
+        distributed = world_size > 1
+        command = (
+            self._distributed_worker_command(task)
+            if distributed
+            else self._worker_command(task)
+        )
         subprocess.run(
             [
                 "srun",
@@ -107,12 +161,20 @@ class SlurmAllocationExecutor(PoolExecutor):
                 "--exact",
                 "--nodes=1",
                 "--ntasks=1",
-                f"--cpus-per-task={cpus_per_gpu()}",
-                "--gpus-per-task=1",
-                *step_memory_arguments(gpus=1),
-                "--gpu-bind=single:1",
-                *self._worker_command(task),
+                f"--cpus-per-task={cpus_per_gpu() * world_size}",
+                f"--gpus-per-task={world_size}",
+                *step_memory_arguments(gpus=world_size),
+                "--gpu-bind=none",
+                *command,
             ],
             check=True,
-            env=self._worker_environment(),
+            env=self._worker_environment(distributed=distributed),
         )
+
+    def _master_port(self, task: Task) -> int:
+        job_digits = "".join(
+            character for character in self.job_id if character.isdigit()
+        )
+        job_id = int(job_digits or 0)
+        identity = task.rung * 10_000 + task.task * 2 + int(task.anchor)
+        return 15_000 + (job_id + identity) % 40_000

--- a/src/samudra/search/executors/slurm_allocation.py
+++ b/src/samudra/search/executors/slurm_allocation.py
@@ -74,6 +74,17 @@ def gpus_per_node() -> int:
     return value
 
 
+def world_size_placement(world_size: int) -> tuple[int, int] | None:
+    """Return ``(nodes, processes_per_node)`` for a uniform placement."""
+    per_node = gpus_per_node()
+    available_nodes = _positive_int_environment("SLURM_NNODES") or 1
+    for nodes in range(1, available_nodes + 1):
+        processes_per_node, remainder = divmod(world_size, nodes)
+        if remainder == 0 and 0 < processes_per_node <= per_node:
+            return nodes, processes_per_node
+    return None
+
+
 class SlurmAllocationExecutor(PoolExecutor):
     """Use exclusive one-GPU job steps within the current allocation."""
 
@@ -94,6 +105,14 @@ class SlurmAllocationExecutor(PoolExecutor):
     def resource_capacity(self) -> int:
         return allocation_gpu_count()
 
+    @property
+    def placeable_world_sizes(self) -> set[int]:
+        return {
+            size
+            for size in range(1, self.resource_capacity + 1)
+            if world_size_placement(size) is not None
+        }
+
     def _run_tasks(self, tasks: list[Task]) -> None:
         if not tasks:
             return
@@ -112,17 +131,17 @@ class SlurmAllocationExecutor(PoolExecutor):
         self._run_concurrently(tasks, concurrency, self._run_slurm_task)
 
     def _run_slurm_task(self, task: Task) -> None:
-        per_node = gpus_per_node()
         world_size = getattr(task, "world_size", 1)
-        if world_size <= per_node:
+        placement = world_size_placement(world_size)
+        if placement is None:
+            raise ValueError(
+                f"world_size={world_size} cannot be placed uniformly across "
+                "this Slurm allocation"
+            )
+        nodes, processes_per_node = placement
+        if nodes == 1:
             self._run_single_node_task(task, world_size=world_size)
             return
-        if world_size % per_node:
-            raise ValueError(
-                f"world_size={world_size} cannot be placed on homogeneous "
-                f"{per_node}-GPU nodes"
-            )
-        nodes = world_size // per_node
         subprocess.run(
             [
                 "srun",
@@ -131,15 +150,15 @@ class SlurmAllocationExecutor(PoolExecutor):
                 f"--nodes={nodes}",
                 f"--ntasks={nodes}",
                 "--ntasks-per-node=1",
-                f"--cpus-per-task={cpus_per_gpu() * per_node}",
-                f"--gpus-per-task={per_node}",
-                *step_memory_arguments(gpus=per_node),
+                f"--cpus-per-task={cpus_per_gpu() * processes_per_node}",
+                f"--gpus-per-task={processes_per_node}",
+                *step_memory_arguments(gpus=processes_per_node),
                 "--gpu-bind=none",
                 sys.executable,
                 "-m",
                 "samudra.search.node_launcher",
                 f"--nnodes={nodes}",
-                f"--nproc-per-node={per_node}",
+                f"--nproc-per-node={processes_per_node}",
                 f"--master-port={self._master_port(task)}",
                 *self._worker_arguments(task),
             ],

--- a/src/samudra/search/node_launcher.py
+++ b/src/samudra/search/node_launcher.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Launch one torchrun agent per node for an allocated search trial."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--nnodes", type=int, required=True)
+    parser.add_argument("--nproc-per-node", type=int, required=True)
+    parser.add_argument("--master-port", type=int, required=True)
+    parser.add_argument("worker_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if not args.worker_args:
+        raise ValueError("worker arguments are required")
+
+    node_list = os.environ["SLURM_STEP_NODELIST"]
+    hosts = subprocess.run(
+        ["scontrol", "show", "hostnames", node_list],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    if not hosts:
+        raise RuntimeError(f"Slurm returned no hosts for {node_list!r}")
+    node_rank = int(os.environ["SLURM_NODEID"])
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            f"--nnodes={args.nnodes}",
+            f"--nproc-per-node={args.nproc_per_node}",
+            f"--node-rank={node_rank}",
+            f"--master-addr={hosts[0]}",
+            f"--master-port={args.master_port}",
+            "--module",
+            "samudra.search.worker",
+            *args.worker_args,
+        ],
+        check=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/samudra/search/resources.py
+++ b/src/samudra/search/resources.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic GPU and batch planning for search candidates."""
+
+from __future__ import annotations
+
+import warnings
+
+from samudra.config import TrainConfig
+from samudra.search.config import AdaptiveDataParallelResourceConfig, ResourceConfig
+from samudra.search.state import CandidateResourceState
+
+
+def plan_candidate_resources(
+    policy: ResourceConfig,
+    candidates: dict[str, TrainConfig],
+    *,
+    gpu_capacity: int,
+    candidate_concurrency: int | None = None,
+    force_single_gpu: bool = False,
+) -> dict[str, CandidateResourceState]:
+    """Resolve reproducible world sizes without changing configured batch sizes."""
+    if not candidates:
+        return {}
+    if not isinstance(policy, AdaptiveDataParallelResourceConfig):
+        return {
+            name: _configured_plan(config, world_size=1)
+            for name, config in candidates.items()
+        }
+    incompatible_backends = [
+        name for name, config in candidates.items() if config.backend != "auto"
+    ]
+    if incompatible_backends:
+        raise ValueError(
+            "adaptive_data_parallel requires backend='auto' so a candidate can "
+            "move between single-process and distributed rungs; incompatible "
+            f"candidates: {', '.join(incompatible_backends)}"
+        )
+
+    requested = 1
+    if not force_single_gpu:
+        concurrent = candidate_concurrency or len(candidates)
+        per_candidate = max(1, gpu_capacity // concurrent)
+        requested = max(
+            size
+            for size in policy.allowed_world_sizes
+            if size <= min(per_candidate, policy.max_gpus_per_candidate)
+        )
+
+    plans: dict[str, CandidateResourceState] = {}
+    for name, config in candidates.items():
+        compatible = [
+            size
+            for size in policy.allowed_world_sizes
+            if size <= requested
+            and policy.effective_global_batch_size % (config.batch_size * size) == 0
+        ]
+        if not compatible:
+            warnings.warn(
+                f"Candidate {name!r} cannot realize effective_global_batch_size="
+                f"{policy.effective_global_batch_size} with its configured "
+                f"batch_size={config.batch_size}, even on one GPU. Its batch and "
+                "gradient accumulation settings are unchanged and adaptive "
+                "scaling is disabled for this candidate. Choose a batch size "
+                "that divides effective_global_batch_size to enable it.",
+                UserWarning,
+                stacklevel=2,
+            )
+            plans[name] = _configured_plan(config, world_size=1)
+            continue
+
+        world_size = max(compatible)
+        if world_size != requested:
+            warnings.warn(
+                f"Adaptive data parallelism requested world_size={requested} "
+                f"for candidate {name!r}, but effective_global_batch_size="
+                f"{policy.effective_global_batch_size} is not divisible by "
+                f"batch_size={config.batch_size} times that world size. Keeping "
+                f"the configured batch size and using world_size={world_size}. "
+                "Choose a local batch size that divides "
+                "effective_global_batch_size / world_size to use the requested "
+                "GPUs.",
+                UserWarning,
+                stacklevel=2,
+            )
+        denominator = config.batch_size * world_size
+        accumulation = policy.effective_global_batch_size // denominator
+        plans[name] = CandidateResourceState(
+            world_size=world_size,
+            local_batch_size=config.batch_size,
+            gradient_accumulation_steps=accumulation,
+            effective_global_batch_size=policy.effective_global_batch_size,
+        )
+    return plans
+
+
+def _configured_plan(config: TrainConfig, *, world_size: int) -> CandidateResourceState:
+    return CandidateResourceState(
+        world_size=world_size,
+        local_batch_size=config.batch_size,
+        gradient_accumulation_steps=config.gradient_accumulation_steps,
+        effective_global_batch_size=(
+            config.batch_size * config.gradient_accumulation_steps * world_size
+        ),
+    )

--- a/src/samudra/search/resources.py
+++ b/src/samudra/search/resources.py
@@ -19,6 +19,7 @@ def plan_candidate_resources(
     *,
     gpu_capacity: int,
     candidate_concurrency: int | None = None,
+    placeable_world_sizes: set[int] | None = None,
     force_single_gpu: bool = False,
 ) -> dict[str, CandidateResourceState]:
     """Resolve reproducible world sizes without changing configured batch sizes."""
@@ -39,21 +40,38 @@ def plan_candidate_resources(
             f"candidates: {', '.join(incompatible_backends)}"
         )
 
+    allowed_world_sizes = [
+        size
+        for size in policy.allowed_world_sizes
+        if placeable_world_sizes is None or size in placeable_world_sizes
+    ]
+    if 1 not in allowed_world_sizes:
+        raise ValueError("The executor must support world_size=1")
+
     requested = 1
     if not force_single_gpu:
         concurrent = candidate_concurrency or len(candidates)
         per_candidate = max(1, gpu_capacity // concurrent)
-        requested = max(
-            size
-            for size in policy.allowed_world_sizes
-            if size <= min(per_candidate, policy.max_gpus_per_candidate)
+        limit = min(per_candidate, policy.max_gpus_per_candidate)
+        capacity_world_size = max(
+            size for size in policy.allowed_world_sizes if size <= limit
         )
+        requested = max(size for size in allowed_world_sizes if size <= limit)
+        if requested != capacity_world_size:
+            warnings.warn(
+                f"world_size={capacity_world_size} fits the GPU count but cannot "
+                "be placed uniformly on this allocation's nodes; using "
+                f"world_size={requested}. Choose a placeable allowed_world_sizes "
+                "entry to avoid idle GPUs.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     plans: dict[str, CandidateResourceState] = {}
     for name, config in candidates.items():
         compatible = [
             size
-            for size in policy.allowed_world_sizes
+            for size in allowed_world_sizes
             if size <= requested
             and policy.effective_global_batch_size % (config.batch_size * size) == 0
         ]

--- a/src/samudra/search/state.py
+++ b/src/samudra/search/state.py
@@ -24,6 +24,13 @@ class ProbeState(BaseModel):
     status: Literal["array_submitted", "submitted", "complete", "failed"]
 
 
+class CandidateResourceState(BaseModel):
+    world_size: int = Field(ge=1)
+    local_batch_size: int = Field(ge=1)
+    gradient_accumulation_steps: int = Field(ge=1)
+    effective_global_batch_size: int = Field(ge=1)
+
+
 class RungState(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -37,6 +44,7 @@ class RungState(BaseModel):
     controller_job_id: str | None = None
     submission_stage: Literal["array_submitted", "controller_submitted"] | None = None
     probe: ProbeState | None = None
+    resources: dict[str, CandidateResourceState] = Field(default_factory=dict)
 
 
 class AnchorState(BaseModel):
@@ -45,6 +53,7 @@ class AnchorState(BaseModel):
     candidates: list[str]
     results: list[dict[str, Any]]
     job_id: str | None = None
+    resources: dict[str, CandidateResourceState] = Field(default_factory=dict)
 
 
 class FailureState(BaseModel):

--- a/src/samudra/search/successive_halving.py
+++ b/src/samudra/search/successive_halving.py
@@ -268,6 +268,7 @@ class SuccessiveHalving:
         *,
         gpu_capacity: int,
         candidate_concurrency: int | None = None,
+        placeable_world_sizes: set[int] | None = None,
         force_single_gpu: bool = False,
     ) -> dict[str, dict[str, int]]:
         configs = {
@@ -279,6 +280,7 @@ class SuccessiveHalving:
             configs,
             gpu_capacity=gpu_capacity,
             candidate_concurrency=candidate_concurrency,
+            placeable_world_sizes=placeable_world_sizes,
             force_single_gpu=force_single_gpu,
         )
         return {name: plan.model_dump(mode="json") for name, plan in plans.items()}

--- a/src/samudra/search/successive_halving.py
+++ b/src/samudra/search/successive_halving.py
@@ -22,6 +22,7 @@ import yaml
 from samudra.config import SearchRunConfig, TrainConfig
 from samudra.search.artifacts import ArtifactPublisher, atomic_local_parquet
 from samudra.search.config import (
+    AdaptiveDataParallelResourceConfig,
     CandidateConfig,
     SearchConfig,
     SlurmExecutorConfig,
@@ -34,6 +35,7 @@ from samudra.search.executors import (
     SlurmExecutor,
 )
 from samudra.search.report import write_search_report
+from samudra.search.resources import plan_candidate_resources
 from samudra.search.state import SearchState
 from samudra.train import Trainer
 from samudra.utils.atomic import atomic_path
@@ -260,6 +262,27 @@ class SuccessiveHalving:
     def candidate(self, name: str) -> CandidateConfig:
         return next(item for item in self.config.candidates if item.name == name)
 
+    def plan_resources(
+        self,
+        candidates: list[str],
+        *,
+        gpu_capacity: int,
+        candidate_concurrency: int | None = None,
+        force_single_gpu: bool = False,
+    ) -> dict[str, dict[str, int]]:
+        configs = {
+            name: TrainConfig.from_yaml_and_cli([self.candidate(name).config])
+            for name in candidates
+        }
+        plans = plan_candidate_resources(
+            self.config.resources,
+            configs,
+            gpu_capacity=gpu_capacity,
+            candidate_concurrency=candidate_concurrency,
+            force_single_gpu=force_single_gpu,
+        )
+        return {name: plan.model_dump(mode="json") for name, plan in plans.items()}
+
     def output_dir(self, candidate: str, rung: int) -> Path:
         return self.config.executor.output_dir / (
             f"{self.run_id}--{resource_slug(candidate)}--e{self.rungs[rung]}"
@@ -290,6 +313,26 @@ class SuccessiveHalving:
             raise ValueError(f"Refusing to overwrite {output}")
         args = [candidate.config, *candidate.args]
         train_config = TrainConfig.from_yaml_and_cli(args)
+        resource_group = (
+            state["anchors"]["resources"]
+            if anchor
+            else state["rungs"][rung]["resources"]
+        )
+        resource_values = resource_group.get(name)
+        if resource_values is None:
+            resource_values = {
+                "world_size": 1,
+                "local_batch_size": train_config.batch_size,
+                "gradient_accumulation_steps": (
+                    train_config.gradient_accumulation_steps
+                ),
+                "effective_global_batch_size": (
+                    train_config.batch_size * train_config.gradient_accumulation_steps
+                ),
+            }
+        train_config.gradient_accumulation_steps = resource_values[
+            "gradient_accumulation_steps"
+        ]
         train_config.epochs = self.rungs[rung]
         if (
             train_config.scheduler is not None
@@ -326,6 +369,13 @@ class SuccessiveHalving:
             job_id=os.environ.get("SLURM_JOB_ID", self.config.executor.type),
             parent_checkpoint=(
                 str(parent_checkpoint) if parent_checkpoint is not None else None
+            ),
+            world_size=resource_values["world_size"],
+            local_batch_size=resource_values["local_batch_size"],
+            gradient_accumulation_steps=resource_values["gradient_accumulation_steps"],
+            effective_global_batch_size=resource_values["effective_global_batch_size"],
+            adaptive_data_parallel=isinstance(
+                self.config.resources, AdaptiveDataParallelResourceConfig
             ),
         )
         train_config.experiment.wandb.group = self.run_id

--- a/src/samudra/train.py
+++ b/src/samudra/train.py
@@ -63,6 +63,7 @@ from samudra.utils.data import BatchPreprocessor, get_inference_steps
 from samudra.utils.device import using_gpu
 from samudra.utils.distributed import (
     all_reduce_mean,
+    get_rank,
     get_world_size,
     is_main_process,
     set_seed,
@@ -84,6 +85,7 @@ from samudra.utils.rollout_validation import (
 from samudra.utils.samplers import (
     DistributedEquivalenceGroupBatchSampler,
     EquivalenceGroupBatchSampler,
+    FixedGlobalBatchSampler,
 )
 from samudra.utils.train import (
     CheckpointPaths,
@@ -320,6 +322,28 @@ class Trainer:
         self._rollout_validation_pg: torch.distributed.ProcessGroup | None = None
         self.output_dir = cfg.experiment.output_dir
         self.search_run = cfg.experiment.search
+        if self.search_run is not None and self.search_run.adaptive_data_parallel:
+            if self.world_size != self.search_run.world_size:
+                raise RuntimeError(
+                    "Adaptive search planned world_size="
+                    f"{self.search_run.world_size}, but the worker initialized "
+                    f"world_size={self.world_size}"
+                )
+            if cfg.batch_size != self.search_run.local_batch_size:
+                raise RuntimeError(
+                    "Adaptive search resource state does not match the configured "
+                    f"batch size ({self.search_run.local_batch_size} != "
+                    f"{cfg.batch_size})"
+                )
+            effective_batch_size = (
+                cfg.batch_size * cfg.gradient_accumulation_steps * self.world_size
+            )
+            if effective_batch_size != self.search_run.effective_global_batch_size:
+                raise RuntimeError(
+                    "Adaptive search planned effective_global_batch_size="
+                    f"{self.search_run.effective_global_batch_size}, but the "
+                    f"worker resolved {effective_batch_size}"
+                )
         self.debug = cfg.debug
         self.data_stride: list[int] = cfg.data_stride
         self.batch_size: int = cfg.batch_size
@@ -351,7 +375,9 @@ class Trainer:
 
         # Add type annotations for samplers
         self.train_sampler: (
-            EquivalenceGroupBatchSampler | DistributedEquivalenceGroupBatchSampler
+            EquivalenceGroupBatchSampler
+            | DistributedEquivalenceGroupBatchSampler
+            | FixedGlobalBatchSampler
         )
         self.val_sampler: (
             EquivalenceGroupBatchSampler | DistributedEquivalenceGroupBatchSampler
@@ -629,24 +655,32 @@ class Trainer:
             if self.num_batches_seen == 0:
                 get_model_summary(self.model, batch, self.debug)
 
+            is_last = batch_index + 1 == total_batches
+            should_step = (batch_index + 1) % self.gradient_accumulation_steps == 0
+            optimizer_stepped = should_step or is_last
+            sync_context: contextlib.AbstractContextManager[Any] = (
+                contextlib.nullcontext()
+            )
+            if self.distributed is not None and not optimizer_stepped:
+                assert isinstance(self.model, nn.parallel.DistributedDataParallel)
+                sync_context = self.model.no_sync()
+
             with self.train_progress.batch(
                 batch, world_size=self.world_size, device=self.device
             ) as batch_progress:
-                batch_output: TrainBatchOutput = train_batch(
-                    self.model, batch, self.loss_fn
-                )
+                with sync_context:
+                    batch_output: TrainBatchOutput = train_batch(
+                        self.model, batch, self.loss_fn
+                    )
 
-                # Scale loss by this accumulation cycle's actual microbatch count.
-                scaled_loss = batch_output.loss / r
-                scaled_loss.backward()
+                    # Scale loss by this accumulation cycle's actual microbatch count.
+                    scaled_loss = batch_output.loss / r
+                    scaled_loss.backward()
 
                 train_aggregator.record_batch(batch_output)
 
                 self.num_batches_seen += 1
 
-                is_last = batch_index + 1 == total_batches
-                should_step = (batch_index + 1) % self.gradient_accumulation_steps == 0
-                optimizer_stepped = should_step or is_last
                 batch_progress.optimizer_stepped = optimizer_stepped
                 # Step optimizer after accumulating enough batches or at the end
                 if optimizer_stepped:
@@ -1148,7 +1182,29 @@ class Trainer:
         def group_key(ds):
             return tuple(source.grid_size for source in ds.sources)
 
-        if self.distributed is not None:
+        adaptive_batching = (
+            self.search_run is not None and self.search_run.adaptive_data_parallel
+        )
+        train_batch_sampler: (
+            EquivalenceGroupBatchSampler
+            | DistributedEquivalenceGroupBatchSampler
+            | FixedGlobalBatchSampler
+        )
+        val_batch_sampler: (
+            EquivalenceGroupBatchSampler | DistributedEquivalenceGroupBatchSampler
+        )
+        if adaptive_batching:
+            train_batch_sampler = FixedGlobalBatchSampler.from_datasets(
+                datasets=train_datasets,
+                group_key=group_key,
+                local_batch_size=self.batch_size,
+                world_size=self.world_size,
+                rank=get_rank(),
+                accumulation_steps=self.gradient_accumulation_steps,
+                shuffle=True,
+                seed=self.rand_seed,
+            )
+        elif self.distributed is not None:
             # Distributed training
             assert self.distributed.world_size is not None
             assert self.distributed.rank is not None
@@ -1163,6 +1219,19 @@ class Trainer:
                 seed=self.rand_seed,
             )
 
+        else:
+            train_batch_sampler = EquivalenceGroupBatchSampler.from_datasets(  # type: ignore
+                datasets=train_datasets,
+                group_key=group_key,
+                batch_size=self.batch_size,
+                shuffle=True,
+                drop_last=True,
+                seed=self.rand_seed,
+            )
+
+        if self.distributed is not None:
+            assert self.distributed.world_size is not None
+            assert self.distributed.rank is not None
             val_batch_sampler = DistributedEquivalenceGroupBatchSampler(
                 datasets=val_datasets,
                 group_key=group_key,
@@ -1174,16 +1243,6 @@ class Trainer:
                 seed=self.rand_seed,
             )
         else:
-            # Non-distributed training
-            train_batch_sampler = EquivalenceGroupBatchSampler.from_datasets(  # type: ignore
-                datasets=train_datasets,
-                group_key=group_key,
-                batch_size=self.batch_size,
-                shuffle=True,
-                drop_last=True,
-                seed=self.rand_seed,
-            )
-
             val_batch_sampler = EquivalenceGroupBatchSampler.from_datasets(  # type: ignore
                 datasets=val_datasets,
                 group_key=group_key,

--- a/src/samudra/utils/samplers.py
+++ b/src/samudra/utils/samplers.py
@@ -189,6 +189,114 @@ class EquivalenceGroupBatchSampler(Sampler[Batch]):
         return total_batches
 
 
+class FixedGlobalBatchSampler(Sampler[Batch]):
+    """Partition invariant global optimizer batches across ranks and microsteps.
+
+    Each rank constructs the same shuffled sequence of global batches. A global
+    batch is then sliced first by gradient-accumulation microstep and then by
+    rank, so changing ``world_size`` does not change which examples contribute
+    to an optimizer update.
+    """
+
+    def __init__(
+        self,
+        groups: list[list[int]],
+        *,
+        local_batch_size: int,
+        world_size: int,
+        rank: int,
+        accumulation_steps: int,
+        shuffle: bool,
+        seed: int,
+    ) -> None:
+        super().__init__()
+        if local_batch_size < 1 or world_size < 1 or accumulation_steps < 1:
+            raise ValueError(
+                "local_batch_size, world_size, and accumulation_steps must be positive"
+            )
+        if not 0 <= rank < world_size:
+            raise ValueError(f"rank {rank} is outside world_size {world_size}")
+        self.groups = groups
+        self.local_batch_size = local_batch_size
+        self.world_size = world_size
+        self.rank = rank
+        self.accumulation_steps = accumulation_steps
+        self.shuffle = shuffle
+        self.seed = seed
+        self.epoch = 0
+        self.global_batch_size = local_batch_size * world_size * accumulation_steps
+        if not any(len(group) >= self.global_batch_size for group in groups):
+            raise ValueError(
+                "No equivalence group contains one complete effective global "
+                f"batch of {self.global_batch_size} samples"
+            )
+
+    @classmethod
+    def from_datasets(
+        cls,
+        datasets: list["TorchTrainDataset"],
+        group_key: Callable[["TorchTrainDataset"], Hashable],
+        *,
+        local_batch_size: int,
+        world_size: int,
+        rank: int,
+        accumulation_steps: int,
+        shuffle: bool,
+        seed: int,
+    ) -> Self:
+        grouped = EquivalenceGroupBatchSampler.from_datasets(
+            datasets=datasets,
+            group_key=group_key,
+            batch_size=local_batch_size,
+            shuffle=False,
+            drop_last=True,
+            seed=seed,
+        )
+        return cls(
+            grouped.groups,
+            local_batch_size=local_batch_size,
+            world_size=world_size,
+            rank=rank,
+            accumulation_steps=accumulation_steps,
+            shuffle=shuffle,
+            seed=seed,
+        )
+
+    def set_epoch(self, epoch: int) -> None:
+        self.epoch = epoch
+
+    def __iter__(self):
+        rng = random.Random(self.seed + self.epoch)
+        optimizer_batches: list[list[int]] = []
+        for group in self.groups:
+            indices = list(group)
+            if self.shuffle:
+                rng.shuffle(indices)
+            complete = len(indices) // self.global_batch_size
+            optimizer_batches.extend(
+                indices[start : start + self.global_batch_size]
+                for start in range(
+                    0,
+                    complete * self.global_batch_size,
+                    self.global_batch_size,
+                )
+            )
+        if self.shuffle:
+            rng.shuffle(optimizer_batches)
+
+        microbatch_width = self.local_batch_size * self.world_size
+        for optimizer_batch in optimizer_batches:
+            for microstep in range(self.accumulation_steps):
+                start = microstep * microbatch_width + self.rank * self.local_batch_size
+                yield optimizer_batch[start : start + self.local_batch_size]
+
+    def __len__(self) -> int:
+        optimizer_steps = sum(
+            len(group) // self.global_batch_size for group in self.groups
+        )
+        return optimizer_steps * self.accumulation_steps
+
+
 class DistributedEquivalenceGroupBatchSampler(Sampler[Batch]):
     """Distributed version of EquivalenceGroupBatchSampler for multi-GPU training.
 

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -10,6 +10,7 @@ from samudra.constants import GridSize
 from samudra.utils.samplers import (
     DistributedEquivalenceGroupBatchSampler,
     EquivalenceGroupBatchSampler,
+    FixedGlobalBatchSampler,
 )
 
 
@@ -159,6 +160,61 @@ class TestEquivalenceGroupBatchSampler:
 
         # Should cover all indices 0-7
         assert set(all_indices) == set(range(8))
+
+
+class TestFixedGlobalBatchSampler:
+    @staticmethod
+    def _optimizer_batches(
+        groups: list[list[int]], *, world_size: int, accumulation_steps: int
+    ) -> list[list[int]]:
+        samplers = [
+            iter(
+                FixedGlobalBatchSampler(
+                    groups,
+                    local_batch_size=2,
+                    world_size=world_size,
+                    rank=rank,
+                    accumulation_steps=accumulation_steps,
+                    shuffle=True,
+                    seed=17,
+                )
+            )
+            for rank in range(world_size)
+        ]
+        optimizer_steps = sum(len(group) // 8 for group in groups)
+        batches = []
+        for _ in range(optimizer_steps):
+            batch = []
+            for _ in range(accumulation_steps):
+                for sampler in samplers:
+                    batch.extend(next(sampler))
+            batches.append(batch)
+        return batches
+
+    def test_optimizer_batches_are_invariant_to_world_size(self):
+        groups = [list(range(24)), list(range(24, 40))]
+
+        single_gpu = self._optimizer_batches(groups, world_size=1, accumulation_steps=4)
+        two_gpus = self._optimizer_batches(groups, world_size=2, accumulation_steps=2)
+        four_gpus = self._optimizer_batches(groups, world_size=4, accumulation_steps=1)
+
+        assert single_gpu == two_gpus == four_gpus
+        assert all(len(batch) == 8 for batch in single_gpu)
+        assert len({index for batch in single_gpu for index in batch}) == 40
+
+    def test_drops_the_same_incomplete_tail_from_each_group(self):
+        sampler = FixedGlobalBatchSampler(
+            [list(range(10)), list(range(10, 21))],
+            local_batch_size=2,
+            world_size=2,
+            rank=0,
+            accumulation_steps=2,
+            shuffle=False,
+            seed=0,
+        )
+
+        assert len(sampler) == 4
+        assert list(sampler) == [[0, 1], [4, 5], [10, 11], [14, 15]]
 
 
 class TestSamplersFromDatasets:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
@@ -12,13 +14,18 @@ from pydantic import ValidationError
 
 from samudra.config import TrainConfig
 from samudra.search import SearchConfig
-from samudra.search.config import ArtifactConfig, SlurmExecutorConfig
+from samudra.search.config import (
+    AdaptiveDataParallelResourceConfig,
+    ArtifactConfig,
+    SlurmExecutorConfig,
+)
 from samudra.search.executors import (
     LocalExecutor,
     SlurmAllocationExecutor,
     SlurmExecutor,
 )
 from samudra.search.executors.pool import PoolExecutor, Task
+from samudra.search.node_launcher import main as node_launcher_main
 from samudra.utils.location import S3Location
 from samudra.utils.schedule import CosineSchedulerConfig
 from samudra.utils.training_summary import (
@@ -123,6 +130,18 @@ def test_slurm_rejects_dirty_worktree_before_submission(tmp_path):
     value["allow_dirty"] = True
 
     with pytest.raises(ValidationError, match="not supported by the submitting Slurm"):
+        SearchConfig.model_validate(value)
+
+
+def test_submitted_slurm_rejects_adaptive_data_parallelism(tmp_path):
+    value = config(tmp_path, executor="slurm").model_dump(mode="json")
+    value["resources"] = {
+        "strategy": "adaptive_data_parallel",
+        "max_gpus_per_candidate": 8,
+        "effective_global_batch_size": 64,
+    }
+
+    with pytest.raises(ValidationError, match="do not share an allocation"):
         SearchConfig.model_validate(value)
 
 
@@ -771,6 +790,125 @@ def test_local_executor_preserves_visible_gpu_identifiers(tmp_path, monkeypatch)
     assert all("samudra.search.worker" in command for command, _ in calls)
 
 
+def test_local_executor_launches_one_torchrun_across_reserved_gpus(
+    tmp_path, monkeypatch
+):
+    search = config(tmp_path).build()
+    assert isinstance(search.executor, LocalExecutor)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-a,GPU-b,GPU-c,GPU-d")
+    calls = []
+    monkeypatch.setattr(
+        "samudra.search.executors.local.subprocess.run",
+        lambda command, *, check, env: calls.append((command, env)),
+    )
+
+    search.executor._run_tasks([Task(rung=1, task=0, anchor=False, world_size=4)])
+
+    command, environment = calls[0]
+    assert "torch.distributed.run" in command
+    assert "--nproc-per-node=4" in command
+    assert environment["CUDA_VISIBLE_DEVICES"] == "GPU-a,GPU-b,GPU-c,GPU-d"
+    assert "SAMUDRA_DISABLE_DISTRIBUTED" not in environment
+
+
+def test_slurm_allocation_launches_multi_node_torchrun(tmp_path, monkeypatch):
+    search = config(tmp_path, executor="slurm_allocation").build()
+    assert isinstance(search.executor, SlurmAllocationExecutor)
+    monkeypatch.setenv("SLURM_JOB_ID", "123")
+    monkeypatch.setenv("SLURM_NNODES", "2")
+    monkeypatch.setenv("SLURM_GPUS_ON_NODE", "8")
+    monkeypatch.setenv("SLURM_CPUS_ON_NODE", "128")
+    monkeypatch.setenv("SLURM_MEM_PER_NODE", "1048576")
+    calls = []
+    monkeypatch.setattr(
+        "samudra.search.executors.slurm_allocation.subprocess.run",
+        lambda command, *, check, env: calls.append((command, env)),
+    )
+
+    search.executor._run_slurm_task(Task(rung=1, task=0, anchor=False, world_size=16))
+
+    command, environment = calls[0]
+    assert "--nodes=2" in command
+    assert "--ntasks=2" in command
+    assert "--gpus-per-task=8" in command
+    assert "--mem=1048576M" in command
+    assert "samudra.search.node_launcher" in command
+    assert "--nnodes=2" in command
+    assert "--nproc-per-node=8" in command
+    assert "SAMUDRA_DISABLE_DISTRIBUTED" not in environment
+
+
+def test_node_launcher_maps_slurm_node_rank_to_torchrun(monkeypatch):
+    monkeypatch.setenv("SLURM_STEP_NODELIST", "node-[01-02]")
+    monkeypatch.setenv("SLURM_NODEID", "1")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "node_launcher",
+            "--nnodes=2",
+            "--nproc-per-node=8",
+            "--master-port=23456",
+            "task",
+            "config.yaml",
+            "state.json",
+            "1",
+            "0",
+        ],
+    )
+    commands = []
+
+    def run(command, **kwargs):
+        if command[0] == "scontrol":
+            return SimpleNamespace(stdout="node-01\nnode-02\n")
+        commands.append(command)
+        return SimpleNamespace()
+
+    monkeypatch.setattr("samudra.search.node_launcher.subprocess.run", run)
+
+    node_launcher_main()
+
+    command = commands[0]
+    assert "--node-rank=1" in command
+    assert "--master-addr=node-01" in command
+    assert "--master-port=23456" in command
+    assert command[-5:] == ["task", "config.yaml", "state.json", "1", "0"]
+
+
+def test_adaptive_resource_plan_is_reused_on_submission_retry(tmp_path, monkeypatch):
+    search = config(tmp_path).build()
+    search.config.resources = AdaptiveDataParallelResourceConfig(
+        max_gpus_per_candidate=4,
+        effective_global_batch_size=32,
+    )
+    search.config.executor.dry_run = True
+    search.search_dir.mkdir(parents=True)
+    state = search_state(search, status="prepared")
+    state["rungs"][0]["candidates"] = ["a"]
+    search.write_state(state)
+    calls = 0
+
+    def plan_resources(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return {
+            "a": {
+                "world_size": 4,
+                "local_batch_size": 2,
+                "gradient_accumulation_steps": 4,
+                "effective_global_batch_size": 32,
+            }
+        }
+
+    monkeypatch.setattr(search, "plan_resources", plan_resources)
+
+    search.executor.submit_rung(state, 0)
+    search.executor.submit_rung(search.read_state(), 0)
+
+    assert calls == 1
+    assert search.read_state()["rungs"][0]["resources"]["a"]["world_size"] == 4
+
+
 def test_local_executor_keeps_later_rung_trials_on_one_gpu(tmp_path, monkeypatch):
     search = config(tmp_path).build()
     assert isinstance(search.executor, LocalExecutor)
@@ -936,6 +1074,11 @@ def test_task_builds_train_config_and_calls_trainer_directly(tmp_path, monkeypat
         [str(Path("tests/configs/train_default.yaml").resolve())]
     )
     candidate_config.scheduler = CosineSchedulerConfig()
+    effective_batch_size = candidate_config.batch_size * 4 * 3
+    search_config.resources = AdaptiveDataParallelResourceConfig(
+        max_gpus_per_candidate=4,
+        effective_global_batch_size=effective_batch_size,
+    )
     candidate_path = tmp_path / "candidate.yaml"
     candidate_path.write_text(
         yaml.safe_dump(candidate_config.model_dump(mode="json")), encoding="utf-8"
@@ -947,6 +1090,14 @@ def test_task_builds_train_config_and_calls_trainer_directly(tmp_path, monkeypat
     search.search_dir.mkdir(parents=True)
     state = search_state(search)
     state["rungs"][0]["candidates"] = ["a"]
+    state["rungs"][0]["resources"] = {
+        "a": {
+            "world_size": 4,
+            "local_batch_size": candidate_config.batch_size,
+            "gradient_accumulation_steps": 3,
+            "effective_global_batch_size": effective_batch_size,
+        }
+    }
     search.write_state(state)
     received = []
 
@@ -973,7 +1124,14 @@ def test_task_builds_train_config_and_calls_trainer_directly(tmp_path, monkeypat
     assert train_config.epochs == 1
     assert train_config.scheduler is not None
     assert train_config.scheduler.target_epochs == 3
+    assert train_config.batch_size == candidate_config.batch_size
+    assert train_config.gradient_accumulation_steps == 3
     assert train_config.experiment.search.candidate == "a"
+    assert train_config.experiment.search.world_size == 4
+    assert train_config.experiment.search.effective_global_batch_size == (
+        effective_batch_size
+    )
+    assert train_config.experiment.search.adaptive_data_parallel is True
     assert train_config.experiment.search.artifacts_uri == str(
         tmp_path / "published/test-search--run"
     )

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -811,6 +811,17 @@ def test_local_executor_launches_one_torchrun_across_reserved_gpus(
     assert "SAMUDRA_DISABLE_DISTRIBUTED" not in environment
 
 
+def test_local_executor_rejects_persisted_plan_larger_than_visible_gpus(
+    tmp_path, monkeypatch
+):
+    search = config(tmp_path).build()
+    assert isinstance(search.executor, LocalExecutor)
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "GPU-a,GPU-b")
+
+    with pytest.raises(RuntimeError, match="requires 4 GPUs.*only 2.*visible"):
+        search.executor._run_tasks([Task(rung=1, task=0, anchor=False, world_size=4)])
+
+
 def test_slurm_allocation_launches_multi_node_torchrun(tmp_path, monkeypatch):
     search = config(tmp_path, executor="slurm_allocation").build()
     assert isinstance(search.executor, SlurmAllocationExecutor)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -838,6 +838,33 @@ def test_slurm_allocation_launches_multi_node_torchrun(tmp_path, monkeypatch):
     assert "SAMUDRA_DISABLE_DISTRIBUTED" not in environment
 
 
+def test_slurm_allocation_spreads_ranks_over_partially_used_nodes(
+    tmp_path, monkeypatch
+):
+    search = config(tmp_path, executor="slurm_allocation").build()
+    assert isinstance(search.executor, SlurmAllocationExecutor)
+    monkeypatch.setenv("SLURM_JOB_ID", "123")
+    monkeypatch.setenv("SLURM_NNODES", "2")
+    monkeypatch.setenv("SLURM_GPUS_ON_NODE", "6")
+    monkeypatch.setenv("SLURM_CPUS_ON_NODE", "96")
+    monkeypatch.setenv("SLURM_MEM_PER_NODE", "600000")
+    calls = []
+    monkeypatch.setattr(
+        "samudra.search.executors.slurm_allocation.subprocess.run",
+        lambda command, *, check, env: calls.append(command),
+    )
+
+    search.executor._run_slurm_task(Task(rung=1, task=0, anchor=False, world_size=8))
+
+    command = calls[0]
+    assert "--nodes=2" in command
+    assert "--ntasks-per-node=1" in command
+    assert "--gpus-per-task=4" in command
+    assert "--cpus-per-task=64" in command
+    assert "--mem=400000M" in command
+    assert "--nproc-per-node=4" in command
+
+
 def test_node_launcher_maps_slurm_node_rank_to_torchrun(monkeypatch):
     monkeypatch.setenv("SLURM_STEP_NODELIST", "node-[01-02]")
     monkeypatch.setenv("SLURM_NODEID", "1")

--- a/tests/test_search_resources.py
+++ b/tests/test_search_resources.py
@@ -83,3 +83,18 @@ def test_adaptive_plan_requires_auto_backend():
 
     with pytest.raises(ValueError, match="requires backend='auto'"):
         plan_candidate_resources(policy(), {"model": candidate}, gpu_capacity=8)
+
+
+def test_adaptive_plan_warns_and_uses_a_placeable_world_size():
+    candidate = train_config(batch_size=2)
+
+    with pytest.warns(UserWarning, match="cannot be placed uniformly"):
+        plan = plan_candidate_resources(
+            policy(),
+            {"model": candidate},
+            gpu_capacity=8,
+            placeable_world_sizes={1, 2, 4},
+        )["model"]
+
+    assert plan.world_size == 4
+    assert plan.gradient_accumulation_steps == 8

--- a/tests/test_search_resources.py
+++ b/tests/test_search_resources.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from samudra.config import TrainConfig
+from samudra.search.config import AdaptiveDataParallelResourceConfig
+from samudra.search.resources import plan_candidate_resources
+
+
+def train_config(*, batch_size: int, accumulation_steps: int = 1) -> TrainConfig:
+    config = TrainConfig.from_yaml_and_cli(
+        [str(Path("tests/configs/train_default.yaml").resolve())]
+    )
+    config.batch_size = batch_size
+    config.gradient_accumulation_steps = accumulation_steps
+    return config
+
+
+def policy(*, effective_batch: int = 64) -> AdaptiveDataParallelResourceConfig:
+    return AdaptiveDataParallelResourceConfig(
+        max_gpus_per_candidate=8,
+        effective_global_batch_size=effective_batch,
+    )
+
+
+def test_adaptive_plan_expands_as_candidate_concurrency_falls():
+    candidates = {name: train_config(batch_size=2) for name in ("a", "b", "c", "d")}
+
+    crowded = plan_candidate_resources(
+        policy(), candidates, gpu_capacity=8, candidate_concurrency=4
+    )
+    survivors = plan_candidate_resources(
+        policy(), {"a": candidates["a"]}, gpu_capacity=8, candidate_concurrency=1
+    )
+
+    assert {plan.world_size for plan in crowded.values()} == {2}
+    assert {plan.gradient_accumulation_steps for plan in crowded.values()} == {16}
+    assert survivors["a"].world_size == 8
+    assert survivors["a"].gradient_accumulation_steps == 4
+    assert all(
+        plan.local_batch_size * plan.world_size * plan.gradient_accumulation_steps == 64
+        for plan in [*crowded.values(), *survivors.values()]
+    )
+
+
+def test_incompatible_batch_warns_and_preserves_user_choice():
+    candidate = train_config(batch_size=4, accumulation_steps=7)
+
+    with pytest.warns(UserWarning, match="Choose a local batch size"):
+        plan = plan_candidate_resources(
+            policy(effective_batch=48), {"model": candidate}, gpu_capacity=8
+        )["model"]
+
+    assert candidate.batch_size == 4
+    assert plan.local_batch_size == 4
+    assert plan.world_size == 4
+    assert plan.gradient_accumulation_steps == 3
+    assert plan.effective_global_batch_size == 48
+
+
+def test_irreconcilable_batch_warns_and_disables_adaptation():
+    candidate = train_config(batch_size=3, accumulation_steps=7)
+
+    with pytest.warns(UserWarning) as caught:
+        plan = plan_candidate_resources(
+            policy(effective_batch=64), {"model": candidate}, gpu_capacity=8
+        )["model"]
+
+    assert len(caught) == 1
+    assert plan.world_size == 1
+    assert plan.local_batch_size == 3
+    assert plan.gradient_accumulation_steps == 7
+    assert plan.effective_global_batch_size == 21
+
+
+def test_adaptive_plan_requires_auto_backend():
+    candidate = train_config(batch_size=2)
+    candidate.backend = "cuda"
+
+    with pytest.raises(ValueError, match="requires backend='auto'"):
+        plan_candidate_resources(policy(), {"model": candidate}, gpu_capacity=8)


### PR DESCRIPTION
## Summary

- add an opt-in `adaptive_data_parallel` search resource policy
- expand surviving candidates onto idle GPUs while preserving the configured local batch size and a fixed effective global batch
- launch candidate-local `torchrun` jobs on local GPUs and across homogeneous nodes in an existing Slurm allocation
- plan uniform placements across partially used nodes (for example, world size 8 as 4 ranks per node on a 2×6-GPU allocation) and filter out unplaceable custom world sizes
- persist each rung's resource plan so controller retries keep identical training semantics
- fail fast with recovery guidance if a local retry exposes fewer GPUs than its persisted plan requires
- warn and fall back to the largest compatible world size when a candidate batch size cannot use the requested GPUs; never override the configured batch size

## Scientific semantics

The planner computes `gradient_accumulation_steps = effective_global_batch_size / (batch_size * world_size)`. A fixed-global-batch sampler partitions the same epoch-seeded optimizer batches across ranks and accumulation microsteps, so changing world size does not change the samples or optimizer-step count. Learning-rate and scheduler settings are therefore left unchanged. DDP synchronization is skipped on non-final accumulation microsteps with `no_sync()`.

Candidate configs must use `backend: auto`, which lets the existing `init_distributed_mode()` machinery select single-process execution or initialize from `torchrun` environment variables. Fixed anchors remain single-GPU. The separately submitted Slurm-array executor rejects this policy because those jobs do not share an allocation.

## Batch-size and placement warnings

If `effective_global_batch_size` is not divisible by `batch_size * requested_world_size`, the controller emits a warning with the candidate and configured batch size, preserves that choice, and selects the largest smaller compatible world size. If the batch size cannot realize the target even on one GPU, adaptive scaling is disabled for that candidate and its original accumulation setting is retained.

The allocation executor separately constrains plans to world sizes that can be distributed uniformly without exceeding the visible GPUs on any node. If topology rules out an otherwise compatible world size, the controller warns and selects the largest placeable alternative.

## Testing

- `uv run python -m pytest tests/test_search_resources.py tests/test_samplers.py tests/test_search.py -q` — 82 passed
- `uv run python -m pytest -m "not manual and not cuda" -n auto` — 480 passed, 2 skipped, 10 xfailed
- `uvx pre-commit run --all-files` — all hooks passed

Tests cover 1/2/4-rank optimizer-batch invariance, adaptive expansion, compatible and irreconcilable batch warnings, retry plan persistence, local multi-GPU launch construction, partially occupied multi-node placement, and Slurm/torchrun rendezvous construction. This machine has no CUDA/Slurm allocation, so the real 8- and 16-GPU smoke runs remain deployment checks.

## Stack

This is intentionally based on #865 and contains only the adaptive data-parallel follow-up. It can be retargeted to `main` after #865 merges.
