### PR TITLE
Support tripolar grids in viz

### DIFF
--- a/data/ocean_preprocessing/__main__.py
+++ b/data/ocean_preprocessing/__main__.py
@@ -24,6 +24,7 @@ import fire
 import fsspec
 import xarray as xr
 
+from ocean_preprocessing.basin_masks import basin_masks_from_static
 from ocean_preprocessing.dataset_validation import (
     ds_flattened_input_validate,
     ds_input_validate,
@@ -521,6 +522,46 @@ class CLI:
         logger.info("collecting!")
         self._collect(ds)
         logger.info("done!")
+
+    def basin_masks(self, static_path: str):
+        """Build ocean-basin masks on a model's native horizontal grid.
+
+        The published basin masks are all on regular lat-lon grids, so none of
+        them applies to OM4's native 1080x1440 tripolar grid. OM4's
+        `ocean_static` already carries integer region codes there, alongside the
+        real 2-D cell centers and the wet mask, so the masks can be built
+        directly with no regridding.
+
+        Args:
+            static_path: An OM4 `ocean_static` store, e.g.
+                `s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr`.
+
+        Example:
+            python -m ocean_preprocessing \
+              --output_path=basin_masks_native.zarr \
+              basin_masks \
+              --static_path=s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr
+        """
+        logger.info(f"reading ocean_static from {static_path}")
+        static = xr.open_zarr(static_path, chunks={})
+        if "time" in static.dims:
+            static = static.isel(time=0, drop=True)
+
+        masks = basin_masks_from_static(static)
+        logger.info(
+            "built masks: "
+            + ", ".join(
+                f"{name}={int(masks[name].sum())} cells" for name in masks.data_vars
+            )
+        )
+
+        if self.dry_run:
+            logger.info(masks)
+            return
+
+        logger.info(f"writing masks to {self.output_path}")
+        masks.to_zarr(self.output_path, mode="w", consolidated=True, zarr_format=2)
+        logger.info("zarr write complete")
 
     def cm4(self):
         """Process the CM4 oceans dataset (a coupled ocean model from CMIP)."""

--- a/data/ocean_preprocessing/__main__.py
+++ b/data/ocean_preprocessing/__main__.py
@@ -235,16 +235,20 @@ class CLI:
         self.wfo_source_path = wfo_source_path
         self.dask_client = init_cluster(cluster, **cluster_opts)
 
-    def _collect(self, ds: xr.Dataset):
+    def _collect(self, ds: xr.Dataset, *, compress: bool = False):
         """Finalize and write the processed dataset to disk.
 
         Args:
             ds: The processed dataset to write. Should already be chunked appropriately.
+            compress: Leave zarr's default compressor in place. The training
+                stores turn compression off so the loader can read them without
+                a decompression pass; the basin masks are small and are read by
+                hand, so they keep the compression the published masks use.
 
         Note:
             Respects dry_run and small_run flags.
         """
-        if self.small_run:
+        if self.small_run and "time" in ds.dims:
             ds = ds.isel(time=slice(0, 10))
         if self.dry_run:
             if self.dask_client is not None:
@@ -261,9 +265,11 @@ class CLI:
             mode="w",
             consolidated=True,
             zarr_format=2,
-            encoding={
-                var_name: {"compressor": None} for var_name in ds.data_vars.keys()
-            },  # Compression turned off
+            encoding=(
+                None
+                if compress
+                else {var_name: {"compressor": None} for var_name in ds.data_vars}
+            ),
             compute=False,
         )
         # Reading blosc-compressed source chunks over S3 occasionally returns a
@@ -555,13 +561,9 @@ class CLI:
             )
         )
 
-        if self.dry_run:
-            logger.info(masks)
-            return
-
-        logger.info(f"writing masks to {self.output_path}")
-        masks.to_zarr(self.output_path, mode="w", consolidated=True, zarr_format=2)
-        logger.info("zarr write complete")
+        # `compress=True` keeps zarr's default blosc/lz4, which is what the
+        # published masks use, so the two sets of masks stay byte-comparable.
+        self._collect(masks, compress=True)
 
     def cm4(self):
         """Process the CM4 oceans dataset (a coupled ocean model from CMIP)."""

