### PR TITLE
Retry transient normalization failures

### DIFF
--- a/data/ocean_preprocessing/make_norm_datasets.py
+++ b/data/ocean_preprocessing/make_norm_datasets.py
@@ -4,16 +4,34 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""A quick utility script to create *_means.zarr and *_stds.zarr from a dataset."""
+"""Create *_means.zarr and *_stds.zarr from a dataset."""
 
+import argparse
 import os
-import sys
 
-import fsspec
 import xarray as xr
-from dask.distributed import LocalCluster
+from dask.distributed import Client, LocalCluster
 
-if __name__ == "__main__":
+
+def write_zarr_with_retries(
+    ds: xr.Dataset, path: str, client: Client, write_retries: int
+) -> None:
+    """Write a derived dataset, retrying failed Dask tasks in place."""
+    delayed = ds.to_zarr(
+        path,
+        mode="w",
+        zarr_format=2,
+        consolidated=True,
+        compute=False,
+    )
+    client.compute(delayed, retries=write_retries, sync=True)
+
+
+def main(src: str, write_retries: int = 5) -> None:
+    """Calculate and write normalization statistics for ``src``."""
+    if write_retries < 0:
+        raise ValueError("write_retries must be non-negative")
+
     client = LocalCluster().get_client()
     # This could be the OSN pod, it just has to be set via environment variable like so:
     # ```
@@ -21,9 +39,6 @@ if __name__ == "__main__":
     # export AWS_ACCESS_KEY_ID=...
     # export AWS_SECRET_ACCESS_KEY=...
     # ```
-    fs_src = fsspec.filesystem("s3")
-
-    src = sys.argv[1]
     assert src.startswith("s3://"), f"{src=} must start with `s3://`"
 
     path, base = os.path.dirname(src), os.path.basename(src)
@@ -74,10 +89,29 @@ if __name__ == "__main__":
     mean_path = os.path.join(path, f"{ds_name}_means{ds_ext}")
     print(f"Writing mean Zarr to {mean_path!r}.")
     # These stores are derived entirely from ``src``. Replace a partial store
-    # left by an interrupted attempt so that batch-level retries are safe.
-    ds_means.to_zarr(mean_path, mode="w", zarr_format=2, consolidated=True)
+    # left by an interrupted/requeued attempt so that restarting is safe.
+    write_zarr_with_retries(ds_means, mean_path, client, write_retries)
     stds_path = os.path.join(path, f"{ds_name}_stds{ds_ext}")
     print(f"Writing std Zarr to {stds_path!r}.")
-    ds_stds.to_zarr(stds_path, mode="w", zarr_format=2, consolidated=True)
+    write_zarr_with_retries(ds_stds, stds_path, client, write_retries)
 
     print("done.")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("src", help="s3:// path to the source Zarr dataset")
+    parser.add_argument(
+        "--write-retries",
+        "--write_retries",
+        type=int,
+        default=5,
+        help="number of Dask retries for each failed write task (default: 5)",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args.src, args.write_retries)

--- a/data/ocean_preprocessing/make_norm_datasets.py
+++ b/data/ocean_preprocessing/make_norm_datasets.py
@@ -73,9 +73,11 @@ if __name__ == "__main__":
 
     mean_path = os.path.join(path, f"{ds_name}_means{ds_ext}")
     print(f"Writing mean Zarr to {mean_path!r}.")
-    ds_means.to_zarr(mean_path, zarr_format=2, consolidated=True)
+    # These stores are derived entirely from ``src``. Replace a partial store
+    # left by an interrupted attempt so that batch-level retries are safe.
+    ds_means.to_zarr(mean_path, mode="w", zarr_format=2, consolidated=True)
     stds_path = os.path.join(path, f"{ds_name}_stds{ds_ext}")
     print(f"Writing std Zarr to {stds_path!r}.")
-    ds_stds.to_zarr(stds_path, zarr_format=2, consolidated=True)
+    ds_stds.to_zarr(stds_path, mode="w", zarr_format=2, consolidated=True)
 
     print("done.")

--- a/data/ocean_preprocessing/make_norm_datasets.py
+++ b/data/ocean_preprocessing/make_norm_datasets.py
@@ -6,11 +6,16 @@
 
 """Create *_means.zarr and *_stds.zarr from a dataset."""
 
+from __future__ import annotations
+
 import argparse
 import os
+from typing import TYPE_CHECKING
 
 import xarray as xr
-from dask.distributed import Client, LocalCluster
+
+if TYPE_CHECKING:
+    from dask.distributed import Client
 
 
 def write_zarr_with_retries(
@@ -29,6 +34,8 @@ def write_zarr_with_retries(
 
 def main(src: str, write_retries: int = 5) -> None:
     """Calculate and write normalization statistics for ``src``."""
+    from dask.distributed import LocalCluster
+
     if write_retries < 0:
         raise ValueError("write_retries must be non-negative")
 

--- a/data/tests/test_make_norm_datasets.py
+++ b/data/tests/test_make_norm_datasets.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock
+
+from ocean_preprocessing.make_norm_datasets import write_zarr_with_retries
+
+
+def test_write_zarr_uses_dask_task_retries():
+    ds = Mock()
+    client = Mock()
+    delayed = object()
+    ds.to_zarr.return_value = delayed
+
+    write_zarr_with_retries(ds, "s3://test/output.zarr", client, write_retries=7)
+
+    ds.to_zarr.assert_called_once_with(
+        "s3://test/output.zarr",
+        mode="w",
+        zarr_format=2,
+        consolidated=True,
+        compute=False,
+    )
+    client.compute.assert_called_once_with(delayed, retries=7, sync=True)

--- a/data/tests/test_slurm_harness.py
+++ b/data/tests/test_slurm_harness.py
@@ -13,6 +13,7 @@ SLURM_HARNESSES = [
     VARIANT_SCRIPT.parent / "slurm_preprocess_om4.sbatch",
     VARIANT_SCRIPT.parent / "slurm_make_norm_om4.sbatch",
 ]
+NORM_HARNESS = SLURM_HARNESSES[1]
 
 
 def _resolve_variant(variant: str) -> subprocess.CompletedProcess[str]:
@@ -80,3 +81,65 @@ def test_preprocessing_harness_runs_selected_data_subproject():
     assert script.index('cd "${REPO_DIR}/data"') < script.index(
         "\npython -m ocean_preprocessing om4"
     )
+
+
+def _run_norm_harness(tmp_path, *, max_attempts, succeed_on_attempt):
+    conda_sh = tmp_path / "conda.sh"
+    conda_sh.write_text("conda() { :; }\n")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_python = bin_dir / "python"
+    fake_python.write_text(
+        "#!/bin/bash\n"
+        "count=0\n"
+        '[[ -f "$NORM_TEST_STATE" ]] && read -r count < "$NORM_TEST_STATE"\n'
+        "count=$((count + 1))\n"
+        'printf "%s\\n" "$count" > "$NORM_TEST_STATE"\n'
+        "(( count >= NORM_SUCCEED_ON_ATTEMPT ))\n"
+    )
+    fake_python.chmod(0o755)
+
+    state = tmp_path / "attempts"
+    env = os.environ | {
+        "AWS_ACCESS_KEY_ID": "test",
+        "AWS_SECRET_ACCESS_KEY": "test",  # pragma: allowlist secret
+        "CONDA_SH": str(conda_sh),
+        "NORM_MAX_ATTEMPTS": str(max_attempts),
+        "NORM_RETRY_DELAY_SECONDS": "0",
+        "NORM_SUCCEED_ON_ATTEMPT": str(succeed_on_attempt),
+        "NORM_TEST_STATE": str(state),
+        "OUTPUT_PATH": "s3://test/input/OM4.zarr",
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "REPO_DIR": str(VARIANT_SCRIPT.parents[1]),
+    }
+    result = subprocess.run(
+        ["bash", str(NORM_HARNESS)],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    return result, int(state.read_text())
+
+
+def test_norm_harness_retries_then_succeeds(tmp_path):
+    result, attempts = _run_norm_harness(tmp_path, max_attempts=3, succeed_on_attempt=3)
+
+    assert result.returncode == 0
+    assert attempts == 3
+    assert "Normalization attempt 3/3" in result.stdout
+
+
+def test_norm_harness_stops_after_bounded_attempts(tmp_path):
+    result, attempts = _run_norm_harness(
+        tmp_path, max_attempts=2, succeed_on_attempt=99
+    )
+
+    assert result.returncode != 0
+    assert attempts == 2
+    assert "normalization failed after 2 attempts" in result.stderr
+
+
+def test_norm_harness_is_requeueable():
+    assert "#SBATCH --requeue" in NORM_HARNESS.read_text()

--- a/data/tests/test_slurm_harness.py
+++ b/data/tests/test_slurm_harness.py
@@ -83,63 +83,12 @@ def test_preprocessing_harness_runs_selected_data_subproject():
     )
 
 
-def _run_norm_harness(tmp_path, *, max_attempts, succeed_on_attempt):
-    conda_sh = tmp_path / "conda.sh"
-    conda_sh.write_text("conda() { :; }\n")
-
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    fake_python = bin_dir / "python"
-    fake_python.write_text(
-        "#!/bin/bash\n"
-        "count=0\n"
-        '[[ -f "$NORM_TEST_STATE" ]] && read -r count < "$NORM_TEST_STATE"\n'
-        "count=$((count + 1))\n"
-        'printf "%s\\n" "$count" > "$NORM_TEST_STATE"\n'
-        "(( count >= NORM_SUCCEED_ON_ATTEMPT ))\n"
-    )
-    fake_python.chmod(0o755)
-
-    state = tmp_path / "attempts"
-    env = os.environ | {
-        "AWS_ACCESS_KEY_ID": "test",
-        "AWS_SECRET_ACCESS_KEY": "test",  # pragma: allowlist secret
-        "CONDA_SH": str(conda_sh),
-        "NORM_MAX_ATTEMPTS": str(max_attempts),
-        "NORM_RETRY_DELAY_SECONDS": "0",
-        "NORM_SUCCEED_ON_ATTEMPT": str(succeed_on_attempt),
-        "NORM_TEST_STATE": str(state),
-        "OUTPUT_PATH": "s3://test/input/OM4.zarr",
-        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
-        "REPO_DIR": str(VARIANT_SCRIPT.parents[1]),
-    }
-    result = subprocess.run(
-        ["bash", str(NORM_HARNESS)],
-        check=False,
-        capture_output=True,
-        env=env,
-        text=True,
-    )
-    return result, int(state.read_text())
-
-
-def test_norm_harness_retries_then_succeeds(tmp_path):
-    result, attempts = _run_norm_harness(tmp_path, max_attempts=3, succeed_on_attempt=3)
-
-    assert result.returncode == 0
-    assert attempts == 3
-    assert "Normalization attempt 3/3" in result.stdout
-
-
-def test_norm_harness_stops_after_bounded_attempts(tmp_path):
-    result, attempts = _run_norm_harness(
-        tmp_path, max_attempts=2, succeed_on_attempt=99
-    )
-
-    assert result.returncode != 0
-    assert attempts == 2
-    assert "normalization failed after 2 attempts" in result.stderr
-
-
 def test_norm_harness_is_requeueable():
     assert "#SBATCH --requeue" in NORM_HARNESS.read_text()
+
+
+def test_norm_harness_configures_dask_write_retries():
+    script = NORM_HARNESS.read_text()
+
+    assert 'NORM_WRITE_RETRIES="${NORM_WRITE_RETRIES:-5}"' in script
+    assert '--write-retries="${NORM_WRITE_RETRIES}"' in script

--- a/scripts/slurm_make_norm_om4.sbatch
+++ b/scripts/slurm_make_norm_om4.sbatch
@@ -22,6 +22,8 @@
 #   PREPROC_ENV  conda env name (default: ocean_preprocessing)
 #   CONDA_SH     path to conda.sh (autodetected from $CONDA_EXE / common dirs)
 #   REPO_DIR     repo checkout (default: $SLURM_SUBMIT_DIR)
+#   NORM_MAX_ATTEMPTS          total attempts for transient failures (default: 3)
+#   NORM_RETRY_DELAY_SECONDS   delay between attempts in seconds (default: 60)
 #
 # Credentials (required to WRITE to OSN):
 #   export FSSPEC_S3_ENDPOINT_URL=https://nyu1.osn.mghpcc.org/
@@ -44,6 +46,7 @@
 #SBATCH --cpus-per-task=32
 #SBATCH --mem=480G
 #SBATCH --time=12:00:00
+#SBATCH --requeue
 
 set -euo pipefail
 
@@ -109,9 +112,35 @@ export PYTHONUNBUFFERED=1
 
 cd "${REPO_DIR}/data"
 
+NORM_MAX_ATTEMPTS="${NORM_MAX_ATTEMPTS:-3}"
+NORM_RETRY_DELAY_SECONDS="${NORM_RETRY_DELAY_SECONDS:-60}"
+if [[ ! "${NORM_MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: NORM_MAX_ATTEMPTS must be a positive integer; got '${NORM_MAX_ATTEMPTS}'." >&2
+  exit 2
+fi
+if [[ ! "${NORM_RETRY_DELAY_SECONDS}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: NORM_RETRY_DELAY_SECONDS must be a non-negative integer; got '${NORM_RETRY_DELAY_SECONDS}'." >&2
+  exit 2
+fi
+
 echo "Building means/stds for: ${OUTPUT_PATH}"
-set -x
-python ocean_preprocessing/make_norm_datasets.py "${OUTPUT_PATH}"
-set +x
+attempt=1
+while (( attempt <= NORM_MAX_ATTEMPTS )); do
+  echo "Normalization attempt ${attempt}/${NORM_MAX_ATTEMPTS}"
+  if python ocean_preprocessing/make_norm_datasets.py "${OUTPUT_PATH}"; then
+    break
+  else
+    status=$?
+  fi
+
+  if (( attempt == NORM_MAX_ATTEMPTS )); then
+    echo "ERROR: normalization failed after ${NORM_MAX_ATTEMPTS} attempts (exit ${status})." >&2
+    exit "${status}"
+  fi
+
+  echo "Normalization attempt ${attempt} failed (exit ${status}); retrying in ${NORM_RETRY_DELAY_SECONDS}s." >&2
+  sleep "${NORM_RETRY_DELAY_SECONDS}"
+  ((attempt += 1))
+done
 
 echo "Normalization datasets written next to ${OUTPUT_PATH}"

--- a/scripts/slurm_make_norm_om4.sbatch
+++ b/scripts/slurm_make_norm_om4.sbatch
@@ -22,8 +22,7 @@
 #   PREPROC_ENV  conda env name (default: ocean_preprocessing)
 #   CONDA_SH     path to conda.sh (autodetected from $CONDA_EXE / common dirs)
 #   REPO_DIR     repo checkout (default: $SLURM_SUBMIT_DIR)
-#   NORM_MAX_ATTEMPTS          total attempts for transient failures (default: 3)
-#   NORM_RETRY_DELAY_SECONDS   delay between attempts in seconds (default: 60)
+#   NORM_WRITE_RETRIES  retries per failed Dask task during writes (default: 5)
 #
 # Credentials (required to WRITE to OSN):
 #   export FSSPEC_S3_ENDPOINT_URL=https://nyu1.osn.mghpcc.org/
@@ -112,35 +111,15 @@ export PYTHONUNBUFFERED=1
 
 cd "${REPO_DIR}/data"
 
-NORM_MAX_ATTEMPTS="${NORM_MAX_ATTEMPTS:-3}"
-NORM_RETRY_DELAY_SECONDS="${NORM_RETRY_DELAY_SECONDS:-60}"
-if [[ ! "${NORM_MAX_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
-  echo "ERROR: NORM_MAX_ATTEMPTS must be a positive integer; got '${NORM_MAX_ATTEMPTS}'." >&2
-  exit 2
-fi
-if [[ ! "${NORM_RETRY_DELAY_SECONDS}" =~ ^[0-9]+$ ]]; then
-  echo "ERROR: NORM_RETRY_DELAY_SECONDS must be a non-negative integer; got '${NORM_RETRY_DELAY_SECONDS}'." >&2
+NORM_WRITE_RETRIES="${NORM_WRITE_RETRIES:-5}"
+if [[ ! "${NORM_WRITE_RETRIES}" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: NORM_WRITE_RETRIES must be a non-negative integer; got '${NORM_WRITE_RETRIES}'." >&2
   exit 2
 fi
 
 echo "Building means/stds for: ${OUTPUT_PATH}"
-attempt=1
-while (( attempt <= NORM_MAX_ATTEMPTS )); do
-  echo "Normalization attempt ${attempt}/${NORM_MAX_ATTEMPTS}"
-  if python ocean_preprocessing/make_norm_datasets.py "${OUTPUT_PATH}"; then
-    break
-  else
-    status=$?
-  fi
-
-  if (( attempt == NORM_MAX_ATTEMPTS )); then
-    echo "ERROR: normalization failed after ${NORM_MAX_ATTEMPTS} attempts (exit ${status})." >&2
-    exit "${status}"
-  fi
-
-  echo "Normalization attempt ${attempt} failed (exit ${status}); retrying in ${NORM_RETRY_DELAY_SECONDS}s." >&2
-  sleep "${NORM_RETRY_DELAY_SECONDS}"
-  ((attempt += 1))
-done
+python ocean_preprocessing/make_norm_datasets.py \
+  "${OUTPUT_PATH}" \
+  --write-retries="${NORM_WRITE_RETRIES}"
 
 echo "Normalization datasets written next to ${OUTPUT_PATH}"


### PR DESCRIPTION
## Summary

- retry individual failed Dask tasks during normalization writes, five times by default
- expose the retry count through `NORM_WRITE_RETRIES` in the Slurm harness
- mark normalization Slurm jobs requeueable for scheduler or node interruptions
- replace partial derived normalization stores so a requeued job can restart safely
- test the Dask retry wiring and Slurm harness configuration

## Failure handling

- transient S3/Dask task failure: Dask retries only the failed task
- scheduler or node interruption: Slurm may requeue the job
- interrupted partial output: `mode="w"` safely replaces the derived store

## Testing

- `bash -n scripts/slurm_make_norm_om4.sbatch`
- `uv run pytest data/tests/test_slurm_harness.py data/tests/test_make_norm_datasets.py -q`
- `uvx pre-commit run --all-files`

The September normalization jobs remain paused until this PR is approved.