### PR TITLE
Archive W&B runs to OSN weekly

### DIFF
--- a/.github/wandb-archive.yaml
+++ b/.github/wandb-archive.yaml
@@ -6,8 +6,13 @@ source:
   entity: ocean_emulators
   timeout_seconds: 60
   projects:
-    include: ["*"]
-    exclude: ["scratch-*"]
+    # Keep public publication opt-in: new W&B projects must be reviewed here.
+    include:
+      - default
+      - marin
+      - ocean-emulators
+      - samudra-multi-decoder
+    exclude: []
   runs:
     states: [finished, failed, crashed, killed, preempted]
   retry:

--- a/.github/wandb-archive.yaml
+++ b/.github/wandb-archive.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+source:
+  entity: ocean_emulators
+  timeout_seconds: 60
+  projects:
+    include: ["*"]
+    exclude: ["scratch-*"]
+  runs:
+    states: [finished, failed, crashed, killed, preempted]
+  retry:
+    attempts: 6
+    initial_delay_seconds: 1
+    maximum_delay_seconds: 60
+
+destination:
+  type: s3
+  endpoint_url: https://nyu1.osn.mghpcc.org
+  bucket: m2lines-pubs
+  prefix: Samudra/wandb
+  public_url: https://nyu1.osn.mghpcc.org/m2lines-pubs/Samudra/wandb
+
+archive:
+  strict: true
+  include:
+    histories: true
+    system_metrics: true
+    media: true
+    tables: true
+    run_files: safe
+    logged_artifacts: safe
+    used_artifacts: references
+    code: false
+    console_logs: false
+  security:
+    profile: public-safe
+    on_sensitive_value: fail
+  transfers:
+    concurrency: 16
+    retries: 5

--- a/.github/workflows/wandb-archive.yml
+++ b/.github/workflows/wandb-archive.yml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Archive W&B runs
+
+on:
+  schedule:
+    # Weekly updates keep each incremental backup small. Avoid the top of the hour,
+    # when scheduled GitHub Actions experience the most load.
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wandb-archive-osn
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check archive credentials
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OSN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OSN_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in WANDB_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("${name}")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            echo "Missing required archive credential(s): ${missing[*]}" >&2
+            exit 1
+          fi
+
+  ec2:
+    needs: preflight
+    permissions:
+      contents: read
+      id-token: write
+    uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
+    with:
+      aws_region: us-east-1
+      # Export is W&B API/network-bound and does not benefit from a GPU.
+      ec2_instance_type: m7i.xlarge
+      # Ubuntu 24.04 LTS amd64 hvm ebs-gp3 in us-east-1, Canonical owner 099720109477.
+      ec2_image_id: ami-04b70fa74e45c3917
+      ec2_root_device_size: 200
+      max_instance_lifetime: "720"
+      aws_tags: '[{"Key": "project", "Value": "fomo"}, {"Key": "purpose", "Value": "wandb-archive"}]'
+    secrets:
+      GH_SA_TOKEN: ${{ secrets.GH_SA_TOKEN }}
+
+  archive:
+    needs: ec2
+    runs-on: ${{ needs.ec2.outputs.id }}
+    timeout-minutes: 690
+    steps:
+      - name: Check out code
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+
+      - name: Archive W&B runs to OSN
+        uses: Open-Athena/wandb-archive@5646c052f6e552e8f23e83f345926ad7edf62e2e # v0.1.1
+        with:
+          config: .github/wandb-archive.yaml
+          command: backup
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.OSN_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OSN_SECRET_ACCESS_KEY }}
+          # OSN's S3 implementation does not support the new AWS SDK checksum headers.
+          AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+          AWS_RESPONSE_CHECKSUM_VALIDATION: when_required

--- a/.github/workflows/wandb-archive.yml
+++ b/.github/workflows/wandb-archive.yml
@@ -24,17 +24,21 @@ jobs:
     steps:
       - name: Check archive credentials
         env:
-          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.OSN_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.OSN_SECRET_ACCESS_KEY }}
+          HAS_WANDB_API_KEY: ${{ secrets.WANDB_API_KEY != '' }}
+          HAS_OSN_ACCESS_KEY_ID: ${{ secrets.OSN_ACCESS_KEY_ID != '' }}
+          HAS_OSN_SECRET_ACCESS_KEY: ${{ secrets.OSN_SECRET_ACCESS_KEY != '' }}
         run: |
           set -euo pipefail
           missing=()
-          for name in WANDB_API_KEY AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY; do
-            if [ -z "${!name:-}" ]; then
-              missing+=("${name}")
-            fi
-          done
+          if [ "${HAS_WANDB_API_KEY}" != "true" ]; then
+            missing+=(WANDB_API_KEY)
+          fi
+          if [ "${HAS_OSN_ACCESS_KEY_ID}" != "true" ]; then
+            missing+=(OSN_ACCESS_KEY_ID)
+          fi
+          if [ "${HAS_OSN_SECRET_ACCESS_KEY}" != "true" ]; then
+            missing+=(OSN_SECRET_ACCESS_KEY)
+          fi
           if [ "${#missing[@]}" -ne 0 ]; then
             echo "Missing required archive credential(s): ${missing[*]}" >&2
             exit 1
@@ -45,8 +49,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@v2
+    uses: Open-Athena/ec2-gha/.github/workflows/runner.yml@e021da12a946b653a717738bc704aa7baa95ae8e
     with:
+      action_ref: e021da12a946b653a717738bc704aa7baa95ae8e # pragma: allowlist secret
       aws_region: us-east-1
       # Export is W&B API/network-bound and does not benefit from a GPU.
       ec2_instance_type: m7i.xlarge
@@ -65,6 +70,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/wandb-archive.yaml
+          sparse-checkout-cone-mode: false
 
       - name: Archive W&B runs to OSN
         uses: Open-Athena/wandb-archive@5646c052f6e552e8f23e83f345926ad7edf62e2e # v0.1.1


### PR DESCRIPTION
## Summary

- archive terminal W&B runs to the public OSN pod every Monday at 07:17 UTC and on manual dispatch
- launch an AWS `m7i.xlarge` CPU runner with 200 GB of temporary disk and a 12-hour lifetime ceiling
- use the pinned W&B Archive v0.1.1 action with public-safe filtering, retries, incremental/idempotent publishing, and a single-writer concurrency guard
- fail in a GitHub-hosted preflight before launching EC2 when archive credentials are missing

Weekly incremental exports keep each update smaller, surface failures sooner, and reduce exposure to W&B quota pressure. A GPU is intentionally not requested because the export is limited by W&B API and network throughput rather than CUDA compute.

## Required repository secrets

These secrets must be configured before the workflow is run:

- `WANDB_API_KEY`
- `OSN_ACCESS_KEY_ID`
- `OSN_SECRET_ACCESS_KEY`

The existing `GH_SA_TOKEN` and AWS repository variables continue to launch the self-hosted runner through `Open-Athena/ec2-gha`.

## Validation

- `uvx pre-commit run --files .github/wandb-archive.yaml .github/workflows/wandb-archive.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/wandb-archive.yml`
- loaded `.github/wandb-archive.yaml` with the published `wandb-archive==0.1.1` configuration model

The initial historical backfill can continue on Torch; this workflow is designed primarily for idempotent weekly increments, while retaining enough runtime headroom to catch up after a missed run.