--- a/data/ocean_preprocessing/basin_masks.py
+++ b/data/ocean_preprocessing/basin_masks.py
@@ -1,0 +1,199 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ocean-basin masks on a model's native horizontal grid.
+
+The published basin masks (``s3://m2lines-pubs/Samudra/basins/``) are all on
+regular lat-lon grids, so none of them can be applied to OM4's native 1080x1440
+tripolar grid: the shapes do not match, and where they happen to match on some
+other curvilinear grid, matching shapes would not imply matching geography.
+
+OM4's ``ocean_static`` already carries a ``basin`` field of integer region codes
+on the native grid, alongside the real 2-D cell centers and the wet mask. That
+is enough to build native masks directly, with no regridding and no polygon
+work: the codes partition the grid by construction, so a cell cannot land in two
+basins.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+# Region codes on OM4's `ocean_static.basin`, from its own CF flag attributes:
+#   flag_values:   0 1 2 3 4 5 6 7 8 9 10
+#   flag_meanings: global_land southern_ocean atlantic_ocean pacific_ocean
+#                  arctic_ocean indian_ocean mediterranean_sea black_sea
+#                  hudson_bay baltic_sea red_sea
+OM4_BASIN_CODES: dict[str, int] = {
+    "basin_southern": 1,
+    "basin_atlantic": 2,
+    "basin_pacific": 3,
+    "basin_arctic": 4,
+    "basin_indian": 5,
+}
+
+# The marginal seas (codes 6-10). The published Gaussian masks leave every one
+# of them unassigned -- checked against `basin_masks_original.zarr`, where the
+# Mediterranean, Black Sea, Red Sea, Hudson Bay and Baltic are zero in all five
+# basins -- so we drop them too rather than inventing an attribution the rest of
+# the basin diagnostics have never made.
+OM4_MARGINAL_SEA_CODES: tuple[int, ...] = (6, 7, 8, 9, 10)
+
+# `basin_id` as the published masks number them. This is *not* OM4's code: the
+# published stores use their own ordering, and we keep it so the two sets of
+# masks describe themselves the same way.
+PUBLISHED_BASIN_IDS: dict[str, int] = {
+    "basin_arctic": 1,
+    "basin_atlantic": 2,
+    "basin_indian": 3,
+    "basin_pacific": 4,
+    "basin_southern": 5,
+}
+
+_LONG_NAMES: dict[str, str] = {
+    "basin_arctic": "Arctic",
+    "basin_atlantic": "Atlantic",
+    "basin_indian": "Indian",
+    "basin_pacific": "Pacific",
+    "basin_southern": "Southern",
+}
+
+
+def basin_masks_from_static(
+    static: xr.Dataset,
+    *,
+    basin_var: str = "basin",
+    wet_var: str = "wet",
+    lat_var: str = "geolat",
+    lon_var: str = "geolon",
+) -> xr.Dataset:
+    """Build native-grid basin masks from an OM4 ``ocean_static`` dataset.
+
+    Args:
+        static: OM4 ``ocean_static``, carrying integer region codes, a wet mask
+            and the real 2-D cell centers on the native horizontal grid.
+        basin_var: Name of the integer region-code field.
+        wet_var: Name of the wet (ocean fraction) mask.
+        lat_var: Name of the 2-D cell-center latitude.
+        lon_var: Name of the 2-D cell-center longitude.
+
+    Returns:
+        A dataset of five boolean masks stored as int8, on horizontal dims named
+        ``lat``/``lon`` (the index axes, matching what ``samudra viz`` renames
+        its data to), carrying the true cell centers as ``lat_2d``/``lon_2d`` so
+        the masks can be matched to data by geography rather than by position.
+    """
+    for name in (basin_var, wet_var, lat_var, lon_var):
+        if name not in static.variables:
+            raise ValueError(
+                f"ocean_static carries no {name!r}. Native basin masks need the "
+                f"region codes ({basin_var!r}), the wet mask ({wet_var!r}) and "
+                f"the real 2-D cell centers ({lat_var!r}/{lon_var!r})."
+            )
+
+    basin = static[basin_var]
+    if basin.ndim != 2:
+        raise ValueError(
+            f"{basin_var!r} must be 2-D on the horizontal grid, got dims {basin.dims}."
+        )
+
+    dims = basin.dims
+    codes = np.asarray(basin.values)
+    wet = np.asarray(static[wet_var].values) > 0.5
+    lat2d = np.asarray(static[lat_var].values, dtype=np.float64)
+    lon2d = np.asarray(static[lon_var].values, dtype=np.float64)
+
+    for name, array in ((wet_var, wet), (lat_var, lat2d), (lon_var, lon2d)):
+        if array.shape != codes.shape:
+            raise ValueError(
+                f"{name!r} has shape {array.shape} but {basin_var!r} is "
+                f"{codes.shape}; they must be on the same horizontal grid."
+            )
+
+    ny, nx = codes.shape
+    data_vars: dict[str, xr.DataArray] = {}
+    for mask_name, code in OM4_BASIN_CODES.items():
+        mask = (codes == code) & wet
+        long_name = _LONG_NAMES[mask_name]
+        data_vars[mask_name] = xr.DataArray(
+            mask.astype(np.int8),
+            dims=("lat", "lon"),
+            attrs={
+                "basin_id": PUBLISHED_BASIN_IDS[mask_name],
+                "description": (
+                    f"Boolean mask for {long_name} basin "
+                    "(1=in basin, 0=not in basin or land)"
+                ),
+                "dtype": "bool",
+                "long_name": f"{long_name} basin mask",
+                "note": (
+                    "Zero values represent land/non-basin areas and remain unassigned"
+                ),
+                "source": (
+                    f"ocean_static '{basin_var}' region code {code} on the native "
+                    "grid, intersected with the wet mask"
+                ),
+                "om4_basin_code": code,
+            },
+        )
+
+    masks = xr.Dataset(
+        data_vars,
+        coords={
+            # Index axes, carried over from the source so the store is
+            # self-describing; viz matches on the 2-D coords below.
+            "lat": ("lat", _axis(static, dims[0], ny)),
+            "lon": ("lon", _axis(static, dims[1], nx)),
+            "lat_2d": (("lat", "lon"), lat2d),
+            "lon_2d": (("lat", "lon"), lon2d),
+        },
+        attrs={
+            "description": (
+                "Ocean-basin masks on the model's native horizontal grid, built "
+                "from OM4 ocean_static region codes."
+            ),
+            "marginal_seas": (
+                "Codes "
+                + ", ".join(str(c) for c in OM4_MARGINAL_SEA_CODES)
+                + " (Mediterranean, Black Sea, Hudson Bay, Baltic, Red Sea) are "
+                "left unassigned, matching the published Gaussian masks."
+            ),
+        },
+    )
+
+    validate_basin_masks(masks, wet=wet)
+    return masks
+
+
+def _axis(static: xr.Dataset, dim: str, size: int) -> np.ndarray:
+    """The source's index axis for `dim`, or a plain range when it has none."""
+    if dim in static.coords:
+        return np.asarray(static.coords[dim].values)
+    return np.arange(size)
+
+
+def validate_basin_masks(masks: xr.Dataset, *, wet: np.ndarray | None = None) -> None:
+    """Check the masks partition the ocean, as the basin diagnostics assume.
+
+    Raises:
+        ValueError: If any cell is claimed by more than one basin, or if a mask
+            claims a cell the wet mask calls land.
+    """
+    names = list(OM4_BASIN_CODES)
+    stacked = np.stack([np.asarray(masks[name].values) for name in names])
+    overlap = stacked.sum(axis=0) > 1
+    if overlap.any():
+        raise ValueError(
+            f"{int(overlap.sum())} cells are assigned to more than one basin; "
+            "the masks must partition the ocean."
+        )
+
+    if wet is not None:
+        on_land = (stacked.sum(axis=0) > 0) & ~wet
+        if on_land.any():
+            raise ValueError(
+                f"{int(on_land.sum())} cells are assigned to a basin but are "
+                "land in the wet mask."
+            )

--- a/data/ocean_preprocessing/basin_masks.py
+++ b/data/ocean_preprocessing/basin_masks.py
@@ -21,7 +21,18 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-# Region codes on OM4's `ocean_static.basin`, from its own CF flag attributes:
+# Region codes on OM4's `ocean_static.basin`. The field is self-describing: it
+# carries CF flag attributes that name every code, so this table is transcribed
+# rather than chosen. Read them back with
+#
+#   xr.open_zarr(
+#       "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr"
+#   ).basin.attrs
+#
+# which gives, as of the store published at the time of writing:
+#
+#   standard_name: region
+#   long_name:     Region Selection Index
 #   flag_values:   0 1 2 3 4 5 6 7 8 9 10
 #   flag_meanings: global_land southern_ocean atlantic_ocean pacific_ocean
 #                  arctic_ocean indian_ocean mediterranean_sea black_sea
@@ -37,13 +48,18 @@ OM4_BASIN_CODES: dict[str, int] = {
 # The marginal seas (codes 6-10). The published Gaussian masks leave every one
 # of them unassigned -- checked against `basin_masks_original.zarr`, where the
 # Mediterranean, Black Sea, Red Sea, Hudson Bay and Baltic are zero in all five
-# basins -- so we drop them too rather than inventing an attribution the rest of
-# the basin diagnostics have never made.
+# basins, and where each variable says as much in its own `note` attribute --
+# so we drop them too rather than inventing an attribution the rest of the
+# basin diagnostics have never made.
 OM4_MARGINAL_SEA_CODES: tuple[int, ...] = (6, 7, 8, 9, 10)
 
-# `basin_id` as the published masks number them. This is *not* OM4's code: the
-# published stores use their own ordering, and we keep it so the two sets of
-# masks describe themselves the same way.
+# `basin_id` as the published masks number them. This is *not* OM4's code and
+# there is no standard behind it: it is read off the `basin_id` attribute each
+# variable in `s3://m2lines-pubs/Samudra/basins/basin_masks_original.zarr`
+# already carries. That store attributes itself to `basin_<Name>.nc via combined
+# original data`, and the numbering is alphabetical by basin name rather than
+# physical. We reproduce it so the native masks and the published ones describe
+# themselves the same way, not because the order means anything.
 PUBLISHED_BASIN_IDS: dict[str, int] = {
     "basin_arctic": 1,
     "basin_atlantic": 2,

--- a/data/tests/test_basin_masks.py
+++ b/data/tests/test_basin_masks.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native-grid basin masks built from OM4 region codes."""
+
+import numpy as np
+import pytest
+import xarray as xr
+from ocean_preprocessing.basin_masks import (
+    OM4_BASIN_CODES,
+    basin_masks_from_static,
+    validate_basin_masks,
+)
+
+NY, NX = 4, 6
+
+
+def _static(codes: np.ndarray | None = None, wet: np.ndarray | None = None):
+    """A miniature `ocean_static` on a nonseparable (curvilinear) grid."""
+    y = np.linspace(-60.0, 60.0, NY)
+    x = np.linspace(0.0, 270.0, NX)
+    # Both coordinates vary along both dims, as they do near the tripolar fold.
+    lat2d = y[:, None] + 0.1 * x[None, :]
+    lon2d = x[None, :] + 0.1 * y[:, None]
+
+    if codes is None:
+        # One row per basin, plus a row of land and marginal seas.
+        codes = np.array(
+            [
+                [1] * NX,
+                [2] * NX,
+                [3] * NX,
+                [0, 4, 4, 5, 5, 6],
+            ],
+            dtype=np.int32,
+        )
+    if wet is None:
+        wet = (codes != 0).astype(np.float64)
+
+    return xr.Dataset(
+        {
+            "basin": (("yh", "xh"), codes),
+            "wet": (("yh", "xh"), wet),
+            "geolat": (("yh", "xh"), lat2d),
+            "geolon": (("yh", "xh"), lon2d),
+        },
+        coords={"yh": y, "xh": x},
+    )
+
+
+def test_masks_follow_the_region_codes():
+    masks = basin_masks_from_static(_static())
+
+    assert set(masks.data_vars) == set(OM4_BASIN_CODES)
+    np.testing.assert_array_equal(masks["basin_southern"].values[0], np.ones(NX))
+    np.testing.assert_array_equal(masks["basin_atlantic"].values[1], np.ones(NX))
+    np.testing.assert_array_equal(masks["basin_pacific"].values[2], np.ones(NX))
+    np.testing.assert_array_equal(masks["basin_arctic"].values[3], [0, 1, 1, 0, 0, 0])
+    np.testing.assert_array_equal(masks["basin_indian"].values[3], [0, 0, 0, 1, 1, 0])
+
+
+def test_marginal_seas_are_left_unassigned():
+    """Matches the published Gaussian masks, where they are zero everywhere.
+
+    The last cell carries code 6 (Mediterranean). No basin may claim it.
+    """
+    masks = basin_masks_from_static(_static())
+
+    claimed = sum(masks[name].values[3, -1] for name in OM4_BASIN_CODES)
+    assert claimed == 0
+
+
+def test_land_is_never_assigned():
+    masks = basin_masks_from_static(_static())
+
+    claimed = sum(masks[name].values[3, 0] for name in OM4_BASIN_CODES)
+    assert claimed == 0
+
+
+def test_every_wet_cell_belongs_to_at_most_one_basin():
+    masks = basin_masks_from_static(_static())
+
+    stacked = np.stack([masks[name].values for name in OM4_BASIN_CODES])
+    assert stacked.sum(axis=0).max() <= 1
+
+
+def test_masks_carry_the_real_2d_cell_centers():
+    """Without these, a mask can only be matched to data by position."""
+    static = _static()
+    masks = basin_masks_from_static(static)
+
+    assert masks["lat_2d"].dims == ("lat", "lon")
+    assert masks["lon_2d"].dims == ("lat", "lon")
+    np.testing.assert_array_equal(masks["lat_2d"].values, static["geolat"].values)
+    np.testing.assert_array_equal(masks["lon_2d"].values, static["geolon"].values)
+
+
+def test_cell_centers_are_not_recoverable_by_broadcasting():
+    """Guards the fixture: a rectilinear grid would make the test above vacuous."""
+    static = _static()
+    lat2d = static["geolat"].values
+    assert not np.allclose(
+        np.broadcast_to(static["yh"].values[:, None], lat2d.shape), lat2d
+    )
+
+
+def test_masks_are_on_lat_lon_index_axes():
+    """`samudra viz` renames its own y/x to lat/lon; masks must match."""
+    masks = basin_masks_from_static(_static())
+
+    assert masks["basin_atlantic"].dims == ("lat", "lon")
+    assert masks.sizes["lat"] == NY and masks.sizes["lon"] == NX
+
+
+def test_masks_describe_themselves_like_the_published_stores():
+    masks = basin_masks_from_static(_static())
+
+    attrs = masks["basin_atlantic"].attrs
+    assert attrs["basin_id"] == 2
+    assert attrs["long_name"] == "Atlantic basin mask"
+    assert attrs["om4_basin_code"] == OM4_BASIN_CODES["basin_atlantic"]
+
+
+def test_missing_inputs_fail_loudly():
+    static = _static().drop_vars("geolat")
+
+    with pytest.raises(ValueError, match="geolat"):
+        basin_masks_from_static(static)
+
+
+def test_mismatched_grids_fail_loudly():
+    """A wet mask on a different grid than the region codes is refused."""
+    static = _static()
+    # A distinct dim name, so xarray keeps the mismatch instead of aligning it.
+    static["wet"] = (("yh", "xh_other"), np.ones((NY, NX - 1)))
+
+    with pytest.raises(ValueError, match="same horizontal grid"):
+        basin_masks_from_static(static)
+
+
+def test_validation_rejects_overlapping_basins():
+    masks = basin_masks_from_static(_static())
+    masks["basin_pacific"] = masks["basin_atlantic"]
+
+    with pytest.raises(ValueError, match="more than one basin"):
+        validate_basin_masks(masks)

--- a/data/tests/test_basin_masks.py
+++ b/data/tests/test_basin_masks.py
@@ -9,11 +9,25 @@ import pytest
 import xarray as xr
 from ocean_preprocessing.basin_masks import (
     OM4_BASIN_CODES,
+    OM4_MARGINAL_SEA_CODES,
+    PUBLISHED_BASIN_IDS,
     basin_masks_from_static,
     validate_basin_masks,
 )
 
 NY, NX = 4, 6
+
+# `ocean_static.basin`'s CF flag attributes, copied verbatim from the published
+# store so the tables in `basin_masks` can be checked against what they claim to
+# transcribe:
+#   xr.open_zarr(
+#       "s3://m2lines-pubs/Samudra/raw/ocean_static_no_mask_table.zarr"
+#   ).basin.attrs
+OM4_FLAG_VALUES = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+OM4_FLAG_MEANINGS = (
+    "global_land southern_ocean atlantic_ocean pacific_ocean arctic_ocean "
+    "indian_ocean mediterranean_sea black_sea hudson_bay baltic_sea red_sea"
+)
 
 
 def _static(codes: np.ndarray | None = None, wet: np.ndarray | None = None):
@@ -145,3 +159,32 @@ def test_validation_rejects_overlapping_basins():
 
     with pytest.raises(ValueError, match="more than one basin"):
         validate_basin_masks(masks)
+
+
+def test_basin_codes_transcribe_om4s_cf_flag_attributes():
+    """The code table is a transcription, so pin it to what it transcribes."""
+    published = dict(zip(OM4_FLAG_MEANINGS.split(), OM4_FLAG_VALUES, strict=True))
+
+    assert OM4_BASIN_CODES == {
+        "basin_southern": published["southern_ocean"],
+        "basin_atlantic": published["atlantic_ocean"],
+        "basin_pacific": published["pacific_ocean"],
+        "basin_arctic": published["arctic_ocean"],
+        "basin_indian": published["indian_ocean"],
+    }
+
+
+def test_every_om4_region_code_is_accounted_for():
+    """A code we neither map nor drop would vanish without anyone noticing."""
+    land = 0
+
+    assert {land, *OM4_BASIN_CODES.values(), *OM4_MARGINAL_SEA_CODES} == set(
+        OM4_FLAG_VALUES
+    )
+
+
+def test_published_basin_ids_are_alphabetical():
+    """The published stores number their basins by name, not by geography."""
+    assert PUBLISHED_BASIN_IDS == {
+        name: number for number, name in enumerate(sorted(OM4_BASIN_CODES), start=1)
+    }

--- a/data/tests/test_main.py
+++ b/data/tests/test_main.py
@@ -31,6 +31,51 @@ def test_collect_explicitly_writes_zarr_v2(tmp_path):
     assert metadata["zarr_format"] == 2
 
 
+def test_collect_turns_compression_off_by_default(tmp_path):
+    """The training stores are read without a decompression pass."""
+    output = tmp_path / "output.zarr"
+    pipeline = CLI(output_path=str(output))
+    ds = xr.Dataset({"value": ("time", np.arange(3))}).chunk({"time": 1})
+
+    pipeline._collect(ds)
+
+    metadata = json.loads((output / "value" / ".zarray").read_text(encoding="utf-8"))
+    assert metadata["compressor"] is None
+
+
+def test_collect_can_keep_zarrs_default_compressor(tmp_path):
+    """The basin masks keep the compression the published masks use."""
+    output = tmp_path / "output.zarr"
+    pipeline = CLI(output_path=str(output))
+    ds = xr.Dataset({"value": ("time", np.arange(3))}).chunk({"time": 1})
+
+    pipeline._collect(ds, compress=True)
+
+    metadata = json.loads((output / "value" / ".zarray").read_text(encoding="utf-8"))
+    assert metadata["compressor"]["id"] == "blosc"
+
+
+def test_small_run_leaves_a_dataset_without_time_alone(tmp_path):
+    """Not everything written here is a time series; basin masks are not."""
+    output = tmp_path / "output.zarr"
+    pipeline = CLI(output_path=str(output), small_run=True)
+    ds = xr.Dataset({"mask": (("lat", "lon"), np.ones((4, 6)))})
+
+    pipeline._collect(ds)
+
+    assert xr.open_zarr(output)["mask"].shape == (4, 6)
+
+
+def test_small_run_still_truncates_a_time_series(tmp_path):
+    output = tmp_path / "output.zarr"
+    pipeline = CLI(output_path=str(output), small_run=True)
+    ds = xr.Dataset({"value": ("time", np.arange(50))}).chunk({"time": 1})
+
+    pipeline._collect(ds)
+
+    assert xr.open_zarr(output).sizes["time"] == 10
+
+
 def test_wfo_source_path_is_not_forwarded_to_cluster(monkeypatch, tmp_path):
     cluster_calls = []
 

--- a/src/samudra/constants.py
+++ b/src/samudra/constants.py
@@ -56,12 +56,31 @@ MAX_TRAIN_MODEL_STEPS_FORWARD = 200
 
 # Horizontal grid geometry. "gaussian" is a regular/rectilinear lat-lon grid whose
 # 2D lat/lon are the outer product of the 1D axes, so they can be reconstructed by
-# broadcasting. "tripolar" is curvilinear: lat/lon vary along both horizontal dims
-# and cannot be rebuilt by broadcasting, so the real 2D coordinates must be carried
-# with the data. Downstream code that reconstructs geometry must branch on this.
-GridType = Literal["gaussian", "tripolar"]
+# broadcasting. The rest are curvilinear: lat/lon vary along both horizontal dims and
+# cannot be rebuilt by broadcasting, so the real 2D coordinates must be carried with
+# the data.
+#
+#   "tripolar" is OM4's native grid, which moves the northern singularity onto two
+#     poles over land so the Arctic is not a hole in the model.
+#   "llc" is MITgcm's lat-lon-cap: 13 faces, regular within each face but not across
+#     them. See https://gmd.copernicus.org/articles/16/7143/2023/ section 2.2.
+#
+# Downstream code depends on the rectilinear/curvilinear split rather than on which
+# curvilinear grid it is, so branch with `is_curvilinear` and not on the name.
+GridType = Literal["gaussian", "tripolar", "llc"]
 PrognosticVarNames = list[str]
 BoundaryVarNames = list[str]
+
+
+def is_curvilinear(grid_type: GridType) -> bool:
+    """Whether 2D lat/lon have to be carried rather than rebuilt from the axes.
+
+    Area weighting, map coordinates and mask alignment are each valid only on
+    the rectilinear grid, and that is the one thing they all test. Asking the
+    question this way means a new curvilinear grid added to `GridType` is
+    refused or handled, rather than quietly falling into the rectilinear path.
+    """
+    return grid_type != "gaussian"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -493,9 +512,7 @@ def build_llc_layout(
             },
         },
         ocean_heat_temperature_var="Theta",
-        # LLC (lat-lon-cap) is curvilinear, so its 2D geometry can't be broadcast
-        # from 1D axes -- same broadcast-unsafe class as the tripolar grid.
-        grid_type="tripolar",
+        grid_type="llc",
     )
 
 

--- a/src/samudra/metrics/observations.py
+++ b/src/samudra/metrics/observations.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import xarray as xr
 
-from samudra.constants import DataLayout
+from samudra.constants import DataLayout, is_curvilinear
 from samudra.metrics import kernels
 from samudra.utils.location import ResolvedLocation
 
@@ -183,7 +183,7 @@ def model_on_latlon_grid(ds: xr.Dataset, data_layout: DataLayout) -> xr.Dataset:
     index space, not degrees, and comparing against observations needs a real
     regridding step (xesmf) that is not implemented here yet.
     """
-    if data_layout.grid_type != "gaussian":
+    if is_curvilinear(data_layout.grid_type):
         raise NotImplementedError(
             f"Observation metrics need a rectilinear model grid, but this dataset "
             f"has grid_type={data_layout.grid_type!r}. On a curvilinear grid the "

--- a/src/samudra/viz/config.py
+++ b/src/samudra/viz/config.py
@@ -11,8 +11,14 @@ from typing import Annotated
 
 from pydantic import BaseModel, BeforeValidator, Field, WithJsonSchema
 
-from samudra.config import DataConfig, ObsMetricsConfig, Om4TimeConfig
+from samudra.config import (
+    DataConfig,
+    LlcDataSourceConfig,
+    ObsMetricsConfig,
+    Om4TimeConfig,
+)
 from samudra.config_base import TopLevelConfig
+from samudra.constants import GridType
 from samudra.utils.location import LocalLocation, Location, ResolvedLocation
 from samudra.utils.logging import handle_logging
 from samudra.viz.core import Viz, VizRun
@@ -116,6 +122,23 @@ class VizConfig(TopLevelConfig):
             "data source (e.g. --data @data/om4_demo.yaml)."
         )
 
+    def _grid_type(self) -> GridType:
+        """Horizontal grid geometry, reused from the data source.
+
+        Viz must branch on this: on a curvilinear ("tripolar") grid the 2-D
+        lat/lon cannot be rebuilt from the 1-D axes and the rectilinear area
+        helpers are invalid. We read it off the primary source rather than
+        configuring it separately so viz cannot disagree with train/eval.
+        """
+        if self.data is None:
+            return "gaussian"
+        source = self.data.sources[0]
+        if isinstance(source, LlcDataSourceConfig):
+            # LLC (lat-lon-cap) carries no `grid_type` field because it is only
+            # ever curvilinear; `build_llc_layout` hard-codes it.
+            return "tripolar"
+        return source.grid_type
+
     def build(self, default_root: ResolvedLocation) -> Viz:
         if self.data_root is None:
             data_root = default_root
@@ -136,6 +159,7 @@ class VizConfig(TopLevelConfig):
             self.groundtruth_time_range.time_slice,
             observations=self.observations,
             data_root=data_root,
+            grid_type=self._grid_type(),
         )
 
 

--- a/src/samudra/viz/config.py
+++ b/src/samudra/viz/config.py
@@ -7,8 +7,9 @@ import logging
 import time
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, get_args
 
+import xarray as xr
 from pydantic import BaseModel, BeforeValidator, Field, WithJsonSchema
 
 from samudra.config import (
@@ -122,22 +123,46 @@ class VizConfig(TopLevelConfig):
             "data source (e.g. --data @data/om4_demo.yaml)."
         )
 
-    def _grid_type(self) -> GridType:
-        """Horizontal grid geometry, reused from the data source.
-
-        Viz must branch on this: on a curvilinear ("tripolar") grid the 2-D
-        lat/lon cannot be rebuilt from the 1-D axes and the rectilinear area
-        helpers are invalid. We read it off the primary source rather than
-        configuring it separately so viz cannot disagree with train/eval.
-        """
+    def _configured_grid_type(self) -> GridType | None:
+        """Grid geometry named by the data source, if there is one."""
         if self.data is None:
-            return "gaussian"
+            return None
         source = self.data.sources[0]
         if isinstance(source, LlcDataSourceConfig):
             # LLC (lat-lon-cap) carries no `grid_type` field because it is only
             # ever curvilinear; `build_llc_layout` hard-codes it.
             return "tripolar"
         return source.grid_type
+
+    def _grid_type(self, groundtruth: xr.Dataset) -> GridType:
+        """Horizontal grid geometry for this run.
+
+        Viz must branch on this: on a curvilinear ("tripolar") grid the 2-D
+        lat/lon cannot be rebuilt from the 1-D axes and the rectilinear area
+        helpers are invalid.
+
+        A data source names it, and preprocessing also records it on the store
+        it writes. `groundtruth_location` is a supported way to point viz at a
+        rollout with no data block at all, so the store's own attribute has to
+        be honoured: defaulting to "gaussian" there would silently plot a
+        tripolar rollout against its index axes.
+        """
+        configured = self._configured_grid_type()
+        recorded = groundtruth.attrs.get("grid_type")
+
+        if recorded is not None and recorded not in get_args(GridType):
+            raise ValueError(
+                f"Ground-truth store records grid_type={recorded!r}, which is "
+                f"not one of {get_args(GridType)}."
+            )
+        if configured is not None and recorded is not None and configured != recorded:
+            raise ValueError(
+                f"The data source says grid_type={configured!r} but the "
+                f"ground-truth store records {recorded!r}. Point viz at the "
+                "matching store, or fix the source, rather than letting the two "
+                "disagree about the same grid."
+            )
+        return configured or recorded or "gaussian"
 
     def build(self, default_root: ResolvedLocation) -> Viz:
         if self.data_root is None:
@@ -159,7 +184,7 @@ class VizConfig(TopLevelConfig):
             self.groundtruth_time_range.time_slice,
             observations=self.observations,
             data_root=data_root,
-            grid_type=self._grid_type(),
+            grid_type=self._grid_type(groundtruth_rollout),
         )
 
 

--- a/src/samudra/viz/config.py
+++ b/src/samudra/viz/config.py
@@ -129,9 +129,9 @@ class VizConfig(TopLevelConfig):
             return None
         source = self.data.sources[0]
         if isinstance(source, LlcDataSourceConfig):
-            # LLC (lat-lon-cap) carries no `grid_type` field because it is only
-            # ever curvilinear; `build_llc_layout` hard-codes it.
-            return "tripolar"
+            # LLC carries no `grid_type` field because it is only ever
+            # lat-lon-cap; `build_llc_layout` hard-codes it.
+            return "llc"
         return source.grid_type
 
     def _grid_type(self, groundtruth: xr.Dataset) -> GridType:

--- a/src/samudra/viz/core.py
+++ b/src/samudra/viz/core.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import functools
 import gc
 import glob
 import logging
@@ -31,7 +32,7 @@ from dask.diagnostics.progress import ProgressBar
 from matplotlib.ticker import FixedLocator, MaxNLocator, ScalarFormatter
 from tqdm.auto import tqdm
 
-from samudra.constants import DataLayout, build_om4_layout
+from samudra.constants import DataLayout, GridType, build_om4_layout
 from samudra.metrics.run import score_rollouts
 from samudra.utils.data import (
     spherical_area,
@@ -68,37 +69,29 @@ class Viz:
         time_range: slice,
         observations: "ObsMetricsConfig | None" = None,
         data_root: ResolvedLocation | None = None,
+        grid_type: GridType = "gaussian",
     ):
         pred_dict: dict[str, dict[str, Any]] = {}
         for run in runs:
             pred_dict[run.name] = {
                 "name": run.name,
-                "data": run.data,
+                # Rollouts are written on y/x with 2-D lat/lon (see `ZarrWriter`),
+                # the same layout the ground truth arrives in, so they need the
+                # same rename. A no-op for runs already on lat/lon.
+                "data": preserve_2d_coords(run.data),
                 "ls": run.variables,
             }
 
         key1 = runs[0].name
         # TODO: Support non-OM4 data layouts in visualization.
-        self.data_layout = build_om4_layout()
+        self.data_layout = build_om4_layout(grid_type=grid_type)
         levels = len(self.data_layout.depth_levels)
 
         groundtruth_rollout = groundtruth_rollout.sel(time=time_range)
 
-        if "y" in groundtruth_rollout.coords:
-            groundtruth_rollout = groundtruth_rollout.drop_vars(
-                ["lat", "lon"], errors="ignore"
-            )
-            groundtruth_rollout = groundtruth_rollout.rename({"y": "lat", "x": "lon"})
+        groundtruth_rollout = preserve_2d_coords(groundtruth_rollout)
 
-        groundtruth_rollout = groundtruth_rollout.assign(
-            areacello=(["lat", "lon"], spherical_area_weights(groundtruth_rollout))
-        )
-
-        # Compute real grid cell areas for physical calculations
-        groundtruth_rollout["areacello_spherical"] = (
-            ["lat", "lon"],
-            spherical_area(groundtruth_rollout),
-        )
+        groundtruth_rollout = self._with_cell_areas(groundtruth_rollout)
 
         # This function processes the ds_groundtruth and predictions for plotting
         # The predictions are loaded into pred_dict
@@ -155,31 +148,11 @@ class Viz:
 
         clist = ["#ff807a", "#1e8685", "#ffb579", "#63c8ab"]
 
-        atlantic_mask0 = basins["basin_atlantic"]
-        atlantic_mask = atlantic_mask0.where(atlantic_mask0["lat"] >= -32)
-        atlantic_mask = process_mask(data, atlantic_mask)
-        pacific_mask0 = basins["basin_pacific"]
-        pacific_mask = pacific_mask0.where(
-            pacific_mask0["lat"] >= -32
-        )  # TODO: include this -32 masking in the basin data
-        pacific_mask = process_mask(data, pacific_mask)
-        indian_ocean_mask0 = basins["basin_indian"]
-        indian_ocean_mask = indian_ocean_mask0.where(indian_ocean_mask0["lat"] >= -32)
-        indian_ocean_mask = process_mask(data, indian_ocean_mask)
-        southern_ocean_mask0 = basins["basin_southern"]
-        southern_ocean_mask = process_mask(data, southern_ocean_mask0)
-        arctic_mask0 = basins["basin_arctic"]
-        arctic_ocean_mask = process_mask(data, arctic_mask0)
-
-        self.basin_masks = xr.Dataset(
-            {
-                "Atlantic": atlantic_mask,
-                "Pacific": pacific_mask,
-                "Southern": southern_ocean_mask,
-                "Indian": indian_ocean_mask,
-                "Arctic": arctic_ocean_mask,
-            }
-        )
+        # Basin masks are built on first use, not here: only the basin steps
+        # need them, and aligning them can fail on a grid whose published mask
+        # does not match. Constructing them eagerly made every other step --
+        # including a plain smoke test -- depend on that alignment succeeding.
+        self._basins: xr.Dataset = basins
 
         # Compute profile means
         with ProgressBar():
@@ -211,6 +184,121 @@ class Viz:
         self.raw_runs: list[VizRun] = list(runs)
         self.obs_path = os.path.join(output_path, "Figures_observations")
         self._obs_cache: tuple | None = None
+
+    @functools.cached_property
+    def basin_masks(self) -> xr.Dataset:
+        """Basin masks aligned onto the plotting grid, built on first use."""
+        basins = self._basins
+        data = self.data
+        grid_type = self.data_layout.grid_type
+
+        atlantic_mask0 = basins["basin_atlantic"]
+        atlantic_mask = atlantic_mask0.where(atlantic_mask0["lat"] >= -32)
+        atlantic_mask = process_mask(data, atlantic_mask, grid_type)
+        pacific_mask0 = basins["basin_pacific"]
+        pacific_mask = pacific_mask0.where(
+            pacific_mask0["lat"] >= -32
+        )  # TODO: include this -32 masking in the basin data
+        pacific_mask = process_mask(data, pacific_mask, grid_type)
+        indian_ocean_mask0 = basins["basin_indian"]
+        indian_ocean_mask = indian_ocean_mask0.where(indian_ocean_mask0["lat"] >= -32)
+        indian_ocean_mask = process_mask(data, indian_ocean_mask, grid_type)
+        southern_ocean_mask0 = basins["basin_southern"]
+        southern_ocean_mask = process_mask(data, southern_ocean_mask0, grid_type)
+        arctic_mask0 = basins["basin_arctic"]
+        arctic_ocean_mask = process_mask(data, arctic_mask0, grid_type)
+
+        return xr.Dataset(
+            {
+                "Atlantic": atlantic_mask,
+                "Pacific": pacific_mask,
+                "Southern": southern_ocean_mask,
+                "Indian": indian_ocean_mask,
+                "Arctic": arctic_ocean_mask,
+            }
+        )
+
+    def _with_cell_areas(self, data: xr.Dataset) -> xr.Dataset:
+        """Attach the two area fields the reductions downstream expect.
+
+        `areacello` is the *weighting* field (normalized to sum to one) and
+        `areacello_spherical` is the physical cell area in m^2. On a rectilinear
+        grid both follow analytically from the 1-D axes. On a curvilinear grid
+        they do not: once the grid folds, `cos(lat)` stops being proportional to
+        cell area and `np.diff(lat).mean()` stops describing the spacing, so we
+        use the source's own `areacello` and refuse to invent one.
+        """
+        if self.data_layout.grid_type == "gaussian":
+            data = data.assign(areacello=(["lat", "lon"], spherical_area_weights(data)))
+            data["areacello_spherical"] = (["lat", "lon"], spherical_area(data))
+            return data
+
+        if "areacello" not in data.variables:
+            raise ValueError(
+                "Cannot build cell areas for "
+                f"grid_type={self.data_layout.grid_type!r}: the source carries no "
+                "'areacello'. The rectilinear helpers (spherical_area_weights / "
+                "spherical_area) assume separable, uniformly spaced 1-D lat/lon "
+                "and are invalid on a curvilinear grid, so there is nothing safe "
+                "to fall back to. Preserve 'areacello' through preprocessing."
+            )
+
+        area = np.asarray(data["areacello"].values, dtype=np.float64)
+        expected = (data.sizes["lat"], data.sizes["lon"])
+        if area.shape != expected:
+            raise ValueError(
+                f"Source 'areacello' has shape {area.shape}, expected {expected} "
+                "to match the horizontal grid. Cell areas must be given on the "
+                "same grid as the data."
+            )
+        if not np.isfinite(area).any() or np.nansum(area) <= 0:
+            raise ValueError(
+                "Source 'areacello' has no positive finite values, so it cannot "
+                "be used to weight reductions."
+            )
+
+        weights = np.where(np.isfinite(area), area, 0.0)
+        weights = weights / weights.sum()
+
+        # Drop first: `areacello` arrives as a coordinate on OM4 sources, and we
+        # need both fields as data variables for the reductions downstream.
+        data = data.drop_vars(["areacello", "areacello_spherical"], errors="ignore")
+        return data.assign(
+            areacello=(["lat", "lon"], weights),
+            areacello_spherical=(["lat", "lon"], area),
+        )
+
+    def _map_coords(self, data) -> tuple:
+        """Coordinates to hand `pcolormesh`, as (x, y).
+
+        The index axes are only geographic on a rectilinear grid. On a
+        curvilinear grid they are cell indices, and plotting against them draws
+        the fold as if it were geography, so we use the preserved 2-D
+        coordinates instead.
+        """
+        if self.data_layout.grid_type == "gaussian":
+            return data["x"], data["y"]
+        if "lon_2d" in data.coords and "lat_2d" in data.coords:
+            return data["lon_2d"], data["lat_2d"]
+        raise ValueError(
+            "Cannot plot a map for "
+            f"grid_type={self.data_layout.grid_type!r}: no 'lat_2d'/'lon_2d' "
+            "coordinates survived preprocessing, and the 'x'/'y' axes are cell "
+            "indices rather than degrees on a curvilinear grid. Preserve the "
+            "true 2-D coordinates through preprocessing."
+        )
+
+    def _reject_on_curvilinear(self, step: str, reason: str) -> None:
+        """Refuse a step whose maths only holds on a rectilinear grid.
+
+        A clear error beats a plausible-looking wrong figure.
+        """
+        if self.data_layout.grid_type != "gaussian":
+            raise NotImplementedError(
+                f"Step {step!r} is not implemented for "
+                f"grid_type={self.data_layout.grid_type!r}: {reason} Run it on a "
+                "'gaussian' source, or exclude it with --not_steps."
+            )
 
     def step_timeseries_plots(self):
         ### Plotting timeseries for each variable for each level
@@ -1437,6 +1525,13 @@ class Viz:
         )
 
     def step_ocean_temperature_profile_plots(self):
+        self._reject_on_curvilinear(
+            "ocean_temperature_profile_plots",
+            "it averages each basin over 'x' into a section and plots it "
+            "against 'y' labelled as latitude, which only holds when rows of "
+            "the grid follow lines of constant latitude.",
+        )
+
         def ocean_temperature_profile(datasets, titles, plot_title):
             # We import here to avoid importing tk unconditionally above
             from xarrayutils.plotting import linear_piecewise_scale  # type: ignore
@@ -1708,6 +1803,12 @@ class Viz:
         return GT_salinity_slope
 
     def step_thetao_mae_metrics(self):
+        self._reject_on_curvilinear(
+            "thetao_mae_metrics",
+            "it averages over 'x' to form a zonal-mean section, which is only "
+            "a zonal mean when rows of the grid follow lines of constant "
+            "latitude.",
+        )
         da_temp = self.data["thetao"]  # Directly use temperature variable
         section_mask = isnan(da_temp).all("x").isel(time=0)
         da_temp_int_x = da_temp.weighted(self.data["areacello"]).mean(["x", "time"])
@@ -1835,6 +1936,12 @@ class Viz:
         )
 
     def step_enso_plots(self):
+        self._reject_on_curvilinear(
+            "enso_plots",
+            "it selects the Nino regions and averages over 'x' using index "
+            "ranges, which only track the intended geographic boxes on a "
+            "rectilinear grid.",
+        )
         clim = (
             self.data["thetao"]
             .sel(lev=slice(0, 500))
@@ -2261,9 +2368,10 @@ class Viz:
             )  # cm.cm.thermal  # Using thermal colormap from cmocean
             colormap.set_bad(color=(0.7, 0.7, 0.7, 0))
             norm = symmetric_percentile_norm(ohc_data)
+            map_x, map_y = self._map_coords(ohc_data)
             im = ax.pcolormesh(
-                ohc_data["x"],
-                ohc_data["y"],
+                map_x,
+                map_y,
                 ohc_data,
                 shading="auto",
                 cmap=colormap,
@@ -2290,9 +2398,10 @@ class Viz:
             colormap.set_bad(color=(0.7, 0.7, 0.7, 0))
             bias_ohc = ohc_data - gt_ohc_data
             norm = symmetric_percentile_norm(bias_ohc)
+            map_x, map_y = self._map_coords(bias_ohc)
             im = ax.pcolormesh(
-                bias_ohc["x"],
-                bias_ohc["y"],
+                map_x,
+                map_y,
                 bias_ohc,
                 shading="auto",
                 cmap=colormap,
@@ -2520,9 +2629,10 @@ class Viz:
         colormap = cm.cm.thermal
         colormap.set_bad(color=(0.7, 0.7, 0.7, 0))
         norm = percentile_norm(data)
+        map_x, map_y = self._map_coords(data)
         im = ax.pcolormesh(
-            data["x"],
-            data["y"],
+            map_x,
+            map_y,
             data,
             shading="auto",
             cmap=colormap,
@@ -2547,9 +2657,10 @@ class Viz:
         colormap.set_bad(color=(0.7, 0.7, 0.7, 0))
         bias = data - gt_data
         norm = symmetric_percentile_norm(bias)
+        map_x, map_y = self._map_coords(bias)
         im = ax.pcolormesh(
-            bias["x"],
-            bias["y"],
+            map_x,
+            map_y,
             bias,
             shading="auto",
             cmap=colormap,
@@ -2846,6 +2957,11 @@ class Viz:
     # Need atleast two keys otherwise duplicate maps
 
     def step_movies(self):
+        self._reject_on_curvilinear(
+            "movies",
+            "its frames plot against the 'x'/'y' index axes rather than the "
+            "2-D geographic coordinates.",
+        )
         keys = list(self.pred_dict.keys())
         # assert len(keys) >= 2, "Maps supported by atleast two keys"
         self.key1 = keys[0]
@@ -4044,12 +4160,92 @@ def remove_climatology(ds):
     return res
 
 
-def process_mask(data, mask):
+def preserve_2d_coords(data: xr.Dataset) -> xr.Dataset:
+    """Rename y/x to lat/lon, keeping any true 2-D geography as lat_2d/lon_2d.
+
+    Viz works internally on axes named "lat"/"lon" that are really the y/x cell
+    indices. Renaming onto them used to drop the source's real 2-D "lat"/"lon"
+    to avoid the name collision, which is lossless only on a rectilinear grid,
+    where they can be rebuilt by broadcasting. On a curvilinear grid they are
+    the only record of where each cell is, so we move them aside first, the way
+    `with_lat_lon_coords()` and `ZarrWriter` already do.
+    """
+    if "y" not in data.coords:
+        return data
+    # Only move a coordinate aside if its 2-D name is still free. A source that
+    # already carries `lat_2d`/`lon_2d` has been through this once (or through
+    # `with_lat_lon_coords`), and renaming onto an occupied name is an error.
+    names = [name for name in ("lat", "lon") if name in data.coords]
+    preserve = {n: f"{n}_2d" for n in names if f"{n}_2d" not in data.coords}
+    already = [n for n in names if f"{n}_2d" in data.coords]
+    return data.drop_vars(already).rename(preserve).rename({"y": "lat", "x": "lon"})
+
+
+def process_mask(data, mask, grid_type: GridType = "gaussian"):
+    """Align a basin mask onto the plotting grid.
+
+    The mask arrives on its own lat/lon axes and has to end up on the data's
+    y/x axes. Relabeling it by position is only defensible when the two grids
+    are the same rectilinear grid; on a curvilinear grid identical shapes do
+    not imply identical geography, so a positional relabel can silently put the
+    Atlantic where the Pacific is. We check the shape either way, and check the
+    coordinates too when we cannot rely on rectilinearity.
+    """
     mask = mask.where(mask != 0, np.nan)
     mask = mask.transpose("lat", "lon")
+
+    expected = (data.sizes["y"], data.sizes["x"])
+    if mask.shape != expected:
+        raise ValueError(
+            f"Basin mask has shape {mask.shape} but the data grid is {expected}. "
+            "Basin masks must be given on the same grid as the data; the "
+            "published Gaussian masks cannot be reused on a native curvilinear "
+            "grid. Generate a mask on this grid instead."
+        )
+
+    if grid_type != "gaussian":
+        _check_mask_coords_align(data, mask, grid_type)
+
     mask = mask.assign_coords(lat=data.y.values, lon=data.x.values)
     mask = mask.rename({"lat": "y", "lon": "x"})
     return mask
+
+
+def _check_mask_coords_align(data, mask, grid_type: GridType) -> None:
+    """Require a curvilinear mask to carry geography that matches the data.
+
+    Matching shapes are not enough off a rectilinear grid, so the mask has to
+    bring its own 2-D cell centers and they have to agree with the data's.
+    """
+    if "lat_2d" not in data.coords or "lon_2d" not in data.coords:
+        raise ValueError(
+            f"Cannot align a basin mask on grid_type={grid_type!r}: the data "
+            "carries no 'lat_2d'/'lon_2d', so there is nothing to check the "
+            "mask against. Preserve the true 2-D coordinates through "
+            "preprocessing."
+        )
+
+    have = {name for name in ("lat_2d", "lon_2d") if name in mask.coords}
+    if have != {"lat_2d", "lon_2d"}:
+        raise ValueError(
+            f"Cannot align a basin mask on grid_type={grid_type!r}: the mask "
+            "carries no 2-D 'lat_2d'/'lon_2d' cell centers, so it can only be "
+            "matched to the data by position, which does not imply matching "
+            "geography on a curvilinear grid. Generate the mask from the real "
+            "cell centers and keep them on it."
+        )
+
+    for name in ("lat_2d", "lon_2d"):
+        theirs = np.asarray(mask.coords[name].values, dtype=np.float64)
+        ours = np.asarray(data.coords[name].values, dtype=np.float64)
+        if theirs.shape != ours.shape or not np.allclose(
+            theirs, ours, rtol=0, atol=1e-4, equal_nan=True
+        ):
+            raise ValueError(
+                f"Basin mask {name!r} does not match the data's {name!r}. The "
+                "mask is on a different grid than the data, so applying it "
+                "would attribute cells to the wrong basins."
+            )
 
 
 def profile_mean(ds: xr.Dataset) -> xr.Dataset:

--- a/src/samudra/viz/core.py
+++ b/src/samudra/viz/core.py
@@ -288,6 +288,22 @@ class Viz:
             "true 2-D coordinates through preprocessing."
         )
 
+    def _map_plot_kwargs(self, data) -> dict:
+        """Keyword arguments that put an xarray `.plot()` in geographic space.
+
+        `.plot()` picks its own axes from the array's dims. Those are degrees
+        on a rectilinear grid and cell indices on a curvilinear one, so there
+        we have to name the 2-D coordinates and say what they mean.
+        """
+        if self.data_layout.grid_type == "gaussian":
+            return {}
+        map_x, map_y = self._map_coords(data)
+        return {
+            "x": map_x.name,
+            "y": map_y.name,
+            "transform": ccrs.PlateCarree(),
+        }
+
     def _reject_on_curvilinear(self, step: str, reason: str) -> None:
         """Refuse a step whose maths only holds on a rectilinear grid.
 
@@ -2500,6 +2516,7 @@ class Viz:
                 cmap=new_cmap,
                 norm=norm,
                 add_colorbar=False,
+                **self._map_plot_kwargs(data_pred1),
             )
             ax.add_feature(cfeature.COASTLINE, edgecolor="black", linewidth=0.1)
             ax.set_title(self.pred_dict[self.key1]["name"] + " Bias", fontsize=14)

--- a/src/samudra/viz/core.py
+++ b/src/samudra/viz/core.py
@@ -192,29 +192,22 @@ class Viz:
         data = self.data
         grid_type = self.data_layout.grid_type
 
-        atlantic_mask0 = basins["basin_atlantic"]
-        atlantic_mask = atlantic_mask0.where(atlantic_mask0["lat"] >= -32)
-        atlantic_mask = process_mask(data, atlantic_mask, grid_type)
-        pacific_mask0 = basins["basin_pacific"]
-        pacific_mask = pacific_mask0.where(
-            pacific_mask0["lat"] >= -32
-        )  # TODO: include this -32 masking in the basin data
-        pacific_mask = process_mask(data, pacific_mask, grid_type)
-        indian_ocean_mask0 = basins["basin_indian"]
-        indian_ocean_mask = indian_ocean_mask0.where(indian_ocean_mask0["lat"] >= -32)
-        indian_ocean_mask = process_mask(data, indian_ocean_mask, grid_type)
-        southern_ocean_mask0 = basins["basin_southern"]
-        southern_ocean_mask = process_mask(data, southern_ocean_mask0, grid_type)
-        arctic_mask0 = basins["basin_arctic"]
-        arctic_ocean_mask = process_mask(data, arctic_mask0, grid_type)
-
+        # Atlantic, Pacific and Indian used to be cut at 32S here, to keep them
+        # off the Southern Ocean. The masks already draw that line themselves:
+        # in `basin_masks_original.zarr` the Southern Ocean stops at 32.5S and
+        # the other three start at 32S, so the cut removed nothing. It is not
+        # harmless on every mask set, though. Masks built from OM4's own region
+        # codes put the boundary further south, and there the cut deleted 26207
+        # ocean cells that the Southern Ocean mask does not reach up to claim,
+        # dropping them out of every basin. Trust the mask set instead; the
+        # boundary is the data's to draw, not ours.
         return xr.Dataset(
             {
-                "Atlantic": atlantic_mask,
-                "Pacific": pacific_mask,
-                "Southern": southern_ocean_mask,
-                "Indian": indian_ocean_mask,
-                "Arctic": arctic_ocean_mask,
+                "Atlantic": process_mask(data, basins["basin_atlantic"], grid_type),
+                "Pacific": process_mask(data, basins["basin_pacific"], grid_type),
+                "Southern": process_mask(data, basins["basin_southern"], grid_type),
+                "Indian": process_mask(data, basins["basin_indian"], grid_type),
+                "Arctic": process_mask(data, basins["basin_arctic"], grid_type),
             }
         )
 

--- a/src/samudra/viz/core.py
+++ b/src/samudra/viz/core.py
@@ -32,7 +32,7 @@ from dask.diagnostics.progress import ProgressBar
 from matplotlib.ticker import FixedLocator, MaxNLocator, ScalarFormatter
 from tqdm.auto import tqdm
 
-from samudra.constants import DataLayout, GridType, build_om4_layout
+from samudra.constants import DataLayout, GridType, build_om4_layout, is_curvilinear
 from samudra.metrics.run import score_rollouts
 from samudra.utils.data import (
     spherical_area,
@@ -228,7 +228,7 @@ class Viz:
         cell area and `np.diff(lat).mean()` stops describing the spacing, so we
         use the source's own `areacello` and refuse to invent one.
         """
-        if self.data_layout.grid_type == "gaussian":
+        if not is_curvilinear(self.data_layout.grid_type):
             data = data.assign(areacello=(["lat", "lon"], spherical_area_weights(data)))
             data["areacello_spherical"] = (["lat", "lon"], spherical_area(data))
             return data
@@ -276,7 +276,7 @@ class Viz:
         the fold as if it were geography, so we use the preserved 2-D
         coordinates instead.
         """
-        if self.data_layout.grid_type == "gaussian":
+        if not is_curvilinear(self.data_layout.grid_type):
             return data["x"], data["y"]
         if "lon_2d" in data.coords and "lat_2d" in data.coords:
             return data["lon_2d"], data["lat_2d"]
@@ -295,7 +295,7 @@ class Viz:
         on a rectilinear grid and cell indices on a curvilinear one, so there
         we have to name the 2-D coordinates and say what they mean.
         """
-        if self.data_layout.grid_type == "gaussian":
+        if not is_curvilinear(self.data_layout.grid_type):
             return {}
         map_x, map_y = self._map_coords(data)
         return {
@@ -309,7 +309,7 @@ class Viz:
 
         A clear error beats a plausible-looking wrong figure.
         """
-        if self.data_layout.grid_type != "gaussian":
+        if is_curvilinear(self.data_layout.grid_type):
             raise NotImplementedError(
                 f"Step {step!r} is not implemented for "
                 f"grid_type={self.data_layout.grid_type!r}: {reason} Run it on a "
@@ -4220,7 +4220,7 @@ def process_mask(data, mask, grid_type: GridType = "gaussian"):
             "grid. Generate a mask on this grid instead."
         )
 
-    if grid_type != "gaussian":
+    if is_curvilinear(grid_type):
         _check_mask_coords_align(data, mask, grid_type)
 
     mask = mask.assign_coords(lat=data.y.values, lon=data.x.values)

--- a/tests/test_viz_config.py
+++ b/tests/test_viz_config.py
@@ -5,6 +5,7 @@
 """Ground-truth resolution for viz: `--data` vs. explicit `groundtruth_location`."""
 
 import pytest
+import xarray as xr
 
 from samudra.config import LlcDataSourceConfig, Om4DataSourceConfig
 from samudra.utils.location import S3Location, UnresolvedLocation
@@ -57,7 +58,7 @@ def test_grid_type_comes_from_the_data_source():
     assert isinstance(source, Om4DataSourceConfig)
     source.grid_type = "tripolar"
 
-    assert cfg._grid_type() == "tripolar"
+    assert cfg._grid_type(xr.Dataset()) == "tripolar"
 
 
 def test_grid_type_defaults_to_gaussian_without_a_data_source():
@@ -65,7 +66,7 @@ def test_grid_type_defaults_to_gaussian_without_a_data_source():
     cfg = _cfg()
     cfg.data = None
 
-    assert cfg._grid_type() == "gaussian"
+    assert cfg._grid_type(xr.Dataset()) == "gaussian"
 
 
 def test_llc_sources_are_always_curvilinear():
@@ -78,4 +79,38 @@ def test_llc_sources_are_always_curvilinear():
     assert cfg.data is not None
     cfg.data.sources[0] = LlcDataSourceConfig.model_construct()
 
-    assert cfg._grid_type() == "tripolar"
+    assert cfg._grid_type(xr.Dataset()) == "tripolar"
+
+
+def test_grid_type_is_read_from_the_store_when_there_is_no_data_block():
+    """`groundtruth_location` alone is a supported way to run viz.
+
+    Preprocessing records the geometry on the store it writes, so a tripolar
+    rollout pointed at directly must not be treated as rectilinear.
+    """
+    cfg = _cfg()
+    cfg.data = None
+    store = xr.Dataset(attrs={"grid_type": "tripolar"})
+
+    assert cfg._grid_type(store) == "tripolar"
+
+
+def test_a_source_and_store_that_disagree_is_an_error():
+    cfg = _cfg("--data", "@data/om4_demo.yaml")
+    assert cfg.data is not None
+    source = cfg.data.sources[0]
+    assert isinstance(source, Om4DataSourceConfig)
+    source.grid_type = "gaussian"
+    store = xr.Dataset(attrs={"grid_type": "tripolar"})
+
+    with pytest.raises(ValueError, match="disagree"):
+        cfg._grid_type(store)
+
+
+def test_an_unrecognised_recorded_grid_type_is_an_error():
+    cfg = _cfg()
+    cfg.data = None
+    store = xr.Dataset(attrs={"grid_type": "cubed_sphere"})
+
+    with pytest.raises(ValueError, match="not one of"):
+        cfg._grid_type(store)

--- a/tests/test_viz_config.py
+++ b/tests/test_viz_config.py
@@ -6,6 +6,7 @@
 
 import pytest
 
+from samudra.config import LlcDataSourceConfig, Om4DataSourceConfig
 from samudra.utils.location import S3Location, UnresolvedLocation
 from samudra.viz.config import VizConfig
 
@@ -42,3 +43,39 @@ def test_missing_groundtruth_and_data_is_an_error():
 
     with pytest.raises(ValueError, match="groundtruth_location"):
         cfg._groundtruth_location()
+
+
+def test_grid_type_comes_from_the_data_source():
+    """Viz reuses the source's grid_type instead of configuring its own.
+
+    Configuring it separately would let viz disagree with train and eval about
+    the geometry of the same dataset.
+    """
+    cfg = _cfg("--data", "@data/om4_demo.yaml")
+    assert cfg.data is not None
+    source = cfg.data.sources[0]
+    assert isinstance(source, Om4DataSourceConfig)
+    source.grid_type = "tripolar"
+
+    assert cfg._grid_type() == "tripolar"
+
+
+def test_grid_type_defaults_to_gaussian_without_a_data_source():
+    """An explicit groundtruth_location carries no grid metadata."""
+    cfg = _cfg()
+    cfg.data = None
+
+    assert cfg._grid_type() == "gaussian"
+
+
+def test_llc_sources_are_always_curvilinear():
+    """LLC carries no `grid_type` field, but its layout is never rectilinear.
+
+    Defaulting a missing field to "gaussian" would quietly tell viz that
+    lat-lon-cap data can be plotted against its index axes.
+    """
+    cfg = _cfg("--data", "@data/om4_demo.yaml")
+    assert cfg.data is not None
+    cfg.data.sources[0] = LlcDataSourceConfig.model_construct()
+
+    assert cfg._grid_type() == "tripolar"

--- a/tests/test_viz_config.py
+++ b/tests/test_viz_config.py
@@ -8,6 +8,7 @@ import pytest
 import xarray as xr
 
 from samudra.config import LlcDataSourceConfig, Om4DataSourceConfig
+from samudra.constants import is_curvilinear
 from samudra.utils.location import S3Location, UnresolvedLocation
 from samudra.viz.config import VizConfig
 
@@ -69,7 +70,7 @@ def test_grid_type_defaults_to_gaussian_without_a_data_source():
     assert cfg._grid_type(xr.Dataset()) == "gaussian"
 
 
-def test_llc_sources_are_always_curvilinear():
+def test_llc_sources_are_llc():
     """LLC carries no `grid_type` field, but its layout is never rectilinear.
 
     Defaulting a missing field to "gaussian" would quietly tell viz that
@@ -79,7 +80,10 @@ def test_llc_sources_are_always_curvilinear():
     assert cfg.data is not None
     cfg.data.sources[0] = LlcDataSourceConfig.model_construct()
 
-    assert cfg._grid_type(xr.Dataset()) == "tripolar"
+    grid_type = cfg._grid_type(xr.Dataset())
+
+    assert grid_type == "llc"
+    assert is_curvilinear(grid_type)
 
 
 def test_grid_type_is_read_from_the_store_when_there_is_no_data_block():

--- a/tests/test_viz_core.py
+++ b/tests/test_viz_core.py
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: 2026 Samudra Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Grid-geometry handling in the visualization path.
+
+`samudra viz` was written for rectilinear ("gaussian") grids: it rebuilt cell
+areas from the 1-D axes, dropped the source's 2-D lat/lon, aligned basin masks
+by position, and plotted against the index axes. All four are wrong on a
+curvilinear ("tripolar") grid, where lat/lon vary along both horizontal dims.
+These tests pin the curvilinear behaviour while leaving the Gaussian path as it
+was.
+"""
+
+import types
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from samudra.constants import GridType, build_om4_layout
+from samudra.viz.core import Viz, preserve_2d_coords, process_mask
+
+NY, NX = 4, 6
+
+
+def _tripolar_coords(ny: int = NY, nx: int = NX):
+    """A nonseparable grid: both coordinates vary along both dims.
+
+    This is the property that matters. Broadcasting the 1-D axes cannot
+    reproduce it, so anything that reconstructs geometry that way is caught.
+    """
+    y = np.linspace(-60.0, 60.0, ny)
+    x = np.linspace(0.0, 270.0, nx)
+    lat2d = y[:, None] + 0.1 * x[None, :]
+    lon2d = x[None, :] + 0.1 * y[:, None]
+    return y, x, lat2d, lon2d
+
+
+def _source(ny: int = NY, nx: int = NX, *, areacello=None) -> xr.Dataset:
+    """A minimal source dataset in the layout viz receives from eval."""
+    y, x, lat2d, lon2d = _tripolar_coords(ny, nx)
+    coords = {
+        "y": y,
+        "x": x,
+        "lat": (("y", "x"), lat2d),
+        "lon": (("y", "x"), lon2d),
+    }
+    data_vars = {"tos": (("y", "x"), np.ones((ny, nx)))}
+    if areacello is not None:
+        data_vars["areacello"] = (("y", "x"), areacello)
+    return xr.Dataset(data_vars, coords=coords)
+
+
+def _viz(grid_type: GridType):
+    """A stand-in exposing just what the geometry helpers read off `self`.
+
+    Constructing a real `Viz` needs a full rollout, predictions and an output
+    tree; these helpers only touch `data_layout`, so binding them to a stub
+    keeps the tests about geometry.
+    """
+    stub = types.SimpleNamespace(data_layout=build_om4_layout(grid_type=grid_type))
+    # Bind the real helpers so methods that call them through `self` work too.
+    for name in ("_with_cell_areas", "_map_coords", "_reject_on_curvilinear"):
+        setattr(stub, name, types.MethodType(getattr(Viz, name), stub))
+    return stub
+
+
+# --- 2-D coordinates survive preprocessing ------------------------------------
+
+
+def test_preserve_2d_coords_keeps_nonseparable_geography():
+    """The real cell centers survive the y/x -> lat/lon rename, exactly."""
+    _, _, lat2d, lon2d = _tripolar_coords()
+
+    out = preserve_2d_coords(_source())
+
+    assert out["lat_2d"].dims == ("lat", "lon")
+    assert out["lon_2d"].dims == ("lat", "lon")
+    np.testing.assert_array_equal(out["lat_2d"].values, lat2d)
+    np.testing.assert_array_equal(out["lon_2d"].values, lon2d)
+
+
+def test_preserve_2d_coords_geography_is_not_recoverable_by_broadcasting():
+    """Guards the fixture: broadcasting the axes must not reproduce the truth.
+
+    Without this the test above would still pass on a rectilinear grid and
+    would not be testing anything.
+    """
+    y, x, lat2d, lon2d = _tripolar_coords()
+
+    assert not np.allclose(np.broadcast_to(y[:, None], lat2d.shape), lat2d)
+    assert not np.allclose(np.broadcast_to(x[None, :], lon2d.shape), lon2d)
+
+
+def test_preserve_2d_coords_is_idempotent():
+    """A source that has already been through this must not crash.
+
+    Renaming `lat` onto an occupied `lat_2d` is an xarray error, and rollouts
+    can arrive already carrying the preserved names.
+    """
+    once = preserve_2d_coords(_source())
+    # Put it back on y/x, keeping the preserved names, as a re-fed rollout would.
+    again = once.rename({"lat": "y", "lon": "x"})
+
+    out = preserve_2d_coords(again)
+
+    _, _, lat2d, lon2d = _tripolar_coords()
+    np.testing.assert_array_equal(out["lat_2d"].values, lat2d)
+    np.testing.assert_array_equal(out["lon_2d"].values, lon2d)
+    assert out["tos"].dims == ("lat", "lon")
+
+
+def test_preserve_2d_coords_renames_axes_to_lat_lon():
+    """The index axes still land on the names the rest of viz works in."""
+    out = preserve_2d_coords(_source())
+
+    assert out["tos"].dims == ("lat", "lon")
+    assert "y" not in out.dims and "x" not in out.dims
+
+
+# --- cell areas ----------------------------------------------------------------
+
+
+def test_tripolar_uses_source_areacello_not_cosine_latitude():
+    """Weighted means must follow the real areas, not cos(lat).
+
+    On a tripolar grid the two disagree: cell area collapses towards the
+    Arctic fold while cos(lat) does not know the grid has folded.
+    """
+    area = np.linspace(1.0, 50.0, NY * NX).reshape(NY, NX)
+    data = preserve_2d_coords(_source(areacello=area))
+
+    out = Viz._with_cell_areas(_viz("tripolar"), data)
+
+    # `areacello` is the weighting field, normalized; `areacello_spherical` is
+    # the physical area in m^2. Both must come from the source.
+    np.testing.assert_allclose(out["areacello_spherical"].values, area)
+    np.testing.assert_allclose(out["areacello"].values, area / area.sum())
+
+    field = xr.DataArray(
+        np.linspace(0.0, 1.0, NY * NX).reshape(NY, NX), dims=("lat", "lon")
+    )
+    weighted = float(field.weighted(out["areacello"]).mean().values)
+
+    lat2d = data["lat_2d"].values
+    cosine = np.cos(np.deg2rad(lat2d))
+    cosine_weighted = float((field.values * cosine).sum() / cosine.sum())
+
+    assert not np.isclose(weighted, cosine_weighted, rtol=1e-3), (
+        "areacello weighting is indistinguishable from cosine-latitude "
+        "weighting, so this test cannot detect the bug it exists for"
+    )
+
+
+def test_tripolar_without_areacello_fails_loudly():
+    """A wrong figure is worse than an error, so refuse to invent areas."""
+    data = preserve_2d_coords(_source())
+
+    with pytest.raises(ValueError, match="carries no 'areacello'"):
+        Viz._with_cell_areas(_viz("tripolar"), data)
+
+
+def test_tripolar_rejects_areacello_on_the_wrong_grid():
+    """Areas given on a different grid than the data are refused."""
+    data = preserve_2d_coords(_source())
+    # A distinct dim name, so xarray keeps the mismatch instead of aligning it.
+    data["areacello"] = (("lat", "lon_other"), np.ones((NY, NX - 1)))
+
+    with pytest.raises(ValueError, match="expected"):
+        Viz._with_cell_areas(_viz("tripolar"), data)
+
+
+def test_tripolar_rejects_unusable_areacello():
+    """Areas that are all NaN cannot weight anything."""
+    data = preserve_2d_coords(_source())
+    data["areacello"] = (("lat", "lon"), np.full((NY, NX), np.nan))
+
+    with pytest.raises(ValueError, match="no positive finite values"):
+        Viz._with_cell_areas(_viz("tripolar"), data)
+
+
+def test_gaussian_area_path_is_unchanged():
+    """The rectilinear path still derives areas from the axes."""
+    ny, nx = 5, 8
+    data = xr.Dataset(
+        {"tos": (("lat", "lon"), np.ones((ny, nx)))},
+        coords={
+            "lat": np.linspace(-80.0, 80.0, ny),
+            "lon": np.linspace(0.0, 350.0, nx),
+        },
+    )
+
+    out = Viz._with_cell_areas(_viz("gaussian"), data)
+
+    assert "areacello" in out and "areacello_spherical" in out
+    # Cosine weights, normalized, as before.
+    expected = np.cos(np.deg2rad(data["lat"].values))
+    expected = np.repeat(expected[:, None], nx, axis=1)
+    expected = expected / expected.sum()
+    np.testing.assert_allclose(out["areacello"].values, expected, rtol=1e-6)
+
+
+# --- maps ----------------------------------------------------------------------
+
+
+def test_map_coords_are_2d_geographic_on_tripolar():
+    """pcolormesh must receive degrees, not cell indices."""
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+
+    map_x, map_y = Viz._map_coords(_viz("tripolar"), data)
+
+    assert map_x.name == "lon_2d" and map_y.name == "lat_2d"
+    assert map_x.dims == ("y", "x") and map_y.dims == ("y", "x")
+    _, _, lat2d, lon2d = _tripolar_coords()
+    np.testing.assert_array_equal(map_y.values, lat2d)
+    np.testing.assert_array_equal(map_x.values, lon2d)
+
+
+def test_map_coords_stay_on_index_axes_for_gaussian():
+    """The fast rectilinear path is untouched."""
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+
+    map_x, map_y = Viz._map_coords(_viz("gaussian"), data)
+
+    assert map_x.name == "x" and map_y.name == "y"
+
+
+def test_map_coords_fail_loudly_when_geography_was_lost():
+    data = xr.Dataset(
+        {"tos": (("y", "x"), np.ones((NY, NX)))},
+        coords={"y": np.arange(NY), "x": np.arange(NX)},
+    )
+
+    with pytest.raises(ValueError, match="lat_2d"):
+        Viz._map_coords(_viz("tripolar"), data)
+
+
+def test_map_helpers_pass_2d_coords_and_plate_carree(monkeypatch):
+    """The surface-map helper hands pcolormesh 2-D coords and a transform."""
+    import cartopy.crs as ccrs  # type: ignore[import-untyped]
+
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})["tos"]
+    captured = {}
+
+    class _Axis:
+        def pcolormesh(self, x, y, values, **kwargs):
+            captured["x"] = x
+            captured["y"] = y
+            captured["transform"] = kwargs["transform"]
+            return "image"
+
+        def add_feature(self, *args, **kwargs):
+            pass
+
+        def set_title(self, *args, **kwargs):
+            pass
+
+        def gridlines(self, *args, **kwargs):
+            return types.SimpleNamespace(
+                top_labels=True,
+                right_labels=True,
+                left_labels=True,
+                xlabel_style={},
+                ylabel_style={},
+                xlocator=None,
+            )
+
+    viz = _viz("tripolar")
+    Viz.plot_surface_map(viz, _Axis(), data, "title", 0)
+
+    assert captured["x"].name == "lon_2d"
+    assert captured["y"].name == "lat_2d"
+    assert isinstance(captured["transform"], ccrs.PlateCarree)
+
+
+# --- basin masks ---------------------------------------------------------------
+
+
+def _mask(ny: int, nx: int, *, with_coords: xr.Dataset | None = None):
+    mask = xr.DataArray(
+        np.ones((ny, nx)),
+        dims=("lat", "lon"),
+        coords={"lat": np.arange(ny), "lon": np.arange(nx)},
+    )
+    if with_coords is not None:
+        mask = mask.assign_coords(
+            lat_2d=(("lat", "lon"), with_coords["lat_2d"].values),
+            lon_2d=(("lat", "lon"), with_coords["lon_2d"].values),
+        )
+    return mask
+
+
+def test_mismatched_basin_dimensions_fail_loudly():
+    """The published Gaussian mask cannot be stretched onto a native grid."""
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+
+    with pytest.raises(ValueError, match="same grid as the data"):
+        process_mask(data, _mask(NY + 1, NX), "tripolar")
+
+
+def test_basin_mask_without_2d_coords_fails_loudly():
+    """Matching shapes do not imply matching geography off a rectilinear grid."""
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+
+    with pytest.raises(ValueError, match="no 2-D"):
+        process_mask(data, _mask(NY, NX), "tripolar")
+
+
+def test_basin_mask_on_a_different_grid_fails_loudly():
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+    other = preserve_2d_coords(_source())
+    other["lat_2d"] = other["lat_2d"] + 5.0
+    mask = _mask(NY, NX, with_coords=other)
+
+    with pytest.raises(ValueError, match="does not match"):
+        process_mask(data, mask, "tripolar")
+
+
+def test_coordinate_matched_basin_mask_aligns():
+    """A mask carrying this grid's own cell centers is accepted."""
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+    mask = _mask(NY, NX, with_coords=preserve_2d_coords(_source()))
+
+    out = process_mask(data, mask, "tripolar")
+
+    assert out.dims == ("y", "x")
+    np.testing.assert_array_equal(out["y"].values, data["y"].values)
+    np.testing.assert_array_equal(out["x"].values, data["x"].values)
+
+
+def test_coordinate_matched_mask_gives_the_expected_basin_weighted_result():
+    """A basin mean must reduce over exactly the cells the mask selects."""
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+    mask = _mask(NY, NX, with_coords=preserve_2d_coords(_source()))
+    # Select a single column, so the expected answer is arithmetic.
+    mask = mask.where(mask["lon"] == 2, 0)
+
+    aligned = process_mask(data, mask, "tripolar")
+
+    field = xr.DataArray(
+        np.arange(NY * NX, dtype=float).reshape(NY, NX), dims=("y", "x")
+    )
+    got = float((field * aligned).mean().values)
+    expected = float(field.isel(x=2).mean().values)
+
+    assert np.isclose(got, expected)
+
+
+def test_gaussian_mask_path_is_unchanged():
+    """Positional relabeling still happens on a rectilinear grid."""
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+
+    out = process_mask(data, _mask(NY, NX), "gaussian")
+
+    assert out.dims == ("y", "x")
+    np.testing.assert_array_equal(out["y"].values, data["y"].values)
+
+
+# --- refusing steps that only hold on a rectilinear grid ------------------------
+
+
+def test_rectilinear_only_step_is_rejected_on_tripolar():
+    with pytest.raises(NotImplementedError, match="thetao_mae_metrics"):
+        Viz._reject_on_curvilinear(_viz("tripolar"), "thetao_mae_metrics", "reason.")
+
+
+@pytest.mark.parametrize(
+    "step",
+    [
+        "thetao_mae_metrics",
+        "enso_plots",
+        "movies",
+        "ocean_temperature_profile_plots",
+    ],
+)
+def test_every_rectilinear_only_step_is_guarded(step):
+    """These steps average over 'x' or select by index range.
+
+    Neither is meaningful once rows of the grid stop following lines of
+    constant latitude, so each must refuse rather than draw a wrong figure.
+    """
+    viz = _viz("tripolar")
+    with pytest.raises(NotImplementedError, match=step):
+        getattr(Viz, f"step_{step}")(viz)
+
+
+def test_rectilinear_only_step_runs_on_gaussian():
+    """No exception is the whole assertion here."""
+    Viz._reject_on_curvilinear(_viz("gaussian"), "thetao_mae_metrics", "reason.")

--- a/tests/test_viz_core.py
+++ b/tests/test_viz_core.py
@@ -61,7 +61,12 @@ def _viz(grid_type: GridType):
     """
     stub = types.SimpleNamespace(data_layout=build_om4_layout(grid_type=grid_type))
     # Bind the real helpers so methods that call them through `self` work too.
-    for name in ("_with_cell_areas", "_map_coords", "_reject_on_curvilinear"):
+    for name in (
+        "_with_cell_areas",
+        "_map_coords",
+        "_map_plot_kwargs",
+        "_reject_on_curvilinear",
+    ):
         setattr(stub, name, types.MethodType(getattr(Viz, name), stub))
     return stub
 
@@ -215,6 +220,25 @@ def test_map_coords_are_2d_geographic_on_tripolar():
     _, _, lat2d, lon2d = _tripolar_coords()
     np.testing.assert_array_equal(map_y.values, lat2d)
     np.testing.assert_array_equal(map_x.values, lon2d)
+
+
+def test_map_plot_kwargs_name_the_2d_coords_on_tripolar():
+    """`.plot()` would otherwise use the index dims as plotting axes."""
+    import cartopy.crs as ccrs  # type: ignore[import-untyped]
+
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})["tos"]
+
+    kwargs = Viz._map_plot_kwargs(_viz("tripolar"), data)
+
+    assert kwargs["x"] == "lon_2d" and kwargs["y"] == "lat_2d"
+    assert isinstance(kwargs["transform"], ccrs.PlateCarree)
+
+
+def test_map_plot_kwargs_are_empty_for_gaussian():
+    """The rectilinear path keeps letting xarray choose."""
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})["tos"]
+
+    assert Viz._map_plot_kwargs(_viz("gaussian"), data) == {}
 
 
 def test_map_coords_stay_on_index_axes_for_gaussian():

--- a/tests/test_viz_core.py
+++ b/tests/test_viz_core.py
@@ -469,7 +469,10 @@ def _aligned_basins(grid_type: GridType, data: xr.Dataset, basins: xr.Dataset):
     stub = _viz(grid_type)
     stub.data = data
     stub._basins = basins
-    return Viz.basin_masks.func(stub)
+    # `Viz.basin_masks` is the descriptor itself at runtime, but mypy types
+    # class-level access as the value it resolves to, so it sees no `.func`.
+    # `__dict__` reaches the same object by a route mypy does not model.
+    return Viz.__dict__["basin_masks"].func(stub)
 
 
 def test_basin_masks_keep_every_cell_the_mask_set_assigns(preserved, curvilinear_data):

--- a/tests/test_viz_core.py
+++ b/tests/test_viz_core.py
@@ -433,6 +433,83 @@ def test_gaussian_mask_path_is_unchanged(curvilinear_data):
     np.testing.assert_array_equal(out["y"].values, curvilinear_data["y"].values)
 
 
+_BASIN_NAMES = (
+    "basin_atlantic",
+    "basin_pacific",
+    "basin_indian",
+    "basin_southern",
+    "basin_arctic",
+)
+
+
+def _basin_set(preserved: xr.Dataset, assignment: np.ndarray) -> xr.Dataset:
+    """A partitioning mask set on this grid, from one code per cell.
+
+    Codes run 1-5 over `_BASIN_NAMES` in order; 0 leaves a cell unassigned, as
+    the marginal seas and the land are.
+    """
+    return xr.Dataset(
+        {
+            name: (("lat", "lon"), (assignment == code).astype(float))
+            for code, name in enumerate(_BASIN_NAMES, start=1)
+        },
+        coords={
+            # Nominal 1-D axes, as both the published masks and OM4's native
+            # ones carry. The true centers are the 2-D pair below.
+            "lat": preserved["lat"].values,
+            "lon": preserved["lon"].values,
+            "lat_2d": (("lat", "lon"), preserved["lat_2d"].values),
+            "lon_2d": (("lat", "lon"), preserved["lon_2d"].values),
+        },
+    )
+
+
+def _aligned_basins(grid_type: GridType, data: xr.Dataset, basins: xr.Dataset):
+    """`Viz.basin_masks` off a stub, bypassing the cached_property descriptor."""
+    stub = _viz(grid_type)
+    stub.data = data
+    stub._basins = basins
+    return Viz.basin_masks.func(stub)
+
+
+def test_basin_masks_keep_every_cell_the_mask_set_assigns(preserved, curvilinear_data):
+    """A cell in exactly one basin going in must be in exactly one coming out.
+
+    This used to cut the Atlantic, Pacific and Indian at 32S. That was written
+    for the published Gaussian masks, whose Southern Ocean runs north to 32.5S,
+    so it removed nothing there. Masks built from OM4's own region codes put
+    the boundary further south, and the cells between the two lines were
+    deleted from the three basins without the Southern Ocean reaching up to
+    claim them, dropping them out of the basin diagnostics entirely.
+    """
+    lat2d = preserved["lat_2d"].values
+    # Southern Ocean stopping well south of 32S, Atlantic running down to meet
+    # it, which is how OM4's region codes divide this boundary.
+    assignment = np.where(lat2d < -45.0, 4, 1)
+    basins = _basin_set(preserved, assignment)
+
+    masks = _aligned_basins("tripolar", curvilinear_data, basins)
+
+    # `process_mask` writes unassigned cells as NaN rather than zero.
+    claimed = sum(np.nan_to_num(masks[name].values) for name in masks.data_vars)
+    np.testing.assert_array_equal(claimed, np.ones_like(lat2d))
+
+
+def test_the_basin_fixture_straddles_the_old_cut(preserved):
+    """Guards the test above: it only bites if cells sit between the lines.
+
+    Without cells that are south of 32S and north of the Southern Ocean, the
+    old cut would have been a no-op here too and the test would pass either
+    way.
+    """
+    lat2d = preserved["lat_2d"].values
+    nominal = np.broadcast_to(preserved["lat"].values[:, None], lat2d.shape)
+
+    at_risk = (nominal < -32.0) & (lat2d >= -45.0)
+
+    assert at_risk.any()
+
+
 # --- refusing steps that only hold on a rectilinear grid ------------------------
 
 

--- a/tests/test_viz_core.py
+++ b/tests/test_viz_core.py
@@ -71,14 +71,64 @@ def _viz(grid_type: GridType):
     return stub
 
 
+# The builders above stay functions because they take arguments and call each
+# other. These fixtures cover the defaults, which is what almost every test
+# below wants.
+
+
+@pytest.fixture
+def tripolar_coords():
+    """The nonseparable axes and 2-D centers the other fixtures are built on."""
+    return _tripolar_coords()
+
+
+@pytest.fixture
+def source():
+    """A source dataset as it arrives from eval, on y/x with 2-D lat/lon."""
+    return _source()
+
+
+@pytest.fixture
+def preserved(source):
+    """`source` after preprocessing: y/x renamed, true geography kept as *_2d."""
+    return preserve_2d_coords(source)
+
+
+@pytest.fixture
+def curvilinear_data(preserved):
+    """`preserved` back on the y/x axis names the plotting helpers read."""
+    return preserved.rename({"lat": "y", "lon": "x"})
+
+
+@pytest.fixture
+def curvilinear_field(curvilinear_data):
+    """A single variable off `curvilinear_data`, for the `.plot()` helpers."""
+    return curvilinear_data["tos"]
+
+
+@pytest.fixture
+def gaussian_viz():
+    return _viz("gaussian")
+
+
+@pytest.fixture
+def tripolar_viz():
+    return _viz("tripolar")
+
+
+@pytest.fixture
+def llc_viz():
+    return _viz("llc")
+
+
 # --- 2-D coordinates survive preprocessing ------------------------------------
 
 
-def test_preserve_2d_coords_keeps_nonseparable_geography():
+def test_preserve_2d_coords_keeps_nonseparable_geography(source, tripolar_coords):
     """The real cell centers survive the y/x -> lat/lon rename, exactly."""
-    _, _, lat2d, lon2d = _tripolar_coords()
+    _, _, lat2d, lon2d = tripolar_coords
 
-    out = preserve_2d_coords(_source())
+    out = preserve_2d_coords(source)
 
     assert out["lat_2d"].dims == ("lat", "lon")
     assert out["lon_2d"].dims == ("lat", "lon")
@@ -86,39 +136,41 @@ def test_preserve_2d_coords_keeps_nonseparable_geography():
     np.testing.assert_array_equal(out["lon_2d"].values, lon2d)
 
 
-def test_preserve_2d_coords_geography_is_not_recoverable_by_broadcasting():
+def test_preserve_2d_coords_geography_is_not_recoverable_by_broadcasting(
+    tripolar_coords,
+):
     """Guards the fixture: broadcasting the axes must not reproduce the truth.
 
     Without this the test above would still pass on a rectilinear grid and
     would not be testing anything.
     """
-    y, x, lat2d, lon2d = _tripolar_coords()
+    y, x, lat2d, lon2d = tripolar_coords
 
     assert not np.allclose(np.broadcast_to(y[:, None], lat2d.shape), lat2d)
     assert not np.allclose(np.broadcast_to(x[None, :], lon2d.shape), lon2d)
 
 
-def test_preserve_2d_coords_is_idempotent():
+def test_preserve_2d_coords_is_idempotent(source, tripolar_coords):
     """A source that has already been through this must not crash.
 
     Renaming `lat` onto an occupied `lat_2d` is an xarray error, and rollouts
     can arrive already carrying the preserved names.
     """
-    once = preserve_2d_coords(_source())
+    once = preserve_2d_coords(source)
     # Put it back on y/x, keeping the preserved names, as a re-fed rollout would.
     again = once.rename({"lat": "y", "lon": "x"})
 
     out = preserve_2d_coords(again)
 
-    _, _, lat2d, lon2d = _tripolar_coords()
+    _, _, lat2d, lon2d = tripolar_coords
     np.testing.assert_array_equal(out["lat_2d"].values, lat2d)
     np.testing.assert_array_equal(out["lon_2d"].values, lon2d)
     assert out["tos"].dims == ("lat", "lon")
 
 
-def test_preserve_2d_coords_renames_axes_to_lat_lon():
+def test_preserve_2d_coords_renames_axes_to_lat_lon(source):
     """The index axes still land on the names the rest of viz works in."""
-    out = preserve_2d_coords(_source())
+    out = preserve_2d_coords(source)
 
     assert out["tos"].dims == ("lat", "lon")
     assert "y" not in out.dims and "x" not in out.dims
@@ -127,7 +179,7 @@ def test_preserve_2d_coords_renames_axes_to_lat_lon():
 # --- cell areas ----------------------------------------------------------------
 
 
-def test_tripolar_uses_source_areacello_not_cosine_latitude():
+def test_tripolar_uses_source_areacello_not_cosine_latitude(tripolar_viz):
     """Weighted means must follow the real areas, not cos(lat).
 
     On a tripolar grid the two disagree: cell area collapses towards the
@@ -136,7 +188,7 @@ def test_tripolar_uses_source_areacello_not_cosine_latitude():
     area = np.linspace(1.0, 50.0, NY * NX).reshape(NY, NX)
     data = preserve_2d_coords(_source(areacello=area))
 
-    out = Viz._with_cell_areas(_viz("tripolar"), data)
+    out = Viz._with_cell_areas(tripolar_viz, data)
 
     # `areacello` is the weighting field, normalized; `areacello_spherical` is
     # the physical area in m^2. Both must come from the source.
@@ -158,34 +210,30 @@ def test_tripolar_uses_source_areacello_not_cosine_latitude():
     )
 
 
-def test_tripolar_without_areacello_fails_loudly():
+def test_tripolar_without_areacello_fails_loudly(tripolar_viz, preserved):
     """A wrong figure is worse than an error, so refuse to invent areas."""
-    data = preserve_2d_coords(_source())
-
     with pytest.raises(ValueError, match="carries no 'areacello'"):
-        Viz._with_cell_areas(_viz("tripolar"), data)
+        Viz._with_cell_areas(tripolar_viz, preserved)
 
 
-def test_tripolar_rejects_areacello_on_the_wrong_grid():
+def test_tripolar_rejects_areacello_on_the_wrong_grid(tripolar_viz, preserved):
     """Areas given on a different grid than the data are refused."""
-    data = preserve_2d_coords(_source())
     # A distinct dim name, so xarray keeps the mismatch instead of aligning it.
-    data["areacello"] = (("lat", "lon_other"), np.ones((NY, NX - 1)))
+    preserved["areacello"] = (("lat", "lon_other"), np.ones((NY, NX - 1)))
 
     with pytest.raises(ValueError, match="expected"):
-        Viz._with_cell_areas(_viz("tripolar"), data)
+        Viz._with_cell_areas(tripolar_viz, preserved)
 
 
-def test_tripolar_rejects_unusable_areacello():
+def test_tripolar_rejects_unusable_areacello(tripolar_viz, preserved):
     """Areas that are all NaN cannot weight anything."""
-    data = preserve_2d_coords(_source())
-    data["areacello"] = (("lat", "lon"), np.full((NY, NX), np.nan))
+    preserved["areacello"] = (("lat", "lon"), np.full((NY, NX), np.nan))
 
     with pytest.raises(ValueError, match="no positive finite values"):
-        Viz._with_cell_areas(_viz("tripolar"), data)
+        Viz._with_cell_areas(tripolar_viz, preserved)
 
 
-def test_gaussian_area_path_is_unchanged():
+def test_gaussian_area_path_is_unchanged(gaussian_viz):
     """The rectilinear path still derives areas from the axes."""
     ny, nx = 5, 8
     data = xr.Dataset(
@@ -196,7 +244,7 @@ def test_gaussian_area_path_is_unchanged():
         },
     )
 
-    out = Viz._with_cell_areas(_viz("gaussian"), data)
+    out = Viz._with_cell_areas(gaussian_viz, data)
 
     assert "areacello" in out and "areacello_spherical" in out
     # Cosine weights, normalized, as before.
@@ -209,78 +257,71 @@ def test_gaussian_area_path_is_unchanged():
 # --- maps ----------------------------------------------------------------------
 
 
-def test_map_coords_are_2d_geographic_on_tripolar():
+def test_map_coords_are_2d_geographic_on_tripolar(
+    tripolar_viz, curvilinear_data, tripolar_coords
+):
     """pcolormesh must receive degrees, not cell indices."""
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
-
-    map_x, map_y = Viz._map_coords(_viz("tripolar"), data)
+    map_x, map_y = Viz._map_coords(tripolar_viz, curvilinear_data)
 
     assert map_x.name == "lon_2d" and map_y.name == "lat_2d"
     assert map_x.dims == ("y", "x") and map_y.dims == ("y", "x")
-    _, _, lat2d, lon2d = _tripolar_coords()
+    _, _, lat2d, lon2d = tripolar_coords
     np.testing.assert_array_equal(map_y.values, lat2d)
     np.testing.assert_array_equal(map_x.values, lon2d)
 
 
-def test_llc_takes_the_curvilinear_path_too():
+def test_llc_takes_the_curvilinear_path_too(llc_viz, curvilinear_data):
     """Tripolar is not the only curvilinear grid `GridType` names.
 
     Every branch asks `is_curvilinear`, so lat-lon-cap has to get the 2-D
     coordinates rather than the rectilinear default it would fall into if the
     branches tested for a specific grid by name.
     """
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
-
-    map_x, map_y = Viz._map_coords(_viz("llc"), data)
+    map_x, map_y = Viz._map_coords(llc_viz, curvilinear_data)
 
     assert map_x.name == "lon_2d" and map_y.name == "lat_2d"
     with pytest.raises(NotImplementedError, match="llc"):
-        Viz._reject_on_curvilinear(_viz("llc"), "movies", "reason.")
+        Viz._reject_on_curvilinear(llc_viz, "movies", "reason.")
 
 
-def test_map_plot_kwargs_name_the_2d_coords_on_tripolar():
+def test_map_plot_kwargs_name_the_2d_coords_on_tripolar(
+    tripolar_viz, curvilinear_field
+):
     """`.plot()` would otherwise use the index dims as plotting axes."""
     import cartopy.crs as ccrs  # type: ignore[import-untyped]
 
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})["tos"]
-
-    kwargs = Viz._map_plot_kwargs(_viz("tripolar"), data)
+    kwargs = Viz._map_plot_kwargs(tripolar_viz, curvilinear_field)
 
     assert kwargs["x"] == "lon_2d" and kwargs["y"] == "lat_2d"
     assert isinstance(kwargs["transform"], ccrs.PlateCarree)
 
 
-def test_map_plot_kwargs_are_empty_for_gaussian():
+def test_map_plot_kwargs_are_empty_for_gaussian(gaussian_viz, curvilinear_field):
     """The rectilinear path keeps letting xarray choose."""
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})["tos"]
-
-    assert Viz._map_plot_kwargs(_viz("gaussian"), data) == {}
+    assert Viz._map_plot_kwargs(gaussian_viz, curvilinear_field) == {}
 
 
-def test_map_coords_stay_on_index_axes_for_gaussian():
+def test_map_coords_stay_on_index_axes_for_gaussian(gaussian_viz, curvilinear_data):
     """The fast rectilinear path is untouched."""
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
-
-    map_x, map_y = Viz._map_coords(_viz("gaussian"), data)
+    map_x, map_y = Viz._map_coords(gaussian_viz, curvilinear_data)
 
     assert map_x.name == "x" and map_y.name == "y"
 
 
-def test_map_coords_fail_loudly_when_geography_was_lost():
+def test_map_coords_fail_loudly_when_geography_was_lost(tripolar_viz):
     data = xr.Dataset(
         {"tos": (("y", "x"), np.ones((NY, NX)))},
         coords={"y": np.arange(NY), "x": np.arange(NX)},
     )
 
     with pytest.raises(ValueError, match="lat_2d"):
-        Viz._map_coords(_viz("tripolar"), data)
+        Viz._map_coords(tripolar_viz, data)
 
 
-def test_map_helpers_pass_2d_coords_and_plate_carree(monkeypatch):
+def test_map_helpers_pass_2d_coords_and_plate_carree(tripolar_viz, curvilinear_field):
     """The surface-map helper hands pcolormesh 2-D coords and a transform."""
     import cartopy.crs as ccrs  # type: ignore[import-untyped]
 
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})["tos"]
     captured = {}
 
     class _Axis:
@@ -306,8 +347,7 @@ def test_map_helpers_pass_2d_coords_and_plate_carree(monkeypatch):
                 xlocator=None,
             )
 
-    viz = _viz("tripolar")
-    Viz.plot_surface_map(viz, _Axis(), data, "title", 0)
+    Viz.plot_surface_map(tripolar_viz, _Axis(), curvilinear_field, "title", 0)
 
     assert captured["x"].name == "lon_2d"
     assert captured["y"].name == "lat_2d"
@@ -331,52 +371,50 @@ def _mask(ny: int, nx: int, *, with_coords: xr.Dataset | None = None):
     return mask
 
 
-def test_mismatched_basin_dimensions_fail_loudly():
+@pytest.fixture
+def matching_mask(preserved):
+    """A mask carrying this grid's own cell centers, so alignment succeeds."""
+    return _mask(NY, NX, with_coords=preserved)
+
+
+def test_mismatched_basin_dimensions_fail_loudly(curvilinear_data):
     """The published Gaussian mask cannot be stretched onto a native grid."""
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
-
     with pytest.raises(ValueError, match="same grid as the data"):
-        process_mask(data, _mask(NY + 1, NX), "tripolar")
+        process_mask(curvilinear_data, _mask(NY + 1, NX), "tripolar")
 
 
-def test_basin_mask_without_2d_coords_fails_loudly():
+def test_basin_mask_without_2d_coords_fails_loudly(curvilinear_data):
     """Matching shapes do not imply matching geography off a rectilinear grid."""
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
-
     with pytest.raises(ValueError, match="no 2-D"):
-        process_mask(data, _mask(NY, NX), "tripolar")
+        process_mask(curvilinear_data, _mask(NY, NX), "tripolar")
 
 
-def test_basin_mask_on_a_different_grid_fails_loudly():
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+def test_basin_mask_on_a_different_grid_fails_loudly(curvilinear_data):
     other = preserve_2d_coords(_source())
     other["lat_2d"] = other["lat_2d"] + 5.0
     mask = _mask(NY, NX, with_coords=other)
 
     with pytest.raises(ValueError, match="does not match"):
-        process_mask(data, mask, "tripolar")
+        process_mask(curvilinear_data, mask, "tripolar")
 
 
-def test_coordinate_matched_basin_mask_aligns():
+def test_coordinate_matched_basin_mask_aligns(curvilinear_data, matching_mask):
     """A mask carrying this grid's own cell centers is accepted."""
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
-    mask = _mask(NY, NX, with_coords=preserve_2d_coords(_source()))
-
-    out = process_mask(data, mask, "tripolar")
+    out = process_mask(curvilinear_data, matching_mask, "tripolar")
 
     assert out.dims == ("y", "x")
-    np.testing.assert_array_equal(out["y"].values, data["y"].values)
-    np.testing.assert_array_equal(out["x"].values, data["x"].values)
+    np.testing.assert_array_equal(out["y"].values, curvilinear_data["y"].values)
+    np.testing.assert_array_equal(out["x"].values, curvilinear_data["x"].values)
 
 
-def test_coordinate_matched_mask_gives_the_expected_basin_weighted_result():
+def test_coordinate_matched_mask_gives_the_expected_basin_weighted_result(
+    curvilinear_data, matching_mask
+):
     """A basin mean must reduce over exactly the cells the mask selects."""
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
-    mask = _mask(NY, NX, with_coords=preserve_2d_coords(_source()))
     # Select a single column, so the expected answer is arithmetic.
-    mask = mask.where(mask["lon"] == 2, 0)
+    mask = matching_mask.where(matching_mask["lon"] == 2, 0)
 
-    aligned = process_mask(data, mask, "tripolar")
+    aligned = process_mask(curvilinear_data, mask, "tripolar")
 
     field = xr.DataArray(
         np.arange(NY * NX, dtype=float).reshape(NY, NX), dims=("y", "x")
@@ -387,22 +425,20 @@ def test_coordinate_matched_mask_gives_the_expected_basin_weighted_result():
     assert np.isclose(got, expected)
 
 
-def test_gaussian_mask_path_is_unchanged():
+def test_gaussian_mask_path_is_unchanged(curvilinear_data):
     """Positional relabeling still happens on a rectilinear grid."""
-    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
-
-    out = process_mask(data, _mask(NY, NX), "gaussian")
+    out = process_mask(curvilinear_data, _mask(NY, NX), "gaussian")
 
     assert out.dims == ("y", "x")
-    np.testing.assert_array_equal(out["y"].values, data["y"].values)
+    np.testing.assert_array_equal(out["y"].values, curvilinear_data["y"].values)
 
 
 # --- refusing steps that only hold on a rectilinear grid ------------------------
 
 
-def test_rectilinear_only_step_is_rejected_on_tripolar():
+def test_rectilinear_only_step_is_rejected_on_tripolar(tripolar_viz):
     with pytest.raises(NotImplementedError, match="thetao_mae_metrics"):
-        Viz._reject_on_curvilinear(_viz("tripolar"), "thetao_mae_metrics", "reason.")
+        Viz._reject_on_curvilinear(tripolar_viz, "thetao_mae_metrics", "reason.")
 
 
 @pytest.mark.parametrize(
@@ -414,17 +450,16 @@ def test_rectilinear_only_step_is_rejected_on_tripolar():
         "ocean_temperature_profile_plots",
     ],
 )
-def test_every_rectilinear_only_step_is_guarded(step):
+def test_every_rectilinear_only_step_is_guarded(step, tripolar_viz):
     """These steps average over 'x' or select by index range.
 
     Neither is meaningful once rows of the grid stop following lines of
     constant latitude, so each must refuse rather than draw a wrong figure.
     """
-    viz = _viz("tripolar")
     with pytest.raises(NotImplementedError, match=step):
-        getattr(Viz, f"step_{step}")(viz)
+        getattr(Viz, f"step_{step}")(tripolar_viz)
 
 
-def test_rectilinear_only_step_runs_on_gaussian():
+def test_rectilinear_only_step_runs_on_gaussian(gaussian_viz):
     """No exception is the whole assertion here."""
-    Viz._reject_on_curvilinear(_viz("gaussian"), "thetao_mae_metrics", "reason.")
+    Viz._reject_on_curvilinear(gaussian_viz, "thetao_mae_metrics", "reason.")

--- a/tests/test_viz_core.py
+++ b/tests/test_viz_core.py
@@ -222,6 +222,22 @@ def test_map_coords_are_2d_geographic_on_tripolar():
     np.testing.assert_array_equal(map_x.values, lon2d)
 
 
+def test_llc_takes_the_curvilinear_path_too():
+    """Tripolar is not the only curvilinear grid `GridType` names.
+
+    Every branch asks `is_curvilinear`, so lat-lon-cap has to get the 2-D
+    coordinates rather than the rectilinear default it would fall into if the
+    branches tested for a specific grid by name.
+    """
+    data = preserve_2d_coords(_source()).rename({"lat": "y", "lon": "x"})
+
+    map_x, map_y = Viz._map_coords(_viz("llc"), data)
+
+    assert map_x.name == "lon_2d" and map_y.name == "lat_2d"
+    with pytest.raises(NotImplementedError, match="llc"):
+        Viz._reject_on_curvilinear(_viz("llc"), "movies", "reason.")
+
+
 def test_map_plot_kwargs_name_the_2d_coords_on_tripolar():
     """`.plot()` would otherwise use the index dims as plotting axes."""
     import cartopy.crs as ccrs  # type: ignore[import-untyped]


### PR DESCRIPTION
This is #869.

Viz never learned what grid it was on. `Viz.__init__` hard-coded `build_om4_layout()`, which defaults to gaussian, so everything downstream treated the native tripolar grid as if it were rectilinear and got away with it quietly. It now takes the grid type from the data source and branches on it.

Thanks @alxmrs for pointing me at `raw/om4_5daily.zarr` and `raw/ocean_static_no_mask_table.zarr`. Everything below is measured against those rather than a fixture.

The clearest way I found to show why the areas matter is global mean `zos`. It's an anomaly about the global mean, so the answer has to be zero:

| weighting | global mean `zos` |
| --- | --- |
| source `areacello` | `-3.4e-10 m` |
| `cos(lat)`, as before | `-0.1345 m` |

13.5 cm of artifact. Cosine weighting starves the tropics by about 8 points of total area and inflates the Arctic by 70%, because near the fold the cells are small and `cos(lat)` doesn't know that. This isn't only a plotting problem, `spherical_area_weights()` overwrote the source `areacello` and fed about thirty reductions including OHC and global mean SST.

What changed:

- 2-D lat/lon survive the y/x rename as `lat_2d`/`lon_2d`, following `with_lat_lon_coords()` and `ZarrWriter`. Predictions too, since rollouts land in the same layout.
- Real `areacello` on curvilinear grids, and a loud failure when it's missing.
- Basin masks validated instead of relabeled by position.
- Maps plot against the 2-D coords, all six `pcolormesh` sites.
- Four steps refuse curvilinear input: `thetao_mae_metrics`, `enso_plots`, `movies`, `ocean_temperature_profile_plots`. The last one averages each basin over `x` and then labels that axis "Latitude".
- Basin masks build lazily, so a smoke test no longer depends on mask alignment succeeding.

This also turns on the guard already sitting in `metrics/observations.py`, which could never fire before.

New `ocean_preprocessing basin_masks` subcommand for the native masks, since the published ones are all rectilinear. No regridding needed, `ocean_static` already has integer region codes on the native grid next to the real cell centers and the wet mask, and integer codes partition by construction. Against the public store it assigns 953,060 of 969,446 wet cells, max one basin per cell. Marginal seas stay unassigned, which I checked against `basin_masks_original.zarr` rather than guessing.

Against the acceptance criteria in #869:

| | criterion | |
| --- | --- | --- |
| 1 | Nonseparable fixture keeps exact 2-D lat/lon | ✅ |
| 2 | Exact `areacello` retained, distinguished from cos-lat | ✅ |
| 3 | Mismatched basin masks fail with an actionable error | ✅ |
| 4 | Matching native mask aligns, expected basin result | ✅ |
| 5 | Map test asserts 2-D coords and Plate Carrée | ✅ |
| 6 | Gaussian tests unchanged | ✅ |
| 7 | Torch smoke viz, then the full #492 job | ❌ |

7 needs a tripolar rollout and I don't have Torch access. Happy to run it once @YuanYuan98's export lands, or it may be quicker for someone with cluster access to run it against this branch.

Ran locally: 86 tests across viz, writer and config, 78 across metrics and utils, 11 in the data env, pre-commit clean. The full suite OOMs on my laptop so I'm leaning on CI for the rest.

